### PR TITLE
vulndash: add new flag to filter the vulnerabilities only for the registry hostname us.gcr.io

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -112,6 +112,7 @@ periodics:
         - --bucket=k8s-artifacts-prod-vuln-dashboard
         - --dashboard-file-path=/home/prow/go/src/github.com/kubernetes/release/cmd/vulndash/
         - --page-size=1000
+        - --registry-hostname=us.gcr.io
       resources:
         requests:
           cpu: 4


### PR DESCRIPTION
To enable the new flag as part of this PR: https://github.com/kubernetes/release/pull/1847

/assign @justaugustus @hasheddan @spiffxp 