### PR TITLE
use bazel:latest-kubernetse-master in repo-infra

### DIFF
--- a/config/jobs/kubernetes/repo-infra/repo-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/repo-infra/repo-infra-presubmits.yaml
@@ -9,9 +9,10 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: launcher.gcr.io/google/bazel:2.2.0
+      - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:latest-kubernetes-master
         command:
         - ./presubmit.sh
+        imagePullPolicy: Always
     annotations:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: repo-infra


### PR DESCRIPTION
It's desirable to keep repo-infra in sync with k/k bazel-test. This
avoids some future toil next time we do a version bump.

This unbreaks https://github.com/kubernetes/repo-infra/pull/217