### PR TITLE
Add a metric for client creation failures

### DIFF
--- a/prow/flagutil/BUILD.bazel
+++ b/prow/flagutil/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//prow/jira:go_default_library",
         "//prow/kube:go_default_library",
         "@com_github_dgrijalva_jwt_go_v4//:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@in_gopkg_fsnotify_v1//:go_default_library",
         "@io_k8s_apimachinery//pkg/util/errors:go_default_library",


### PR DESCRIPTION
Plank and Sinker gracefuly handle client creation failures and just emit
an error. If this was a transient issue, a couple of hours might pass
until someone notices that error in the log.

This change adds a metric, so its possible to alert on this.