### PR TITLE
Change image pull policy: Always -> IfNotPresent

### DIFF
--- a/config/jobs/kubernetes/sig-instrumentation/verify-govet-levee.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/verify-govet-levee.yaml
@@ -17,7 +17,7 @@ presubmits:
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20201225-59e70a3-master
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command:
         - make
         args:


### PR DESCRIPTION
This change was prompted by a comment from @BenTheElder on #20164.

Since the image isn't using a mutable tag, `imagePullPolicy: Always` is not necessary.