### PR TITLE
Kops - update experimental kubetest2 job to use repo's makefile

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -122,23 +122,8 @@ presubmits:
         command:
         - runner.sh
         args:
-        - bash
-        - -c
-        - set -o errexit;
-          set -o nounset;
-          set -o pipefail;
-          set -o xtrace;
-          cd /home/prow/go/src/k8s.io/kops/tests/e2e;
-          export GO111MODULE=on;
-          go get sigs.k8s.io/kubetest2@latest;
-          go install ./kubetest2-kops;
-          env;
-          kubetest2 kops
-            -v 2
-            --build --up --down
-            --cloud-provider=aws
-            --kops-binary-path=/home/prow/go/src/k8s.io/kops/bazel-bin/cmd/kops/linux-amd64/kops
-          ;
+        - make
+        - test-e2e
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
This should make it easier to iterate on the kubetest2 commands.  Note this make target doesn't exist yet, I'll open a WIP PR with it next.