### PR TITLE
Fix CAPI e2e-k8s-latest-main using env variables

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -180,6 +180,21 @@ presubmits:
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
+        env:
+          - name: BUILD_NODE_IMAGE_TAG
+            value: "ci/latest"
+          - name: KUBERNETES_VERSION
+            value: "ci/latest"
+          - name: KUBERNETES_VERSION_UPGRADE_FROM
+            value: "v1.20.0"
+          - name: KUBERNETES_VERSION_UPGRADE_TO
+            value: "ci/latest"
+          - name: ETCD_VERSION_UPGRADE_TO
+            value: "3.4.13-0"
+          - name: COREDNS_VERSION_UPGRADE_TO
+            value: "1.7.0"
+          - name: GINKGO_FOCUS
+            value: "\\[Periodic-K8SVersion\\]"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true


### PR DESCRIPTION
This PR fixes a temporary job created for testing https://github.com/kubernetes-sigs/cluster-api/pull/3916 by adding env variables.
If this works, then it will be easier to create all the permutations for the Kubernetes version in scope for the CAPI test matrix.

/cc @vincepri 