### PR TITLE
Kops - increase retention on all grid jobs to 90 days

### DIFF
--- a/config/jobs/kubernetes/kops/build-grid.py
+++ b/config/jobs/kubernetes/kops/build-grid.py
@@ -351,6 +351,7 @@ def build_test(cloud='aws',
 
     annotations = {
         'testgrid-dashboards': ', '.join(dashboards),
+        'testgrid-days-of-results': '90',
         'testgrid-tab-name': tab,
     }
     for (k, v) in spec.items():

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -48,6 +48,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
@@ -97,6 +98,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
@@ -146,6 +148,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": null, "networking": null}
@@ -195,6 +198,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
@@ -244,6 +248,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
@@ -293,6 +298,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": null}
@@ -342,6 +348,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
@@ -391,6 +398,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_version": null, "networking": null}
@@ -440,6 +448,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": null}
@@ -489,6 +498,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
@@ -538,6 +548,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
@@ -587,6 +598,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": null, "networking": null}
@@ -636,6 +648,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
@@ -685,6 +698,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
@@ -734,6 +748,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": null}
@@ -783,6 +798,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
@@ -832,6 +848,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_version": null, "networking": null}
@@ -881,6 +898,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": null}
@@ -930,6 +948,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
@@ -979,6 +998,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
@@ -1028,6 +1048,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": null, "networking": null}
@@ -1077,6 +1098,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
@@ -1126,6 +1148,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
@@ -1175,6 +1198,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": null}
@@ -1224,6 +1248,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
@@ -1273,6 +1298,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_version": null, "networking": null}
@@ -1322,6 +1348,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": null}
@@ -1371,6 +1398,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
@@ -1420,6 +1448,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
@@ -1469,6 +1498,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": null, "networking": null}
@@ -1518,6 +1548,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
@@ -1567,6 +1598,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
@@ -1616,6 +1648,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": null}
@@ -1665,6 +1698,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
@@ -1714,6 +1748,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_version": null, "networking": null}
@@ -1763,6 +1798,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": null}
@@ -1812,6 +1848,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
@@ -1861,6 +1898,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
@@ -1910,6 +1948,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": null, "networking": null}
@@ -1959,6 +1998,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
@@ -2008,6 +2048,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
@@ -2057,6 +2098,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": null}
@@ -2106,6 +2148,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
@@ -2155,6 +2198,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_version": null, "networking": null}
@@ -2204,6 +2248,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": null}
@@ -2253,6 +2298,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
@@ -2302,6 +2348,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
@@ -2351,6 +2398,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": null, "networking": null}
@@ -2400,6 +2448,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
@@ -2449,6 +2498,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
@@ -2498,6 +2548,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": null}
@@ -2547,6 +2598,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
@@ -2596,6 +2648,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_version": null, "networking": null}
@@ -2645,6 +2698,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": null}
@@ -2694,6 +2748,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
@@ -2743,6 +2798,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
@@ -2792,6 +2848,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": null, "networking": null}
@@ -2841,6 +2898,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
@@ -2890,6 +2948,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
@@ -2939,6 +2998,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": null}
@@ -2988,6 +3048,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
@@ -3037,6 +3098,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_version": null, "networking": null}
@@ -3086,6 +3148,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": null}
@@ -3135,6 +3198,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
@@ -3184,6 +3248,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
@@ -3233,6 +3298,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": null, "networking": null}
@@ -3282,6 +3348,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
@@ -3331,6 +3398,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
@@ -3380,6 +3448,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": null}
@@ -3429,6 +3498,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
@@ -3478,6 +3548,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_version": null, "networking": null}
@@ -3527,6 +3598,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -3576,6 +3648,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
@@ -3625,6 +3698,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -3674,6 +3748,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -3723,6 +3798,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
@@ -3772,6 +3848,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -3821,6 +3898,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -3870,6 +3948,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -3919,6 +3998,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -3968,6 +4048,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -4017,6 +4098,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
@@ -4066,6 +4148,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -4115,6 +4198,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -4164,6 +4248,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
@@ -4213,6 +4298,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -4262,6 +4348,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -4311,6 +4398,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -4360,6 +4448,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -4409,6 +4498,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -4458,6 +4548,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
@@ -4507,6 +4598,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -4556,6 +4648,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -4605,6 +4698,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
@@ -4654,6 +4748,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -4703,6 +4798,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -4752,6 +4848,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -4801,6 +4898,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -4850,6 +4948,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -4899,6 +4998,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
@@ -4948,6 +5048,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -4997,6 +5098,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -5046,6 +5148,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
@@ -5095,6 +5198,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -5144,6 +5248,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -5193,6 +5298,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -5242,6 +5348,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -5291,6 +5398,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -5340,6 +5448,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
@@ -5389,6 +5498,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -5438,6 +5548,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -5487,6 +5598,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
@@ -5536,6 +5648,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -5585,6 +5698,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -5634,6 +5748,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -5683,6 +5798,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -5732,6 +5848,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -5781,6 +5898,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
@@ -5830,6 +5948,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -5879,6 +5998,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -5928,6 +6048,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
@@ -5977,6 +6098,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -6026,6 +6148,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -6075,6 +6198,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -6124,6 +6248,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -6173,6 +6298,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -6222,6 +6348,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
@@ -6271,6 +6398,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -6320,6 +6448,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -6369,6 +6498,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
@@ -6418,6 +6548,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -6467,6 +6598,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -6516,6 +6648,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -6565,6 +6698,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -6614,6 +6748,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -6663,6 +6798,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
@@ -6712,6 +6848,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -6761,6 +6898,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -6810,6 +6948,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
@@ -6859,6 +6998,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -6908,6 +7048,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -6957,6 +7098,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -7006,6 +7148,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -7055,6 +7198,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -7104,6 +7248,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
@@ -7153,6 +7298,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -7202,6 +7348,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -7251,6 +7398,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
@@ -7300,6 +7448,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -7349,6 +7498,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -7398,6 +7548,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -7447,6 +7598,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -7496,6 +7648,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -7545,6 +7698,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
@@ -7594,6 +7748,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -7643,6 +7798,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -7692,6 +7848,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
@@ -7741,6 +7898,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -7790,6 +7948,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -7839,6 +7998,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -7888,6 +8048,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -7937,6 +8098,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -7986,6 +8148,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
@@ -8035,6 +8198,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -8084,6 +8248,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -8133,6 +8298,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
@@ -8182,6 +8348,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -8231,6 +8398,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -8280,6 +8448,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -8329,6 +8498,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -8378,6 +8548,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -8427,6 +8598,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
@@ -8476,6 +8648,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -8525,6 +8698,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -8574,6 +8748,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
@@ -8623,6 +8798,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -8672,6 +8848,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -8721,6 +8898,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -8770,6 +8948,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -8819,6 +8998,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -8868,6 +9048,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
@@ -8917,6 +9098,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -8966,6 +9148,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -9015,6 +9198,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
@@ -9064,6 +9248,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -9113,6 +9298,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -9162,6 +9348,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -9211,6 +9398,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -9260,6 +9448,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -9309,6 +9498,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
@@ -9358,6 +9548,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -9407,6 +9598,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -9456,6 +9648,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
@@ -9505,6 +9698,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -9554,6 +9748,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -9603,6 +9798,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -9652,6 +9848,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -9701,6 +9898,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -9750,6 +9948,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
@@ -9799,6 +9998,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -9848,6 +10048,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -9897,6 +10098,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
@@ -9946,6 +10148,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -9995,6 +10198,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -10044,6 +10248,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -10093,6 +10298,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -10142,6 +10348,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -10191,6 +10398,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
@@ -10240,6 +10448,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -10289,6 +10498,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -10338,6 +10548,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
@@ -10387,6 +10598,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -10436,6 +10648,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -10485,6 +10698,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -10534,6 +10748,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -10583,6 +10798,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -10632,6 +10848,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
@@ -10681,6 +10898,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -10730,6 +10948,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -10779,6 +10998,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
@@ -10828,6 +11048,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -10877,6 +11098,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -10926,6 +11148,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -10975,6 +11198,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -11024,6 +11248,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -11073,6 +11298,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
@@ -11122,6 +11348,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -11171,6 +11398,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -11220,6 +11448,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
@@ -11269,6 +11498,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -11318,6 +11548,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -11367,6 +11598,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -11416,6 +11648,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -11465,6 +11698,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -11514,6 +11748,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
@@ -11563,6 +11798,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -11612,6 +11848,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -11661,6 +11898,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
@@ -11710,6 +11948,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -11759,6 +11998,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -11808,6 +12048,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -11857,6 +12098,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -11906,6 +12148,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -11955,6 +12198,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
@@ -12004,6 +12248,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -12053,6 +12298,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -12102,6 +12348,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
@@ -12151,6 +12398,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -12200,6 +12448,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -12249,6 +12498,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -12298,6 +12548,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -12347,6 +12598,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -12396,6 +12648,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
@@ -12445,6 +12698,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -12494,6 +12748,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -12543,6 +12798,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
@@ -12592,6 +12848,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -12641,6 +12898,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -12690,6 +12948,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -12739,6 +12998,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -12788,6 +13048,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -12837,6 +13098,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
@@ -12886,6 +13148,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -12935,6 +13198,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -12984,6 +13248,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
@@ -13033,6 +13298,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -13082,6 +13348,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -13131,6 +13398,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -13180,6 +13448,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -13229,6 +13498,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -13278,6 +13548,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
@@ -13327,6 +13598,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -13376,6 +13648,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -13425,6 +13698,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
@@ -13474,6 +13748,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -13523,6 +13798,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -13572,6 +13848,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -13621,6 +13898,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -13670,6 +13948,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -13719,6 +13998,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
@@ -13768,6 +14048,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -13817,6 +14098,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -13866,6 +14148,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
@@ -13915,6 +14198,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -13964,6 +14248,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -14013,6 +14298,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -14062,6 +14348,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -14111,6 +14398,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
@@ -14160,6 +14448,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
@@ -14209,6 +14498,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
@@ -14258,6 +14548,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
@@ -14307,6 +14598,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
@@ -14356,6 +14648,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
@@ -14405,6 +14698,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
@@ -14454,6 +14748,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
@@ -14503,6 +14798,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
@@ -14552,6 +14848,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
@@ -14601,6 +14898,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
@@ -14650,6 +14948,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
@@ -14699,6 +14998,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
@@ -14748,6 +15048,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
@@ -14797,6 +15098,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
@@ -14846,6 +15148,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
@@ -14895,6 +15198,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
@@ -14944,6 +15248,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
@@ -14993,6 +15298,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
@@ -15042,6 +15348,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
@@ -15091,6 +15398,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
@@ -15140,6 +15448,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
@@ -15189,6 +15498,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
@@ -15238,6 +15548,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
@@ -15287,6 +15598,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
@@ -15336,6 +15648,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
@@ -15385,6 +15698,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
@@ -15434,6 +15748,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
@@ -15483,6 +15798,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
@@ -15532,6 +15848,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
@@ -15581,6 +15898,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
@@ -15630,6 +15948,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
@@ -15679,6 +15998,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
@@ -15728,6 +16048,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
@@ -15777,6 +16098,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
@@ -15826,6 +16148,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
@@ -15875,6 +16198,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
@@ -15924,6 +16248,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
@@ -15973,6 +16298,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
@@ -16022,6 +16348,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
@@ -16071,6 +16398,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
@@ -16120,6 +16448,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
@@ -16169,6 +16498,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
@@ -16218,6 +16548,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
@@ -16267,6 +16598,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
@@ -16316,6 +16648,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
@@ -16365,6 +16698,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
@@ -16414,6 +16748,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
@@ -16463,6 +16798,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
@@ -16512,6 +16848,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
@@ -16561,6 +16898,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
@@ -16610,6 +16948,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
@@ -16659,6 +16998,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
@@ -16708,6 +17048,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
@@ -16757,6 +17098,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
@@ -16806,6 +17148,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
@@ -16855,6 +17198,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
@@ -16904,6 +17248,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
@@ -16953,6 +17298,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
@@ -17002,6 +17348,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
@@ -17051,6 +17398,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
@@ -17100,6 +17448,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
@@ -17149,6 +17498,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
@@ -17198,6 +17548,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k20-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
@@ -17247,6 +17598,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k17-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
@@ -17296,6 +17648,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
@@ -17345,6 +17698,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k17-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
@@ -17394,6 +17748,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
@@ -17443,6 +17798,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.18
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k18-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
@@ -17492,6 +17848,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k18-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
@@ -17541,6 +17898,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
@@ -17590,6 +17948,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k19-ko19-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
@@ -17639,6 +17998,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k20-docker
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -17688,6 +18048,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -17737,6 +18098,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -17786,6 +18148,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -17835,6 +18198,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -17884,6 +18248,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -17933,6 +18298,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -17982,6 +18348,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -18031,6 +18398,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -18080,6 +18448,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -18129,6 +18498,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -18178,6 +18548,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -18227,6 +18598,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -18276,6 +18648,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -18325,6 +18698,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -18374,6 +18748,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -18423,6 +18798,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -18472,6 +18848,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -18521,6 +18898,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -18570,6 +18948,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -18619,6 +18998,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -18668,6 +19048,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -18717,6 +19098,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -18766,6 +19148,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -18815,6 +19198,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -18864,6 +19248,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -18913,6 +19298,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -18962,6 +19348,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -19011,6 +19398,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -19060,6 +19448,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -19109,6 +19498,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -19158,6 +19548,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -19207,6 +19598,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -19256,6 +19648,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -19305,6 +19698,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -19354,6 +19748,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -19403,6 +19798,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -19452,6 +19848,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -19501,6 +19898,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -19550,6 +19948,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -19599,6 +19998,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -19648,6 +20048,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -19697,6 +20098,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -19746,6 +20148,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -19795,6 +20198,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -19844,6 +20248,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -19893,6 +20298,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -19942,6 +20348,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -19991,6 +20398,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -20040,6 +20448,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
@@ -20089,6 +20498,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
@@ -20138,6 +20548,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
@@ -20187,6 +20598,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
@@ -20236,6 +20648,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
@@ -20285,6 +20698,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
@@ -20334,6 +20748,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
@@ -20383,6 +20798,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -20432,6 +20848,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -20481,6 +20898,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -20530,6 +20948,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -20579,6 +20998,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -20628,6 +21048,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -20677,6 +21098,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -20726,6 +21148,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -20775,6 +21198,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -20824,6 +21248,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -20873,6 +21298,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -20922,6 +21348,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -20971,6 +21398,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -21020,6 +21448,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -21069,6 +21498,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -21118,6 +21548,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -21167,6 +21598,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -21216,6 +21648,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -21265,6 +21698,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -21314,6 +21748,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -21363,6 +21798,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -21412,6 +21848,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -21461,6 +21898,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -21510,6 +21948,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -21559,6 +21998,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -21608,6 +22048,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -21657,6 +22098,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -21706,6 +22148,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -21755,6 +22198,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -21804,6 +22248,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -21853,6 +22298,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -21902,6 +22348,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -21951,6 +22398,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -22000,6 +22448,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -22049,6 +22498,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -22098,6 +22548,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -22147,6 +22598,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -22196,6 +22648,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -22245,6 +22698,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -22294,6 +22748,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -22343,6 +22798,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -22392,6 +22848,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -22441,6 +22898,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -22490,6 +22948,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -22539,6 +22998,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -22588,6 +23048,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -22637,6 +23098,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -22686,6 +23148,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -22735,6 +23198,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -22784,6 +23248,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
@@ -22833,6 +23298,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
@@ -22882,6 +23348,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
@@ -22931,6 +23398,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
@@ -22980,6 +23448,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
@@ -23029,6 +23498,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
@@ -23078,6 +23548,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
@@ -23127,6 +23598,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -23176,6 +23648,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -23225,6 +23698,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -23274,6 +23748,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -23323,6 +23798,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -23372,6 +23848,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -23421,6 +23898,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -23470,6 +23948,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -23519,6 +23998,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -23568,6 +24048,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -23617,6 +24098,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -23666,6 +24148,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -23715,6 +24198,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -23764,6 +24248,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -23813,6 +24298,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -23862,6 +24348,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -23911,6 +24398,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -23960,6 +24448,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -24009,6 +24498,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -24058,6 +24548,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -24107,6 +24598,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -24156,6 +24648,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -24205,6 +24698,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -24254,6 +24748,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -24303,6 +24798,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -24352,6 +24848,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -24401,6 +24898,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -24450,6 +24948,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -24499,6 +24998,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -24548,6 +25048,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -24597,6 +25098,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -24646,6 +25148,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -24695,6 +25198,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -24744,6 +25248,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -24793,6 +25298,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -24842,6 +25348,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -24891,6 +25398,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -24940,6 +25448,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -24989,6 +25498,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -25038,6 +25548,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -25087,6 +25598,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -25136,6 +25648,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -25185,6 +25698,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -25234,6 +25748,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -25283,6 +25798,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -25332,6 +25848,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -25381,6 +25898,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -25430,6 +25948,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -25479,6 +25998,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -25528,6 +26048,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
@@ -25577,6 +26098,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k17-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
@@ -25626,6 +26148,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k17-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
@@ -25675,6 +26198,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
@@ -25724,6 +26248,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k18-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
@@ -25773,6 +26298,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
@@ -25822,6 +26348,7 @@ periodics:
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-1.19
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k19-ko19-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
@@ -25871,6 +26398,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.20, kops-latest
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k20-containerd
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--node-size=m6g.large --master-size=m6g.large --image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20201201", "k8s_version": null, "kops_version": null, "kops_zones": "us-east-2b", "networking": null}
@@ -25923,6 +26451,7 @@ periodics:
     test.kops.k8s.io/kops_zones: us-east-2b
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest, kops-latest, kops-misc
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-scenario-arm64
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--api-loadbalancer-type=public", "feature_flags": "UseServiceAccountIAM,PublicJWKS", "k8s_version": null, "kops_version": null, "networking": null}
@@ -25975,6 +26504,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest, kops-latest, kops-misc
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-scenario-public-jwks
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--override=cluster.spec.cloudControllerManager.cloudProvider=aws", "feature_flags": "EnableExternalCloudController,SpecOverrideFlag", "k8s_version": "1.19", "kops_version": null, "networking": null}
@@ -26027,6 +26557,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, kops-latest, sig-aws-cloud-provider-aws, kops-misc
+    testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-scenario-aws-cloud-controller-manager
 
 # 531 jobs, total of 945 runs per week


### PR DESCRIPTION
Almost all of these run weekly so we're going from 2 runs to 12 runs. 

followup to https://github.com/kubernetes/test-infra/pull/20399