### PR TITLE
Tide: Allow constructing per-org queries

### DIFF
--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -213,38 +213,80 @@ type TideQuery struct {
 	ReviewApprovedRequired bool `json:"reviewApprovedRequired,omitempty"`
 }
 
-// Query returns the corresponding github search string for the tide query.
-func (tq *TideQuery) Query() string {
-	toks := []string{"is:pr", "state:open", "archived:false"}
+// constructQuery returns a map[org][]orgSpecificQueryParts (org, repo, -repo), remainingQueryString
+func (tq *TideQuery) constructQuery() (map[string][]string, string) {
+	// map org->repo directives (if any)
+	orgScopedIdentifiers := map[string][]string{}
 	for _, o := range tq.Orgs {
-		toks = append(toks, fmt.Sprintf("org:\"%s\"", o))
+		if _, ok := orgScopedIdentifiers[o]; !ok {
+			orgScopedIdentifiers[o] = []string{fmt.Sprintf(`org:"%s"`, o)}
+		}
 	}
 	for _, r := range tq.Repos {
-		toks = append(toks, fmt.Sprintf("repo:\"%s\"", r))
+		if org, _, ok := splitOrgRepoString(r); ok {
+			orgScopedIdentifiers[org] = append(orgScopedIdentifiers[org], fmt.Sprintf("repo:\"%s\"", r))
+		}
 	}
+
 	for _, r := range tq.ExcludedRepos {
-		toks = append(toks, fmt.Sprintf("-repo:\"%s\"", r))
+		if org, _, ok := splitOrgRepoString(r); ok {
+			orgScopedIdentifiers[org] = append(orgScopedIdentifiers[org], fmt.Sprintf("-repo:\"%s\"", r))
+		}
 	}
+
+	queryString := []string{"is:pr", "state:open", "archived:false"}
 	if tq.Author != "" {
-		toks = append(toks, fmt.Sprintf("author:\"%s\"", tq.Author))
+		queryString = append(queryString, fmt.Sprintf("author:\"%s\"", tq.Author))
 	}
 	for _, b := range tq.ExcludedBranches {
-		toks = append(toks, fmt.Sprintf("-base:\"%s\"", b))
+		queryString = append(queryString, fmt.Sprintf("-base:\"%s\"", b))
 	}
 	for _, b := range tq.IncludedBranches {
-		toks = append(toks, fmt.Sprintf("base:\"%s\"", b))
+		queryString = append(queryString, fmt.Sprintf("base:\"%s\"", b))
 	}
 	for _, l := range tq.Labels {
-		toks = append(toks, fmt.Sprintf("label:\"%s\"", l))
+		queryString = append(queryString, fmt.Sprintf("label:\"%s\"", l))
 	}
 	for _, l := range tq.MissingLabels {
-		toks = append(toks, fmt.Sprintf("-label:\"%s\"", l))
+		queryString = append(queryString, fmt.Sprintf("-label:\"%s\"", l))
 	}
 	if tq.Milestone != "" {
-		toks = append(toks, fmt.Sprintf("milestone:\"%s\"", tq.Milestone))
+		queryString = append(queryString, fmt.Sprintf("milestone:\"%s\"", tq.Milestone))
 	}
 	if tq.ReviewApprovedRequired {
-		toks = append(toks, "review:approved")
+		queryString = append(queryString, "review:approved")
+	}
+
+	return orgScopedIdentifiers, strings.Join(queryString, " ")
+}
+
+func splitOrgRepoString(orgRepo string) (string, string, bool) {
+	split := strings.Split(orgRepo, "/")
+	if len(split) != 2 {
+		// Just do it like the github search itself and ignore invalid orgRepo identifiers
+		return "", "", false
+	}
+	return split[0], split[1], true
+}
+
+// OrgQueries returns the GitHub search string for the query, sharded
+// by org.
+func (tq *TideQuery) OrgQueries() map[string]string {
+	orgRepoIdentifiers, queryString := tq.constructQuery()
+	result := map[string]string{}
+	for org, repoIdentifiers := range orgRepoIdentifiers {
+		result[org] = queryString + " " + strings.Join(repoIdentifiers, " ")
+	}
+
+	return result
+}
+
+// Query returns the corresponding github search string for the tide query.
+func (tq *TideQuery) Query() string {
+	orgRepoIdentifiers, queryString := tq.constructQuery()
+	toks := []string{queryString}
+	for _, repoIdentifiers := range orgRepoIdentifiers {
+		toks = append(toks, repoIdentifiers...)
 	}
 	return strings.Join(toks, " ")
 }

--- a/prow/config/tide_test.go
+++ b/prow/config/tide_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -33,6 +34,7 @@ import (
 var testQuery = TideQuery{
 	Orgs:                   []string{"org"},
 	Repos:                  []string{"k/k", "k/t-i"},
+	ExcludedRepos:          []string{"org/repo"},
 	Labels:                 []string{labels.LGTM, labels.Approved},
 	MissingLabels:          []string{"foo"},
 	Author:                 "batman",
@@ -40,26 +42,92 @@ var testQuery = TideQuery{
 	ReviewApprovedRequired: true,
 }
 
+var expectedQueryComponents = []string{
+	"is:pr",
+	"state:open",
+	"archived:false",
+	"label:\"lgtm\"",
+	"label:\"approved\"",
+	"-label:\"foo\"",
+	"author:\"batman\"",
+	"milestone:\"milestone\"",
+	"review:approved",
+}
+
 func TestTideQuery(t *testing.T) {
 	q := " " + testQuery.Query() + " "
-	checkTok := func(tok string) {
-		if !strings.Contains(q, " "+tok+" ") {
-			t.Errorf("Expected query to contain \"%s\", got \"%s\"", tok, q)
-		}
-	}
+	checkTok := checkTok(t, q)
 
-	checkTok("is:pr")
-	checkTok("state:open")
-	checkTok("archived:false")
 	checkTok("org:\"org\"")
 	checkTok("repo:\"k/k\"")
 	checkTok("repo:\"k/t-i\"")
-	checkTok("label:\"lgtm\"")
-	checkTok("label:\"approved\"")
-	checkTok("-label:\"foo\"")
-	checkTok("author:\"batman\"")
-	checkTok("milestone:\"milestone\"")
-	checkTok("review:approved")
+	checkTok("-repo:\"org/repo\"")
+	for _, expectedComponent := range expectedQueryComponents {
+		checkTok(expectedComponent)
+	}
+
+	elements := strings.Fields(q)
+	alreadySeen := sets.String{}
+	for _, element := range elements {
+		if alreadySeen.Has(element) {
+			t.Errorf("element %q was multiple times in the query string", element)
+		}
+		alreadySeen.Insert(element)
+	}
+}
+
+func checkTok(t *testing.T, q string) func(tok string) {
+	return func(tok string) {
+		t.Run("Query string contains "+tok, func(t *testing.T) {
+			if !strings.Contains(q, " "+tok+" ") {
+				t.Errorf("Expected query to contain \"%s\", got \"%s\"", tok, q)
+			}
+		})
+	}
+}
+
+func TestOrgQueries(t *testing.T) {
+	queries := testQuery.OrgQueries()
+	if n := len(queries); n != 2 {
+		t.Errorf("expected exactly two queries, got %d", n)
+	}
+	if queries["org"] == "" {
+		t.Error("no query for org org found")
+	}
+	if queries["k"] == "" {
+		t.Error("no query for org k found")
+	}
+
+	for org, query := range queries {
+		t.Run(org, func(t *testing.T) {
+			checkTok := checkTok(t, " "+query+" ")
+			t.Logf("query: %s", query)
+
+			for _, expectedComponent := range expectedQueryComponents {
+				checkTok(expectedComponent)
+			}
+
+			elements := strings.Fields(query)
+			alreadySeen := sets.String{}
+			for _, element := range elements {
+				if alreadySeen.Has(element) {
+					t.Errorf("element %q was multiple times in the query string", element)
+				}
+				alreadySeen.Insert(element)
+			}
+
+			if org == "org" {
+				checkTok(`org:"org"`)
+				checkTok(`-repo:"org/repo"`)
+			}
+
+			if org == "k" {
+				for _, repo := range testQuery.Repos {
+					checkTok(fmt.Sprintf(`repo:"%s"`, repo))
+				}
+			}
+		})
+	}
 }
 
 func TestOrgExceptionsAndRepos(t *testing.T) {


### PR DESCRIPTION
This change allows to get per-org query strings from a tide query. This
is the first step towards adding github apps support for Tide and was
extracted from the full changeset to make reviewing easier.

The old code is left, because we want only want to do this when github
apps auth is used, as it might result in higher token usage.

FTR, the full changeset for tide github apps support that appears to generally be working but needs some prettying and tests is here: https://github.com/kubernetes/test-infra/compare/master...alvaroaleman:tide-github-apps?expand=1