### PR TITLE
[Kettle] Api end points changed, update

### DIFF
--- a/kettle/deployment-staging.yaml
+++ b/kettle/deployment-staging.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kettle-staging
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: kettle-staging
   template:
     metadata:
       labels:

--- a/kettle/deployment.yaml
+++ b/kettle/deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kettle
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: kettle
   template:
     metadata:
       labels:


### PR DESCRIPTION
Old Api was causing 
```
error: unable to recognize "STDIN": no matches for kind "Deployment" in version "extensions/v1beta1"
```
This update brings everything up to date
/area kettle