### PR TITLE
[Kettle] Add some docs on Kettle and PubSub

### DIFF
--- a/kettle/README.md
+++ b/kettle/README.md
@@ -102,7 +102,9 @@ A [postsubmit job](https://github.com/kubernetes/test-infra/blob/master/config/j
 
 # PubSub
 
-Kettle `stream.py` leverages Google Cloud [PubSub] to alert on GCS changes. These events are tied to the `gcs-changes` Topic in the `kubernetes-jenkins` project where Prow job artifacts are collated. Each time an artifact is finalized, a PubSub event is triggered and Kettle collects job information when it sees a resource uploaded called `finished.json` (indicating the build completed).
+Kettle `stream.py` leverages Google Cloud [PubSub] to alert on GCS changes within the `kubernetes-jenkins` bucket. These events are tied to the `gcs-changes` Topic in the `kubernetes-jenkins` project where Prow job artifacts are collated. Each time an artifact is finalized, a PubSub event is triggered and Kettle collects job information when it sees a resource uploaded called `finished.json` (indicating the build completed).
+
+[Topic Creation] can be performed by running `gsutil notification create -t gcs-chances -f json gs://kubernetes-jenkins`
 
 [Subscriptions] are in Kuberenetes Jenkins Build - PubSub.
 - kettle
@@ -110,8 +112,19 @@ Kettle `stream.py` leverages Google Cloud [PubSub] to alert on GCS changes. Thes
 
 They are split so that the staging instance does not consume events aimed at production.
 
+These can be created via:
+```
+gcloud pubsub subscriptions create <subscription name> --topic=gcs-changes --topic-project="kubernetes-jenkins" --message-filter='attributes.eventType = "OBJECT_FINALIZE"'
+```
+
 ### Auth
-For kettle to have permisions, kettle's user needs access. When updating or changing a [Subscription] make sure to add `kettle@k8s-gubernator.iam.gserviceaccount.com` as a `PubSub Editor`.
+For kettle to have permission, kettle's user needs access. When updating or changing a [Subscription] make sure to add `kettle@k8s-gubernator.iam.gserviceaccount.com` as a `PubSub Editor`.
+```
+gcloud pubsub subscriptions add-iam-policy-binding \
+  projects/kubernetes-jenkins/subscriptions/kettle-staging \
+  --member=serviceAccount:kettle@k8s-gubernator.iam.gserviceaccount.com \
+  --role=roles/pubsub.editor
+```
 
 # Known Issues
 
@@ -122,3 +135,4 @@ For kettle to have permisions, kettle's user needs access. When updating or chan
 [Big Query Staging]: https://console.cloud.google.com/bigquery?project=k8s-gubernator&page=table&t=staging&d=build&p=k8s-gubernator
 [PubSub]: https://cloud.google.com/pubsub/docs
 [Subscriptions]: https://console.cloud.google.com/cloudpubsub/subscription/list?project=kubernetes-jenkins
+[Topic Creation]: https://cloud.google.com/storage/docs/reporting-changes#enabling

--- a/kettle/README.md
+++ b/kettle/README.md
@@ -100,6 +100,19 @@ gs://<bucket path>: #bucket url
 
 A [postsubmit job](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml#L203-L210) runs that pushes Kettle on changes.
 
+# PubSub
+
+Kettle `stream.py` leverages Google Cloud [PubSub] to alert on GCS changes. These events are tied to the `gcs-changes` Topic in the `kubernetes-jenkins` project where Prow job artifacts are collated. Each time an artifact is finalized, a PubSub event is triggered and Kettle collects job information when it sees a resource uploaded called `finished.json` (indicating the build completed).
+
+[Subscriptions] are in Kuberenetes Jenkins Build - PubSub.
+- kettle
+- kettle-staging
+
+They are split so that the staging instance does not consume events aimed at production.
+
+### Auth
+For kettle to have permisions, kettle's user needs access. When updating or changing a [Subscription] make sure to add `kettle@k8s-gubernator.iam.gserviceaccount.com` as a `PubSub Editor`.
+
 # Known Issues
 
 - Occasionally data from Kettle stops updating, we suspect this is due to a transient hang when contacting GCS ([#8800](https://github.com/kubernetes/test-infra/issues/8800)). If this happens, [restart kettle](#restarting)
@@ -107,3 +120,5 @@ A [postsubmit job](https://github.com/kubernetes/test-infra/blob/master/config/j
 [Big Query Tables]: https://console.cloud.google.com/bigquery?utm_source=bqui&utm_medium=link&utm_campaign=classic&project=k8s-gubernator
 [Big Query All]: https://console.cloud.google.com/bigquery?project=k8s-gubernator&page=table&t=all&d=build&p=k8s-gubernator
 [Big Query Staging]: https://console.cloud.google.com/bigquery?project=k8s-gubernator&page=table&t=staging&d=build&p=k8s-gubernator
+[PubSub]: https://cloud.google.com/pubsub/docs
+[Subscriptions]: https://console.cloud.google.com/cloudpubsub/subscription/list?project=kubernetes-jenkins


### PR DESCRIPTION
Describe auth needs to PubSub changes that I made this morning. 

For reference the failure was as follows:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.6/dist-packages/google/cloud/pubsub_v1/_gapic.py", line 40, in <lambda>
    fx = lambda self, *a, **kw: wrapped_fx(self.api, *a, **kw)  # noqa
  File "/usr/local/lib/python3.6/dist-packages/google/pubsub_v1/services/subscriber/client.py", line 1012, in pull
    response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
  File "/usr/local/lib/python3.6/dist-packages/google/api_core/gapic_v1/method.py", line 145, in __call__
    return wrapped_func(*args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/google/api_core/retry.py", line 286, in retry_wrapped_func
    on_error=on_error,
  File "/usr/local/lib/python3.6/dist-packages/google/api_core/retry.py", line 184, in retry_target
    return target()
  File "/usr/local/lib/python3.6/dist-packages/google/api_core/grpc_helpers.py", line 59, in error_remapped_callable
    six.raise_from(exceptions.from_grpc_error(exc), exc)
  File "<string>", line 3, in raise_from
google.api_core.exceptions.PermissionDenied: 403 User not authorized to perform this action.
```
/area kettle
/cc @spiffxp @amwat  