### PR TITLE
Github v4: Remove unnecesary lock that causes deadlock

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -442,8 +442,6 @@ func (t *throttler) Query(ctx context.Context, q interface{}, vars map[string]in
 
 func (t *throttler) QueryWithGitHubAppsSupport(ctx context.Context, q interface{}, vars map[string]interface{}, org string) error {
 	t.Wait()
-	t.lock.Lock()
-	defer t.lock.Unlock()
 	return t.graph.QueryWithGitHubAppsSupport(ctx, q, vars, org)
 }
 


### PR DESCRIPTION
The V4 client acquires the throttlers lock, which causes a deadlock when
using apps auth becausen we end up with a callchain of:

* V4 query, acquires lock
* AppsAuthTransport uses V3 client to get a token to authenticate the
  request
* V3 client tries to acquire whe lock when calling the throttlers.Wait()

And we are deadlocked.

As this doesn't seem to protect anything, it is likely a remainder that
happened to not be an issue so far.