### PR TITLE
Crier, Deck, Prow-CM, Tide: Restart on kubeconfig changes

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -375,6 +375,15 @@ func main() {
 			logrus.Fatal("Timed out waiting for cachesync")
 		}
 
+		// The watch apimachinery doesn't support restarts, so just exit the binary if a kubeconfig changes
+		// to make the kubelet restart us.
+		if err := o.kubernetes.AddKubeconfigChangeCallback(func() {
+			logrus.Info("Kubeconfig changed, exiting to trigger a restart")
+			interrupts.Terminate()
+		}); err != nil {
+			logrus.WithError(err).Fatal("Failed to register kubeconfig change callback")
+		}
+
 		pjListingClient = &pjListingClientWrapper{mgr.GetClient()}
 
 		// We use the GH client to resolve GH teams when determining who is permitted to rerun a job.

--- a/prow/cmd/prow-controller-manager/main.go
+++ b/prow/cmd/prow-controller-manager/main.go
@@ -164,6 +164,15 @@ func main() {
 		}
 	}
 
+	// The watch apimachinery doesn't support restarts, so just exit the binary if a kubeconfig changes
+	// to make the kubelet restart us.
+	if err := o.kubernetes.AddKubeconfigChangeCallback(func() {
+		logrus.Info("Kubeconfig changed, exiting to trigger a restart")
+		interrupts.Terminate()
+	}); err != nil {
+		logrus.WithError(err).Fatal("Failed to register kubeconfig change callback")
+	}
+
 	enabledControllersSet := sets.NewString(o.enabledControllers.Strings()...)
 
 	if enabledControllersSet.Has(plank.ControllerName) {


### PR DESCRIPTION
This change makes Crier, Deck, the Prow Controller Manager and Tide exit
on kubeconfig changes to make the Kubelet restart them in order to pick
up those changes.

The underlying funtionality was added and enabled in Sinker a couple of
weeks back in 3b2ff68d029fce94fd9c1fbd3651b6427db34219 and seems to be
working fine.