### PR TITLE
GitHub: Improve error message when PR creation fails

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -1918,7 +1918,7 @@ func (c *client) CreatePullRequest(org, repo, title, body, head, base string, ca
 		exitCodes:   []int{201},
 	}, &resp)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to create pull request against %s/%s#%s from %s: %v", org, repo, head, base, err)
 	}
 	return resp.Num, nil
 }


### PR DESCRIPTION
If this is incorrect, GitHub only gives an error message like
`{"resource":"PullRequest","field":"head","code":"invalid"}` which is
extremely hard to reason about without knowing some more details about
the original request.