### PR TITLE
Show last 270 builds of 5k test in perf-dash

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -52,6 +52,7 @@ periodics:
   name: ci-kubernetes-e2e-gce-scale-performance
   tags:
   - "perfDashPrefix: gce-5000Nodes"
+  - "perfDashBuildsCount: 270"
   - "perfDashJobType: performance"
   cluster: scalability
   labels:


### PR DESCRIPTION
We run 5k 3x a day, so 270 should translate to ~3 months (which matches our GCS retention policy)

/assign @tosi3k 

Ref https://github.com/kubernetes/kubernetes/issues/97798