### PR TITLE
Make build target match with dockerfile for autobumper

### DIFF
--- a/experiment/autobumper/cloudbuild.yaml
+++ b/experiment/autobumper/cloudbuild.yaml
@@ -6,7 +6,7 @@ steps:
     - -mod=readonly
     - -a
     - -installsuffix=cgo
-    - -o=./experiment/autobumper/generic_autobumper
+    - -o=./experiment/autobumper/generic_autobump
     - ./experiment/autobumper/main.go
     env:
     - CGO_ENABLED=0


### PR DESCRIPTION
Dockerfile was expecting executable to be called generic_autobump, but it was called generic_autobumper