### PR TITLE
Fix an extremely rare race in the GitHub reporter.

### DIFF
--- a/prow/crier/reporters/github/reporter_test.go
+++ b/prow/crier/reporters/github/reporter_test.go
@@ -163,7 +163,7 @@ func TestPresumitReportingLocks(t *testing.T) {
 
 func TestShardedLockCleanup(t *testing.T) {
 	t.Parallel()
-	sl := &shardedLock{mapLock: &sync.Mutex{}, locks: map[simplePull]*sync.Mutex{}}
+	sl := &shardedLock{mapLock: &sync.RWMutex{}, locks: map[simplePull]*sync.Mutex{}}
 	key := simplePull{"org", "repo", 1}
 	sl.locks[key] = &sync.Mutex{}
 	sl.cleanup()


### PR DESCRIPTION
Previously there was a possible race between the cleanup thread and two threads (**A** and **B**) attempting to lock the same PR.
1. **A**: Calls `getLock()` for PR X and is returned a reference to the lock, but has not yet acquired it with `lock.Lock()`.
1. **Cleanup**: Locks the map.
1. **Cleanup**: Acquires PR X's lock, then removes the lock from the map and releases it.
1. **Cleanup**: Finishes cleaning and release the map lock.
1. **A**: Calls `lock.Lock()` on the PR X lock that is no longer in the map.
1. **B**: Calls `getLock()` for PR X and is returned a reference to the **new** PR X lock. **B** acquires the lock and now may conflict with **A**.

Returning the lock from `getLock()` already acquired ensures that the cleanup thread cannot remove the lock from the map before it is used. In other words step 3 would not be possible since step 5 would have already happened as part of step 1 and PR X's lock would already be held.

We'd probably never hit this in a million years, but it is technically possible 🙃 
/kind bug
/assign @fejta @chaodaiG @alvaroaleman 