### PR TITLE
GHProxy: Manage cache metrics for v4 api

### DIFF
--- a/ghproxy/ghcache/coalesce.go
+++ b/ghproxy/ghcache/coalesce.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -59,7 +60,17 @@ type responseWaiter struct {
 func (r *requestCoalescer) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Only coalesce GET requests
 	if req.Method != http.MethodGet {
-		return r.delegate.RoundTrip(req)
+		resp, err := r.delegate.RoundTrip(req)
+		if strings.HasPrefix(req.URL.Path, "graphql") || strings.HasPrefix(req.URL.Path, "/graphql") {
+			var tokenBudgetName string
+			if val := req.Header.Get(TokenBudgetIdentifierHeader); val != "" {
+				tokenBudgetName = val
+			} else {
+				tokenBudgetName = r.hasher.Hash(req)
+			}
+			collectMetrics(ModeNoStore, req, resp, tokenBudgetName)
+		}
+		return resp, err
 	}
 
 	var cacheMode = ModeError
@@ -140,6 +151,11 @@ func (r *requestCoalescer) RoundTrip(req *http.Request) (*http.Response, error) 
 		tokenBudgetName = r.hasher.Hash(req)
 	}
 
+	collectMetrics(cacheMode, req, resp, tokenBudgetName)
+	return resp, err
+}
+
+func collectMetrics(cacheMode CacheResponseMode, req *http.Request, resp *http.Response, tokenBudgetName string) {
 	ghmetrics.CollectCacheRequestMetrics(string(cacheMode), req.URL.Path, req.Header.Get("User-Agent"), tokenBudgetName)
 	if resp != nil {
 		resp.Header.Set(CacheModeHeader, string(cacheMode))
@@ -148,9 +164,8 @@ func (r *requestCoalescer) RoundTrip(req *http.Request) (*http.Response, error) 
 			if err != nil {
 				logrus.WithError(err).WithField("header-value", resp.Header.Get(cacheEntryCreationDateHeader)).Warn("Failed to convert cacheEntryCreationDateHeader value to int")
 			} else {
-				ghmetrics.CollectCacheEntryAgeMetrics(float64(time.Now().Unix()-int64(intVal)), req.URL.Path, req.Header.Get("User-Agent"), r.hasher.Hash(req))
+				ghmetrics.CollectCacheEntryAgeMetrics(float64(time.Now().Unix()-int64(intVal)), req.URL.Path, req.Header.Get("User-Agent"), tokenBudgetName)
 			}
 		}
 	}
-	return resp, err
 }


### PR DESCRIPTION
The cache metrics are the only way to figure out token consumption by
user agent. This change makes ghproxy track them for the V4 api as well,
using a hardcoded NoStore mode, as those calls are not cacheable.