### PR TITLE
Don't protect aws-{fsx/efs}-csi-driver gh-pages branches

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -422,6 +422,14 @@ branch-protection:
           branches:
             gh-pages:
               protect: false
+        aws-efs-csi-driver:
+          branches:
+            gh-pages:
+              protect: false
+        aws-fsx-csi-driver:
+          branches:
+            gh-pages:
+              protect: false
         kube-batch:
           required_status_checks:
             contexts:


### PR DESCRIPTION
Same as was done for EBS https://github.com/kubernetes/test-infra/pull/20157, I plan to implement automatic helm chart-releaser actions for the EFS and FSx repositories.

Copy/pasting reasoning from that PR:

"
We want this GitHub action https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/.github/workflows/helm-chart-release.yaml (using https://github.com/helm/chart-releaser-action) to automatically update our index file https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/gh-pages/index.yaml and create GitHub releases.

To allow the GitHub action to push to GitHub, the gh-pages branch can't be protected. ! [remote rejected] HEAD -> gh-pages (protected branch hook declined) https://github.com/kubernetes-sigs/aws-ebs-csi-driver/runs/1513656332. So I am making the branch unprotected. We won't accept PRs to it, from now on only the GitHub action ought to write to it.
"

Thanks!

@ayberk