### PR TITLE
Skip presubmits for gh-pages branch in fsx, efs csi repos

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-efs-csi-driver/aws-efs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-efs-csi-driver/aws-efs-csi-driver-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   - name: pull-aws-efs-csi-driver-verify
     always_run: true
     decorate: true
+    skip_branches:
+    - gh-pages
     labels:
       preset-service-account: "true"
     spec:
@@ -21,6 +23,8 @@ presubmits:
   - name: pull-aws-efs-csi-driver-unit
     always_run: true
     decorate: true
+    skip_branches:
+    - gh-pages
     labels:
       preset-service-account: "true"
     spec:
@@ -39,6 +43,8 @@ presubmits:
   - name: pull-aws-efs-csi-driver-e2e
     always_run: true
     decorate: true
+    skip_branches:
+    - gh-pages
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/aws-fsx-csi-driver/aws-fsx-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-fsx-csi-driver/aws-fsx-csi-driver-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   - name: pull-aws-fsx-csi-driver-verify
     always_run: true
     decorate: true
+    skip_branches:
+    - gh-pages
     labels:
       preset-service-account: "true"
     spec:
@@ -21,6 +23,8 @@ presubmits:
   - name: pull-aws-fsx-csi-driver-unit
     always_run: true
     decorate: true
+    skip_branches:
+    - gh-pages
     labels:
       preset-service-account: "true"
     spec:
@@ -39,6 +43,8 @@ presubmits:
   - name: pull-aws-fsx-csi-driver-e2e
     always_run: true
     decorate: true
+    skip_branches:
+    - gh-pages
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"


### PR DESCRIPTION
I marked the gh-pages branches unprotected in https://github.com/kubernetes/test-infra/pull/20323/files but there are still presubmits configured to run there, so branchprotector sees that as a conflict.

Fix by removing the presubmits from gh-pages branch, same as how it was done for ebs. https://github.com/kubernetes/test-infra/pull/20026

REF: https://prow.k8s.io/?job=ci-test-infra-branchprotector