### PR TITLE
Trigger: Retry ProwJob creation

### DIFF
--- a/prow/plugins/trigger/BUILD.bazel
+++ b/prow/plugins/trigger/BUILD.bazel
@@ -26,7 +26,6 @@ go_test(
         "//prow/labels:go_default_library",
         "//prow/pjutil:go_default_library",
         "//prow/plugins:go_default_library",
-        "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/api/equality:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
@@ -63,6 +62,7 @@ go_library(
         "@io_k8s_apimachinery//pkg/labels:go_default_library",
         "@io_k8s_apimachinery//pkg/util/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/wait:go_default_library",
     ],
 )
 

--- a/prow/plugins/trigger/push.go
+++ b/prow/plugins/trigger/push.go
@@ -19,8 +19,6 @@ package trigger
 import (
 	"context"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
@@ -88,7 +86,7 @@ func handlePE(c Client, pe github.PushEvent) error {
 		labels[github.EventGUID] = pe.GUID
 		pj := pjutil.NewProwJob(pjutil.PostsubmitSpec(j, refs), labels, j.Annotations)
 		c.Logger.WithFields(pjutil.ProwJobFields(&pj)).Info("Creating a new prowjob.")
-		if _, err := c.ProwJobClient.Create(context.TODO(), &pj, metav1.CreateOptions{}); err != nil {
+		if err := createWithRetry(context.TODO(), c.ProwJobClient, &pj); err != nil {
 			return err
 		}
 	}

--- a/prow/plugins/trigger/trigger_test.go
+++ b/prow/plugins/trigger/trigger_test.go
@@ -18,10 +18,12 @@ package trigger
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -520,6 +522,65 @@ func TestGetPostsubmits(t *testing.T) {
 
 			if !tc.expectedPostsubmits.Equal(actualPostsubmits) {
 				t.Errorf("got a different set of postsubmits than expected, diff: %v", tc.expectedPostsubmits.Difference(actualPostsubmits))
+			}
+		})
+	}
+}
+
+func TestCreateWithRetry(t *testing.T) {
+	testCases := []struct {
+		name            string
+		numFailedCreate int
+		expectedErrMsg  string
+	}{
+		{
+			name: "Initial success",
+		},
+		{
+			name:            "Success after retry",
+			numFailedCreate: 7,
+		},
+		{
+			name:            "Failure",
+			numFailedCreate: 8,
+			expectedErrMsg:  "need retrying",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+
+			fakeProwJobClient := fake.NewSimpleClientset()
+			fakeProwJobClient.PrependReactor("*", "*", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+				if _, ok := action.(clienttesting.CreateActionImpl); ok && tc.numFailedCreate > 0 {
+					tc.numFailedCreate--
+					return true, nil, errors.New("need retrying")
+				}
+				return false, nil, nil
+			})
+
+			pj := &prowapi.ProwJob{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
+
+			var errMsg string
+			err := createWithRetry(context.TODO(), fakeProwJobClient.ProwV1().ProwJobs(""), pj, time.Nanosecond)
+			if err != nil {
+				errMsg = err.Error()
+			}
+			if errMsg != tc.expectedErrMsg {
+				t.Fatalf("expected error %s, got error %v", tc.expectedErrMsg, err)
+			}
+			if err != nil {
+				return
+			}
+
+			result, err := fakeProwJobClient.ProwV1().ProwJobs("").List(context.Background(), metav1.ListOptions{})
+			if err != nil {
+				t.Fatalf("faile to list prowjobs: %v", err)
+			}
+
+			if len(result.Items) != 1 {
+				t.Errorf("expected to find exactly one prowjob, got %+v", result.Items)
 			}
 		})
 	}


### PR DESCRIPTION
Triggers Prowjob creation is entriely eventbased and if it encounters a
transient error, the user has to manually issue a /retest or /test
jobame to recover from that situation. This change makes us retry with
an exponential backoff instead.