### PR TITLE
skip cloud provider tests for network policies

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -46,8 +46,8 @@ presubmits:
         - --gcp-zone=us-west1-b
         - --provider=gce
         # Skipping snat tests probably GCE related? https://github.com/kubernetes/test-infra/issues/20321
-        # Skipping lb tests for speed
-        - --test_args=--ginkgo.focus=\[sig-network\]|\[Conformance\]|\[Feature:NetworkPolicy\] --ginkgo.skip=\[Feature:(Networking-IPv6|Example|Federation|PerformanceDNS)\]|DualStack|GCE|SCTP|Disruptive|Serial|SNAT|LB.health.check|LoadBalancer|load.balancer
+        # Skipping Cloud Provider specific tests: LoadBalancer, ESIPP (Source IP Preservation)
+        - --test_args=--ginkgo.focus=\[sig-network\]|\[Conformance\]|\[Feature:NetworkPolicy\] --ginkgo.skip=\[Feature:(Networking-IPv6|Example|Federation|PerformanceDNS)\]|DualStack|GCE|SCTP|Disruptive|Serial|SNAT|LB.health.check|LoadBalancer|load.balancer|ESIPP
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-ubuntu-gce-network-policies
         - --ginkgo-parallel=30
         - --timeout=50m
@@ -629,8 +629,8 @@ periodics:
       - --gcp-zone=us-west1-b
       - --provider=gce
       # Skipping snat tests probably GCE related? https://github.com/kubernetes/test-infra/issues/20321
-      # Skipping lb tests for speed
-      - --test_args=--ginkgo.focus=\[sig-network\]|\[Conformance\]|\[Feature:NetworkPolicy\] --ginkgo.skip=\[Feature:(Networking-IPv6|Example|Federation|PerformanceDNS)\]|DualStack|GCE|SCTP|Disruptive|Serial|SNAT|LB.health.check|LoadBalancer|load.balancer
+      # Skipping Cloud Provider specific tests: LoadBalancer, ESIPP (Source IP Preservation)
+      - --test_args=--ginkgo.focus=\[sig-network\]|\[Conformance\]|\[Feature:NetworkPolicy\] --ginkgo.skip=\[Feature:(Networking-IPv6|Example|Federation|PerformanceDNS)\]|DualStack|GCE|SCTP|Disruptive|Serial|SNAT|LB.health.check|LoadBalancer|load.balancer|ESIPP
       - --extract=ci/latest
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master


### PR DESCRIPTION
There are several tests that depend on the Cloud Provider, we must
skip those tests when testing general features, because those
should be owned by the specific Cloud Provider.

This is needed because of:

 - the test failure can be related to the Cloud Provider infra, and that
will be not possible to debug for the Kubernetes community.

 - the features are not standard, so we can extrapolate that what works
   in A will work in B.