### PR TITLE
Deprecate 'preset-e2e-scalability-containerd' as containerd is defauft CRI

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-adhoc.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-adhoc.yaml
@@ -20,7 +20,6 @@ presubmits:
       preset-k8s-ssh: "true"
       preset-bazel-scratch-dir: "true"
       preset-e2e-scalability-common: "true"
-      preset-e2e-scalability-containerd: "true"
     annotations:
       testgrid-dashboards: presubmits-kubernetes-scalability
       testgrid-tab-name: pull-perf-tests-100-adhoc

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -57,7 +57,6 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
     preset-e2e-scalability-node: "true"
-    preset-e2e-scalability-containerd: "true"
     preset-e2e-scalability-periodics: "true"
     preset-e2e-scalability-periodics-master: "true"
   annotations:

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -226,17 +226,18 @@ presets:
     value: 50
   - name: PERF_TESTS_PRINT_COMMIT_HISTORY
     value: true
+  - name: LOG_DUMP_SAVE_SERVICES
+    value: "containerd"
 
   ###### Scalability Envs
   ### Common env variables for containerd scalability-related suites.
+  # Deprecated. Should be removed after 1.20 branch will be removed from testing
 - labels:
     preset-e2e-scalability-containerd: "true"
   env:
   - name: CL2_PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT
     value: "10m"
   - name: KUBE_CONTAINER_RUNTIME
-    value: "containerd"
-  - name: LOG_DUMP_SAVE_SERVICES
     value: "containerd"
 
 ###### Scalability Envs

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -14,7 +14,6 @@ presubmits:
       preset-k8s-ssh: "true"
       preset-bazel-scratch-dir: "true"
       preset-e2e-scalability-common: "true"
-      preset-e2e-scalability-containerd: "true"
       preset-e2e-scalability-presubmits: "true"
     annotations:
       fork-per-release: "true"
@@ -73,7 +72,6 @@ presubmits:
       preset-k8s-ssh: "true"
       preset-bazel-scratch-dir: "true"
       preset-e2e-scalability-common: "true"
-      preset-e2e-scalability-containerd: "true"
       preset-e2e-scalability-presubmits: "true"
     spec:
       containers:
@@ -179,7 +177,6 @@ presubmits:
       preset-k8s-ssh: "true"
       preset-bazel-scratch-dir: "true"
       preset-e2e-scalability-common: "true"
-      preset-e2e-scalability-containerd: "true"
       preset-e2e-scalability-presubmits: "true"
     spec:
       containers:
@@ -418,7 +415,6 @@ presubmits:
       preset-k8s-ssh: "true"
       preset-bazel-scratch-dir: "true"
       preset-e2e-scalability-common: "true"
-      preset-e2e-scalability-containerd: "true"
       preset-e2e-scalability-presubmits: "true"
     run_if_changed: ^clusterloader2/.*$
     spec:

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -58,7 +58,6 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
     preset-e2e-scalability-common: "true"
-    preset-e2e-scalability-containerd: "true"
     preset-e2e-scalability-periodics: "true"
     preset-e2e-scalability-periodics-master: "true"
   annotations:
@@ -128,7 +127,6 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
     preset-e2e-scalability-common: "true"
-    preset-e2e-scalability-containerd: "true"
     preset-e2e-scalability-periodics: "true"
     preset-e2e-scalability-periodics-master: "true"
   annotations:


### PR DESCRIPTION
We cannot delete preset, as there are existing tests for 1.19 and 1.20 release that depend on this preset

`preset-e2e-scalability-containerd` set following envs:

1. Setting runtime to containerd (already a default)
2. Setting timeout for perf-test probes to 10 min (we want to remove that)
3. Dumping containerd logs (we should do that for all tests)

/cc @wojtek-t 

Result from [this comment](https://github.com/kubernetes/kubernetes/issues/94256#issuecomment-753912951) 