### PR TITLE
Decrease prometheus retention to 90 days from 180 days

### DIFF
--- a/config/prow/cluster/monitoring/prow_prometheus.yaml
+++ b/config/prow/cluster/monitoring/prow_prometheus.yaml
@@ -16,7 +16,7 @@ spec:
         resources:
           requests:
             storage: 100Gi
-  retention: "180d"
+  retention: "90d" # TODO(chaodaiG): change back to 180d once figure out how to properly increase the volume.
   serviceAccountName: prometheus-prow
   alerting:
     alertmanagers:


### PR DESCRIPTION
Prometheus is crash looping due to disk full: https://github.com/kubernetes/test-infra/issues/20439

Decrease the retention for now before we figure out how to increase the volume size appropriately