### PR TITLE
Unprotect the gh-pages branch in nfs-subdir-external-provisioner for helm chart release action

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -441,6 +441,10 @@ branch-protection:
           required_status_checks:
             contexts:
             - Kubespray CI Pipeline
+        nfs-subdir-external-provisioner:
+          branches:
+            gh-pages:
+              protect: false
         node-feature-discovery:
           branches:
             gh-pages:


### PR DESCRIPTION
As previously done in #20323 and #20157, we are automating the helm chart release in the [nfs-subdir-external-provisioner](pull/35) repository: https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/pull/35

In order to do that, we need to configure prow to ignore the `gh-pages` branch as it will be used by github action's user which cannot sign CLA. 
No PR's will be approved for this branch and the `gh-pages` branch will be used only as helm chart repository.

@wongma7 @kmova 