### PR TITLE
Add chaodaiG to OWNERS of a few prow components

### DIFF
--- a/prow/cmd/crier/OWNERS
+++ b/prow/cmd/crier/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
-
+reviewers:
+- chaodaiG
+- fejta
+approvers:
+- chaodaiG
+- fejta
 emeritus_approvers:
 - krzyzacy
 labels:

--- a/prow/cmd/crier/OWNERS
+++ b/prow/cmd/crier/OWNERS
@@ -1,9 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 reviewers:
 - chaodaiG
+- cjwagner
 - fejta
 approvers:
-- chaodaiG
+- cjwagner
 - fejta
 emeritus_approvers:
 - krzyzacy

--- a/prow/cmd/deck/OWNERS
+++ b/prow/cmd/deck/OWNERS
@@ -3,10 +3,6 @@ reviewers:
 - chaodaiG
 - e-blackwelder
 - michelle192837
-approvers:
-- chaodaiG
-- e-blackwelder
-- michelle192837
 emeritus_approvers:
  - Katharine
 labels:

--- a/prow/cmd/deck/OWNERS
+++ b/prow/cmd/deck/OWNERS
@@ -1,5 +1,12 @@
 # See the OWNERS docs at https://go.k8s.io/owners
-
+reviewers:
+- chaodaiG
+- e-blackwelder
+- michelle192837
+approvers:
+- chaodaiG
+- e-blackwelder
+- michelle192837
 emeritus_approvers:
  - Katharine
 labels:

--- a/prow/cmd/gerrit/OWNERS
+++ b/prow/cmd/gerrit/OWNERS
@@ -2,8 +2,12 @@
 
 reviewers:
 - amwat
+- chaodaiG
+- fejta
 approvers:
 - amwat
+- chaodaiG
+- fejta
 emeritus_approvers:
 - krzyzacy
 labels:

--- a/prow/cmd/gerrit/OWNERS
+++ b/prow/cmd/gerrit/OWNERS
@@ -6,8 +6,6 @@ reviewers:
 - fejta
 approvers:
 - amwat
-- chaodaiG
-- fejta
 emeritus_approvers:
 - krzyzacy
 labels:

--- a/prow/cmd/horologium/OWNERS
+++ b/prow/cmd/horologium/OWNERS
@@ -3,7 +3,6 @@ reviewers:
 - chaodaiG
 - fejta
 approvers:
-- chaodaiG
 - fejta
 labels:
 - area/prow/horologium

--- a/prow/cmd/horologium/OWNERS
+++ b/prow/cmd/horologium/OWNERS
@@ -1,4 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
-
+reviewers:
+- chaodaiG
+- fejta
+approvers:
+- chaodaiG
+- fejta
 labels:
- - area/prow/horologium
+- area/prow/horologium

--- a/prow/crier/OWNERS
+++ b/prow/crier/OWNERS
@@ -1,6 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
+reviewers:
+- chaodaiG
+- fejta
 approvers:
-- cjwagner
+- chaodaiG
 - fejta
 emeritus_approvers:
 - krzyzacy

--- a/prow/crier/OWNERS
+++ b/prow/crier/OWNERS
@@ -1,9 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 reviewers:
 - chaodaiG
+- cjwagner
 - fejta
 approvers:
-- chaodaiG
+- cjwagner
 - fejta
 emeritus_approvers:
 - krzyzacy

--- a/prow/deck/OWNERS
+++ b/prow/deck/OWNERS
@@ -1,4 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
-
+reviewers:
+- chaodaiG
+- e-blackwelder
+- michelle192837
+approvers:
+- chaodaiG
+- e-blackwelder
+- michelle192837
 labels:
  - area/prow/deck

--- a/prow/deck/OWNERS
+++ b/prow/deck/OWNERS
@@ -3,9 +3,5 @@ reviewers:
 - chaodaiG
 - e-blackwelder
 - michelle192837
-approvers:
-- chaodaiG
-- e-blackwelder
-- michelle192837
 labels:
  - area/prow/deck

--- a/prow/gerrit/OWNERS
+++ b/prow/gerrit/OWNERS
@@ -4,7 +4,6 @@ reviewers:
 - chaodaiG
 - fejta
 approvers:
-- chaodaiG
 - fejta
 emeritus_approvers:
 - Katharine

--- a/prow/gerrit/OWNERS
+++ b/prow/gerrit/OWNERS
@@ -1,8 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
+- chaodaiG
 - fejta
 approvers:
+- chaodaiG
 - fejta
 emeritus_approvers:
 - Katharine


### PR DESCRIPTION
So that code reviews can be redirected to chaodaiG, also by the way added reviewers and approvers sections under `prow/cmd` for each components.

/assign @fejta @cjwagner @michelle192837 @e-blackwelder 