### PR TITLE
Upgrade promethues and alertmanager to latest

### DIFF
--- a/config/prow/cluster/monitoring/prow_alertmanager.yaml
+++ b/config/prow/cluster/monitoring/prow_alertmanager.yaml
@@ -13,7 +13,7 @@ spec:
     runAsNonRoot: true
     runAsUser: 1000
   serviceAccountName: alertmanager
-  version: v0.15.2
+  version: v0.21.0
   storage: # Note that this section is immutable so changes require deleting and recreating the resource.
     volumeClaimTemplate:
       metadata:

--- a/config/prow/cluster/monitoring/prow_prometheus.yaml
+++ b/config/prow/cluster/monitoring/prow_prometheus.yaml
@@ -32,7 +32,7 @@ spec:
     matchExpressions:
     - key: app
       operator: Exists
-  version: v2.7.1
+  version: v2.22.2
   baseImage: docker.io/prom/prometheus
   externalLabels: {}
   listenLocal: false


### PR DESCRIPTION
Prometheus pod ran out of persistent volume claim space and failed to start in https://github.com/kubernetes/test-infra/issues/20439, reducing retention period in https://github.com/kubernetes/test-infra/pull/20440 didn't immediately fix the problem, as pod crashed before reaching pruning phase, as mentioned in #20439, upgrading prometheus is likely solving the problem, by the way upgrading alertmanager, both to LTS.

/assign @cjwagner 
/cc @spiffxp