### PR TITLE
prune deleted remote branches on git fetch

### DIFF
--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -179,7 +179,7 @@ func (c *Client) Clone(organization, repository string) (*Repo, error) {
 	} else {
 		// Cache hit. Do a git fetch to keep updated.
 		c.logger.Infof("Fetching %s.", repo)
-		if b, err := retryCmd(c.logger, cache, c.git, "fetch"); err != nil {
+		if b, err := retryCmd(c.logger, cache, c.git, "fetch", "--prune"); err != nil {
 			return nil, fmt.Errorf("git fetch error: %v. output: %s", err, string(b))
 		}
 	}

--- a/prow/git/v2/interactor.go
+++ b/prow/git/v2/interactor.go
@@ -266,7 +266,7 @@ func (i *interactor) Am(path string) error {
 // RemoteUpdate fetches all updates from the remote.
 func (i *interactor) RemoteUpdate() error {
 	i.logger.Info("Updating from remote")
-	if out, err := i.executor.Run("remote", "update"); err != nil {
+	if out, err := i.executor.Run("remote", "update", "--prune"); err != nil {
 		return fmt.Errorf("error updating: %v %v", err, string(out))
 	}
 	return nil

--- a/prow/git/v2/interactor_test.go
+++ b/prow/git/v2/interactor_test.go
@@ -1037,24 +1037,24 @@ func TestInteractor_RemoteUpdate(t *testing.T) {
 		{
 			name: "happy case",
 			responses: map[string]execResponse{
-				"remote update": {
+				"remote update --prune": {
 					out: []byte(`ok`),
 				},
 			},
 			expectedCalls: [][]string{
-				{"remote", "update"},
+				{"remote", "update", "--prune"},
 			},
 			expectedErr: false,
 		},
 		{
 			name: "update fails",
 			responses: map[string]execResponse{
-				"remote update": {
+				"remote update --prune": {
 					err: errors.New("oops"),
 				},
 			},
 			expectedCalls: [][]string{
-				{"remote", "update"},
+				{"remote", "update", "--prune"},
 			},
 			expectedErr: true,
 		},


### PR DESCRIPTION
fixes #20464.

This PR makes prow's git client prune deleted remote branches while it fetches updates for a cloned repo.
This prevents name conflicts with deleted braches.