### PR TITLE
feat: added new prow job for full eks e2e test

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -193,6 +193,45 @@ presubmits:
               value: "us-west-2"
             - name: NEW_E2E_FLOW
               value: "1"
+            - name: E2E_ARGS
+              value: "--skip-eks-upgrade-tests"
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 1
+              memory: "4Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+      testgrid-tab-name: pr-e2e-eks
+      testgrid-num-columns-recent: '20'
+  - name: pull-cluster-api-provider-aws-e2e-eks-full
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+    always_run: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    max_concurrency: 1
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-service-account: "true"
+      preset-aws-ssh: "true"
+      preset-aws-credential: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-1.18
+          command:
+            - "runner.sh"
+            - "./scripts/ci-e2e-eks.sh"
+          env:
+            - name: BOSKOS_HOST
+              value: "boskos.test-pods.svc.cluster.local"
+            - name: AWS_REGION
+              value: "us-west-2"
+            - name: NEW_E2E_FLOW
+              value: "1"
           securityContext:
             privileged: true
           resources:


### PR DESCRIPTION
Change the existing eks e2e job so that it skips the upgrade test, this job will become a "fast" e2e test. And add a new job that will become a full eks e2e job with extra scenarios

Fixes: https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2212