### PR TITLE
Update env file to reflect the changes in the containerd release

### DIFF
--- a/jobs/e2e_node/containerd/containerd-master/env
+++ b/jobs/e2e_node/containerd/containerd-master/env
@@ -1,7 +1,7 @@
 CONTAINERD_TEST: 'true'
 CONTAINERD_LOG_LEVEL: 'debug'
-CONTAINERD_DEPLOY_PATH: 'cri-containerd-staging/containerd'
-CONTAINERD_PKG_PREFIX: 'containerd-cni'
+CONTAINERD_DEPLOY_PATH: 'cri-containerd-staging'
+CONTAINERD_PKG_PREFIX: 'cri-containerd-cni'
 
 CONTAINERD_EXTRA_RUNTIME_HANDLER: 'test-handler'
 CONTAINERD_EXTRA_RUNTIME_OPTIONS: |


### PR DESCRIPTION
fixes issue https://github.com/kubernetes/test-infra/issues/20374

containerd binaries were not downloaded during to the changes in the containerd release job changes. 

Updated the env variables as per the changes for now.