### PR TITLE
Add external e2e k8s test in CI pipeline and enhance kubetest to run the same

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -540,3 +540,62 @@ presubmits:
       testgrid-tab-name: pr-in-tree-azure-disk-e2e-windows
       description: "Run Azure Disk e2e test on a Windows cluster with Azure Disk in-tree volume plugin."
       testgrid-num-columns-recent: '30'
+  - name: pull-azuredisk-csi-driver-external-e2e-single-az
+    decorate: true
+    always_run: false
+    path_alias: sigs.k8s.io/azuredisk-csi-driver
+    branches:
+    - master
+    labels:
+      preset-service-account: "true"
+      preset-azure-cred: "true"
+      preset-dind-enabled: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201225-59e70a3-master
+        command:
+        - runner.sh
+        - kubetest
+        args:
+        # Generic e2e test args
+        - --test
+        - --up
+        - --down
+        - --dump=$(ARTIFACTS)
+        # Azure-specific test args
+        - --provider=skeleton
+        - --deployment=aksengine
+        - --aksengine-admin-username=azureuser
+        - --aksengine-creds=$(AZURE_CREDENTIALS)
+        - --aksengine-orchestratorRelease=1.16
+        - --aksengine-location=eastus2
+        - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
+        - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/test/e2e/manifest/single-az.json
+        - --aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz
+        # Ginkgo specific args
+        - --ginkgo-focus='External.Storage.*disk.csi.azure.com'
+        - --ginkgo-skip='\[Disruptive\]|\[Slow\]|\[Feature:VolumeSnapshotDataSource\]'
+        # Specific test args
+        - --test-azure-disk-csi-driver
+        - --run-external-e2e-ginkgo-test
+        - --storage-testdriver-repo-path=test/external-e2e/testdriver.yaml
+        securityContext:
+          privileged: true
+        env:
+          - name: ENABLE_TOPOLOGY
+            value: "false"
+          - name: KUBERNETES_PROVIDER
+            value: azure
+          - name: KUBERNETES_CONFORMANCE_PROVIDER
+            value: azure
+    annotations:
+      testgrid-dashboards: provider-azure-azuredisk-csi-driver, provider-azure-presubmit
+      testgrid-tab-name: pr-azuredisk-csi-driver-external-e2e-single-az
+      description: "Run k8s External E2E tests on a single-az cluster for Azure Disk CSI driver."
+      testgrid-num-columns-recent: '30'

--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -792,8 +792,9 @@ func (t *GinkgoScriptTester) Run(control *process.Control, testArgs []string) er
 // toBuildTesterOptions builds the BuildTesterOptions data structure for passing to BuildTester
 func toBuildTesterOptions(o *options) *e2e.BuildTesterOptions {
 	return &e2e.BuildTesterOptions{
-		FocusRegex:  o.focusRegex,
-		SkipRegex:   o.skipRegex,
-		Parallelism: o.ginkgoParallel.Get(),
+		FocusRegex:            o.focusRegex,
+		SkipRegex:             o.skipRegex,
+		Parallelism:           o.ginkgoParallel.Get(),
+		StorageTestDriverPath: o.storageTestDriverPath,
 	}
 }

--- a/kubetest/e2e/interfaces.go
+++ b/kubetest/e2e/interfaces.go
@@ -31,9 +31,10 @@ type TestBuilder interface {
 	BuildTester(options *BuildTesterOptions) (Tester, error)
 }
 
-// BuildTesterOptions is the options structt that should be passed to testBuilder::BuildTester
+// BuildTesterOptions is the options struct that should be passed to testBuilder::BuildTester
 type BuildTesterOptions struct {
-	FocusRegex  string
-	SkipRegex   string
-	Parallelism int
+	FocusRegex            string
+	SkipRegex             string
+	StorageTestDriverPath string
+	Parallelism           int
 }

--- a/kubetest/e2e/runner.go
+++ b/kubetest/e2e/runner.go
@@ -62,6 +62,7 @@ type GinkgoTester struct {
 	NumNodes              int
 	ReportDir             string
 	ReportPrefix          string
+	StorageTestDriver     string
 
 	// Other ginkgo options
 	FocusRegex      string
@@ -190,6 +191,7 @@ func (t *GinkgoTester) Run(control *process.Control, extraArgs []string) error {
 	a.addIfNonEmpty("report-prefix", t.ReportPrefix)
 
 	a.addIfNonEmpty("systemd-services", strings.Join(t.SystemdServices, ","))
+	a.addIfNonEmpty("storage.testdriver", t.StorageTestDriver)
 
 	ginkgoArgs := append(a.values, extraArgs...)
 

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -114,6 +114,7 @@ type options struct {
 	soakDuration            time.Duration
 	sshUser                 string
 	stage                   stageStrategy
+	storageTestDriverPath   string
 	test                    bool
 	testArgs                string
 	testCmd                 string
@@ -179,6 +180,7 @@ func defineFlags() *options {
 	flag.DurationVar(&o.soakDuration, "soak-duration", 7*24*time.Hour, "Maximum age of a soak cluster before it gets recycled")
 	flag.Var(&o.stage, "stage", "Upload binaries to gs://bucket/devel/job-suffix if set")
 	flag.StringVar(&o.stage.versionSuffix, "stage-suffix", "", "Append suffix to staged version when set")
+	flag.StringVar(&o.storageTestDriverPath, "storage-testdriver-repo-path", "", "Relative path for external e2e test driver config in the csi driver repo")
 	flag.BoolVar(&o.test, "test", false, "Run Ginkgo tests.")
 	flag.StringVar(&o.testArgs, "test_args", "", "Space-separated list of arguments to pass to Ginkgo test runner.")
 	flag.StringVar(&o.testCmd, "test-cmd", "", "command to run against the cluster instead of Ginkgo e2e tests")


### PR DESCRIPTION
This PR is to enhance kubetest to setup k8s cluster and run external e2e k8s tests: [Issue#577](https://github.com/kubernetes-sigs/azuredisk-csi-driver/issues/577)

- Added a new pipeline to run the external e2e tests
- Enhanced kubetest to accept args for the driver config path from the csi driver repo using storage-testdriver-repo-path and run ginkgo tests directly if run-external-e2e-ginkgo-test is set.

