### PR TITLE
Add initial config for KubeVirt TestGrid

### DIFF
--- a/config/testgrids/kubevirt/OWNERS
+++ b/config/testgrids/kubevirt/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+- rmohr
+- dhiller
+- fgimenez
+approvers:
+- rmohr
+- dhiller
+- fgimenez

--- a/config/testgrids/kubevirt/OWNERS
+++ b/config/testgrids/kubevirt/OWNERS
@@ -1,8 +1,0 @@
-reviewers:
-- rmohr
-- dhiller
-- fgimenez
-approvers:
-- rmohr
-- dhiller
-- fgimenez

--- a/config/testgrids/kubevirt/gen-config.yaml
+++ b/config/testgrids/kubevirt/gen-config.yaml
@@ -1,0 +1,96 @@
+dashboard_groups:
+- dashboard_names:
+  - kubevirt-presubmits
+  name: kubevirt
+dashboards:
+- dashboard_tab:
+  - code_search_url_template:
+      url: https://github.com/kubevirt/project-infra/compare/<start-custom-0>...<end-custom-0>
+    name: pull-kubevirt-e2e-k8s-1.20
+    open_bug_template:
+      url: https://github.com/kubevirt/project-infra/issues/
+    test_group_name: pull-kubevirt-e2e-k8s-1.20
+  - code_search_url_template:
+      url: https://github.com/kubevirt/project-infra/compare/<start-custom-0>...<end-custom-0>
+    name: pull-kubevirt-e2e-k8s-1.19
+    open_bug_template:
+      url: https://github.com/kubevirt/project-infra/issues/
+    test_group_name: pull-kubevirt-e2e-k8s-1.19
+  - code_search_url_template:
+      url: https://github.com/kubevirt/project-infra/compare/<start-custom-0>...<end-custom-0>
+    name: pull-kubevirt-e2e-k8s-1.17
+    open_bug_template:
+      url: https://github.com/kubevirt/project-infra/issues/
+    test_group_name: pull-kubevirt-e2e-k8s-1.17
+  - code_search_url_template:
+      url: https://github.com/kubevirt/project-infra/compare/<start-custom-0>...<end-custom-0>
+    name: pull-kubevirt-e2e-k8s-cnao-1.19
+    open_bug_template:
+      url: https://github.com/kubevirt/project-infra/issues/
+    test_group_name: pull-kubevirt-e2e-k8s-cnao-1.19
+  - code_search_url_template:
+      url: https://github.com/kubevirt/project-infra/compare/<start-custom-0>...<end-custom-0>
+    name: pull-kubevirt-e2e-windows2016
+    open_bug_template:
+      url: https://github.com/kubevirt/project-infra/issues/
+    test_group_name: pull-kubevirt-e2e-windows2016
+  - code_search_url_template:
+      url: https://github.com/kubevirt/project-infra/compare/<start-custom-0>...<end-custom-0>
+    name: pull-kubevirt-e2e-kind-1.17-sriov
+    open_bug_template:
+      url: https://github.com/kubevirt/project-infra/issues/
+    test_group_name: pull-kubevirt-e2e-kind-1.17-sriov
+  - code_search_url_template:
+      url: https://github.com/kubevirt/project-infra/compare/<start-custom-0>...<end-custom-0>
+    name: pull-kubevirt-check-tests-for-flakes
+    open_bug_template:
+      url: https://github.com/kubevirt/project-infra/issues/
+    test_group_name: pull-kubevirt-check-tests-for-flakes
+  - code_search_url_template:
+      url: https://github.com/kubevirt/project-infra/compare/<start-custom-0>...<end-custom-0>
+    name: pull-kubevirt-e2e-k8s-1.17-rook-ceph
+    open_bug_template:
+      url: https://github.com/kubevirt/project-infra/issues/
+    test_group_name: pull-kubevirt-e2e-k8s-1.17-rook-ceph
+  - code_search_url_template:
+      url: https://github.com/kubevirt/project-infra/compare/<start-custom-0>...<end-custom-0>
+    name: pull-kubevirt-gosec
+    open_bug_template:
+      url: https://github.com/kubevirt/project-infra/issues/
+    test_group_name: pull-kubevirt-gosec
+  - code_search_url_template:
+      url: https://github.com/kubevirt/project-infra/compare/<start-custom-0>...<end-custom-0>
+    name: pull-kubevirt-unit-test
+    open_bug_template:
+      url: https://github.com/kubevirt/project-infra/issues/
+    test_group_name: pull-kubevirt-unit-test
+  - code_search_url_template:
+      url: https://github.com/kubevirt/project-infra/compare/<start-custom-0>...<end-custom-0>
+    name: pull-kubevirt-goveralls
+    open_bug_template:
+      url: https://github.com/kubevirt/project-infra/issues/
+    test_group_name: pull-kubevirt-goveralls
+  name: kubevirt-presubmits
+test_groups:
+- gcs_prefix: kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.20
+  name: pull-kubevirt-e2e-k8s-1.20
+- gcs_prefix: kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.19
+  name: pull-kubevirt-e2e-k8s-1.19
+- gcs_prefix: kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.17
+  name: pull-kubevirt-e2e-k8s-1.17
+- gcs_prefix: kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-cnao-1.19
+  name: pull-kubevirt-e2e-k8s-cnao-1.19
+- gcs_prefix: kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-windows2016
+  name: pull-kubevirt-e2e-windows2016
+- gcs_prefix: kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-kind-1.17-sriov
+  name: pull-kubevirt-e2e-kind-1.17-sriov
+- gcs_prefix: kubevirt-prow/pr-logs/directory/pull-kubevirt-check-tests-for-flakes
+  name: pull-kubevirt-check-tests-for-flakes
+- gcs_prefix: kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.17-rook-ceph
+  name: pull-kubevirt-e2e-k8s-1.17-rook-ceph
+- gcs_prefix: kubevirt-prow/pr-logs/directory/pull-kubevirt-gosec
+  name: pull-kubevirt-gosec
+- gcs_prefix: kubevirt-prow/pr-logs/directory/pull-kubevirt-unit-test
+  name: pull-kubevirt-unit-test
+- gcs_prefix: kubevirt-prow/pr-logs/directory/pull-kubevirt-goveralls
+  name: pull-kubevirt-goveralls

--- a/config/testgrids/kubevirt/gen-config.yaml
+++ b/config/testgrids/kubevirt/gen-config.yaml
@@ -18,6 +18,12 @@ dashboards:
     test_group_name: pull-kubevirt-e2e-k8s-1.19
   - code_search_url_template:
       url: https://github.com/kubevirt/project-infra/compare/<start-custom-0>...<end-custom-0>
+    name: pull-kubevirt-e2e-k8s-1.18
+    open_bug_template:
+      url: https://github.com/kubevirt/project-infra/issues/
+    test_group_name: pull-kubevirt-e2e-k8s-1.18
+  - code_search_url_template:
+      url: https://github.com/kubevirt/project-infra/compare/<start-custom-0>...<end-custom-0>
     name: pull-kubevirt-e2e-k8s-1.17
     open_bug_template:
       url: https://github.com/kubevirt/project-infra/issues/
@@ -76,6 +82,8 @@ test_groups:
   name: pull-kubevirt-e2e-k8s-1.20
 - gcs_prefix: kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.19
   name: pull-kubevirt-e2e-k8s-1.19
+- gcs_prefix: kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.18
+  name: pull-kubevirt-e2e-k8s-1.18
 - gcs_prefix: kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.17
   name: pull-kubevirt-e2e-k8s-1.17
 - gcs_prefix: kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-cnao-1.19

--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -53,6 +53,7 @@ var (
 		"gardener",
 		"jetstack",
 		"kyma",
+		"kubevirt",
 	}
 	orgs = []string{
 		"conformance",


### PR DESCRIPTION
We would like to add KubeVirt (https://github.com/kubevirt/, https://kubevirt.io) to TestGrid for better insights into our CI. This PR sets an initial KubeVirt dashboard and a few tabs, we'd like add more dashboards and jobs over time. The configuration on our side is proposed here kubevirt/project-infra#820

Thanks!

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>