### PR TITLE
Change autobumper to allow it to create multiple PRs without overriding

### DIFF
--- a/config/prow/autobump-config.yaml
+++ b/config/prow/autobump-config.yaml
@@ -34,7 +34,7 @@ prefixes:
     repo: "https://github.com/kubernetes-sigs/boskos"
     summarise: false
     consistentImages: true
-  - name: "Prow-Test-Images"
+  - name: "K8s-Test-Images"
     prefix: "gcr.io/k8s-testimages/"
     repo: "https://github.com/kubernetes/test-infra"
     summarise: false

--- a/experiment/autobumper/README.md
+++ b/experiment/autobumper/README.md
@@ -51,6 +51,7 @@ We need to fulfil those requirements to use this tool:
 	* extraFiles: The extra non-yaml file to be considered in this bump.
 	* targetVersion: The target version to bump images version to, which can be one of latest, upstream, upstream-staging and vYYYYMMDD-deadbeef.
 	* remoteName: The name used in the address when creating remote. Format will be git@github.com:{GitLogin}/{RemoteName}.git
+	* headBranchName: The name of the branch that will be used when creating the pull request. If unset, defaults to "autobump".
 	* prefixes: List of prefixes that the autobumped is looking for, and other information needed to bump them. The Fields for the Prefix are as follows:
         * name: Name of the tool being bumped
 	    * prefix: The image prefix that the autobumper should look for

--- a/experiment/autobumper/bumper/bumper_test.go
+++ b/experiment/autobumper/bumper/bumper_test.go
@@ -876,9 +876,9 @@ func TestGetVersionsAndCheckConsistency(t *testing.T) {
 }
 
 func TestMakeCommitSummary(t *testing.T) {
-	prowPrefix := Prefix{Prefix: "gcr.io/k8s-prow/", ConsistentImages: true}
-	boskosPrefix := Prefix{Prefix: "gcr.io/k8s-boskos/", ConsistentImages: true}
-	inconsistentPrefix := Prefix{Prefix: "gcr.io/inconsistent/", ConsistentImages: false}
+	prowPrefix := Prefix{Name: "Prow", Prefix: "gcr.io/k8s-prow/", ConsistentImages: true}
+	boskosPrefix := Prefix{Name: "Boskos", Prefix: "gcr.io/k8s-boskos/", ConsistentImages: true}
+	inconsistentPrefix := Prefix{Name: "Inconsistent", Prefix: "gcr.io/inconsistent/", ConsistentImages: false}
 	testCases := []struct {
 		name           string
 		prefixes       []Prefix
@@ -890,25 +890,25 @@ func TestMakeCommitSummary(t *testing.T) {
 			name:           "Two prefixes, but only one bumped",
 			prefixes:       []Prefix{prowPrefix, boskosPrefix},
 			versions:       map[string][]string{"tag1": {"gcr.io/k8s-prow/test:tag1"}},
-			expectedResult: "Update gcr.io/k8s-prow/ to tag1,",
+			expectedResult: "Update Prow to tag1",
 		},
 		{
 			name:           "Two prefixes, both bumped",
 			prefixes:       []Prefix{prowPrefix, boskosPrefix},
 			versions:       map[string][]string{"tag1": {"gcr.io/k8s-prow/test:tag1"}, "tag2": {"gcr.io/k8s-boskos/test:tag2"}},
-			expectedResult: "Update gcr.io/k8s-prow/ to tag1, gcr.io/k8s-boskos/ to tag2,",
+			expectedResult: "Update Prow to tag1, Boskos to tag2",
 		},
 		{
 			name:           "Empty versions",
 			prefixes:       []Prefix{prowPrefix, boskosPrefix},
 			versions:       map[string][]string{},
-			expectedResult: "Update gcr.io/k8s-prow/, gcr.io/k8s-boskos/ images as necessary",
+			expectedResult: "Update Prow, Boskos images as necessary",
 		},
 		{
 			name:           "One bumped inconsistently",
 			prefixes:       []Prefix{prowPrefix, boskosPrefix, inconsistentPrefix},
 			versions:       map[string][]string{"tag1": {"gcr.io/k8s-prow/test:tag1"}, "tag2": {"gcr.io/k8s-boskos/test:tag2"}, "tag3": {"gcr.io/inconsistnet/test:tag2"}},
-			expectedResult: "Update gcr.io/k8s-prow/ to tag1, gcr.io/k8s-boskos/ to tag2, and gcr.io/inconsistent/,  as needed",
+			expectedResult: "Update Prow to tag1, Boskos to tag2 and Inconsistent as needed",
 		},
 	}
 	for _, tc := range testCases {

--- a/robots/pr-creator/updater/updater.go
+++ b/robots/pr-creator/updater/updater.go
@@ -43,18 +43,14 @@ type ensureClient interface {
 	GetIssue(org, repo string, number int) (*github.Issue, error)
 }
 
-func UpdatePR(org, repo, title, body, matchTitle string, gc updateClient) (*int, error) {
-	if matchTitle == "" {
-		return nil, nil
-	}
-
+func UpdatePR(org, repo, title, body, headBranch string, gc updateClient) (*int, error) {
 	logrus.Info("Looking for a PR to reuse...")
 	me, err := gc.BotUser()
 	if err != nil {
 		return nil, fmt.Errorf("bot name: %v", err)
 	}
 
-	issues, err := gc.FindIssues("is:open is:pr archived:false in:title repo:"+org+"/"+repo+" author:"+me.Login+" "+matchTitle, "updated", false)
+	issues, err := gc.FindIssues("is:open is:pr archived:false repo:"+org+"/"+repo+" author:"+me.Login+" head:"+headBranch, "updated", false)
 	if err != nil {
 		return nil, fmt.Errorf("find issues: %v", err)
 	} else if len(issues) == 0 {
@@ -73,17 +69,17 @@ func UpdatePR(org, repo, title, body, matchTitle string, gc updateClient) (*int,
 	return &n, nil
 }
 
-func EnsurePR(org, repo, title, body, source, branch, matchTitle string, allowMods bool, gc ensureClient) (*int, error) {
-	return EnsurePRWithLabels(org, repo, title, body, source, branch, matchTitle, allowMods, gc, nil)
+func EnsurePR(org, repo, title, body, source, branch, headBranch string, allowMods bool, gc ensureClient) (*int, error) {
+	return EnsurePRWithLabels(org, repo, title, body, source, branch, headBranch, allowMods, gc, nil)
 }
 
-func EnsurePRWithLabels(org, repo, title, body, source, branch, matchTitle string, allowMods bool, gc ensureClient, labels []string) (*int, error) {
-	n, err := UpdatePR(org, repo, title, body, matchTitle, gc)
+func EnsurePRWithLabels(org, repo, title, body, source, baseBranch, headBranch string, allowMods bool, gc ensureClient, labels []string) (*int, error) {
+	n, err := UpdatePR(org, repo, title, body, headBranch, gc)
 	if err != nil {
 		return nil, fmt.Errorf("update error: %v", err)
 	}
 	if n == nil {
-		pr, err := gc.CreatePullRequest(org, repo, title, body, source, branch, allowMods)
+		pr, err := gc.CreatePullRequest(org, repo, title, body, source, baseBranch, allowMods)
 		if err != nil {
 			return nil, fmt.Errorf("create error: %v", err)
 		}


### PR DESCRIPTION
In order to use the autobumper to bump different parts of the same repo (canary and prod in testgrid) we need the autobumper to be able to create two pull requests that do not attempt to override one another. Changing the autobumper to match PRs using branch rather than name will allow this functionality as well as be less flaky. 