### PR TITLE
add UltraSSDEnabled field in aks-engine kubetest

### DIFF
--- a/kubetest/aksengine_helpers.go
+++ b/kubetest/aksengine_helpers.go
@@ -193,6 +193,7 @@ type MasterProfile struct {
 	OSDiskSizeGB        int                 `json:"osDiskSizeGB,omitempty" validate:"min=0,max=1023"`
 	AvailabilityProfile string              `json:"availabilityProfile,omitempty"`
 	AvailabilityZones   []string            `json:"availabilityZones,omitempty"`
+	UltraSSDEnabled     bool                `json:"ultraSSDEnabled,omitempty"`
 }
 
 type AgentPoolProfile struct {
@@ -209,6 +210,7 @@ type AgentPoolProfile struct {
 	OSDiskSizeGB           int                 `json:"osDiskSizeGB,omitempty" validate:"min=0,max=1023"`
 	EnableVMSSNodePublicIP bool                `json:"enableVMSSNodePublicIP,omitempty"`
 	StorageProfile         string              `json:"storageProfile,omitempty"`
+	UltraSSDEnabled        bool                `json:"ultraSSDEnabled,omitempty"`
 }
 
 type AzureClient struct {


### PR DESCRIPTION
Would hit this error without this PR when adding `ultraSSDEnabled` field:
```
2020/12/24 03:02:25 main.go:316: Something went wrong: starting e2e cluster: failed to populate aks-engine apimodel template: error unmarshaling ApiModel template file: json: unknown field "ultraSSDEnabled"
```

https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_azuredisk-csi-driver/640/pull-azuredisk-csi-driver-e2e-multi-az/1341941742156386304/build-log.txt