### PR TITLE
Allow k8s-ci-robot and kube-state-metrics-admins/maintainers to push to gh-pages branch

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -276,6 +276,14 @@ branch-protection:
             - ci-validate-docs
             - ci-validate-go-modules
             - ci-validate-manifests
+          branches:
+            gh-pages:
+              restrictions:
+                users:
+                - k8s-ci-robot
+                teams:
+                - kube-state-metrics-admins
+                - kube-state-metrics-maintainers
         kube-scheduler:
           restrictions:
             users: []


### PR DESCRIPTION
trying to fix the release issue: https://github.com/kubernetes/kube-state-metrics/pull/1334

/assign @scottrigby @lilic 