### PR TITLE
Set container runtime to Docker for main e2e presubmit

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -86,6 +86,7 @@ presubmits:
         - --extract=release/latest-1.19
         - --ginkgo-parallel
         - --kops-build
+        - --kops-args=--container-runtime=docker
         - --kops-priority-path=/home/prow/go/src/k8s.io/kops/kubernetes/platforms/linux/amd64
         - --provider=aws
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort


### PR DESCRIPTION
kOps will switch the default for the CRI to containerd soon and this test is based on defaults, but needs to be fixed to Docker to behave correctly.
xRef: https://github.com/kubernetes/kops/pull/10370

/cc @olemarkus @rifelpet 
@bmelbourne