### PR TITLE
Make Golang performance job use N1 nodes

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
@@ -32,7 +32,6 @@ periodics:
             cpu: 4
             memory: "16Gi"
 
-
 - interval: 4h
   name: ci-golang-tip-k8s-1-18
   cluster: scalability
@@ -69,6 +68,76 @@ periodics:
       - --env=KUBEMARK_SCHEDULER_TEST_ARGS=--profiling --kube-api-qps=200 --kube-api-burst=200
       - --extract=gs://k8s-scale-golang-build/ci/latest-1.18.txt
       - --gcp-node-size=n1-standard-8
+      - --gcp-nodes=50
+      - --gcp-project=k8s-presubmit-scale
+      - --gcp-zone=us-east1-b
+      - --provider=gce
+      - --kubemark
+      - --kubemark-nodes=2500
+      - --test=false
+      - --test-cmd=$GOPATH/src/k8s.io/perf-tests/golang/run-e2e.sh
+      - --test-cmd-args=cluster-loader2
+      - --test-cmd-args=--experimental-gcp-snapshot-prometheus-disk=true
+      - --test-cmd-args=--experimental-prometheus-disk-snapshot-name=${JOB_NAME}-${BUILD_ID}
+      - --test-cmd-args=--nodes=2500
+      - --test-cmd-args=--provider=kubemark
+      - --test-cmd-args=--report-dir=/workspace/_artifacts
+      - --test-cmd-args=--testconfig=testing/load/config.yaml
+      - --test-cmd-args=--testoverrides=./testing/experiments/enable_restart_count_check.yaml
+      - --test-cmd-args=--testoverrides=./testing/experiments/ignore_known_kubemark_container_restarts.yaml
+      - --test-cmd-args=--testoverrides=./testing/overrides/5000_nodes.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/golang/custom_api_call_thresholds.yaml
+      - --test-cmd-name=ClusterLoaderV2
+      - --timeout=180m
+      - --use-logexporter
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210108-3c85f1a-master
+      env:
+      - name: CL2_ENABLE_VIOLATIONS_FOR_API_CALL_PROMETHEUS
+        value: "true"
+      # docker-in-docker needs privilged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 6
+          memory: "16Gi"
+        limits:
+          cpu: 6
+          memory: "16Gi"
+
+- interval: 4h
+  name: ci-golang-tip-k8s-e2-1-18
+  cluster: scalability
+  tags:
+  - "perfDashPrefix: golang-tip-k8s-e2-1-18"
+  - "perfDashJobType: performance"
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-dind-enabled: "true"
+    preset-e2e-kubemark-common: "true"
+    preset-e2e-kubemark-gce-scale: "true"
+    preset-e2e-scalability-periodics: "true"
+    preset-e2e-scalability-periodics-master: "true"
+  annotations:
+    testgrid-dashboards: sig-scalability-golang
+    testgrid-tab-name: golang-tip-k8s-e2-1-18
+  spec:
+    containers:
+    - args:
+      - --timeout=210
+      # head of perf-tests' master as of 2020-11-06
+      - --repo=k8s.io/perf-tests=master:39a6c09ddca620a430d38e5de1400844ea954c2f
+      - --root=/go/src
+      - --scenario=kubernetes_e2e
+      - --
+      - --cluster=gce-e2-golang
+      - --env=CL2_ENABLE_PVS=false
+      - --env=CL2_LOAD_TEST_THROUGHPUT=50
+      - --env=KUBEMARK_CONTROLLER_MANAGER_TEST_ARGS=--profiling --kube-api-qps=200 --kube-api-burst=200
+      - --env=KUBEMARK_SCHEDULER_TEST_ARGS=--profiling --kube-api-qps=200 --kube-api-burst=200
+      - --extract=gs://k8s-scale-golang-build/ci/latest-1.18.txt
+      - --gcp-node-size=e2-standard-8
       - --gcp-nodes=50
       - --gcp-project=k8s-presubmit-scale
       - --gcp-zone=us-east1-b

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
@@ -68,7 +68,7 @@ periodics:
       - --env=KUBEMARK_CONTROLLER_MANAGER_TEST_ARGS=--profiling --kube-api-qps=200 --kube-api-burst=200
       - --env=KUBEMARK_SCHEDULER_TEST_ARGS=--profiling --kube-api-qps=200 --kube-api-burst=200
       - --extract=gs://k8s-scale-golang-build/ci/latest-1.18.txt
-      - --gcp-node-size=e2-standard-8
+      - --gcp-node-size=n1-standard-8
       - --gcp-nodes=50
       - --gcp-project=k8s-presubmit-scale
       - --gcp-zone=us-east1-b


### PR DESCRIPTION
This PR does two things:
1. switch the actual Golang performance job to N1 node machines,
2. add an experimental mirror job but using E2 node machines.

/sig scalability
/assign @mm4tt 