### PR TITLE
Make prow integration test as required presubmit test

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -100,9 +100,8 @@ presubmits:
   - name: pull-test-infra-integration
     branches:
     - master
-    always_run: false
+    always_run: true
     decorate: true
-    optional: true
     labels:
       preset-service-account: "true"
       preset-bazel-scratch-dir: "true"


### PR DESCRIPTION
This had been tested in #20451 and confirmed it worked, so make it a required presubmit checking.