### PR TITLE
Remove kube-state-metrics gh-pages branch status checks

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -278,6 +278,8 @@ branch-protection:
             - ci-validate-manifests
           branches:
             gh-pages:
+              required_status_checks:
+                contexts: []
               restrictions:
                 users:
                 - k8s-ci-robot


### PR DESCRIPTION
Follow-up to #20291

Working to fix release for gh-pages PRs:
- kubernetes/kube-state-metrics#1334
- kubernetes/kube-state-metrics#1335
