### PR TITLE
Update autobump description to correctly handle commits past a tag.

### DIFF
--- a/experiment/autobumper/bumper/bumper.go
+++ b/experiment/autobumper/bumper/bumper.go
@@ -706,6 +706,19 @@ func formatTagDate(d string) string {
 	return fmt.Sprintf("%s&#x2011;%s&#x2011;%s", d[0:4], d[4:6], d[6:8])
 }
 
+// commitToRef converts git describe part of a tag to a ref (commit or tag).
+//
+// v0.0.30-14-gdeadbeef => deadbeef
+// v0.0.30 => v0.0.30
+// deadbeef => deadbeef
+func commitToRef(commit string) string {
+	tag, _, commit := imagebumper.DeconstructCommit(commit)
+	if commit != "" {
+		return commit
+	}
+	return tag
+}
+
 func generateSummary(name, repo, prefix string, summarise bool, images map[string]string) string {
 	type delta struct {
 		oldCommit string
@@ -725,6 +738,8 @@ func generateSummary(name, repo, prefix string, summarise bool, images map[strin
 		}
 		oldDate, oldCommit, oldVariant := imagebumper.DeconstructTag(tagFromName(image))
 		newDate, newCommit, _ := imagebumper.DeconstructTag(newTag)
+		oldCommit = commitToRef(oldCommit)
+		newCommit = commitToRef(newCommit)
 		k := oldCommit + ":" + newCommit
 		d := delta{
 			oldCommit: oldCommit,

--- a/experiment/autobumper/bumper/bumper_test.go
+++ b/experiment/autobumper/bumper/bumper_test.go
@@ -34,6 +34,41 @@ import (
 	"k8s.io/test-infra/prow/config/secret"
 )
 
+func TestCommitToRef(t *testing.T) {
+	cases := []struct {
+		name     string
+		commit   string
+		expected string
+	}{
+		{
+			name: "basically works",
+		},
+		{
+			name:     "just tag works",
+			commit:   "v0.0.30",
+			expected: "v0.0.30",
+		},
+		{
+			name:     "just commit works",
+			commit:   "deadbeef",
+			expected: "deadbeef",
+		},
+		{
+			name:     "commits past tag works",
+			commit:   "v0.0.30-14-gdeadbeef",
+			expected: "deadbeef",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if actual, expected := commitToRef(tc.commit), tc.expected; actual != tc.expected {
+				t.Errorf("commitToRef(%q) got %q want %q", tc.commit, actual, expected)
+			}
+		})
+	}
+}
+
 func TestValidateOptions(t *testing.T) {
 	emptyStr := ""
 	whateverStr := "whatever"

--- a/experiment/image-bumper/bumper/bumper.go
+++ b/experiment/image-bumper/bumper/bumper.go
@@ -59,6 +59,41 @@ type manifest map[string]struct {
 	Tags          []string `json:"tag"`
 }
 
+// commit | tag-n-gcommit
+var commitRegexp = regexp.MustCompile(`^([\da-f]+)|(.+?)??(?:-(\d+)-g([\da-f]+))?$`)
+
+// DeconstructCommit separates a git describe commit into its parts.
+
+//
+// Examples:
+//  v0.0.30-14-gdeadbeef => (v0.0.30 14 deadbeef)
+//  v0.0.30 => (v0.0.30 0 "")
+//  deadbeef => ("", 0, deadbeef)
+//
+// See man git describe.
+func DeconstructCommit(commit string) (string, int, string) {
+	parts := commitRegexp.FindStringSubmatch(commit)
+	if parts == nil {
+		return "", 0, ""
+	}
+	if parts[1] != "" {
+		return "", 0, parts[1]
+	}
+	var n int
+	if s := parts[3]; s != "" {
+		var err error
+		n, err = strconv.Atoi(s)
+		if err != nil {
+			panic(err)
+		}
+	}
+	return parts[2], n, parts[4]
+}
+
+// DeconstructTag separates the tag into its vDATE-COMMIT-VARIANT components
+//
+// COMMIT may be in the form vTAG-NEW-gCOMMIT, use PureCommit to further process
+// this down to COMMIT.
 func DeconstructTag(tag string) (date, commit, variant string) {
 	currentTagParts := tagRegexp.FindStringSubmatch(tag)
 	if currentTagParts == nil {

--- a/experiment/image-bumper/bumper/bumper_test.go
+++ b/experiment/image-bumper/bumper/bumper_test.go
@@ -22,6 +22,53 @@ import (
 	"testing"
 )
 
+func TestDeconstructCommit(t *testing.T) {
+	cases := []struct {
+		name           string
+		commit         string
+		tag            string
+		num            int
+		expectedCommit string
+	}{
+		{
+			name: "basically works",
+		},
+		{
+			name:           "just commit works",
+			commit:         "deadbeef",
+			expectedCommit: "deadbeef",
+		},
+		{
+			name:   "just tag works",
+			commit: "v0.0.30",
+			tag:    "v0.0.30",
+		},
+		{
+			name:           "commits past tags work",
+			commit:         "v0.0.30-14-gdeadbeef",
+			tag:            "v0.0.30",
+			num:            14,
+			expectedCommit: "deadbeef",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tag, num, commit := DeconstructCommit(tc.commit)
+			if tag != tc.tag {
+				t.Errorf("DeconstructCommit(%s) got tag %q, want %q", tc.commit, tag, tc.tag)
+			}
+			if num != tc.num {
+				t.Errorf("DeconstructCommit(%s) got tag %d, want %d", tc.commit, num, tc.num)
+			}
+			if commit != tc.expectedCommit {
+				t.Errorf("DeconstructCommit(%s) got commit %q, want %q", tc.commit, commit, tc.expectedCommit)
+			}
+
+		})
+	}
+}
+
 func TestPickBestTag(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
Testgrid tags tend to look like v20210115-v0.0.38-14-g4c88977
This is standard git describe --tags output, so handle it correctly.

/assign @mpherman2 