### PR TITLE
Kops - try increasing job retention to 30 days on a few jobs

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -34,6 +34,7 @@ periodics:
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-misc
+    testgrid-days-of-results: "30"
     testgrid-tab-name: kops-aws-channelalpha
 
 - interval: 1h
@@ -72,6 +73,7 @@ periodics:
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-misc
+    testgrid-days-of-results: "30"
     testgrid-tab-name: kops-aws-ha-euwest1
 
 - interval: 8h


### PR DESCRIPTION
Based on https://github.com/kubernetes/test-infra/pull/18408 we should be able to define the days of results at the job level.

if this works we can roll it out to the grid jobs as well.