### PR TITLE
GHProxy: Make sure all clients get the same apps token

### DIFF
--- a/ghproxy/BUILD.bazel
+++ b/ghproxy/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
     importpath = "k8s.io/test-infra/ghproxy",
     visibility = ["//visibility:private"],
     deps = [
+        "//ghproxy/apptokenequalizer:go_default_library",
         "//ghproxy/ghcache:go_default_library",
         "//greenhouse/diskutil:go_default_library",
         "//prow/config:go_default_library",
@@ -58,6 +59,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//ghproxy/apptokenequalizer:all-srcs",
         "//ghproxy/ghcache:all-srcs",
         "//ghproxy/ghmetrics:all-srcs",
     ],

--- a/ghproxy/OWNERS
+++ b/ghproxy/OWNERS
@@ -2,7 +2,9 @@
 
 reviewers:
   - cjwagner
+  - alvaroaleman
 approvers:
   - cjwagner
+  - alvaroaleman
 labels:
   - area/ghproxy

--- a/ghproxy/apptokenequalizer/BUILD.bazel
+++ b/ghproxy/apptokenequalizer/BUILD.bazel
@@ -1,0 +1,36 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["app_token_equalizer.go"],
+    importpath = "k8s.io/test-infra/ghproxy/apptokenequalizer",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/github:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["app_token_equalizer_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/github:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
+    ],
+)

--- a/ghproxy/apptokenequalizer/app_token_equalizer.go
+++ b/ghproxy/apptokenequalizer/app_token_equalizer.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apptokenequalizer
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+)
+
+func New(delegate http.RoundTripper) http.RoundTripper {
+	return &appTokenEqualizerTransport{
+		delegate:   delegate,
+		tokenCache: map[string]github.AppInstallationToken{},
+	}
+}
+
+type appTokenEqualizerTransport struct {
+	delegate   http.RoundTripper
+	lock       sync.Mutex
+	tokenCache map[string]github.AppInstallationToken
+}
+
+func (t *appTokenEqualizerTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	resp, err := t.delegate.RoundTrip(r)
+	if err != nil || resp.StatusCode != 201 || r.Method != http.MethodPost || !strings.HasPrefix(r.URL.Path, "/app/installations/") {
+		return resp, err
+	}
+	body := resp.Body
+	defer body.Close()
+
+	l := logrus.WithField("path", r.URL.Path)
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		l.WithError(err).Error("Failed to read body")
+		resp.StatusCode = http.StatusInternalServerError
+		resp.Status = http.StatusText(http.StatusInternalServerError)
+		return resp, nil
+	}
+
+	var token github.AppInstallationToken
+	if err := json.Unmarshal(bodyBytes, &token); err != nil {
+		l.WithError(err).Error("Failed to unmarshal")
+		resp.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+		return resp, nil
+	}
+
+	split := strings.Split(r.URL.Path, "/")
+	if n := len(split); n != 5 {
+		l.Errorf("Splitting path %s by '/' didn't yield exactly five elements but %d", r.URL.Path, n)
+		resp.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+		return resp, nil
+	}
+	appId := split[3]
+
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	if cachedToken, ok := t.tokenCache[appId]; ok && cachedToken.ExpiresAt.Add(-time.Minute).After(time.Now()) {
+		token = cachedToken
+	} else {
+		t.tokenCache[appId] = token
+	}
+
+	serializedToken, err := json.Marshal(token)
+	if err != nil {
+		l.WithError(err).Error("Failed to serialize token")
+		resp.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+		return resp, nil
+	}
+
+	resp.Body = ioutil.NopCloser(bytes.NewBuffer(serializedToken))
+	resp.ContentLength = int64(len(serializedToken))
+	resp.Header.Set("X-PROW-GHPROXY-REPLACED-TOKEN", "true")
+	resp.Header.Set("Content-Length", strconv.Itoa(len(serializedToken)))
+	return resp, nil
+}

--- a/ghproxy/apptokenequalizer/app_token_equalizer_test.go
+++ b/ghproxy/apptokenequalizer/app_token_equalizer_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apptokenequalizer
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"k8s.io/test-infra/prow/github"
+)
+
+func TestRoundTrip(t *testing.T) {
+	const appID = "appid"
+	oneHourInFuture := time.Now().Add(time.Hour)
+	testCases := []struct {
+		name             string
+		tokenCache       map[string]github.AppInstallationToken
+		requestPath      string
+		delegateResponse *http.Response
+		delegateError    error
+		expectedResponse *http.Response
+		expectedError    error
+	}{
+		{
+			name:        "Response is served from cache",
+			tokenCache:  map[string]github.AppInstallationToken{appID: {Token: "token", ExpiresAt: oneHourInFuture}},
+			requestPath: fmt.Sprintf("/app/installations/%s/tokens", appID),
+			delegateResponse: &http.Response{
+				StatusCode: 201,
+				Header:     http.Header{},
+				Body:       serializeOrDie(github.AppInstallationToken{Token: "other-token", ExpiresAt: time.Now().Add(time.Hour)}),
+			},
+			expectedResponse: &http.Response{
+				StatusCode: 201,
+				Body:       serializeOrDie(github.AppInstallationToken{Token: "token", ExpiresAt: oneHourInFuture}),
+			},
+		},
+		{
+			name:          "Delegate error is passed on and response is not from cache",
+			tokenCache:    map[string]github.AppInstallationToken{appID: {Token: "token", ExpiresAt: oneHourInFuture}},
+			requestPath:   fmt.Sprintf("/app/installations/%s/tokens", appID),
+			delegateError: ComparableError("some-error"),
+			expectedError: ComparableError("some-error"),
+		},
+		{
+			name:        "Status is not 201, response is not from cache",
+			tokenCache:  map[string]github.AppInstallationToken{appID: {Token: "token", ExpiresAt: oneHourInFuture}},
+			requestPath: fmt.Sprintf("/app/installations/%s/tokens", appID),
+			delegateResponse: &http.Response{
+				StatusCode: 200,
+				Header:     http.Header{},
+				Body:       serializeOrDie(github.AppInstallationToken{Token: "other-token", ExpiresAt: oneHourInFuture}),
+			},
+			expectedResponse: &http.Response{
+				StatusCode: 200,
+				Body:       serializeOrDie(github.AppInstallationToken{Token: "other-token", ExpiresAt: oneHourInFuture}),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			transport := &appTokenEqualizerTransport{
+				tokenCache: tc.tokenCache,
+				delegate: &fakeRoundTripper{
+					response: tc.delegateResponse,
+					err:      tc.delegateError,
+				},
+			}
+
+			r, err := http.NewRequest(http.MethodPost, tc.requestPath, nil)
+			if err != nil {
+				t.Fatalf("failed to construct request: %v", err)
+			}
+
+			response, err := transport.RoundTrip(r)
+			if diff := cmp.Diff(err, tc.expectedError); diff != "" {
+				t.Fatalf("actual error differs from expected: %s", diff)
+			}
+			if err != nil {
+				return
+			}
+
+			if diff := cmp.Diff(response.StatusCode, tc.expectedResponse.StatusCode); diff != "" {
+				t.Errorf("actual status code differs from expected: %s", diff)
+			}
+
+			actualBody, err := ioutil.ReadAll(response.Body)
+			if err != nil {
+				t.Fatalf("failed to read actual response body: %v", err)
+			}
+			expectedBody, err := ioutil.ReadAll(tc.expectedResponse.Body)
+			if err != nil {
+				t.Fatalf("failed to read expected response body: %v", err)
+			}
+			if diff := cmp.Diff(string(actualBody), string(expectedBody)); diff != "" {
+				t.Errorf("actual response differs from expectedResponse: %s", diff)
+			}
+		})
+	}
+}
+
+func serializeOrDie(in interface{}) io.ReadCloser {
+	rawData, err := json.Marshal(in)
+	if err != nil {
+		panic(fmt.Sprintf("Serialization failed: %v", err))
+	}
+	return ioutil.NopCloser(bytes.NewBuffer(rawData))
+}
+
+type fakeRoundTripper struct {
+	response *http.Response
+	err      error
+}
+
+func (frt *fakeRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return frt.response, frt.err
+}
+
+type ComparableError string
+
+func (c ComparableError) Error() string {
+	return string(c)
+}

--- a/ghproxy/ghcache/coalesce.go
+++ b/ghproxy/ghcache/coalesce.go
@@ -148,7 +148,7 @@ func (r *requestCoalescer) RoundTrip(req *http.Request) (*http.Response, error) 
 			if err != nil {
 				logrus.WithError(err).WithField("header-value", resp.Header.Get(cacheEntryCreationDateHeader)).Warn("Failed to convert cacheEntryCreationDateHeader value to int")
 			} else {
-				ghmetrics.CollectCacheEntryAgeMetrics(float64(time.Now().Unix()-int64(intVal)), req.URL.Path, req.Header.Get("User-Agent"), r.hasher.Hash(req))
+				ghmetrics.CollectCacheEntryAgeMetrics(float64(time.Now().Unix()-int64(intVal)), req.URL.Path, req.Header.Get("User-Agent"), tokenBudgetName)
 			}
 		}
 	}

--- a/ghproxy/ghmetrics/ghpath.go
+++ b/ghproxy/ghmetrics/ghpath.go
@@ -105,6 +105,7 @@ func organizationTree() []simplifypath.Node {
 
 var simplifier = simplifypath.NewSimplifier(l("", // shadow element mimicing the root
 	l(""),
+	l("app", l("installations", v("id", l("access_tokens")))),
 	l("repos",
 		v("owner",
 			v("repo",

--- a/prow/github/app_auth_roundtripper_integration_test.go
+++ b/prow/github/app_auth_roundtripper_integration_test.go
@@ -49,7 +49,7 @@ func TestGetOrg(t *testing.T) {
 		appID,
 		func() *rsa.PrivateKey { return key },
 		"https://api.github.com/graphql",
-		"https://api.github.com",
+		"http://localhost:8888",
 	)
 
 	if _, err := client.GetOrg(org); err != nil {


### PR DESCRIPTION
This change adds an in-memory cache to ghproxy that is used to give
multiple clients that request a token for the same installation the same
token. This in turn is needed because the github etags are scoped to a
token, making sure all clients have the same one allows them to share a
cache.

The cached token is only returned after a successful request to github
was made to not allow clients to abuse this.

/assign @stevekuznetsov 