### PR TITLE
Customize column header on testgrid for ppc64le conformance jobs

### DIFF
--- a/config/testgrids/conformance/conformance-all.yaml
+++ b/config/testgrids/conformance/conformance-all.yaml
@@ -315,8 +315,12 @@ test_groups:
 #ibm ppc64le test results
 - name: ppc64le-conformance
   gcs_prefix: ppc64le-kubernetes/logs/periodic-kubernetes-conformance-test-ppc64le
+  column_header:
+  - configuration_value: k8s-build-version
 - name: ppc64le-conformance-containerd
   gcs_prefix: ppc64le-kubernetes/logs/periodic-kubernetes-containerd-conformance-test-ppc64le
+  column_header:
+  - configuration_value: k8s-build-version
 - name: ppc64le-unit
   gcs_prefix: ppc64le-kubernetes/logs/periodic-kubernetes-bazel-test-ppc64le
 #Arm arm64 test results


### PR DESCRIPTION
Test-Grid : https://k8s-testgrid.appspot.com/conformance-ppc64le#Periodic%20ppc64le%20conformance%20test%20on%20local%20cluster

The current commit-id that is being display in test-grid for ppc64le conformance jobs is from the https://github.com/ppc64le-cloud/kubetest2-plugins. 

It needs to be the version of k8s against which the conformance tests are run.
Hence customizing the column header to point to new key `k8s-build-version `which has been added to finished.json file in logs folder of gcs bucket from where the logs are picked up.
Reference: https://github.com/kubernetes/test-infra/blob/master/testgrid/config.md#column-headers