### PR TITLE
Remove gh-pages branch protection for ingress-nginx

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -233,6 +233,10 @@ branch-protection:
           restrictions: # only allow admins
             users: []
             teams: []
+        ingress-nginx:
+          branches:
+            gh-pages:
+              protect: false
         kompose:
           required_status_checks:
             contexts:


### PR DESCRIPTION
So far unsuccessful approach:
- https://github.com/kubernetes/test-infra/pull/20291
- https://github.com/kubernetes/test-infra/pull/20322

This seems to be the successful approach:
- https://github.com/kubernetes/test-infra/pull/20326
- https://github.com/kubernetes/test-infra/pull/20157
- https://github.com/kubernetes/test-infra/pull/20323
- https://github.com/kubernetes/test-infra/pull/19770

CC @aledbf 