### PR TITLE
Add git to the image for the generic autobumper

### DIFF
--- a/experiment/autobumper/Dockerfile
+++ b/experiment/autobumper/Dockerfile
@@ -15,5 +15,7 @@
 FROM golang:1.13-alpine
 
 COPY generic_autobump /generic_autobump
+RUN apk add --no-cache ca-certificates && update-ca-certificates
+RUN apk add --no-cache git openssh
 
 ENTRYPOINT ["/generic_autobump"]


### PR DESCRIPTION
The autobumper uses git, and it is not available by default in the image, so it needs to be installed. 