### PR TITLE
[Kettle] Make day vars Global to help enforce sync between make_json and stream 

### DIFF
--- a/kettle/update.py
+++ b/kettle/update.py
@@ -75,7 +75,7 @@ def main():
         call(f'{mj_cmd} | pv | gzip > build_staging.json.gz')
         call(f'{bq_cmd} k8s-gubernator:build.staging build_staging.json.gz schema.json')
         call('python3 stream.py --poll kubernetes-jenkins/gcs-changes/kettle ' \
-            ' --dataset k8s-gubernator:build --tables staging:0 --stop_at=1')
+            '--dataset k8s-gubernator:build --tables staging:0 --stop_at=1')
 
 if __name__ == '__main__':
     os.chdir(os.path.dirname(__file__))

--- a/kettle/update.py
+++ b/kettle/update.py
@@ -22,6 +22,9 @@ DUMP = 'dump.txt'
 THREADS = 32
 MAX_BAD_RECORDS = 1000
 DAYS_OLD = 1.9
+DAY = 1
+WEEK = 2
+MONTH = 30
 
 def print_dump(file):
     if os.path.exists(file):
@@ -56,18 +59,18 @@ def main():
         mj_ext = ' --reset-emitted'
 
     if os.getenv('DEPLOYMENT', 'staging') == "prod":
-        call(f'{mj_cmd} {mj_ext} --days 1 | pv | gzip > build_day.json.gz')
+        call(f'{mj_cmd} {mj_ext} --days {DAY} | pv | gzip > build_day.json.gz')
         call(f'{bq_cmd} {bq_ext} k8s-gubernator:build.day build_day.json.gz schema.json')
 
-        call(f'{mj_cmd} {mj_ext} --days 7 | pv | gzip > build_week.json.gz')
+        call(f'{mj_cmd} {mj_ext} --days {WEEK} | pv | gzip > build_week.json.gz')
         call(f'{bq_cmd} {bq_ext} k8s-gubernator:build.week build_week.json.gz schema.json')
 
         # TODO: (MushuEE) #20024, remove 30 day limit once issue with all uploads is found
-        call(f'{mj_cmd} --days 30 | pv | gzip > build_all.json.gz')
+        call(f'{mj_cmd} --days {MONTH} | pv | gzip > build_all.json.gz')
         call(f'{bq_cmd} k8s-gubernator:build.all build_all.json.gz schema.json')
 
-        call('python3 stream.py --poll kubernetes-jenkins/gcs-changes/kettle ' \
-            ' --dataset k8s-gubernator:build --tables all:30 day:1 week:7 --stop_at=1')
+        call(f'python3 stream.py --poll kubernetes-jenkins/gcs-changes/kettle ' \
+            '--dataset k8s-gubernator:build --tables all:{MONTH} day:{DAY} week:{WEEK} --stop_at=1')
     else:
         call(f'{mj_cmd} | pv | gzip > build_staging.json.gz')
         call(f'{bq_cmd} k8s-gubernator:build.staging build_staging.json.gz schema.json')

--- a/kettle/update.py
+++ b/kettle/update.py
@@ -23,7 +23,7 @@ THREADS = 32
 MAX_BAD_RECORDS = 1000
 DAYS_OLD = 1.9
 DAY = 1
-WEEK = 2
+WEEK = 7
 MONTH = 30
 
 def print_dump(file):


### PR DESCRIPTION
If these change in one place and not the other the emit tables will be out of sync and can cause dupe data
/area kettle
