### PR TITLE
Kops - Remove broken gce canary job

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
@@ -74,41 +74,6 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-kops-gce, kops-gce
     testgrid-tab-name: kops-gce-latest
 
-# Runs e2e on cluster built with kops master branch and latest released k/k
-- interval: 1h
-  labels:
-    preset-k8s-ssh: "true"
-  name: e2e-kops-canary-gce-stable
-  decorate: true
-  decoration_config:
-    timeout: 140m
-  spec:
-    serviceAccountName: k8s-kops-test
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-canary-gce-stable.k8s.local
-      - --deployment=kops
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/latest
-      - --ginkgo-parallel
-      # - --kops-args=--gce-service-account=pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com
-      - --kops-build
-      - --kops-feature-flags=GoogleCloudBucketACL
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-zones=us-central1-c
-      - --provider=gce
-      - --timeout=140m
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Firewall|Dashboard|Services.*functioning.*NodePort
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201217-addcacd806-master
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-kops-gce, kops-gce
-    testgrid-tab-name: kops-canary-gce-stable
-
 # - interval: 30m
 #   name: e2e-kops-gce-ha
 #   labels:


### PR DESCRIPTION
This job is trying to build kops from source which isn't something that any of our other periodic jobs do.
The other GCE jobs use the latest-ci-updown-green kops version so we're still using a near-latest kops version in those tests

https://testgrid.k8s.io/kops-gce#kops-canary-gce-stable

https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/e2e-kops-canary-gce-stable/1339714968869670912