### PR TITLE
Kops - add testgrid dashboards for each kops version being tested

### DIFF
--- a/config/jobs/kubernetes/kops/build-grid.py
+++ b/config/jobs/kubernetes/kops/build-grid.py
@@ -329,6 +329,11 @@ def build_test(cloud='aws',
     else:
         dashboards.append('kops-k8s-latest')
 
+    if kops_version:
+        dashboards.append('kops-' + kops_version)
+    else:
+        dashboards.append('kops-latest')
+
     if extra_dashboards:
         dashboards.extend(extra_dashboards)
 

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -47,7 +47,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-amzn2-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
@@ -96,7 +96,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-amzn2-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
@@ -145,7 +145,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-amzn2-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": null, "networking": null}
@@ -194,7 +194,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-amzn2-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
@@ -243,7 +243,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-amzn2-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
@@ -292,7 +292,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-amzn2-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": null}
@@ -341,7 +341,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-amzn2-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
@@ -390,7 +390,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-amzn2-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
@@ -439,7 +439,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-amzn2-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_version": null, "networking": null}
@@ -488,7 +488,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-amzn2-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_version": "1.18", "networking": null}
@@ -537,7 +537,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-amzn2-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_version": "1.19", "networking": null}
@@ -586,7 +586,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-amzn2-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": null}
@@ -635,7 +635,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-deb9-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
@@ -684,7 +684,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-deb9-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
@@ -733,7 +733,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-deb9-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": null, "networking": null}
@@ -782,7 +782,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-deb9-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
@@ -831,7 +831,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-deb9-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
@@ -880,7 +880,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-deb9-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": null}
@@ -929,7 +929,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-deb9-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
@@ -978,7 +978,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-deb9-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
@@ -1027,7 +1027,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-deb9-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_version": null, "networking": null}
@@ -1076,7 +1076,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-deb9-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_version": "1.18", "networking": null}
@@ -1125,7 +1125,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-deb9-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_version": "1.19", "networking": null}
@@ -1174,7 +1174,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-deb9-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": null}
@@ -1223,7 +1223,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-deb10-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
@@ -1272,7 +1272,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-deb10-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
@@ -1321,7 +1321,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-deb10-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": null, "networking": null}
@@ -1370,7 +1370,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-deb10-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
@@ -1419,7 +1419,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-deb10-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
@@ -1468,7 +1468,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-deb10-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": null}
@@ -1517,7 +1517,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-deb10-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
@@ -1566,7 +1566,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-deb10-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
@@ -1615,7 +1615,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-deb10-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_version": null, "networking": null}
@@ -1664,7 +1664,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-deb10-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_version": "1.18", "networking": null}
@@ -1713,7 +1713,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-deb10-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_version": "1.19", "networking": null}
@@ -1762,7 +1762,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-deb10-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": null}
@@ -1811,7 +1811,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-flatcar-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
@@ -1860,7 +1860,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-flatcar-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
@@ -1909,7 +1909,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-flatcar-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": null, "networking": null}
@@ -1958,7 +1958,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-flatcar-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
@@ -2007,7 +2007,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-flatcar-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
@@ -2056,7 +2056,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-flatcar-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": null}
@@ -2105,7 +2105,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-flatcar-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
@@ -2154,7 +2154,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-flatcar-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
@@ -2203,7 +2203,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-flatcar-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_version": null, "networking": null}
@@ -2252,7 +2252,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-flatcar-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_version": "1.18", "networking": null}
@@ -2301,7 +2301,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-flatcar-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_version": "1.19", "networking": null}
@@ -2350,7 +2350,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-flatcar-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": null}
@@ -2399,7 +2399,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-rhel7-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
@@ -2448,7 +2448,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-rhel7-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
@@ -2497,7 +2497,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-rhel7-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": null, "networking": null}
@@ -2546,7 +2546,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-rhel7-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
@@ -2595,7 +2595,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-rhel7-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
@@ -2644,7 +2644,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-rhel7-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": null}
@@ -2693,7 +2693,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-rhel7-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
@@ -2742,7 +2742,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-rhel7-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
@@ -2791,7 +2791,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-rhel7-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_version": null, "networking": null}
@@ -2840,7 +2840,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-rhel7-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_version": "1.18", "networking": null}
@@ -2889,7 +2889,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-rhel7-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_version": "1.19", "networking": null}
@@ -2938,7 +2938,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-rhel7-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": null}
@@ -2987,7 +2987,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-rhel8-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
@@ -3036,7 +3036,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-rhel8-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
@@ -3085,7 +3085,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-rhel8-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": null, "networking": null}
@@ -3134,7 +3134,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-rhel8-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
@@ -3183,7 +3183,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-rhel8-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
@@ -3232,7 +3232,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-rhel8-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": null}
@@ -3281,7 +3281,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-rhel8-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
@@ -3330,7 +3330,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-rhel8-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
@@ -3379,7 +3379,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-rhel8-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_version": null, "networking": null}
@@ -3428,7 +3428,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-rhel8-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_version": "1.18", "networking": null}
@@ -3477,7 +3477,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-rhel8-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_version": "1.19", "networking": null}
@@ -3526,7 +3526,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-rhel8-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": null}
@@ -3575,7 +3575,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-u1804-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
@@ -3624,7 +3624,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-u1804-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
@@ -3673,7 +3673,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-u1804-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": null, "networking": null}
@@ -3722,7 +3722,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-u1804-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
@@ -3771,7 +3771,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-u1804-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
@@ -3820,7 +3820,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-u1804-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": null}
@@ -3869,7 +3869,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-u1804-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
@@ -3918,7 +3918,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-u1804-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
@@ -3967,7 +3967,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-u1804-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_version": null, "networking": null}
@@ -4016,7 +4016,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-u1804-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_version": "1.18", "networking": null}
@@ -4065,7 +4065,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-u1804-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_version": "1.19", "networking": null}
@@ -4114,7 +4114,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-u1804-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": null}
@@ -4163,7 +4163,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-u2004-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
@@ -4212,7 +4212,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-u2004-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
@@ -4261,7 +4261,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-u2004-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": null, "networking": null}
@@ -4310,7 +4310,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-u2004-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
@@ -4359,7 +4359,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-u2004-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
@@ -4408,7 +4408,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-u2004-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": null}
@@ -4457,7 +4457,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-u2004-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
@@ -4506,7 +4506,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-u2004-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
@@ -4555,7 +4555,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-u2004-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_version": null, "networking": null}
@@ -4604,7 +4604,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-u2004-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_version": "1.18", "networking": null}
@@ -4653,7 +4653,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-u2004-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_version": "1.19", "networking": null}
@@ -4702,7 +4702,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-u2004-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -4751,7 +4751,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-calico-amzn2-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
@@ -4800,7 +4800,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-calico-amzn2-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -4849,7 +4849,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-calico-amzn2-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -4898,7 +4898,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-calico-amzn2-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
@@ -4947,7 +4947,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-calico-amzn2-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -4996,7 +4996,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-calico-amzn2-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -5045,7 +5045,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-calico-amzn2-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
@@ -5094,7 +5094,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-calico-amzn2-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -5143,7 +5143,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-calico-amzn2-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -5192,7 +5192,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-calico-amzn2-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_version": "1.18", "networking": "calico"}
@@ -5241,7 +5241,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-calico-amzn2-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_version": "1.19", "networking": "calico"}
@@ -5290,7 +5290,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-calico-amzn2-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -5339,7 +5339,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-calico-deb9-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
@@ -5388,7 +5388,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-calico-deb9-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -5437,7 +5437,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-calico-deb9-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -5486,7 +5486,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-calico-deb9-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
@@ -5535,7 +5535,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-calico-deb9-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -5584,7 +5584,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-calico-deb9-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -5633,7 +5633,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-calico-deb9-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
@@ -5682,7 +5682,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-calico-deb9-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -5731,7 +5731,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-calico-deb9-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -5780,7 +5780,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-calico-deb9-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_version": "1.18", "networking": "calico"}
@@ -5829,7 +5829,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-calico-deb9-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_version": "1.19", "networking": "calico"}
@@ -5878,7 +5878,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-calico-deb9-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -5927,7 +5927,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-calico-deb10-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
@@ -5976,7 +5976,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-calico-deb10-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -6025,7 +6025,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-calico-deb10-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -6074,7 +6074,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-calico-deb10-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
@@ -6123,7 +6123,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-calico-deb10-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -6172,7 +6172,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-calico-deb10-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -6221,7 +6221,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-calico-deb10-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
@@ -6270,7 +6270,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-calico-deb10-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -6319,7 +6319,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-calico-deb10-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -6368,7 +6368,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-calico-deb10-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_version": "1.18", "networking": "calico"}
@@ -6417,7 +6417,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-calico-deb10-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_version": "1.19", "networking": "calico"}
@@ -6466,7 +6466,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-calico-deb10-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -6515,7 +6515,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-calico-flatcar-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
@@ -6564,7 +6564,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-calico-flatcar-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -6613,7 +6613,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-calico-flatcar-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -6662,7 +6662,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-calico-flatcar-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
@@ -6711,7 +6711,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-calico-flatcar-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -6760,7 +6760,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-calico-flatcar-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -6809,7 +6809,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-calico-flatcar-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
@@ -6858,7 +6858,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-calico-flatcar-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -6907,7 +6907,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-calico-flatcar-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -6956,7 +6956,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-calico-flatcar-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_version": "1.18", "networking": "calico"}
@@ -7005,7 +7005,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-calico-flatcar-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_version": "1.19", "networking": "calico"}
@@ -7054,7 +7054,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-calico-flatcar-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -7103,7 +7103,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-calico-rhel7-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
@@ -7152,7 +7152,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-calico-rhel7-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -7201,7 +7201,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-calico-rhel7-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -7250,7 +7250,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-calico-rhel7-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
@@ -7299,7 +7299,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-calico-rhel7-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -7348,7 +7348,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-calico-rhel7-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -7397,7 +7397,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-calico-rhel7-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
@@ -7446,7 +7446,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-calico-rhel7-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -7495,7 +7495,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-calico-rhel7-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -7544,7 +7544,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-calico-rhel7-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_version": "1.18", "networking": "calico"}
@@ -7593,7 +7593,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-calico-rhel7-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_version": "1.19", "networking": "calico"}
@@ -7642,7 +7642,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-calico-rhel7-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -7691,7 +7691,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-calico-rhel8-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
@@ -7740,7 +7740,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-calico-rhel8-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -7789,7 +7789,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-calico-rhel8-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -7838,7 +7838,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-calico-rhel8-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
@@ -7887,7 +7887,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-calico-rhel8-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -7936,7 +7936,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-calico-rhel8-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -7985,7 +7985,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-calico-rhel8-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
@@ -8034,7 +8034,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-calico-rhel8-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -8083,7 +8083,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-calico-rhel8-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -8132,7 +8132,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-calico-rhel8-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_version": "1.18", "networking": "calico"}
@@ -8181,7 +8181,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-calico-rhel8-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_version": "1.19", "networking": "calico"}
@@ -8230,7 +8230,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-calico-rhel8-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -8279,7 +8279,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-calico-u1804-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
@@ -8328,7 +8328,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-calico-u1804-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -8377,7 +8377,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-calico-u1804-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -8426,7 +8426,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-calico-u1804-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
@@ -8475,7 +8475,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-calico-u1804-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -8524,7 +8524,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-calico-u1804-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -8573,7 +8573,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-calico-u1804-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
@@ -8622,7 +8622,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-calico-u1804-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -8671,7 +8671,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-calico-u1804-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -8720,7 +8720,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-calico-u1804-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_version": "1.18", "networking": "calico"}
@@ -8769,7 +8769,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-calico-u1804-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_version": "1.19", "networking": "calico"}
@@ -8818,7 +8818,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-calico-u1804-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -8867,7 +8867,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-calico-u2004-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
@@ -8916,7 +8916,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-calico-u2004-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -8965,7 +8965,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-calico-u2004-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -9014,7 +9014,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-calico-u2004-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
@@ -9063,7 +9063,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-calico-u2004-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -9112,7 +9112,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-calico-u2004-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -9161,7 +9161,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-calico-u2004-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
@@ -9210,7 +9210,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-calico-u2004-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -9259,7 +9259,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-calico-u2004-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -9308,7 +9308,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-calico-u2004-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_version": "1.18", "networking": "calico"}
@@ -9357,7 +9357,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-calico-u2004-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_version": "1.19", "networking": "calico"}
@@ -9406,7 +9406,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-calico-u2004-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -9455,7 +9455,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-cilium-amzn2-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
@@ -9504,7 +9504,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-cilium-amzn2-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -9553,7 +9553,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-cilium-amzn2-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -9602,7 +9602,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-cilium-amzn2-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
@@ -9651,7 +9651,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-cilium-amzn2-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -9700,7 +9700,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-cilium-amzn2-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -9749,7 +9749,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-cilium-amzn2-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
@@ -9798,7 +9798,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-cilium-amzn2-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -9847,7 +9847,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-cilium-amzn2-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -9896,7 +9896,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-cilium-amzn2-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_version": "1.18", "networking": "cilium"}
@@ -9945,7 +9945,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-cilium-amzn2-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_version": "1.19", "networking": "cilium"}
@@ -9994,7 +9994,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-cilium-amzn2-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -10043,7 +10043,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-cilium-deb9-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
@@ -10092,7 +10092,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-cilium-deb9-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -10141,7 +10141,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-cilium-deb9-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -10190,7 +10190,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-cilium-deb9-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
@@ -10239,7 +10239,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-cilium-deb9-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -10288,7 +10288,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-cilium-deb9-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -10337,7 +10337,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-cilium-deb9-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
@@ -10386,7 +10386,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-cilium-deb9-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -10435,7 +10435,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-cilium-deb9-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -10484,7 +10484,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-cilium-deb9-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_version": "1.18", "networking": "cilium"}
@@ -10533,7 +10533,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-cilium-deb9-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_version": "1.19", "networking": "cilium"}
@@ -10582,7 +10582,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-cilium-deb9-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -10631,7 +10631,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-cilium-deb10-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
@@ -10680,7 +10680,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-cilium-deb10-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -10729,7 +10729,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-cilium-deb10-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -10778,7 +10778,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-cilium-deb10-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
@@ -10827,7 +10827,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-cilium-deb10-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -10876,7 +10876,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-cilium-deb10-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -10925,7 +10925,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-cilium-deb10-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
@@ -10974,7 +10974,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-cilium-deb10-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -11023,7 +11023,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-cilium-deb10-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -11072,7 +11072,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-cilium-deb10-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_version": "1.18", "networking": "cilium"}
@@ -11121,7 +11121,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-cilium-deb10-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_version": "1.19", "networking": "cilium"}
@@ -11170,7 +11170,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-cilium-deb10-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -11219,7 +11219,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-cilium-flatcar-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
@@ -11268,7 +11268,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-cilium-flatcar-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -11317,7 +11317,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-cilium-flatcar-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -11366,7 +11366,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-cilium-flatcar-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
@@ -11415,7 +11415,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-cilium-flatcar-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -11464,7 +11464,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-cilium-flatcar-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -11513,7 +11513,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-cilium-flatcar-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
@@ -11562,7 +11562,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-cilium-flatcar-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -11611,7 +11611,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-cilium-flatcar-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -11660,7 +11660,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-cilium-flatcar-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_version": "1.18", "networking": "cilium"}
@@ -11709,7 +11709,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-cilium-flatcar-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_version": "1.19", "networking": "cilium"}
@@ -11758,7 +11758,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-cilium-flatcar-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -11807,7 +11807,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-cilium-rhel7-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
@@ -11856,7 +11856,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-cilium-rhel7-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -11905,7 +11905,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-cilium-rhel7-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -11954,7 +11954,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-cilium-rhel7-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
@@ -12003,7 +12003,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-cilium-rhel7-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -12052,7 +12052,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-cilium-rhel7-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -12101,7 +12101,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-cilium-rhel7-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
@@ -12150,7 +12150,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-cilium-rhel7-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -12199,7 +12199,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-cilium-rhel7-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -12248,7 +12248,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-cilium-rhel7-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_version": "1.18", "networking": "cilium"}
@@ -12297,7 +12297,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-cilium-rhel7-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_version": "1.19", "networking": "cilium"}
@@ -12346,7 +12346,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-cilium-rhel7-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -12395,7 +12395,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-cilium-rhel8-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
@@ -12444,7 +12444,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-cilium-rhel8-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -12493,7 +12493,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-cilium-rhel8-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -12542,7 +12542,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-cilium-rhel8-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
@@ -12591,7 +12591,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-cilium-rhel8-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -12640,7 +12640,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-cilium-rhel8-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -12689,7 +12689,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-cilium-rhel8-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
@@ -12738,7 +12738,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-cilium-rhel8-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -12787,7 +12787,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-cilium-rhel8-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -12836,7 +12836,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-cilium-rhel8-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_version": "1.18", "networking": "cilium"}
@@ -12885,7 +12885,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-cilium-rhel8-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_version": "1.19", "networking": "cilium"}
@@ -12934,7 +12934,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-cilium-rhel8-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -12983,7 +12983,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-cilium-u1804-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
@@ -13032,7 +13032,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-cilium-u1804-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -13081,7 +13081,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-cilium-u1804-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -13130,7 +13130,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-cilium-u1804-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
@@ -13179,7 +13179,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-cilium-u1804-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -13228,7 +13228,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-cilium-u1804-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -13277,7 +13277,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-cilium-u1804-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
@@ -13326,7 +13326,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-cilium-u1804-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -13375,7 +13375,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-cilium-u1804-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -13424,7 +13424,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-cilium-u1804-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_version": "1.18", "networking": "cilium"}
@@ -13473,7 +13473,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-cilium-u1804-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_version": "1.19", "networking": "cilium"}
@@ -13522,7 +13522,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-cilium-u1804-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -13571,7 +13571,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-cilium-u2004-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
@@ -13620,7 +13620,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-cilium-u2004-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -13669,7 +13669,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-cilium-u2004-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -13718,7 +13718,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-cilium-u2004-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
@@ -13767,7 +13767,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-cilium-u2004-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -13816,7 +13816,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-cilium-u2004-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -13865,7 +13865,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-cilium-u2004-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
@@ -13914,7 +13914,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-cilium-u2004-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -13963,7 +13963,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-cilium-u2004-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -14012,7 +14012,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-cilium-u2004-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_version": "1.18", "networking": "cilium"}
@@ -14061,7 +14061,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-cilium-u2004-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_version": "1.19", "networking": "cilium"}
@@ -14110,7 +14110,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-cilium-u2004-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -14159,7 +14159,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-flannel-amzn2-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
@@ -14208,7 +14208,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-flannel-amzn2-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -14257,7 +14257,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-flannel-amzn2-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -14306,7 +14306,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-flannel-amzn2-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
@@ -14355,7 +14355,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-flannel-amzn2-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -14404,7 +14404,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-flannel-amzn2-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -14453,7 +14453,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-flannel-amzn2-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
@@ -14502,7 +14502,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-flannel-amzn2-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -14551,7 +14551,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-flannel-amzn2-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -14600,7 +14600,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-flannel-amzn2-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_version": "1.18", "networking": "flannel"}
@@ -14649,7 +14649,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-flannel-amzn2-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_version": "1.19", "networking": "flannel"}
@@ -14698,7 +14698,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-flannel-amzn2-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -14747,7 +14747,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-flannel-deb9-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
@@ -14796,7 +14796,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-flannel-deb9-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -14845,7 +14845,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-flannel-deb9-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -14894,7 +14894,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-flannel-deb9-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
@@ -14943,7 +14943,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-flannel-deb9-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -14992,7 +14992,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-flannel-deb9-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -15041,7 +15041,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-flannel-deb9-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
@@ -15090,7 +15090,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-flannel-deb9-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -15139,7 +15139,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-flannel-deb9-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -15188,7 +15188,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-flannel-deb9-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_version": "1.18", "networking": "flannel"}
@@ -15237,7 +15237,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-flannel-deb9-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_version": "1.19", "networking": "flannel"}
@@ -15286,7 +15286,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-flannel-deb9-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -15335,7 +15335,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-flannel-deb10-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
@@ -15384,7 +15384,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-flannel-deb10-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -15433,7 +15433,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-flannel-deb10-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -15482,7 +15482,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-flannel-deb10-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
@@ -15531,7 +15531,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-flannel-deb10-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -15580,7 +15580,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-flannel-deb10-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -15629,7 +15629,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-flannel-deb10-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
@@ -15678,7 +15678,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-flannel-deb10-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -15727,7 +15727,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-flannel-deb10-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -15776,7 +15776,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-flannel-deb10-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_version": "1.18", "networking": "flannel"}
@@ -15825,7 +15825,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-flannel-deb10-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_version": "1.19", "networking": "flannel"}
@@ -15874,7 +15874,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-flannel-deb10-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -15923,7 +15923,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-flannel-flatcar-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
@@ -15972,7 +15972,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-flannel-flatcar-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -16021,7 +16021,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-flannel-flatcar-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -16070,7 +16070,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-flannel-flatcar-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
@@ -16119,7 +16119,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-flannel-flatcar-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -16168,7 +16168,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-flannel-flatcar-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -16217,7 +16217,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-flannel-flatcar-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
@@ -16266,7 +16266,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-flannel-flatcar-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -16315,7 +16315,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-flannel-flatcar-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -16364,7 +16364,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-flannel-flatcar-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_version": "1.18", "networking": "flannel"}
@@ -16413,7 +16413,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-flannel-flatcar-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_version": "1.19", "networking": "flannel"}
@@ -16462,7 +16462,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-flannel-flatcar-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -16511,7 +16511,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-flannel-rhel7-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
@@ -16560,7 +16560,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-flannel-rhel7-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -16609,7 +16609,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-flannel-rhel7-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -16658,7 +16658,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-flannel-rhel7-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
@@ -16707,7 +16707,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-flannel-rhel7-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -16756,7 +16756,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-flannel-rhel7-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -16805,7 +16805,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-flannel-rhel7-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
@@ -16854,7 +16854,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-flannel-rhel7-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -16903,7 +16903,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-flannel-rhel7-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -16952,7 +16952,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-flannel-rhel7-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_version": "1.18", "networking": "flannel"}
@@ -17001,7 +17001,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-flannel-rhel7-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_version": "1.19", "networking": "flannel"}
@@ -17050,7 +17050,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-flannel-rhel7-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -17099,7 +17099,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-flannel-rhel8-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
@@ -17148,7 +17148,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-flannel-rhel8-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -17197,7 +17197,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-flannel-rhel8-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -17246,7 +17246,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-flannel-rhel8-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
@@ -17295,7 +17295,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-flannel-rhel8-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -17344,7 +17344,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-flannel-rhel8-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -17393,7 +17393,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-flannel-rhel8-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
@@ -17442,7 +17442,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-flannel-rhel8-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -17491,7 +17491,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-flannel-rhel8-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -17540,7 +17540,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-flannel-rhel8-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_version": "1.18", "networking": "flannel"}
@@ -17589,7 +17589,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-flannel-rhel8-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_version": "1.19", "networking": "flannel"}
@@ -17638,7 +17638,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-flannel-rhel8-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -17687,7 +17687,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-flannel-u1804-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
@@ -17736,7 +17736,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-flannel-u1804-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -17785,7 +17785,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-flannel-u1804-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -17834,7 +17834,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-flannel-u1804-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
@@ -17883,7 +17883,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-flannel-u1804-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -17932,7 +17932,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-flannel-u1804-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -17981,7 +17981,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-flannel-u1804-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
@@ -18030,7 +18030,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-flannel-u1804-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -18079,7 +18079,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-flannel-u1804-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -18128,7 +18128,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-flannel-u1804-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_version": "1.18", "networking": "flannel"}
@@ -18177,7 +18177,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-flannel-u1804-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_version": "1.19", "networking": "flannel"}
@@ -18226,7 +18226,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-flannel-u1804-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -18275,7 +18275,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-flannel-u2004-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
@@ -18324,7 +18324,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-flannel-u2004-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -18373,7 +18373,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-flannel-u2004-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -18422,7 +18422,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-flannel-u2004-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
@@ -18471,7 +18471,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-flannel-u2004-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -18520,7 +18520,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-flannel-u2004-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -18569,7 +18569,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-flannel-u2004-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
@@ -18618,7 +18618,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-flannel-u2004-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -18667,7 +18667,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-flannel-u2004-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -18716,7 +18716,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-flannel-u2004-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_version": "1.18", "networking": "flannel"}
@@ -18765,7 +18765,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-flannel-u2004-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_version": "1.19", "networking": "flannel"}
@@ -18814,7 +18814,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-flannel-u2004-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
@@ -18863,7 +18863,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-kopeio-amzn2-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
@@ -18912,7 +18912,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-amzn2-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
@@ -18961,7 +18961,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-amzn2-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
@@ -19010,7 +19010,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-kopeio-amzn2-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
@@ -19059,7 +19059,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-amzn2-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
@@ -19108,7 +19108,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-amzn2-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
@@ -19157,7 +19157,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-kopeio-amzn2-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
@@ -19206,7 +19206,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-amzn2-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
@@ -19255,7 +19255,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-amzn2-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
@@ -19304,7 +19304,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-kopeio-amzn2-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_version": "1.18", "networking": "kopeio"}
@@ -19353,7 +19353,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-amzn2-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_version": "1.19", "networking": "kopeio"}
@@ -19402,7 +19402,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-amzn2-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
@@ -19451,7 +19451,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-kopeio-deb9-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
@@ -19500,7 +19500,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-deb9-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
@@ -19549,7 +19549,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-deb9-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
@@ -19598,7 +19598,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-kopeio-deb9-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
@@ -19647,7 +19647,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-deb9-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
@@ -19696,7 +19696,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-deb9-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
@@ -19745,7 +19745,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-kopeio-deb9-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
@@ -19794,7 +19794,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-deb9-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
@@ -19843,7 +19843,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-deb9-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
@@ -19892,7 +19892,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-kopeio-deb9-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_version": "1.18", "networking": "kopeio"}
@@ -19941,7 +19941,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-deb9-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_version": "1.19", "networking": "kopeio"}
@@ -19990,7 +19990,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-deb9-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
@@ -20039,7 +20039,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-kopeio-deb10-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
@@ -20088,7 +20088,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-deb10-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
@@ -20137,7 +20137,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-deb10-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
@@ -20186,7 +20186,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-kopeio-deb10-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
@@ -20235,7 +20235,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-deb10-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
@@ -20284,7 +20284,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-deb10-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
@@ -20333,7 +20333,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-kopeio-deb10-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
@@ -20382,7 +20382,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-deb10-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
@@ -20431,7 +20431,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-deb10-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
@@ -20480,7 +20480,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-kopeio-deb10-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_version": "1.18", "networking": "kopeio"}
@@ -20529,7 +20529,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-deb10-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_version": "1.19", "networking": "kopeio"}
@@ -20578,7 +20578,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-deb10-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
@@ -20627,7 +20627,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-kopeio-flatcar-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
@@ -20676,7 +20676,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-flatcar-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
@@ -20725,7 +20725,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-flatcar-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
@@ -20774,7 +20774,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-kopeio-flatcar-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
@@ -20823,7 +20823,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-flatcar-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
@@ -20872,7 +20872,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-flatcar-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
@@ -20921,7 +20921,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-kopeio-flatcar-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
@@ -20970,7 +20970,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-flatcar-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
@@ -21019,7 +21019,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-flatcar-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
@@ -21068,7 +21068,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-kopeio-flatcar-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_version": "1.18", "networking": "kopeio"}
@@ -21117,7 +21117,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-flatcar-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_version": "1.19", "networking": "kopeio"}
@@ -21166,7 +21166,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-flatcar-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
@@ -21215,7 +21215,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-kopeio-rhel7-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
@@ -21264,7 +21264,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel7-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
@@ -21313,7 +21313,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel7-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
@@ -21362,7 +21362,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-kopeio-rhel7-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
@@ -21411,7 +21411,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel7-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
@@ -21460,7 +21460,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel7-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
@@ -21509,7 +21509,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-kopeio-rhel7-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
@@ -21558,7 +21558,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel7-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
@@ -21607,7 +21607,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel7-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
@@ -21656,7 +21656,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-kopeio-rhel7-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_version": "1.18", "networking": "kopeio"}
@@ -21705,7 +21705,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel7-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_version": "1.19", "networking": "kopeio"}
@@ -21754,7 +21754,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel7-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
@@ -21803,7 +21803,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-kopeio-rhel8-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
@@ -21852,7 +21852,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel8-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
@@ -21901,7 +21901,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel8-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
@@ -21950,7 +21950,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-kopeio-rhel8-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
@@ -21999,7 +21999,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel8-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
@@ -22048,7 +22048,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel8-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
@@ -22097,7 +22097,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-kopeio-rhel8-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
@@ -22146,7 +22146,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel8-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
@@ -22195,7 +22195,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel8-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
@@ -22244,7 +22244,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-kopeio-rhel8-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_version": "1.18", "networking": "kopeio"}
@@ -22293,7 +22293,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel8-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_version": "1.19", "networking": "kopeio"}
@@ -22342,7 +22342,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel8-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
@@ -22391,7 +22391,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-kopeio-u1804-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
@@ -22440,7 +22440,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-u1804-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
@@ -22489,7 +22489,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-u1804-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
@@ -22538,7 +22538,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-kopeio-u1804-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
@@ -22587,7 +22587,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-u1804-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
@@ -22636,7 +22636,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-u1804-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
@@ -22685,7 +22685,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-kopeio-u1804-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
@@ -22734,7 +22734,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-u1804-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
@@ -22783,7 +22783,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-u1804-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
@@ -22832,7 +22832,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-kopeio-u1804-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_version": "1.18", "networking": "kopeio"}
@@ -22881,7 +22881,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-u1804-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_version": "1.19", "networking": "kopeio"}
@@ -22930,7 +22930,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-u1804-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
@@ -22979,7 +22979,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-kopeio-u2004-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
@@ -23028,7 +23028,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-u2004-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
@@ -23077,7 +23077,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-u2004-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
@@ -23126,7 +23126,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-kopeio-u2004-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
@@ -23175,7 +23175,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-u2004-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
@@ -23224,7 +23224,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-u2004-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
@@ -23273,7 +23273,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-kopeio-u2004-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
@@ -23322,7 +23322,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-u2004-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
@@ -23371,7 +23371,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-u2004-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
@@ -23420,7 +23420,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-kopeio-u2004-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_version": "1.18", "networking": "kopeio"}
@@ -23469,7 +23469,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-u2004-k20-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_version": "1.19", "networking": "kopeio"}
@@ -23518,7 +23518,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-u2004-k20-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": null}
@@ -23567,7 +23567,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-amzn2-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
@@ -23616,7 +23616,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-amzn2-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
@@ -23665,7 +23665,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-amzn2-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": null, "networking": null}
@@ -23714,7 +23714,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-amzn2-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
@@ -23763,7 +23763,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-amzn2-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
@@ -23812,7 +23812,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-amzn2-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": null}
@@ -23861,7 +23861,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-amzn2-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
@@ -23910,7 +23910,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-amzn2-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
@@ -23959,7 +23959,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-amzn2-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_version": null, "networking": null}
@@ -24008,7 +24008,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-amzn2-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_version": "1.18", "networking": null}
@@ -24057,7 +24057,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-amzn2-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_version": "1.19", "networking": null}
@@ -24106,7 +24106,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-amzn2-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": null}
@@ -24155,7 +24155,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-deb9-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
@@ -24204,7 +24204,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-deb9-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
@@ -24253,7 +24253,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-deb9-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": null, "networking": null}
@@ -24302,7 +24302,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-deb9-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
@@ -24351,7 +24351,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-deb9-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
@@ -24400,7 +24400,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-deb9-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": null}
@@ -24449,7 +24449,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-deb9-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
@@ -24498,7 +24498,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-deb9-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
@@ -24547,7 +24547,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-deb9-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_version": null, "networking": null}
@@ -24596,7 +24596,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-deb9-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_version": "1.18", "networking": null}
@@ -24645,7 +24645,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-deb9-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_version": "1.19", "networking": null}
@@ -24694,7 +24694,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-deb9-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": null}
@@ -24743,7 +24743,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-deb10-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
@@ -24792,7 +24792,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-deb10-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
@@ -24841,7 +24841,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-deb10-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": null, "networking": null}
@@ -24890,7 +24890,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-deb10-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
@@ -24939,7 +24939,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-deb10-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
@@ -24988,7 +24988,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-deb10-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": null}
@@ -25037,7 +25037,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-deb10-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
@@ -25086,7 +25086,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-deb10-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
@@ -25135,7 +25135,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-deb10-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_version": null, "networking": null}
@@ -25184,7 +25184,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-deb10-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_version": "1.18", "networking": null}
@@ -25233,7 +25233,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-deb10-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_version": "1.19", "networking": null}
@@ -25282,7 +25282,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-deb10-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": null}
@@ -25331,7 +25331,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-flatcar-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
@@ -25380,7 +25380,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-flatcar-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
@@ -25429,7 +25429,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-flatcar-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": null, "networking": null}
@@ -25478,7 +25478,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-flatcar-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
@@ -25527,7 +25527,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-flatcar-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
@@ -25576,7 +25576,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-flatcar-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": null}
@@ -25625,7 +25625,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-flatcar-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
@@ -25674,7 +25674,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-flatcar-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
@@ -25723,7 +25723,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-flatcar-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_version": null, "networking": null}
@@ -25772,7 +25772,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-flatcar-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_version": "1.18", "networking": null}
@@ -25821,7 +25821,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-flatcar-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_version": "1.19", "networking": null}
@@ -25870,7 +25870,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-flatcar-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": null}
@@ -25919,7 +25919,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-rhel7-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
@@ -25968,7 +25968,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-rhel7-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
@@ -26017,7 +26017,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-rhel7-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": null, "networking": null}
@@ -26066,7 +26066,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-rhel7-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
@@ -26115,7 +26115,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-rhel7-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
@@ -26164,7 +26164,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-rhel7-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": null}
@@ -26213,7 +26213,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-rhel7-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
@@ -26262,7 +26262,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-rhel7-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
@@ -26311,7 +26311,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-rhel7-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_version": null, "networking": null}
@@ -26360,7 +26360,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-rhel7-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_version": "1.18", "networking": null}
@@ -26409,7 +26409,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-rhel7-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_version": "1.19", "networking": null}
@@ -26458,7 +26458,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-rhel7-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": null}
@@ -26507,7 +26507,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-rhel8-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
@@ -26556,7 +26556,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-rhel8-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
@@ -26605,7 +26605,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-rhel8-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": null, "networking": null}
@@ -26654,7 +26654,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-rhel8-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
@@ -26703,7 +26703,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-rhel8-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
@@ -26752,7 +26752,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-rhel8-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": null}
@@ -26801,7 +26801,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-rhel8-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
@@ -26850,7 +26850,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-rhel8-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
@@ -26899,7 +26899,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-rhel8-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_version": null, "networking": null}
@@ -26948,7 +26948,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-rhel8-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_version": "1.18", "networking": null}
@@ -26997,7 +26997,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-rhel8-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_version": "1.19", "networking": null}
@@ -27046,7 +27046,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-rhel8-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": null}
@@ -27095,7 +27095,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-u1804-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
@@ -27144,7 +27144,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-u1804-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
@@ -27193,7 +27193,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-u1804-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": null, "networking": null}
@@ -27242,7 +27242,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-u1804-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
@@ -27291,7 +27291,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-u1804-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
@@ -27340,7 +27340,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-u1804-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": null}
@@ -27389,7 +27389,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-u1804-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
@@ -27438,7 +27438,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-u1804-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
@@ -27487,7 +27487,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-u1804-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_version": null, "networking": null}
@@ -27536,7 +27536,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-u1804-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_version": "1.18", "networking": null}
@@ -27585,7 +27585,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-u1804-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_version": "1.19", "networking": null}
@@ -27634,7 +27634,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-u1804-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": null}
@@ -27683,7 +27683,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-u2004-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
@@ -27732,7 +27732,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-u2004-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
@@ -27781,7 +27781,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-u2004-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": null, "networking": null}
@@ -27830,7 +27830,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-u2004-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
@@ -27879,7 +27879,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-u2004-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
@@ -27928,7 +27928,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-u2004-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": null}
@@ -27977,7 +27977,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-u2004-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
@@ -28026,7 +28026,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-u2004-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
@@ -28075,7 +28075,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-u2004-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_version": null, "networking": null}
@@ -28124,7 +28124,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-u2004-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_version": "1.18", "networking": null}
@@ -28173,7 +28173,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-u2004-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_version": "1.19", "networking": null}
@@ -28222,7 +28222,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-u2004-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -28271,7 +28271,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-calico-amzn2-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
@@ -28320,7 +28320,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-calico-amzn2-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -28369,7 +28369,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-calico-amzn2-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -28418,7 +28418,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-calico-amzn2-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
@@ -28467,7 +28467,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-calico-amzn2-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -28516,7 +28516,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-calico-amzn2-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -28565,7 +28565,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-calico-amzn2-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
@@ -28614,7 +28614,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-calico-amzn2-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -28663,7 +28663,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-calico-amzn2-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -28712,7 +28712,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-calico-amzn2-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_version": "1.18", "networking": "calico"}
@@ -28761,7 +28761,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-calico-amzn2-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_version": "1.19", "networking": "calico"}
@@ -28810,7 +28810,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-calico-amzn2-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -28859,7 +28859,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-calico-deb9-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
@@ -28908,7 +28908,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-calico-deb9-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -28957,7 +28957,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-calico-deb9-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -29006,7 +29006,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-calico-deb9-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
@@ -29055,7 +29055,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-calico-deb9-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -29104,7 +29104,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-calico-deb9-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -29153,7 +29153,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-calico-deb9-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
@@ -29202,7 +29202,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-calico-deb9-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -29251,7 +29251,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-calico-deb9-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -29300,7 +29300,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-calico-deb9-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_version": "1.18", "networking": "calico"}
@@ -29349,7 +29349,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-calico-deb9-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_version": "1.19", "networking": "calico"}
@@ -29398,7 +29398,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-calico-deb9-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -29447,7 +29447,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-calico-deb10-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
@@ -29496,7 +29496,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-calico-deb10-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -29545,7 +29545,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-calico-deb10-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -29594,7 +29594,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-calico-deb10-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
@@ -29643,7 +29643,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-calico-deb10-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -29692,7 +29692,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-calico-deb10-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -29741,7 +29741,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-calico-deb10-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
@@ -29790,7 +29790,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-calico-deb10-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -29839,7 +29839,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-calico-deb10-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -29888,7 +29888,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-calico-deb10-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_version": "1.18", "networking": "calico"}
@@ -29937,7 +29937,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-calico-deb10-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_version": "1.19", "networking": "calico"}
@@ -29986,7 +29986,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-calico-deb10-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -30035,7 +30035,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-calico-flatcar-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
@@ -30084,7 +30084,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-calico-flatcar-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -30133,7 +30133,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-calico-flatcar-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -30182,7 +30182,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-calico-flatcar-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
@@ -30231,7 +30231,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-calico-flatcar-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -30280,7 +30280,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-calico-flatcar-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -30329,7 +30329,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-calico-flatcar-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
@@ -30378,7 +30378,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-calico-flatcar-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -30427,7 +30427,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-calico-flatcar-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -30476,7 +30476,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-calico-flatcar-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_version": "1.18", "networking": "calico"}
@@ -30525,7 +30525,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-calico-flatcar-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_version": "1.19", "networking": "calico"}
@@ -30574,7 +30574,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-calico-flatcar-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -30623,7 +30623,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-calico-rhel7-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
@@ -30672,7 +30672,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-calico-rhel7-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -30721,7 +30721,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-calico-rhel7-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -30770,7 +30770,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-calico-rhel7-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
@@ -30819,7 +30819,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-calico-rhel7-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -30868,7 +30868,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-calico-rhel7-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -30917,7 +30917,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-calico-rhel7-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
@@ -30966,7 +30966,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-calico-rhel7-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -31015,7 +31015,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-calico-rhel7-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -31064,7 +31064,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-calico-rhel7-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_version": "1.18", "networking": "calico"}
@@ -31113,7 +31113,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-calico-rhel7-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_version": "1.19", "networking": "calico"}
@@ -31162,7 +31162,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-calico-rhel7-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -31211,7 +31211,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-calico-rhel8-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
@@ -31260,7 +31260,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-calico-rhel8-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -31309,7 +31309,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-calico-rhel8-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -31358,7 +31358,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-calico-rhel8-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
@@ -31407,7 +31407,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-calico-rhel8-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -31456,7 +31456,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-calico-rhel8-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -31505,7 +31505,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-calico-rhel8-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
@@ -31554,7 +31554,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-calico-rhel8-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -31603,7 +31603,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-calico-rhel8-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -31652,7 +31652,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-calico-rhel8-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_version": "1.18", "networking": "calico"}
@@ -31701,7 +31701,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-calico-rhel8-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_version": "1.19", "networking": "calico"}
@@ -31750,7 +31750,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-calico-rhel8-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -31799,7 +31799,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-calico-u1804-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
@@ -31848,7 +31848,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-calico-u1804-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -31897,7 +31897,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-calico-u1804-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -31946,7 +31946,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-calico-u1804-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
@@ -31995,7 +31995,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-calico-u1804-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -32044,7 +32044,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-calico-u1804-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -32093,7 +32093,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-calico-u1804-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
@@ -32142,7 +32142,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-calico-u1804-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -32191,7 +32191,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-calico-u1804-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -32240,7 +32240,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-calico-u1804-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_version": "1.18", "networking": "calico"}
@@ -32289,7 +32289,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-calico-u1804-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_version": "1.19", "networking": "calico"}
@@ -32338,7 +32338,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-calico-u1804-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -32387,7 +32387,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-calico-u2004-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
@@ -32436,7 +32436,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-calico-u2004-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -32485,7 +32485,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-calico-u2004-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -32534,7 +32534,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-calico-u2004-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
@@ -32583,7 +32583,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-calico-u2004-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -32632,7 +32632,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-calico-u2004-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -32681,7 +32681,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-calico-u2004-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
@@ -32730,7 +32730,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-calico-u2004-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -32779,7 +32779,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-calico-u2004-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -32828,7 +32828,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-calico-u2004-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_version": "1.18", "networking": "calico"}
@@ -32877,7 +32877,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-calico-u2004-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_version": "1.19", "networking": "calico"}
@@ -32926,7 +32926,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-calico-u2004-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -32975,7 +32975,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-cilium-amzn2-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
@@ -33024,7 +33024,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-cilium-amzn2-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -33073,7 +33073,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-cilium-amzn2-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -33122,7 +33122,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-cilium-amzn2-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
@@ -33171,7 +33171,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-cilium-amzn2-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -33220,7 +33220,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-cilium-amzn2-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -33269,7 +33269,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-cilium-amzn2-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
@@ -33318,7 +33318,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-cilium-amzn2-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -33367,7 +33367,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-cilium-amzn2-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -33416,7 +33416,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-cilium-amzn2-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_version": "1.18", "networking": "cilium"}
@@ -33465,7 +33465,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-cilium-amzn2-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_version": "1.19", "networking": "cilium"}
@@ -33514,7 +33514,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-cilium-amzn2-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -33563,7 +33563,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-cilium-deb9-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
@@ -33612,7 +33612,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-cilium-deb9-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -33661,7 +33661,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-cilium-deb9-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -33710,7 +33710,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-cilium-deb9-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
@@ -33759,7 +33759,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-cilium-deb9-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -33808,7 +33808,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-cilium-deb9-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -33857,7 +33857,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-cilium-deb9-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
@@ -33906,7 +33906,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-cilium-deb9-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -33955,7 +33955,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-cilium-deb9-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -34004,7 +34004,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-cilium-deb9-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_version": "1.18", "networking": "cilium"}
@@ -34053,7 +34053,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-cilium-deb9-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_version": "1.19", "networking": "cilium"}
@@ -34102,7 +34102,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-cilium-deb9-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -34151,7 +34151,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-cilium-deb10-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
@@ -34200,7 +34200,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-cilium-deb10-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -34249,7 +34249,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-cilium-deb10-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -34298,7 +34298,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-cilium-deb10-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
@@ -34347,7 +34347,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-cilium-deb10-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -34396,7 +34396,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-cilium-deb10-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -34445,7 +34445,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-cilium-deb10-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
@@ -34494,7 +34494,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-cilium-deb10-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -34543,7 +34543,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-cilium-deb10-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -34592,7 +34592,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-cilium-deb10-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_version": "1.18", "networking": "cilium"}
@@ -34641,7 +34641,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-cilium-deb10-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_version": "1.19", "networking": "cilium"}
@@ -34690,7 +34690,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-cilium-deb10-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -34739,7 +34739,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-cilium-flatcar-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
@@ -34788,7 +34788,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-cilium-flatcar-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -34837,7 +34837,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-cilium-flatcar-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -34886,7 +34886,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-cilium-flatcar-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
@@ -34935,7 +34935,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-cilium-flatcar-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -34984,7 +34984,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-cilium-flatcar-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -35033,7 +35033,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-cilium-flatcar-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
@@ -35082,7 +35082,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-cilium-flatcar-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -35131,7 +35131,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-cilium-flatcar-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -35180,7 +35180,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-cilium-flatcar-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_version": "1.18", "networking": "cilium"}
@@ -35229,7 +35229,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-cilium-flatcar-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_version": "1.19", "networking": "cilium"}
@@ -35278,7 +35278,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-cilium-flatcar-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -35327,7 +35327,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-cilium-rhel7-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
@@ -35376,7 +35376,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-cilium-rhel7-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -35425,7 +35425,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-cilium-rhel7-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -35474,7 +35474,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-cilium-rhel7-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
@@ -35523,7 +35523,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-cilium-rhel7-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -35572,7 +35572,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-cilium-rhel7-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -35621,7 +35621,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-cilium-rhel7-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
@@ -35670,7 +35670,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-cilium-rhel7-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -35719,7 +35719,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-cilium-rhel7-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -35768,7 +35768,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-cilium-rhel7-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_version": "1.18", "networking": "cilium"}
@@ -35817,7 +35817,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-cilium-rhel7-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_version": "1.19", "networking": "cilium"}
@@ -35866,7 +35866,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-cilium-rhel7-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -35915,7 +35915,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-cilium-rhel8-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
@@ -35964,7 +35964,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-cilium-rhel8-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -36013,7 +36013,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-cilium-rhel8-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -36062,7 +36062,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-cilium-rhel8-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
@@ -36111,7 +36111,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-cilium-rhel8-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -36160,7 +36160,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-cilium-rhel8-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -36209,7 +36209,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-cilium-rhel8-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
@@ -36258,7 +36258,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-cilium-rhel8-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -36307,7 +36307,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-cilium-rhel8-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -36356,7 +36356,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-cilium-rhel8-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_version": "1.18", "networking": "cilium"}
@@ -36405,7 +36405,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-cilium-rhel8-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_version": "1.19", "networking": "cilium"}
@@ -36454,7 +36454,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-cilium-rhel8-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -36503,7 +36503,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-cilium-u1804-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
@@ -36552,7 +36552,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-cilium-u1804-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -36601,7 +36601,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-cilium-u1804-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -36650,7 +36650,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-cilium-u1804-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
@@ -36699,7 +36699,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-cilium-u1804-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -36748,7 +36748,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-cilium-u1804-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -36797,7 +36797,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-cilium-u1804-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
@@ -36846,7 +36846,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-cilium-u1804-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -36895,7 +36895,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-cilium-u1804-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -36944,7 +36944,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-cilium-u1804-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_version": "1.18", "networking": "cilium"}
@@ -36993,7 +36993,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-cilium-u1804-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_version": "1.19", "networking": "cilium"}
@@ -37042,7 +37042,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-cilium-u1804-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -37091,7 +37091,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-cilium-u2004-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
@@ -37140,7 +37140,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-cilium-u2004-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -37189,7 +37189,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-cilium-u2004-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -37238,7 +37238,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-cilium-u2004-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
@@ -37287,7 +37287,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-cilium-u2004-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -37336,7 +37336,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-cilium-u2004-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -37385,7 +37385,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-cilium-u2004-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
@@ -37434,7 +37434,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-cilium-u2004-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -37483,7 +37483,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-cilium-u2004-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -37532,7 +37532,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-cilium-u2004-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_version": "1.18", "networking": "cilium"}
@@ -37581,7 +37581,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-cilium-u2004-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_version": "1.19", "networking": "cilium"}
@@ -37630,7 +37630,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-cilium-u2004-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -37679,7 +37679,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-flannel-amzn2-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
@@ -37728,7 +37728,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-flannel-amzn2-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -37777,7 +37777,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-flannel-amzn2-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -37826,7 +37826,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-flannel-amzn2-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
@@ -37875,7 +37875,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-flannel-amzn2-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -37924,7 +37924,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-flannel-amzn2-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -37973,7 +37973,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-flannel-amzn2-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
@@ -38022,7 +38022,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-flannel-amzn2-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -38071,7 +38071,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-flannel-amzn2-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -38120,7 +38120,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-flannel-amzn2-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_version": "1.18", "networking": "flannel"}
@@ -38169,7 +38169,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-flannel-amzn2-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_version": "1.19", "networking": "flannel"}
@@ -38218,7 +38218,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-flannel-amzn2-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -38267,7 +38267,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-flannel-deb9-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
@@ -38316,7 +38316,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-flannel-deb9-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -38365,7 +38365,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-flannel-deb9-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -38414,7 +38414,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-flannel-deb9-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
@@ -38463,7 +38463,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-flannel-deb9-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -38512,7 +38512,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-flannel-deb9-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -38561,7 +38561,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-flannel-deb9-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
@@ -38610,7 +38610,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-flannel-deb9-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -38659,7 +38659,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-flannel-deb9-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -38708,7 +38708,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-flannel-deb9-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_version": "1.18", "networking": "flannel"}
@@ -38757,7 +38757,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-flannel-deb9-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_version": "1.19", "networking": "flannel"}
@@ -38806,7 +38806,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-flannel-deb9-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -38855,7 +38855,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-flannel-deb10-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
@@ -38904,7 +38904,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-flannel-deb10-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -38953,7 +38953,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-flannel-deb10-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -39002,7 +39002,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-flannel-deb10-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
@@ -39051,7 +39051,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-flannel-deb10-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -39100,7 +39100,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-flannel-deb10-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -39149,7 +39149,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-flannel-deb10-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
@@ -39198,7 +39198,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-flannel-deb10-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -39247,7 +39247,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-flannel-deb10-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -39296,7 +39296,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-flannel-deb10-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_version": "1.18", "networking": "flannel"}
@@ -39345,7 +39345,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-flannel-deb10-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_version": "1.19", "networking": "flannel"}
@@ -39394,7 +39394,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-flannel-deb10-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -39443,7 +39443,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-flannel-flatcar-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
@@ -39492,7 +39492,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-flannel-flatcar-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -39541,7 +39541,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-flannel-flatcar-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -39590,7 +39590,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-flannel-flatcar-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
@@ -39639,7 +39639,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-flannel-flatcar-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -39688,7 +39688,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-flannel-flatcar-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -39737,7 +39737,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-flannel-flatcar-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
@@ -39786,7 +39786,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-flannel-flatcar-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -39835,7 +39835,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-flannel-flatcar-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -39884,7 +39884,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-flannel-flatcar-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_version": "1.18", "networking": "flannel"}
@@ -39933,7 +39933,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-flannel-flatcar-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_version": "1.19", "networking": "flannel"}
@@ -39982,7 +39982,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-flannel-flatcar-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -40031,7 +40031,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-flannel-rhel7-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
@@ -40080,7 +40080,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-flannel-rhel7-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -40129,7 +40129,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-flannel-rhel7-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -40178,7 +40178,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-flannel-rhel7-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
@@ -40227,7 +40227,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-flannel-rhel7-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -40276,7 +40276,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-flannel-rhel7-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -40325,7 +40325,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-flannel-rhel7-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
@@ -40374,7 +40374,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-flannel-rhel7-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -40423,7 +40423,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-flannel-rhel7-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -40472,7 +40472,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-flannel-rhel7-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_version": "1.18", "networking": "flannel"}
@@ -40521,7 +40521,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-flannel-rhel7-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_version": "1.19", "networking": "flannel"}
@@ -40570,7 +40570,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-flannel-rhel7-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -40619,7 +40619,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-flannel-rhel8-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
@@ -40668,7 +40668,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-flannel-rhel8-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -40717,7 +40717,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-flannel-rhel8-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -40766,7 +40766,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-flannel-rhel8-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
@@ -40815,7 +40815,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-flannel-rhel8-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -40864,7 +40864,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-flannel-rhel8-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -40913,7 +40913,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-flannel-rhel8-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
@@ -40962,7 +40962,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-flannel-rhel8-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -41011,7 +41011,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-flannel-rhel8-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -41060,7 +41060,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-flannel-rhel8-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_version": "1.18", "networking": "flannel"}
@@ -41109,7 +41109,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-flannel-rhel8-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_version": "1.19", "networking": "flannel"}
@@ -41158,7 +41158,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-flannel-rhel8-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -41207,7 +41207,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-flannel-u1804-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
@@ -41256,7 +41256,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-flannel-u1804-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -41305,7 +41305,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-flannel-u1804-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -41354,7 +41354,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-flannel-u1804-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
@@ -41403,7 +41403,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-flannel-u1804-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -41452,7 +41452,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-flannel-u1804-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -41501,7 +41501,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-flannel-u1804-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
@@ -41550,7 +41550,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-flannel-u1804-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -41599,7 +41599,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-flannel-u1804-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -41648,7 +41648,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-flannel-u1804-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_version": "1.18", "networking": "flannel"}
@@ -41697,7 +41697,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-flannel-u1804-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_version": "1.19", "networking": "flannel"}
@@ -41746,7 +41746,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-flannel-u1804-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -41795,7 +41795,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-flannel-u2004-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
@@ -41844,7 +41844,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-flannel-u2004-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -41893,7 +41893,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-flannel-u2004-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -41942,7 +41942,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-flannel-u2004-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
@@ -41991,7 +41991,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-flannel-u2004-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -42040,7 +42040,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-flannel-u2004-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -42089,7 +42089,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-flannel-u2004-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
@@ -42138,7 +42138,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-flannel-u2004-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -42187,7 +42187,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-flannel-u2004-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -42236,7 +42236,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-flannel-u2004-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_version": "1.18", "networking": "flannel"}
@@ -42285,7 +42285,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-flannel-u2004-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_version": "1.19", "networking": "flannel"}
@@ -42334,7 +42334,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-flannel-u2004-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
@@ -42383,7 +42383,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-kopeio-amzn2-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
@@ -42432,7 +42432,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-amzn2-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
@@ -42481,7 +42481,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-amzn2-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
@@ -42530,7 +42530,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-kopeio-amzn2-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
@@ -42579,7 +42579,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-amzn2-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
@@ -42628,7 +42628,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-amzn2-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
@@ -42677,7 +42677,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-kopeio-amzn2-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
@@ -42726,7 +42726,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-amzn2-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
@@ -42775,7 +42775,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-amzn2-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
@@ -42824,7 +42824,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-kopeio-amzn2-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_version": "1.18", "networking": "kopeio"}
@@ -42873,7 +42873,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-amzn2-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_version": "1.19", "networking": "kopeio"}
@@ -42922,7 +42922,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-amzn2-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
@@ -42971,7 +42971,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-kopeio-deb9-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
@@ -43020,7 +43020,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-deb9-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
@@ -43069,7 +43069,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-deb9-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
@@ -43118,7 +43118,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-kopeio-deb9-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
@@ -43167,7 +43167,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-deb9-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
@@ -43216,7 +43216,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-deb9-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
@@ -43265,7 +43265,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-kopeio-deb9-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
@@ -43314,7 +43314,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-deb9-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
@@ -43363,7 +43363,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-deb9-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
@@ -43412,7 +43412,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-kopeio-deb9-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_version": "1.18", "networking": "kopeio"}
@@ -43461,7 +43461,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-deb9-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_version": "1.19", "networking": "kopeio"}
@@ -43510,7 +43510,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-deb9-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
@@ -43559,7 +43559,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-kopeio-deb10-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
@@ -43608,7 +43608,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-deb10-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
@@ -43657,7 +43657,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-deb10-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
@@ -43706,7 +43706,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-kopeio-deb10-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
@@ -43755,7 +43755,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-deb10-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
@@ -43804,7 +43804,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-deb10-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
@@ -43853,7 +43853,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-kopeio-deb10-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
@@ -43902,7 +43902,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-deb10-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
@@ -43951,7 +43951,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-deb10-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
@@ -44000,7 +44000,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-kopeio-deb10-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_version": "1.18", "networking": "kopeio"}
@@ -44049,7 +44049,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-deb10-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_version": "1.19", "networking": "kopeio"}
@@ -44098,7 +44098,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-deb10-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
@@ -44147,7 +44147,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-kopeio-flatcar-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
@@ -44196,7 +44196,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-flatcar-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
@@ -44245,7 +44245,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-flatcar-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
@@ -44294,7 +44294,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-kopeio-flatcar-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
@@ -44343,7 +44343,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-flatcar-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
@@ -44392,7 +44392,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-flatcar-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
@@ -44441,7 +44441,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-kopeio-flatcar-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
@@ -44490,7 +44490,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-flatcar-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
@@ -44539,7 +44539,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-flatcar-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
@@ -44588,7 +44588,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-kopeio-flatcar-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_version": "1.18", "networking": "kopeio"}
@@ -44637,7 +44637,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-flatcar-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_version": "1.19", "networking": "kopeio"}
@@ -44686,7 +44686,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-flatcar-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
@@ -44735,7 +44735,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-kopeio-rhel7-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
@@ -44784,7 +44784,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel7-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
@@ -44833,7 +44833,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel7-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
@@ -44882,7 +44882,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-kopeio-rhel7-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
@@ -44931,7 +44931,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel7-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
@@ -44980,7 +44980,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel7-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
@@ -45029,7 +45029,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-kopeio-rhel7-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
@@ -45078,7 +45078,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel7-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
@@ -45127,7 +45127,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel7-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
@@ -45176,7 +45176,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-kopeio-rhel7-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_version": "1.18", "networking": "kopeio"}
@@ -45225,7 +45225,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel7-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_version": "1.19", "networking": "kopeio"}
@@ -45274,7 +45274,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel7-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
@@ -45323,7 +45323,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-kopeio-rhel8-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
@@ -45372,7 +45372,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel8-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
@@ -45421,7 +45421,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel8-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
@@ -45470,7 +45470,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-kopeio-rhel8-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
@@ -45519,7 +45519,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel8-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
@@ -45568,7 +45568,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel8-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
@@ -45617,7 +45617,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-kopeio-rhel8-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
@@ -45666,7 +45666,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel8-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
@@ -45715,7 +45715,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel8-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
@@ -45764,7 +45764,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-kopeio-rhel8-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_version": "1.18", "networking": "kopeio"}
@@ -45813,7 +45813,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel8-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_version": "1.19", "networking": "kopeio"}
@@ -45862,7 +45862,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel8-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
@@ -45911,7 +45911,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-kopeio-u1804-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
@@ -45960,7 +45960,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-u1804-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
@@ -46009,7 +46009,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-u1804-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
@@ -46058,7 +46058,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-kopeio-u1804-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
@@ -46107,7 +46107,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-u1804-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
@@ -46156,7 +46156,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-u1804-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
@@ -46205,7 +46205,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-kopeio-u1804-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
@@ -46254,7 +46254,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-u1804-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
@@ -46303,7 +46303,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-u1804-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
@@ -46352,7 +46352,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-kopeio-u1804-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_version": "1.18", "networking": "kopeio"}
@@ -46401,7 +46401,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-u1804-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_version": "1.19", "networking": "kopeio"}
@@ -46450,7 +46450,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-u1804-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
@@ -46499,7 +46499,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-latest
     testgrid-tab-name: kops-grid-kopeio-u2004-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
@@ -46548,7 +46548,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-u2004-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
@@ -46597,7 +46597,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.17'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-u2004-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
@@ -46646,7 +46646,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-latest
     testgrid-tab-name: kops-grid-kopeio-u2004-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
@@ -46695,7 +46695,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-u2004-k18-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
@@ -46744,7 +46744,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.18'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-u2004-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
@@ -46793,7 +46793,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-latest
     testgrid-tab-name: kops-grid-kopeio-u2004-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
@@ -46842,7 +46842,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-u2004-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
@@ -46891,7 +46891,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-u2004-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
@@ -46940,7 +46940,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-latest
     testgrid-tab-name: kops-grid-kopeio-u2004-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_version": "1.18", "networking": "kopeio"}
@@ -46989,7 +46989,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-1.18
     testgrid-tab-name: kops-grid-kopeio-u2004-k20-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_version": "1.19", "networking": "kopeio"}
@@ -47038,7 +47038,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-1.19
     testgrid-tab-name: kops-grid-kopeio-u2004-k20-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--node-size=m6g.large --master-size=m6g.large --image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20201201", "k8s_version": null, "kops_version": null, "kops_zones": "us-east-2b", "networking": null}
@@ -47090,7 +47090,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/kops_zones: us-east-2b
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest, kops-latest
     testgrid-tab-name: kops-grid-scenario-arm64
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--api-loadbalancer-type=public", "feature_flags": "UseServiceAccountIAM,PublicJWKS", "k8s_version": null, "kops_version": null, "networking": null}
@@ -47142,7 +47142,7 @@ periodics:
     test.kops.k8s.io/k8s_version: ''
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest, kops-latest
     testgrid-tab-name: kops-grid-scenario-public-jwks
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--override=cluster.spec.cloudControllerManager.cloudProvider=aws", "feature_flags": "EnableExternalCloudController,SpecOverrideFlag", "k8s_version": "1.19", "kops_version": null, "networking": null}
@@ -47194,7 +47194,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, sig-aws-cloud-provider-aws
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-latest, sig-aws-cloud-provider-aws
     testgrid-tab-name: kops-grid-scenario-aws-cloud-controller-manager
 
 # 963 jobs, total of 1701 runs per week

--- a/config/testgrids/kubernetes/kops/config.yaml
+++ b/config/testgrids/kubernetes/kops/config.yaml
@@ -21,6 +21,9 @@ dashboard_groups:
   - kops-k8s-1.19
   - kops-k8s-1.20
   - kops-k8s-latest
+  - kops-1.18
+  - kops-1.19
+  - kops-latest
 
 dashboards:
 - name: kops-presubmits
@@ -43,3 +46,6 @@ dashboards:
 - name: kops-k8s-1.19
 - name: kops-k8s-1.20
 - name: kops-k8s-latest
+- name: kops-1.18
+- name: kops-1.19
+- name: kops-latest


### PR DESCRIPTION
This makes it easier to view failing jobs for a specific kops version which may impact release decisions