### PR TITLE
Add EKS-D to list of projects using Prow

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -98,6 +98,7 @@ Prow is used by the following organizations and projects:
 - [Feast](https://github.com/gojek/feast)
 - [Falco](http://prow.falco.org)
 - [TiDB](https://prow.tidb.io)
+- [Amazon EKS Distro](https://prow.eks.amazonaws.com/)
 
 [Jenkins X](https://jenkins-x.io/) uses [Prow as part of Serverless Jenkins](https://medium.com/@jdrawlings/serverless-jenkins-with-jenkins-x-9134cbfe6870).
 


### PR DESCRIPTION
We used Prow to power the CI for our project to build, test, and release Amazon EKS Distro. Thank you for all the help in the prow slack channel, and we look forward to contribute in the future to this project!