### PR TITLE
resource request for network policy job

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -634,6 +634,9 @@ periodics:
       - --extract=ci/latest
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20201225-59e70a3-master
+      resources:
+        requests:
+          memory: "6Gi"
   annotations:
     testgrid-dashboards: sig-network-gce
     testgrid-tab-name: network-policies, google-gce


### PR DESCRIPTION
the periodic job that test network policies is not stable, random
test fail but we couldn't observe any pattern.

Some of the test fail because the endpoints are not ready, to discard
first that we have a possible problem with resources constraints, we
allocate memory to the nodes, matching the current presubmit job.