### PR TITLE
Allow setting JobURLPRefix in the decoration config

### DIFF
--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -573,6 +573,9 @@ type GCSConfiguration struct {
 	// builtin's and the local system's defaults.  This maps extensions
 	// to media types, for example: MediaTypes["log"] = "text/plain"
 	MediaTypes map[string]string `json:"mediaTypes,omitempty"`
+	// JobURLPrefix holds the baseURL under which the jobs output can be viewed.
+	// If unset, this will be derived based on org/repo from the job_url_prefix_config.
+	JobURLPrefix string `json:"job_url_prefix,omitempty"`
 
 	// LocalOutputDir specifies a directory where files should be copied INSTEAD of uploading to blob storage.
 	// This option is useful for testing jobs that use the pod-utilities without actually uploading.
@@ -611,15 +614,16 @@ func (g *GCSConfiguration) ApplyDefault(def *GCSConfiguration) *GCSConfiguration
 		merged.DefaultRepo = def.DefaultRepo
 	}
 
-	if merged.MediaTypes == nil {
+	if merged.MediaTypes == nil && len(def.MediaTypes) > 0 {
 		merged.MediaTypes = map[string]string{}
 	}
 
 	for extension, mediaType := range def.MediaTypes {
 		merged.MediaTypes[extension] = mediaType
 	}
-	for extension, mediaType := range g.MediaTypes {
-		merged.MediaTypes[extension] = mediaType
+
+	if merged.JobURLPrefix == "" {
+		merged.JobURLPrefix = def.JobURLPrefix
 	}
 
 	if merged.LocalOutputDir == "" {

--- a/prow/apis/prowjobs/v1/types_test.go
+++ b/prow/apis/prowjobs/v1/types_test.go
@@ -216,7 +216,25 @@ func TestApplyDefaultsAppliesDefaultsForAllFields(t *testing.T) {
 			def := &DecorationConfig{}
 			fuzz.New().Fuzz(def)
 
-			defaulted := (&DecorationConfig{}).ApplyDefault(def)
+			// Each of those three has its own DeepCopy and in case it is nil,
+			// we just call that and return. In order to make this test verify
+			// that copying of their fields also works, we have to set them to
+			// something non-nil.
+			toDefault := &DecorationConfig{
+				UtilityImages:    &UtilityImages{},
+				Resources:        &Resources{},
+				GCSConfiguration: &GCSConfiguration{},
+			}
+			if def.UtilityImages == nil {
+				def.UtilityImages = &UtilityImages{}
+			}
+			if def.Resources == nil {
+				def.Resources = &Resources{}
+			}
+			if def.GCSConfiguration == nil {
+				def.GCSConfiguration = &GCSConfiguration{}
+			}
+			defaulted := toDefault.ApplyDefault(def)
 
 			if diff := cmp.Diff(def, defaulted); diff != "" {
 				t.Errorf("defaulted decoration config didn't get all fields defaulted: %s", diff)

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -506,23 +506,26 @@ func (p Plank) GetDefaultDecorationConfigs(repo string) *prowapi.DecorationConfi
 // (to allow using multiple storageProviders within a repo)
 // we always trim the suffix here. Thus, every caller can assume
 // the job url prefix does not have a storageProvider suffix.
-func (p Plank) GetJobURLPrefix(refs *prowapi.Refs) string {
-	jobURLPrefix := p.getJobURLPrefix(refs)
+func (p Plank) GetJobURLPrefix(pj *prowapi.ProwJob) string {
+	jobURLPrefix := p.getJobURLPrefix(pj)
 	if strings.HasSuffix(jobURLPrefix, "gcs/") {
 		return strings.TrimSuffix(jobURLPrefix, "gcs/")
 	}
 	return strings.TrimSuffix(jobURLPrefix, "gcs")
 }
 
-func (p Plank) getJobURLPrefix(refs *prowapi.Refs) string {
-	if refs == nil {
+func (p Plank) getJobURLPrefix(pj *prowapi.ProwJob) string {
+	if pj.Spec.DecorationConfig != nil && pj.Spec.DecorationConfig.GCSConfiguration != nil && pj.Spec.DecorationConfig.GCSConfiguration.JobURLPrefix != "" {
+		return pj.Spec.DecorationConfig.GCSConfiguration.JobURLPrefix
+	}
+	if pj.Spec.Refs == nil {
 		return p.JobURLPrefixConfig["*"]
 	}
-	if p.JobURLPrefixConfig[fmt.Sprintf("%s/%s", refs.Org, refs.Repo)] != "" {
-		return p.JobURLPrefixConfig[fmt.Sprintf("%s/%s", refs.Org, refs.Repo)]
+	if p.JobURLPrefixConfig[fmt.Sprintf("%s/%s", pj.Spec.Refs.Org, pj.Spec.Refs.Repo)] != "" {
+		return p.JobURLPrefixConfig[fmt.Sprintf("%s/%s", pj.Spec.Refs.Org, pj.Spec.Refs.Repo)]
 	}
-	if p.JobURLPrefixConfig[refs.Org] != "" {
-		return p.JobURLPrefixConfig[refs.Org]
+	if p.JobURLPrefixConfig[pj.Spec.Refs.Org] != "" {
+		return p.JobURLPrefixConfig[pj.Spec.Refs.Org]
 	}
 	return p.JobURLPrefixConfig["*"]
 }

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -495,6 +495,10 @@ plank:
                 # legacy or simple strategy
                 default_repo: ' '
 
+                # JobURLPrefix holds the baseURL under which the jobs output can be viewed.
+                # If unset, this will be derived based on org/repo from the job_url_prefix_config.
+                job_url_prefix: ' '
+
                 # LocalOutputDir specifies a directory where files should be copied INSTEAD of uploading to blob storage.
                 # This option is useful for testing jobs that use the pod-utilities without actually uploading.
                 local_output_dir: ' '

--- a/prow/crier/reporters/pubsub/reporter.go
+++ b/prow/crier/reporters/pubsub/reporter.go
@@ -146,7 +146,7 @@ func (c *Client) generateMessageFromPJ(pj *prowapi.ProwJob) *ReportMessage {
 		// * pj.Status.URL: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-benchmark-microbenchmarks/1258197944759226371
 		// * prefix: https://prow.k8s.io/view/
 		// * storageURLPath: gs/kubernetes-jenkins/logs/ci-benchmark-microbenchmarks/1258197944759226371
-		prefix := c.config().Plank.GetJobURLPrefix(pj.Spec.Refs)
+		prefix := c.config().Plank.GetJobURLPrefix(pj)
 
 		storageURLPath := strings.TrimPrefix(pj.Status.URL, prefix)
 		if strings.HasPrefix(storageURLPath, api.GCSKeyType) {

--- a/prow/pjutil/pjutil.go
+++ b/prow/pjutil/pjutil.go
@@ -272,12 +272,12 @@ func ProwJobFields(pj *prowapi.ProwJob) logrus.Fields {
 //
 // TODO(fejta): consider moving default JobURLTemplate and JobURLPrefix out of plank
 func JobURL(plank config.Plank, pj prowapi.ProwJob, log *logrus.Entry) (string, error) {
-	if pj.Spec.DecorationConfig != nil && plank.GetJobURLPrefix(pj.Spec.Refs) != "" {
+	if pj.Spec.DecorationConfig != nil && plank.GetJobURLPrefix(&pj) != "" {
 		spec := downwardapi.NewJobSpec(pj.Spec, pj.Status.BuildID, pj.Name)
 		gcsConfig := pj.Spec.DecorationConfig.GCSConfiguration
 		_, gcsPath, _ := gcsupload.PathsForJob(gcsConfig, &spec, "")
 
-		prefix, _ := url.Parse(plank.GetJobURLPrefix(pj.Spec.Refs))
+		prefix, _ := url.Parse(plank.GetJobURLPrefix(&pj))
 
 		prowPath, err := prowapi.ParsePath(gcsConfig.Bucket)
 		if err != nil {

--- a/prow/spyglass/lenses/common/common.go
+++ b/prow/spyglass/lenses/common/common.go
@@ -253,7 +253,7 @@ func ProwToGCS(fetcher ProwJobFetcher, config config.Getter, prowKey string) (st
 	}
 
 	url := job.Status.URL
-	prefix := config().Plank.GetJobURLPrefix(job.Spec.Refs)
+	prefix := config().Plank.GetJobURLPrefix(&job)
 	if !strings.HasPrefix(url, prefix) {
 		return "", "", fmt.Errorf("unexpected job URL %q when finding GCS path: expected something starting with %q", url, prefix)
 	}


### PR DESCRIPTION
Currently, the job_url_prefix can only be configured via org/repo. This
is not ideal, because in reality it mostly depends on the bucket which
can be overriden on job level. With this change, it is possible to also
override the job_url_prefix on that same level.