### PR TITLE
JobURLPrefix: Derive org/repo from extra_ref if refs is unset

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -518,14 +518,24 @@ func (p Plank) getJobURLPrefix(pj *prowapi.ProwJob) string {
 	if pj.Spec.DecorationConfig != nil && pj.Spec.DecorationConfig.GCSConfiguration != nil && pj.Spec.DecorationConfig.GCSConfiguration.JobURLPrefix != "" {
 		return pj.Spec.DecorationConfig.GCSConfiguration.JobURLPrefix
 	}
-	if pj.Spec.Refs == nil {
+
+	var org, repo string
+	if pj.Spec.Refs != nil {
+		org = pj.Spec.Refs.Org
+		repo = pj.Spec.Refs.Repo
+	} else if len(pj.Spec.ExtraRefs) > 0 {
+		org = pj.Spec.ExtraRefs[0].Org
+		repo = pj.Spec.ExtraRefs[0].Repo
+	}
+
+	if org == "" {
 		return p.JobURLPrefixConfig["*"]
 	}
-	if p.JobURLPrefixConfig[fmt.Sprintf("%s/%s", pj.Spec.Refs.Org, pj.Spec.Refs.Repo)] != "" {
-		return p.JobURLPrefixConfig[fmt.Sprintf("%s/%s", pj.Spec.Refs.Org, pj.Spec.Refs.Repo)]
+	if p.JobURLPrefixConfig[fmt.Sprintf("%s/%s", org, repo)] != "" {
+		return p.JobURLPrefixConfig[fmt.Sprintf("%s/%s", org, repo)]
 	}
-	if p.JobURLPrefixConfig[pj.Spec.Refs.Org] != "" {
-		return p.JobURLPrefixConfig[pj.Spec.Refs.Org]
+	if p.JobURLPrefixConfig[org] != "" {
+		return p.JobURLPrefixConfig[org]
 	}
 	return p.JobURLPrefixConfig["*"]
 }

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -2952,6 +2952,18 @@ func TestPlankJobURLPrefix(t *testing.T) {
 			expectedJobURLPrefix: "https://my-alternate-prow",
 		},
 		{
+			name: "Matching repo in extraRefs returns JobURLPrefix from repo",
+			plank: Plank{
+				JobURLPrefixConfig: map[string]string{
+					"*":                        "https://my-prow",
+					"my-alternate-org":         "https://my-third-prow",
+					"my-alternate-org/my-repo": "https://my-alternate-prow",
+				},
+			},
+			prowjob:              &prowjobv1.ProwJob{Spec: prowjobv1.ProwJobSpec{ExtraRefs: []prowapi.Refs{{Org: "my-alternate-org", Repo: "my-repo"}}}},
+			expectedJobURLPrefix: "https://my-alternate-prow",
+		},
+		{
 			name: "JobURLPrefix in decoration config overrides job_url_prefix_config",
 			plank: Plank{
 				JobURLPrefixConfig: map[string]string{
@@ -2976,6 +2988,18 @@ func TestPlankJobURLPrefix(t *testing.T) {
 				},
 			},
 			prowjob:              &prowjobv1.ProwJob{Spec: prowjobv1.ProwJobSpec{Refs: &prowapi.Refs{Org: "my-alternate-org", Repo: "my-second-repo"}}},
+			expectedJobURLPrefix: "https://my-third-prow",
+		},
+		{
+			name: "Matching org in extraRefs and not matching repo returns JobURLPrefix from org",
+			plank: Plank{
+				JobURLPrefixConfig: map[string]string{
+					"*":                        "https://my-prow",
+					"my-alternate-org":         "https://my-third-prow",
+					"my-alternate-org/my-repo": "https://my-alternate-prow",
+				},
+			},
+			prowjob:              &prowjobv1.ProwJob{Spec: prowjobv1.ProwJobSpec{ExtraRefs: []prowapi.Refs{{Org: "my-alternate-org", Repo: "my-second-repo"}}}},
 			expectedJobURLPrefix: "https://my-third-prow",
 		},
 		{


### PR DESCRIPTION
The `refs` field is never set on periodics, thus the mechanism we have
today can not work for them. With this change, we will use extra_refs[0]
if defined and refs is undefined.