### PR TITLE
add post image build job for nfs-subdir-external-provisioner

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-sig-storage.sh
+++ b/config/jobs/image-pushing/k8s-staging-sig-storage.sh
@@ -32,6 +32,7 @@ readonly REPOS=(
     kubernetes-csi/csi-driver-nfs
     kubernetes-sigs/sig-storage-local-static-provisioner
     kubernetes-sigs/nfs-ganesha-server-and-external-provisioner
+    kubernetes-sigs/nfs-subdir-external-provisioner
 )
 
 # Repos which should eventually enable cloud image builds but currently

--- a/config/jobs/image-pushing/k8s-staging-sig-storage.yaml
+++ b/config/jobs/image-pushing/k8s-staging-sig-storage.yaml
@@ -378,6 +378,35 @@ postsubmits:
               - --scratch-bucket=gs://k8s-staging-sig-storage-gcb
               - --env-passthrough=PULL_BASE_REF
               - .
+  kubernetes-sigs/nfs-subdir-external-provisioner:
+    - name: post-nfs-subdir-external-provisioner-push-images
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-storage-image-build
+      decorate: true
+      branches:
+        # For publishing canary images.
+        - ^master$
+        - ^release-
+        # For publishing tagged images. Those will only get built once, i.e.
+        # existing images are not getting overwritten. A new tag must be set to
+        # trigger another image build. Images are only built for tags that follow
+        # the semver format (regex from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string).
+        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200901-ab141a0
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR
+              # images are pushed to.
+              - --project=k8s-staging-sig-storage
+              # This is the same as above, but with -gcb appended.
+              - --scratch-bucket=gs://k8s-staging-sig-storage-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - .
   kubernetes-csi/csi-driver-iscsi:
     - name: post-csi-driver-iscsi-push-images
       cluster: k8s-infra-prow-build-trusted
@@ -917,6 +946,37 @@ periodics:
     # the cloud image build.
     - org: kubernetes-csi
       repo: nfs-ganesha-server-and-external-provisioner
+      base_ref: master
+  spec:
+    serviceAccountName: gcb-builder
+    containers:
+      - image: gcr.io/k8s-testimages/image-builder:v20200901-ab141a0
+        command:
+          - /run.sh
+        env:
+        # We need to emulate a pull job for the cloud build to work the same
+        # way as it usually does.
+        - name: PULL_BASE_REF
+          value: master
+        args:
+          # this is the project GCB will run in, which is the same as the GCR
+          # images are pushed to.
+          - --project=k8s-staging-sig-storage
+          # This is the same as above, but with -gcb appended.
+          - --scratch-bucket=gs://k8s-staging-sig-storage-gcb
+          - --env-passthrough=PULL_BASE_REF
+          - .
+- name: canary-nfs-subdir-external-provisioner-push-images
+  cluster: k8s-infra-prow-build-trusted
+  annotations:
+    testgrid-dashboards: sig-storage-image-build
+  decorate: true
+  interval: 168h # one week
+  extra_refs:
+    # This also becomes the current directory for run.sh and thus
+    # the cloud image build.
+    - org: kubernetes-csi
+      repo: nfs-subdir-external-provisioner
       base_ref: master
   spec:
     serviceAccountName: gcb-builder


### PR DESCRIPTION
The required tools are added to the repo.
https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/pull/29

cc: @msau42 @pohly 

Signed-off-by: kmova <kiran.mova@mayadata.io>