### PR TITLE
Prow integration test job report to github

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -102,7 +102,6 @@ presubmits:
     - master
     always_run: false
     decorate: true
-    skip_report: true
     optional: true
     labels:
       preset-service-account: "true"


### PR DESCRIPTION
The integration test introduced in https://github.com/kubernetes/test-infra/pull/20451 works as expected, make it reporting to github before make it required for presubmit