### PR TITLE
Deck: Support filtering periodics by repo

### DIFF
--- a/prow/cmd/deck/static/api/prow.ts
+++ b/prow/cmd/deck/static/api/prow.ts
@@ -93,7 +93,7 @@ export interface ProwJobSpec {
   namespace?: string;
   job?: string;
   refs?: Refs;
-  extra_refs?: Refs;
+  extra_refs?: Refs[];
   report?: boolean;
   context?: string;
   rerun_command?: string;

--- a/prow/cmd/deck/static/prow/prow.ts
+++ b/prow/cmd/deck/static/prow/prow.ts
@@ -509,11 +509,21 @@ function redraw(fz: FuzzySearch, pushState: boolean = true): void {
                 type = "",
                 job = "",
                 agent = "",
-                refs: {org = "", repo = "", repo_link = "", base_sha = "", base_link = "", pulls = [], base_ref = ""} = {},
+                refs: {repo_link = "", base_sha = "", base_link = "", pulls = [], base_ref = ""} = {},
                 pod_spec,
             },
             status: {startTime, completionTime = "", state = "", pod_name, build_id = "", url = ""},
         } = build;
+
+        let org = "";
+        let repo = "";
+        if (build.spec.refs !== undefined) {
+            org = build.spec.refs.org;
+            repo = build.spec.refs.repo;
+        } else if (build.spec.extra_refs !== undefined && build.spec.extra_refs.length > 0 ) {
+            org = build.spec.extra_refs[0].org;
+            repo = build.spec.extra_refs[0].repo;
+        }
 
         if (!equalSelected(typeSel, type)) {
             continue;


### PR DESCRIPTION
Periodics never have the .spec.refs field set, so we have to use their
extra_refs field instead to derive org and repo.

Fixes https://github.com/kubernetes/test-infra/issues/20485