### PR TITLE
Upgrade prometheus operator to 0.45.0

### DIFF
--- a/config/prow/cluster/monitoring/prometheus_operator_deployment.yaml
+++ b/config/prow/cluster/monitoring/prometheus_operator_deployment.yaml
@@ -20,10 +20,9 @@ spec:
       - args:
         - --kubelet-service=kube-system/kubelet
         - --logtostderr=true
-        - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
-        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.29.0
+        - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.45.0
         - --namespaces=prow-monitoring
-        image: quay.io/coreos/prometheus-operator:v0.29.0
+        image: quay.io/prometheus-operator/prometheus-operator:v0.45.0
         name: prometheus-operator
         ports:
         - containerPort: 8080

--- a/config/prow/cluster/monitoring/prometheus_operator_rbac.yaml
+++ b/config/prow/cluster/monitoring/prometheus_operator_rbac.yaml
@@ -18,20 +18,19 @@ metadata:
   name: prow-prometheus-operator
 rules:
 - apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - '*'
-- apiGroups:
   - monitoring.coreos.com
   resources:
   - alertmanagers
   - alertmanagers/finalizers
+  - alertmanagerconfigs
   - prometheuses
   - prometheuses/finalizers
-  - prometheusrules
+  - thanosrulers
+  - thanosrulers/finalizers
   - servicemonitors
+  - podmonitors
+  - probes
+  - prometheusrules
   verbs:
   - '*'
 - apiGroups:
@@ -52,18 +51,17 @@ rules:
   resources:
   - pods
   verbs:
-  - delete
   - list
+  - delete
 - apiGroups:
   - ""
-  attributeRestrictions: null
   resources:
-  - endpoints
   - services
   - services/finalizers
+  - endpoints
   verbs:
-  - create
   - get
+  - create
   - update
   - delete
 - apiGroups:
@@ -77,6 +75,14 @@ rules:
   - ""
   resources:
   - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
   verbs:
   - get
   - list

--- a/config/prow/cluster/monitoring/prow_alertmanager.yaml
+++ b/config/prow/cluster/monitoring/prow_alertmanager.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: prow-monitoring
 spec:
   replicas: 3
-  baseImage: docker.io/prom/alertmanager
+  image: docker.io/prom/alertmanager
   listenLocal: false
   nodeSelector: {}
   securityContext:

--- a/config/prow/cluster/monitoring/prow_prometheus.yaml
+++ b/config/prow/cluster/monitoring/prow_prometheus.yaml
@@ -33,7 +33,7 @@ spec:
     - key: app
       operator: Exists
   version: v2.7.1
-  baseImage: docker.io/prom/prometheus
+  image: docker.io/prom/prometheus
   externalLabels: {}
   listenLocal: false
   nodeSelector: {}


### PR DESCRIPTION
This change is in preparation for upgrading prometheus, which could further help with mitigating https://github.com/kubernetes/test-infra/issues/20439.

Have tried going through CHANGES from https://github.com/prometheus-operator/prometheus-operator/releases and incorporated possible relevant changes in this PR.