### PR TITLE
capz: update to run Windows tests on PRs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -93,9 +93,10 @@ presubmits:
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-e2e-windows
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
-    optional: true
+    optional: false
     decorate: true
-    always_run: false
+    # please see: https://play.golang.org/p/JJSVylVPd53 for more insights
+    run_if_changed: (^[^d].*$)|(^d$)|(^.[^o].*$)|(^do$)|(^..[^c].*$)|(^doc$)|(^...[^s].*$)|(^docs$)|(^....[^/].*$)|(^[^d][^o][^c][^s]/.*$)
     max_concurrency: 5
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
The windows support merged: https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1036

The periodics started to run the windows tests: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-azure#periodic-capi-e2e-full

/cc @CecileRobertMichon @cpanato 