### PR TITLE
Always run the containerd pre-submit job on master

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -149,10 +149,9 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits
       testgrid-tab-name: e2e-kubetest2
   - name: pull-kops-e2e-k8s-containerd
-    skip_report: false
-    run_if_changed: '^(nodeup\/pkg|upup\/pkg\/fi\/cloudup)\/'
     branches:
     - master
+    always_run: true
     labels:
       preset-service-account: "true"
       preset-aws-ssh: "true"


### PR DESCRIPTION
As discussed during the 18.12.2020 office hours, the containerd pre-submit job should always run and eventually replace the Docker job.

/cc @olemarkus @rifelpet 