### PR TITLE
Remove gh-pages branch protection for kube-state-metrics

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -282,14 +282,7 @@ branch-protection:
             - ci-validate-manifests
           branches:
             gh-pages:
-              required_status_checks:
-                contexts: []
-              restrictions:
-                users:
-                - k8s-ci-robot
-                teams:
-                - kube-state-metrics-admins
-                - kube-state-metrics-maintainers
+              protect: false
         kube-scheduler:
           restrictions:
             users: []


### PR DESCRIPTION
For rationale, see https://github.com/kubernetes/test-infra/pull/20425

Follow up to:
- #20291
- #20322