### PR TITLE
Revert "Upgrade promethues and alertmanager to latest"

### DIFF
--- a/config/prow/cluster/monitoring/prow_alertmanager.yaml
+++ b/config/prow/cluster/monitoring/prow_alertmanager.yaml
@@ -13,7 +13,7 @@ spec:
     runAsNonRoot: true
     runAsUser: 1000
   serviceAccountName: alertmanager
-  version: v0.21.0
+  version: v0.15.2
   storage: # Note that this section is immutable so changes require deleting and recreating the resource.
     volumeClaimTemplate:
       metadata:

--- a/config/prow/cluster/monitoring/prow_prometheus.yaml
+++ b/config/prow/cluster/monitoring/prow_prometheus.yaml
@@ -32,7 +32,7 @@ spec:
     matchExpressions:
     - key: app
       operator: Exists
-  version: v2.22.2
+  version: v2.7.1
   baseImage: docker.io/prom/prometheus
   externalLabels: {}
   listenLocal: false


### PR DESCRIPTION
This reverts commit 3e833e3984a54d05067c8b07d2e8a1d4ecde0c91. PR reverted #20456 .

The resulting prometheus deployment crashed:

```
level=warn ts=2021-01-12T22:37:22.372Z caller=main.go:304 deprecation_notice="'storage.tsdb.retention' flag is deprecated use 'storage.tsdb.retention.time' instead."
level=info ts=2021-01-12T22:37:22.372Z caller=main.go:353 msg="Starting Prometheus" version="(version=2.22.2, branch=HEAD, revision=de1c1243f4dd66fbac3e8213e9a7bd8dbc9f38b2)"
level=info ts=2021-01-12T22:37:22.372Z caller=main.go:358 build_context="(go=go1.15.5, user=root@f7d7e91063f0, date=20201116-12:43:43)"
level=info ts=2021-01-12T22:37:22.372Z caller=main.go:359 host_details="(Linux 4.19.112+ #1 SMP Fri Sep 4 12:00:04 PDT 2020 x86_64 prometheus-prow-1 (none))"
level=info ts=2021-01-12T22:37:22.372Z caller=main.go:360 fd_limits="(soft=1048576, hard=1048576)"
level=info ts=2021-01-12T22:37:22.372Z caller=main.go:361 vm_limits="(soft=unlimited, hard=unlimited)"
unexpected fault address 0x7f206b10e000
fatal error: fault
[signal SIGBUS: bus error code=0x2 addr=0x7f206b10e000 pc=0x470ea8]

goroutine 1 [running]:
runtime.throw(0x29adb45, 0x5)
	/usr/local/go/src/runtime/panic.go:1116 +0x72 fp=0xc000e3f268 sp=0xc000e3f238 pc=0x4378b2
runtime.sigpanic()
	/usr/local/go/src/runtime/signal_unix.go:739 +0x485 fp=0xc000e3f298 sp=0xc000e3f268 pc=0x44e085
runtime.memmove(0x7f206b10e000, 0x29aaf78, 0x1)
	/usr/local/go/src/runtime/memmove_amd64.s:148 +0x108 fp=0xc000e3f2a0 sp=0xc000e3f298 pc=0x470ea8
github.com/prometheus/prometheus/promql.NewActiveQueryTracker(0x7ffee9f94855, 0xb, 0x14, 0x3087a40, 0xc000436d80, 0x3087a40)
	/app/promql/query_logger.go:120 +0x3a5 fp=0xc000e3f3f8 sp=0xc000e3f2a0 pc=0xc30925
main.main()
	/app/cmd/prometheus/main.go:388 +0x536c fp=0xc000e3ff88 sp=0xc000e3f3f8 pc=0x21c8b0c
runtime.main()
	/usr/local/go/src/runtime/proc.go:204 +0x209 fp=0xc000e3ffe0 sp=0xc000e3ff88 pc=0x43a0a9
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1374 +0x1 fp=0xc000e3ffe8 sp=0xc000e3ffe0 pc=0x46ffa1

goroutine 82 [select]:
go.opencensus.io/stats/view.(*worker).start(0xc0000fe280)
	/app/vendor/go.opencensus.io/stats/view/worker.go:276 +0x105
created by go.opencensus.io/stats/view.init.0
	/app/vendor/go.opencensus.io/stats/view/worker.go:34 +0x68

goroutine 114 [select]:
github.com/prometheus/prometheus/pkg/logging.(*Deduper).run(0xc000337ac0)
	/app/pkg/logging/dedupe.go:75 +0x1e5
created by github.com/prometheus/prometheus/pkg/logging.Dedupe
	/app/pkg/logging/dedupe.go:61 +0xcf

goroutine 121 [chan receive]:
github.com/prometheus/prometheus/storage/remote.(*WriteStorage).run(0xc000b53c20)
	/app/storage/remote/write.go:93 +0xb6
created by github.com/prometheus/prometheus/storage/remote.NewWriteStorage
	/app/storage/remote/write.go:86 +0x2d8

```