### PR TITLE
Use projected token source to dynamically refresh SA token

### DIFF
--- a/prow/cmd/pipeline/main.go
+++ b/prow/cmd/pipeline/main.go
@@ -120,7 +120,7 @@ func main() {
 		logrus.WithError(err).Fatal("failed to load prow config")
 	}
 
-	configs, err := kube.LoadClusterConfigs(o.kubeconfig)
+	configs, err := kube.LoadClusterConfigs(o.kubeconfig, "")
 	if err != nil {
 		logrus.WithError(err).Fatal("Error building client configs")
 	}


### PR DESCRIPTION
Watching the SA token file is pointless, as it will never change,
because token secret rotation means a new secret gets created. This new
secret will never get used in an old Pod though.

The way to go for this are [projected service acccount token volumes][0]
and setting BeearerTokenFile on the restcfg, this will make client-go
periodically reload it.

[0]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection