### PR TITLE
Controller-Runtime: Use go 1.15 in tests and add presubmits for 0.7 release

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -276,9 +276,9 @@ aliases:
 
   controller-runtime-approvers:
   - gerred
+  - alvaroaleman
 
   controller-runtime-reviewers:
-  - alvaroaleman
   - alenkacz
   - vincepri
   - alexeldeib

--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-master.yaml
@@ -9,7 +9,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: golang:1.13
+      - image: golang:1.15
         command:
         - ./hack/ci-check-everything.sh
         resources:
@@ -27,7 +27,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: golang:1.13
+      - image: golang:1.15
         command:
         - ./hack/apidiff.sh
     annotations:

--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.7.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.7.yaml
@@ -1,0 +1,34 @@
+presubmits:
+  kubernetes-sigs/controller-runtime:
+  - name: pull-controller-runtime-test-release-0-7
+    decorate: true
+    always_run: true
+    path_alias: sigs.k8s.io/controller-runtime
+    branches:
+    - ^release-0.7$
+    spec:
+      containers:
+      - image: golang:1.15
+        command:
+        - ./hack/ci-check-everything.sh
+        resources:
+          requests:
+            cpu: "7000m"
+    annotations:
+      testgrid-dashboards: sig-api-machinery-kubebuilder
+      testgrid-tab-name: controller-runtime-release-0.7
+  - name: pull-controller-runtime-apidiff-release-0-7
+    decorate: true
+    always_run: true
+    optional: true
+    path_alias: sigs.k8s.io/controller-runtime
+    branches:
+    - ^release-0.7$
+    spec:
+      containers:
+      - image: golang:1.15
+        command:
+        - ./hack/apidiff.sh
+    annotations:
+      testgrid-dashboards: sig-api-machinery-kubebuilder
+      testgrid-tab-name: controller-runtime-release-0.7-apidiff


### PR DESCRIPTION
Also adding myself to the c-r approvers just like I already am for the code: https://github.com/kubernetes-sigs/controller-runtime/blob/cf7ac887d082b481ec1389ddcd576f4140b15595/OWNERS_ALIASES#L21

/assign @vincepri @DirectXMan12  