### PR TITLE
Fix performance presubmit test job to release-1.20 branch of k/k

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
@@ -1210,7 +1210,7 @@ presubmits:
       - args:
         - --root=/go/src
         - --repo=k8s.io/kubernetes=$(PULL_REFS)
-        - --repo=k8s.io/perf-tests=master
+        - --repo=k8s.io/perf-tests=release-1.20
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-jenkins/pr-logs
         - --timeout=120


### PR DESCRIPTION
`pull-kubernetes-e2e-gce-100-performance` presubmit to `release-1.20` branch was failing as it was using `master` branch of perf-tests (instead of `release-1.20`) which in turn recently ingested an incompatible change in https://github.com/kubernetes/perf-tests/pull/1647.

This should fix https://github.com/kubernetes/kubernetes/issues/98039.

/sig scalability
/assign @wojtek-t 