### PR TITLE
Remove deprecated configs `WhiteList` and `BranchWhiteList` in `Slack.MergeWarnings`

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -127,6 +127,7 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *January 1, 2021* Support for `whitelist` and `branch_whitelist` fields in Slack merge warning configuration is discontinued. You can use `exempt_users` and `exempt_branches` fields instead. 
  - *November 24, 2020* The `requiresig` plugin has been removed in favor of the `require-matching-label` plugin
     which provides equivalent functionality ([example plugin config](https://github.com/kubernetes/test-infra/blob/e42b0745404017bc71c668da0342ef6857d87fa9/config/prow/plugins.yaml#L494-L498))
  - *November 14, 2020* The `whitelist` and `branch_whitelist` fields in Slack merge warning were deprecated on *August 22, 2020* in favor of the new `exempt_users` and `exempt_branches` fields. The support for these fields shall be stopped in *January 2021*.

--- a/prow/plugins/plugin-config-documented.yaml
+++ b/prow/plugins/plugin-config-documented.yaml
@@ -533,11 +533,7 @@ slack:
     mentionchannels:
       - ""
     mergewarnings:
-      - # Deprecated: Use ExemptBranches instead.
-        branch_whitelist:
-            "": null
-
-        # List of channels on which a event is published.
+      - # List of channels on which a event is published.
         channels:
           - ""
 
@@ -551,10 +547,6 @@ slack:
 
         # Repos is either of the form org/repos or just org.
         repos:
-          - ""
-
-        # Deprecated: Use ExemptUsers instead.
-        whitelist:
           - ""
 triggers:
   - # JoinOrgURL is a link that redirects users to a location where they


### PR DESCRIPTION
fixes #18801
PR # 3 part of https://github.com/kubernetes/test-infra/issues/18801#issuecomment-673269771

Remove deprecated configs `WhiteList` and `BranchWhiteList` in `Slack.MergeWarnings`.

/hold 
This can be merged in Jan 2021 (as mentioned in ANNOUNCEMENTS.md at the time of deprecation).
In the meanwhile please review and run tests.
