### PR TITLE
Move prow version prometheus metrics out of prowjob metrics, more prow components report this metric

### DIFF
--- a/prow/cmd/sinker/BUILD.bazel
+++ b/prow/cmd/sinker/BUILD.bazel
@@ -51,6 +51,7 @@ go_library(
         "//prow/logrusutil:go_default_library",
         "//prow/metrics:go_default_library",
         "//prow/pjutil:go_default_library",
+        "//prow/version:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/prow/cmd/sinker/main.go
+++ b/prow/cmd/sinker/main.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/test-infra/prow/logrusutil"
 	"k8s.io/test-infra/prow/metrics"
 	"k8s.io/test-infra/prow/pjutil"
+	"k8s.io/test-infra/prow/version"
 )
 
 type options struct {
@@ -463,6 +464,7 @@ func (c *controller) clean() {
 	for k, v := range metrics.prowJobsCleaningErrors {
 		sinkerMetrics.prowJobsCleaningErrors.WithLabelValues(k).Set(float64(v))
 	}
+	version.GatherProwVersion(c.logger)
 	c.logger.Info("Sinker reconciliation complete.")
 }
 

--- a/prow/kube/BUILD.bazel
+++ b/prow/kube/BUILD.bazel
@@ -40,7 +40,6 @@ go_library(
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/client/clientset/versioned:go_default_library",
         "//prow/client/clientset/versioned/typed/prowjobs/v1:go_default_library",
-        "//prow/version:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",

--- a/prow/plank/BUILD.bazel
+++ b/prow/plank/BUILD.bazel
@@ -58,6 +58,7 @@ go_library(
         "//prow/kube:go_default_library",
         "//prow/pjutil:go_default_library",
         "//prow/pod-utils/decorate:go_default_library",
+        "//prow/version:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/test-infra/prow/kube"
 	"k8s.io/test-infra/prow/pjutil"
 	"k8s.io/test-infra/prow/pod-utils/decorate"
+	"k8s.io/test-infra/prow/version"
 )
 
 // PodStatus constants
@@ -264,6 +265,7 @@ func (c *Controller) SyncMetrics() {
 	c.pjLock.RLock()
 	defer c.pjLock.RUnlock()
 	kube.GatherProwJobMetrics(c.log, c.pjs)
+	version.GatherProwVersion(c.log)
 }
 
 // terminateDupes aborts presubmits that have a newer version. It modifies pjs

--- a/prow/plank/reconciler.go
+++ b/prow/plank/reconciler.go
@@ -47,6 +47,7 @@ import (
 	"k8s.io/test-infra/prow/kube"
 	"k8s.io/test-infra/prow/pjutil"
 	"k8s.io/test-infra/prow/pod-utils/decorate"
+	"k8s.io/test-infra/prow/version"
 )
 
 const ControllerName = "plank"
@@ -161,6 +162,7 @@ func (r *reconciler) syncMetrics(ctx context.Context) error {
 				continue
 			}
 			kube.GatherProwJobMetrics(r.log, pjs.Items)
+			version.GatherProwVersion(r.log)
 		}
 	}
 }

--- a/prow/tide/BUILD.bazel
+++ b/prow/tide/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//prow/pjutil:go_default_library",
         "//prow/tide/blockers:go_default_library",
         "//prow/tide/history:go_default_library",
+        "//prow/version:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_shurcool_githubv4//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/test-infra/prow/pjutil"
 	"k8s.io/test-infra/prow/tide/blockers"
 	"k8s.io/test-infra/prow/tide/history"
+	"k8s.io/test-infra/prow/version"
 )
 
 // For mocking out sleep during unit tests.
@@ -358,6 +359,7 @@ func (c *Controller) Sync() error {
 		c.logger.WithField("duration", duration.String()).Info("Synced")
 		tideMetrics.syncDuration.Set(duration.Seconds())
 		tideMetrics.syncHeartbeat.WithLabelValues("sync").Inc()
+		version.GatherProwVersion(c.logger)
 	}()
 	defer c.changedFiles.prune()
 	c.config().BranchProtectionWarnings(c.logger, c.config().PresubmitsStatic)

--- a/prow/version/BUILD.bazel
+++ b/prow/version/BUILD.bazel
@@ -2,10 +2,17 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["doc.go"],
+    srcs = [
+        "doc.go",
+        "metrics.go",
+    ],
     importpath = "k8s.io/test-infra/prow/version",
     visibility = ["//visibility:public"],
     x_defs = {"Version": "{DOCKER_TAG}"},
+    deps = [
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+    ],
 )
 
 go_test(

--- a/prow/version/metrics.go
+++ b/prow/version/metrics.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	prowVersion = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "prow_version",
+		Help: "Prow version",
+	})
+)
+
+func init() {
+	prometheus.MustRegister(prowVersion)
+}
+
+// GatherProwVersion reports prow version
+func GatherProwVersion(l *logrus.Entry) {
+	// record prow version
+	version, err := VersionTimestamp()
+	if err != nil {
+		// Not worth panicking
+		l.WithError(err).Debug("Failed to get version timestamp")
+		prowVersion.Set(-1)
+	} else {
+		prowVersion.Set(float64(version))
+	}
+}


### PR DESCRIPTION
Previously the version metrics was mixed with prowjob metrics, which is not ideal for other prow components to use it. Moving it out to version package so that it's easier to be used by others