### PR TITLE
optimization in git clone using --depth

### DIFF
--- a/images/kubemci/Dockerfile
+++ b/images/kubemci/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
 RUN cd /${GOPATH}/src && \
     mkdir -p github.com/GoogleCloudPlatform && \
     cd github.com/GoogleCloudPlatform && \
-    git clone https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress.git && \
+    git clone --depth 1 https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress.git && \
     cd k8s-multicluster-ingress && \
     make build && \
     cp kubemci /bin && \


### PR DESCRIPTION
optimize the git clone using --depth flag in term of size of clone
and also in term's of time taken to fetch the files and commit history
of whole repository .

More detail can be found at blog
https://www.atlassian.com/git/tutorials/big-repositories

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>