### PR TITLE
Set days_of_results to 7 ppc64le-conformance and ppc64le-conformance-containerd jobs

### DIFF
--- a/config/testgrids/conformance/conformance-all.yaml
+++ b/config/testgrids/conformance/conformance-all.yaml
@@ -315,10 +315,12 @@ test_groups:
 #ibm ppc64le test results
 - name: ppc64le-conformance
   gcs_prefix: ppc64le-kubernetes/logs/periodic-kubernetes-conformance-test-ppc64le
+  days_of_results: 7
   column_header:
   - configuration_value: k8s-build-version
 - name: ppc64le-conformance-containerd
   gcs_prefix: ppc64le-kubernetes/logs/periodic-kubernetes-containerd-conformance-test-ppc64le
+  days_of_results: 7
   column_header:
   - configuration_value: k8s-build-version
 - name: ppc64le-unit


### PR DESCRIPTION
The ppc64le-test-grid is showing internal error. 
Currently, it is throwing the following message:

```
Internal Error: Refresh, and file an issue if problem persists. (Your table may be too big; consider lower `days_of_results` or `enable_test_methods = false`).
```
Hence adding days_of_results: 7 to the ppc64le-conformance jobs.