### PR TITLE
GithubV4: Properly set User-Agent header

### DIFF
--- a/prow/github/BUILD.bazel
+++ b/prow/github/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//ghproxy/ghcache:go_default_library",
+        "//prow/version:go_default_library",
         "@com_github_dgrijalva_jwt_go_v4//:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_shurcool_githubv4//:go_default_library",


### PR DESCRIPTION
This change makes the V4 portion of our github client properly set its
User-Agent header by passing it through the upstream githubql client via
it's context and then setting it via the headerSetting transport.