### PR TITLE
Migrate Network Policy testjob to podutils

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -6,6 +6,8 @@ presubmits:
     always_run: false
     run_if_changed: '^(test/e2e/network/|pkg/apis/networking)'
     optional: true
+    decorate: true
+    path_alias: k8s.io/kubernetes
     skip_report: false
     labels:
       preset-service-account: "true"
@@ -16,7 +18,10 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
     spec:
       containers:
-      - args:
+      - command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        args:
         - --timeout=170
         - --root=/go/src
         - --repo=k8s.io/kubernetes=$(PULL_REFS)


### PR DESCRIPTION
Signed-off-by: Ricardo Pchevuzinske Katz <ricardo.katz@gmail.com>

Started migrating sig-net jobs to podutils, for now let's see if the network policy job works fine :)

Part of: #20324 