### PR TITLE
vulndash: increase page size to get the vulnerabilities and increase the resource spec

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -111,13 +111,14 @@ periodics:
         - --project=k8s-artifacts-prod
         - --bucket=k8s-artifacts-prod-vuln-dashboard
         - --dashboard-file-path=/home/prow/go/src/github.com/kubernetes/release/cmd/vulndash/
+        - --page-size=1000
       resources:
         requests:
-          cpu: 2
-          memory: "8Gi"
+          cpu: 4
+          memory: "16Gi"
         limits:
-          cpu: 2
-          memory: "8Gi"
+          cpu: 4
+          memory: "16Gi"
   annotations:
     testgrid-dashboards: sig-release-releng-informing, wg-k8s-infra-k8sio
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io


### PR DESCRIPTION
this is to try to debug why it is timing out because we don't have
enough permissions to test it locally

while we wait to see if we can get some credentials to try locally

/assign @spiffxp @hasheddan 