### PR TITLE
Fix query to support PodUtil Flakes with pr:

### DIFF
--- a/metrics/configs/flakes-experiment-config.yaml
+++ b/metrics/configs/flakes-experiment-config.yaml
@@ -75,9 +75,10 @@ query: |
                 select as struct
                   i
                 from t.metadata i
-                where (i.key = 'repos' or repos is not null) and
-                array_length(split(replace(ifnull(t.repos, i.value),', ', ''), ',')) = 2 /*serial pr jobs only (# of PR refs +1 == 2)*/
-              )
+                where (i.key = 'repos') and
+                array_length(split(replace(i.value,', ', ''), ',')) = 2 /*serial pr jobs only (# of PR refs +1 == 2)*/
+               )
+               or array_length(split(replace(t.repos,', ', ''), ',')) = 2
             )
         )
         group by job, commit


### PR DESCRIPTION
|job|build_consistency | commit_consistency | flakes | runs | commits|
|---|---|---|---|---|---|
|pr:pull-kubernetes-e2e-kind | 0.965 | 0.96 | 21 | 627 | 521|

Looks like there was just some odd behavior with checking in the loop. No all jobs work AFAICT
/area metrics
/cc @spiffxp @BenTheElder 

