### PR TITLE
Switch some ARM64 tests to release/stable

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -98,7 +98,7 @@ periodics:
       - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
       - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/latest
+      - --extract=release/stable
       - --ginkgo-parallel
       - --kops-args=--node-size=m6g.large --master-size=m6g.large --container-runtime=containerd --networking=calico
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20210106
@@ -172,7 +172,7 @@ periodics:
       - --env=KUBE_SSH_USER=ubuntu
       - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release-dev/ci/latest.txt
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=ci/latest
+      - --extract=release/stable
       - --ginkgo-parallel=10
       - --kops-args=--node-size=m6g.large --master-size=m6g.large --container-runtime=containerd --networking=calico
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20210106


### PR DESCRIPTION
There are some issues with latest `kube-proxy` images and they cannot be sideloaded by containerd:
```sh
$ sudo sudo ctr --namespace k8s.io images import kube-proxy.tar 
unpacking k8s.gcr.io/kube-proxy-arm64:v1.21.0-alpha.0 (sha256:35f0306381902d2e975381156d5b40c1d3d5ec9e46d0d8d63ebfd80eec504c3d)...
INFO[0001] apply failure, attempting cleanup
error="failed to extract layer sha256:d5a2ecb5a20a31e40381ee93a91796df4ef8063c5892cdfc6c1e5d9847f88994: failed to get reader from content store:
content digest sha256:d5a2ecb5a20a31e40381ee93a91796df4ef8063c5892cdfc6c1e5d9847f88994: not found" key="extract-491554514-y3iz sha256:8e12d8c9c205e8576e1e9648ac1fb6c0e85f9af2524dfdd2563829d0e0340567"
```

/cc @rifelpet @olemarkus 