### PR TITLE
Add rerun_auth_config for post-kubernetes-push-e2e-*-test-images

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-e2e-test-images.sh
+++ b/config/jobs/image-pushing/k8s-staging-e2e-test-images.sh
@@ -56,6 +56,16 @@ EOF
 for image in "${IMAGES[@]}"; do
     cat >>"${OUTPUT}" <<EOF
     - name: post-kubernetes-push-e2e-${image//\//-}-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images
@@ -104,6 +114,8 @@ periodics:
       - org: kubernetes
         slug: release-engineering
     github_users:
+      - aojea
+      - chewong
       - claudiubelu
   # Since the servercore image is updated once per month, we only need to build this
   # cache once per month.

--- a/config/jobs/image-pushing/k8s-staging-e2e-test-images.yaml
+++ b/config/jobs/image-pushing/k8s-staging-e2e-test-images.yaml
@@ -3,6 +3,16 @@
 postsubmits:
   kubernetes/kubernetes:
     - name: post-kubernetes-push-e2e-agnhost-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images
@@ -32,6 +42,16 @@ postsubmits:
             - name: WHAT
               value: "agnhost"
     - name: post-kubernetes-push-e2e-apparmor-loader-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images
@@ -61,6 +81,16 @@ postsubmits:
             - name: WHAT
               value: "apparmor-loader"
     - name: post-kubernetes-push-e2e-busybox-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images
@@ -90,6 +120,16 @@ postsubmits:
             - name: WHAT
               value: "busybox"
     - name: post-kubernetes-push-e2e-cuda-vector-add-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images
@@ -119,6 +159,16 @@ postsubmits:
             - name: WHAT
               value: "cuda-vector-add"
     - name: post-kubernetes-push-e2e-echoserver-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images
@@ -148,6 +198,16 @@ postsubmits:
             - name: WHAT
               value: "echoserver"
     - name: post-kubernetes-push-e2e-ipc-utils-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images
@@ -177,6 +237,16 @@ postsubmits:
             - name: WHAT
               value: "ipc-utils"
     - name: post-kubernetes-push-e2e-jessie-dnsutils-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images
@@ -206,6 +276,16 @@ postsubmits:
             - name: WHAT
               value: "jessie-dnsutils"
     - name: post-kubernetes-push-e2e-kitten-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images
@@ -235,6 +315,16 @@ postsubmits:
             - name: WHAT
               value: "kitten"
     - name: post-kubernetes-push-e2e-metadata-concealment-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images
@@ -264,6 +354,16 @@ postsubmits:
             - name: WHAT
               value: "metadata-concealment"
     - name: post-kubernetes-push-e2e-nautilus-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images
@@ -293,6 +393,16 @@ postsubmits:
             - name: WHAT
               value: "nautilus"
     - name: post-kubernetes-push-e2e-node-perf-tf-wide-deep-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images
@@ -322,6 +432,16 @@ postsubmits:
             - name: WHAT
               value: "node-perf/tf-wide-deep"
     - name: post-kubernetes-push-e2e-node-perf-npb-ep-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images
@@ -351,6 +471,16 @@ postsubmits:
             - name: WHAT
               value: "node-perf/npb-ep"
     - name: post-kubernetes-push-e2e-node-perf-npb-is-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images
@@ -380,6 +510,16 @@ postsubmits:
             - name: WHAT
               value: "node-perf/npb-is"
     - name: post-kubernetes-push-e2e-nonewprivs-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images
@@ -409,6 +549,16 @@ postsubmits:
             - name: WHAT
               value: "nonewprivs"
     - name: post-kubernetes-push-e2e-nonroot-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images
@@ -438,6 +588,16 @@ postsubmits:
             - name: WHAT
               value: "nonroot"
     - name: post-kubernetes-push-e2e-pets-redis-installer-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images
@@ -467,6 +627,16 @@ postsubmits:
             - name: WHAT
               value: "pets/redis-installer"
     - name: post-kubernetes-push-e2e-pets-peer-finder-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images
@@ -496,6 +666,16 @@ postsubmits:
             - name: WHAT
               value: "pets/peer-finder"
     - name: post-kubernetes-push-e2e-pets-zookeeper-installer-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images
@@ -525,6 +705,16 @@ postsubmits:
             - name: WHAT
               value: "pets/zookeeper-installer"
     - name: post-kubernetes-push-e2e-redis-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images
@@ -554,6 +744,16 @@ postsubmits:
             - name: WHAT
               value: "redis"
     - name: post-kubernetes-push-e2e-regression-issue-74839-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images
@@ -583,6 +783,16 @@ postsubmits:
             - name: WHAT
               value: "regression-issue-74839"
     - name: post-kubernetes-push-e2e-resource-consumer-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images
@@ -612,6 +822,16 @@ postsubmits:
             - name: WHAT
               value: "resource-consumer"
     - name: post-kubernetes-push-e2e-sample-apiserver-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images
@@ -641,6 +861,16 @@ postsubmits:
             - name: WHAT
               value: "sample-apiserver"
     - name: post-kubernetes-push-e2e-sample-device-plugin-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images
@@ -670,6 +900,16 @@ postsubmits:
             - name: WHAT
               value: "sample-device-plugin"
     - name: post-kubernetes-push-e2e-volume-iscsi-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images
@@ -699,6 +939,16 @@ postsubmits:
             - name: WHAT
               value: "volume/iscsi"
     - name: post-kubernetes-push-e2e-volume-rbd-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images
@@ -728,6 +978,16 @@ postsubmits:
             - name: WHAT
               value: "volume/rbd"
     - name: post-kubernetes-push-e2e-volume-nfs-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images
@@ -757,6 +1017,16 @@ postsubmits:
             - name: WHAT
               value: "volume/nfs"
     - name: post-kubernetes-push-e2e-volume-gluster-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images
@@ -801,6 +1071,8 @@ periodics:
       - org: kubernetes
         slug: release-engineering
     github_users:
+      - aojea
+      - chewong
       - claudiubelu
   # Since the servercore image is updated once per month, we only need to build this
   # cache once per month.


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

adding @aojea, @claudiubelu, and myself to `rerun_auth_configs` of all `post-kubernetes-push-e2e-*-test-images` jobs.