### PR TITLE
Update scheduler-plugins CI Job To Go 1.15.5

### DIFF
--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.15.2
+      - image: golang:1.15.5
         command:
         - make
         args:
@@ -18,7 +18,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.15.2
+      - image: golang:1.15.5
         command:
         - make
         args:
@@ -29,7 +29,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.15.2
+      - image: golang:1.15.5
         command:
         - make
         args:
@@ -40,7 +40,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.15.2
+      - image: golang:1.15.5
         command:
         - make
         args:


### PR DESCRIPTION
Follow the [k/k upstream](https://github.com/kubernetes/kubernetes/pull/97246), bump scheduler-plugins CI Job to go 1.15.5