### PR TITLE
Allow jobs to skip_fetch_head and only fetch the base ref.

### DIFF
--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -796,6 +796,10 @@ type Refs struct {
 	// CloneDepth is the depth of the clone that will be used.
 	// A depth of zero will do a full clone.
 	CloneDepth int `json:"clone_depth,omitempty"`
+	// SkipFetchHead tells prow to avoid a git fetch <remote> call.
+	// Multiheaded repos may need to not make this call.
+	// The git fetch <remote> <BaseRef> call occurs regardless.
+	SkipFetchHead bool `json:"skip_fetch_head,omitempty"`
 }
 
 func (r Refs) String() string {

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -423,6 +423,9 @@ type UtilityConfig struct {
 	// CloneDepth is the depth of the clone that will be used.
 	// A depth of zero will do a full clone.
 	CloneDepth int `json:"clone_depth,omitempty"`
+	// SkipFetchHead tells prow to avoid a git fetch <remote> call.
+	// The git fetch <remote> <BaseRef> call occurs regardless.
+	SkipFetchHead bool `json:"skip_fetch_head,omitempty"`
 
 	// ExtraRefs are auxiliary repositories that
 	// need to be cloned, determined from config

--- a/prow/pjutil/BUILD.bazel
+++ b/prow/pjutil/BUILD.bazel
@@ -74,6 +74,7 @@ go_test(
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/kube:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/equality:go_default_library",

--- a/prow/pjutil/pjutil.go
+++ b/prow/pjutil/pjutil.go
@@ -185,8 +185,15 @@ func CompletePrimaryRefs(refs prowapi.Refs, jb config.JobBase) *prowapi.Refs {
 	if jb.CloneURI != "" {
 		refs.CloneURI = jb.CloneURI
 	}
-	refs.SkipSubmodules = jb.SkipSubmodules
-	refs.CloneDepth = jb.CloneDepth
+	if jb.SkipSubmodules {
+		refs.SkipSubmodules = jb.SkipSubmodules
+	}
+	if jb.CloneDepth > 0 {
+		refs.CloneDepth = jb.CloneDepth
+	}
+	if jb.SkipFetchHead {
+		refs.SkipFetchHead = jb.SkipFetchHead
+	}
 	return &refs
 }
 

--- a/prow/pod-utils/clone/BUILD.bazel
+++ b/prow/pod-utils/clone/BUILD.bazel
@@ -40,6 +40,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
-        "@io_k8s_apimachinery//pkg/util/diff:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
     ],
 )


### PR DESCRIPTION
Some multi-headed repos have no root HEAD ref, thus git fetch origin will fail (needs to specify a head ref).
Support these repos by allowing them to specify a skip_fetch_head on either the job base and/or extra_ref level.