### PR TITLE
Hook: Allow to enable/disable on org/repo

### DIFF
--- a/prow/hook/hook_test.go
+++ b/prow/hook/hook_test.go
@@ -167,6 +167,7 @@ func TestHook(t *testing.T) {
 			Plugins:        pa,
 			ConfigAgent:    ca,
 			Metrics:        metrics,
+			RepoEnabled:    func(org, repo string) bool { return true },
 			TokenGenerator: tc.tokenGenerator,
 		})
 		defer s.Close()

--- a/prow/hook/server.go
+++ b/prow/hook/server.go
@@ -44,6 +44,7 @@ type Server struct {
 	ConfigAgent    *config.Agent
 	TokenGenerator func() []byte
 	Metrics        *githubeventserver.Metrics
+	RepoEnabled    func(org, repo string) bool
 
 	// c is an http client used for dispatching events
 	// to external plugin services.
@@ -95,8 +96,10 @@ func (s *Server) demuxEvent(eventType, eventGUID string, payload []byte, h http.
 		}
 		i.GUID = eventGUID
 		srcRepo = i.Repo.FullName
-		s.wg.Add(1)
-		go s.handleIssueEvent(l, i)
+		if s.RepoEnabled(i.Repo.Owner.Login, i.Repo.Name) {
+			s.wg.Add(1)
+			go s.handleIssueEvent(l, i)
+		}
 	case "issue_comment":
 		var ic github.IssueCommentEvent
 		if err := json.Unmarshal(payload, &ic); err != nil {
@@ -104,8 +107,10 @@ func (s *Server) demuxEvent(eventType, eventGUID string, payload []byte, h http.
 		}
 		ic.GUID = eventGUID
 		srcRepo = ic.Repo.FullName
-		s.wg.Add(1)
-		go s.handleIssueCommentEvent(l, ic)
+		if s.RepoEnabled(ic.Repo.Owner.Login, ic.Repo.Name) {
+			s.wg.Add(1)
+			go s.handleIssueCommentEvent(l, ic)
+		}
 	case "pull_request":
 		var pr github.PullRequestEvent
 		if err := json.Unmarshal(payload, &pr); err != nil {
@@ -113,8 +118,10 @@ func (s *Server) demuxEvent(eventType, eventGUID string, payload []byte, h http.
 		}
 		pr.GUID = eventGUID
 		srcRepo = pr.Repo.FullName
-		s.wg.Add(1)
-		go s.handlePullRequestEvent(l, pr)
+		if s.RepoEnabled(pr.Repo.Owner.Login, pr.Repo.Name) {
+			s.wg.Add(1)
+			go s.handlePullRequestEvent(l, pr)
+		}
 	case "pull_request_review":
 		var re github.ReviewEvent
 		if err := json.Unmarshal(payload, &re); err != nil {
@@ -122,8 +129,10 @@ func (s *Server) demuxEvent(eventType, eventGUID string, payload []byte, h http.
 		}
 		re.GUID = eventGUID
 		srcRepo = re.Repo.FullName
-		s.wg.Add(1)
-		go s.handleReviewEvent(l, re)
+		if s.RepoEnabled(re.Repo.Owner.Login, re.Repo.Name) {
+			s.wg.Add(1)
+			go s.handleReviewEvent(l, re)
+		}
 	case "pull_request_review_comment":
 		var rce github.ReviewCommentEvent
 		if err := json.Unmarshal(payload, &rce); err != nil {
@@ -131,8 +140,10 @@ func (s *Server) demuxEvent(eventType, eventGUID string, payload []byte, h http.
 		}
 		rce.GUID = eventGUID
 		srcRepo = rce.Repo.FullName
-		s.wg.Add(1)
-		go s.handleReviewCommentEvent(l, rce)
+		if s.RepoEnabled(rce.Repo.Owner.Login, rce.Repo.Name) {
+			s.wg.Add(1)
+			go s.handleReviewCommentEvent(l, rce)
+		}
 	case "push":
 		var pe github.PushEvent
 		if err := json.Unmarshal(payload, &pe); err != nil {
@@ -140,8 +151,10 @@ func (s *Server) demuxEvent(eventType, eventGUID string, payload []byte, h http.
 		}
 		pe.GUID = eventGUID
 		srcRepo = pe.Repo.FullName
-		s.wg.Add(1)
-		go s.handlePushEvent(l, pe)
+		if s.RepoEnabled(pe.Repo.Owner.Login, pe.Repo.Name) {
+			s.wg.Add(1)
+			go s.handlePushEvent(l, pe)
+		}
 	case "status":
 		var se github.StatusEvent
 		if err := json.Unmarshal(payload, &se); err != nil {
@@ -149,8 +162,10 @@ func (s *Server) demuxEvent(eventType, eventGUID string, payload []byte, h http.
 		}
 		se.GUID = eventGUID
 		srcRepo = se.Repo.FullName
-		s.wg.Add(1)
-		go s.handleStatusEvent(l, se)
+		if s.RepoEnabled(se.Repo.Owner.Login, se.Repo.Name) {
+			s.wg.Add(1)
+			go s.handleStatusEvent(l, se)
+		}
 	default:
 		l.Debug("Ignoring unhandled event type. (Might still be handled by external plugins.)")
 	}
@@ -163,13 +178,21 @@ func (s *Server) demuxEvent(eventType, eventGUID string, payload []byte, h http.
 
 // needDemux returns whether there are any external plugins that need to
 // get the present event.
-func (s *Server) needDemux(eventType, srcRepo string) []plugins.ExternalPlugin {
+func (s *Server) needDemux(eventType, orgRepo string) []plugins.ExternalPlugin {
 	var matching []plugins.ExternalPlugin
-	srcOrg := strings.Split(srcRepo, "/")[0]
+	split := strings.Split(orgRepo, "/")
+	srcOrg := split[0]
+	var srcRepo string
+	if len(split) > 1 {
+		srcRepo = split[1]
+	}
+	if !s.RepoEnabled(srcOrg, srcRepo) {
+		return nil
+	}
 
 	for repo, plugins := range s.Plugins.Config().ExternalPlugins {
 		// Make sure the repositories match
-		if repo != srcRepo && repo != srcOrg {
+		if repo != orgRepo && repo != srcOrg {
 			continue
 		}
 

--- a/prow/hook/server_test.go
+++ b/prow/hook/server_test.go
@@ -52,6 +52,7 @@ foo/bar:
 		Metrics:        metrics,
 		Plugins:        pa,
 		TokenGenerator: getSecret,
+		RepoEnabled:    func(org, repo string) bool { return true },
 	}
 	// This is the SHA1 signature for payload "{}" and signature "abc"
 	// echo -n '{}' | openssl dgst -sha1 -hmac abc
@@ -186,9 +187,10 @@ func TestNeedDemux(t *testing.T) {
 	tests := []struct {
 		name string
 
-		eventType string
-		srcRepo   string
-		plugins   map[string][]plugins.ExternalPlugin
+		eventType   string
+		srcRepo     string
+		repoEnabled func(org, repo string) bool
+		plugins     map[string][]plugins.ExternalPlugin
 
 		expected []plugins.ExternalPlugin
 	}{
@@ -250,37 +252,85 @@ func TestNeedDemux(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "we have variety but disabled that repo",
+
+			eventType: "issue_comment",
+			srcRepo:   "kubernetes/test-infra",
+			repoEnabled: func(org, repo string) bool {
+				if org == "kubernetes" && repo == "test-infra" {
+					return false
+				}
+				return true
+			},
+			plugins: map[string][]plugins.ExternalPlugin{
+				"kubernetes/test-infra": {
+					{
+						Name:   "sandwich",
+						Events: []string{"pull_request"},
+					},
+					{
+						Name: "coffee",
+					},
+				},
+				"kubernetes/kubernetes": {
+					{
+						Name:   "gumbo",
+						Events: []string{"issue_comment"},
+					},
+				},
+				"kubernetes": {
+					{
+						Name:   "chicken",
+						Events: []string{"push"},
+					},
+					{
+						Name: "water",
+					},
+					{
+						Name:   "chocolate",
+						Events: []string{"pull_request", "issue_comment", "issues"},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
-		t.Logf("Running scenario %q", test.name)
+		t.Run(test.name, func(t *testing.T) {
 
-		pa := &plugins.ConfigAgent{}
-		pa.Set(&plugins.Configuration{
-			ExternalPlugins: test.plugins,
+			t.Logf("Running scenario %q", test.name)
+
+			pa := &plugins.ConfigAgent{}
+			pa.Set(&plugins.Configuration{
+				ExternalPlugins: test.plugins,
+			})
+
+			if test.repoEnabled == nil {
+				test.repoEnabled = func(_, _ string) bool { return true }
+			}
+			s := &Server{Plugins: pa, RepoEnabled: test.repoEnabled}
+
+			gotPlugins := s.needDemux(test.eventType, test.srcRepo)
+			if len(gotPlugins) != len(test.expected) {
+				t.Fatalf("expected plugins: %+v, got: %+v", test.expected, gotPlugins)
+			}
+			for _, expected := range test.expected {
+				var found bool
+				for _, got := range gotPlugins {
+					if got.Name != expected.Name {
+						continue
+					}
+					if !reflect.DeepEqual(expected, got) {
+						t.Errorf("expected plugin: %+v, got: %+v", expected, got)
+					}
+					found = true
+				}
+				if !found {
+					t.Errorf("expected plugins: %+v, got: %+v", test.expected, gotPlugins)
+					break
+				}
+			}
 		})
-		s := &Server{Plugins: pa}
-
-		gotPlugins := s.needDemux(test.eventType, test.srcRepo)
-		if len(gotPlugins) != len(test.expected) {
-			t.Errorf("expected plugins: %+v, got: %+v", test.expected, gotPlugins)
-			continue
-		}
-		for _, expected := range test.expected {
-			var found bool
-			for _, got := range gotPlugins {
-				if got.Name != expected.Name {
-					continue
-				}
-				if !reflect.DeepEqual(expected, got) {
-					t.Errorf("expected plugin: %+v, got: %+v", expected, got)
-				}
-				found = true
-			}
-			if !found {
-				t.Errorf("expected plugins: %+v, got: %+v", test.expected, gotPlugins)
-				break
-			}
-		}
 	}
 }


### PR DESCRIPTION
This change allows to enable or disable hook on org or repo level. The
intended use case for this is a migration of Prow from personal access
tokens to a Github App.