### PR TITLE
kOps tests cleanup

### DIFF
--- a/config/jobs/kubernetes/kops/build-pipeline.py
+++ b/config/jobs/kubernetes/kops/build-pipeline.py
@@ -55,6 +55,7 @@ template = """
       - --deployment=kops
       - --provider=aws
       - --cluster={{name}}.test-cncf-aws.k8s.io
+      - --kops-args=--networking=calico
       - --kops-ssh-user=ubuntu
       - --kops-nodes=4
       - --extract={{extract}}

--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -77,7 +77,7 @@ periodics:
     testgrid-tab-name: kops-aws-ha-euwest1
 
 - interval: 8h
-  name: e2e-kops-aws-misc-arm64-latest
+  name: e2e-kops-aws-misc-arm64-release
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -91,14 +91,14 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-aws-arm64-latest.test-cncf-aws.k8s.io
+      - --cluster=e2e-kops-aws-arm64-release.test-cncf-aws.k8s.io
       - --deployment=kops
       - --kops-ssh-user=ubuntu
       - --env=KUBE_SSH_USER=ubuntu
       - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
       - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable
+      - --extract=release/latest
       - --ginkgo-parallel
       - --kops-args=--node-size=m6g.large --master-size=m6g.large --container-runtime=containerd --networking=calico
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20210106
@@ -112,7 +112,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-misc
     testgrid-days-of-results: "30"
-    testgrid-tab-name: kops-aws-arm64-latest
+    testgrid-tab-name: kops-aws-arm64-release
 
 - interval: 8h
   name: e2e-kops-aws-misc-arm64-ci
@@ -172,7 +172,7 @@ periodics:
       - --env=KUBE_SSH_USER=ubuntu
       - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release-dev/ci/latest.txt
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable
+      - --extract=ci/latest
       - --ginkgo-parallel=10
       - --kops-args=--node-size=m6g.large --master-size=m6g.large --container-runtime=containerd --networking=calico
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20210106
@@ -252,11 +252,11 @@ periodics:
       - --extract=release/stable-1.17
       - --ginkgo-parallel
       - --kops-feature-flags=SpecOverrideFlag
-      - --kops-args=--override=cluster.spec.etcdClusters[*].provider=Legacy
+      - --kops-args=--override=cluster.spec.etcdClusters[*].provider=Legacy --networking=calico
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
       - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-1.17
       imagePullPolicy: Always
@@ -289,10 +289,11 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable
       - --ginkgo-parallel
+      - --kops-args=--networking=calico
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
       - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
@@ -326,6 +327,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable
       - --ginkgo-parallel
+      - --kops-args=--networking=calico
       - --kops-publish=gs://kops-ci/bin/latest-ci-updown-green.txt
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt
       - --provider=aws

--- a/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
@@ -359,39 +359,3 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-versions
     testgrid-days-of-results: "30"
     testgrid-tab-name: kops-aws-k8s-1.12
-
-- interval: 12h
-  name: e2e-kops-aws-k8s-1-11
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-aws-k8s-1-11.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=admin
-      - --env=KUBE_SSH_USER=admin
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.11.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --extract=release/stable-1.11
-      - --ginkgo-parallel
-      - --kops-args=--container-runtime=containerd --networking=calico
-      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-07-20-58035
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|AdmissionWebhook|Aggregator|CustomResource|SchedulerPredicates|Lease|hostAliases|NodePort
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-master
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-versions
-    testgrid-days-of-results: "30"
-    testgrid-tab-name: kops-aws-k8s-1.11

--- a/config/jobs/kubernetes/kops/kops-pipeline.yaml
+++ b/config/jobs/kubernetes/kops/kops-pipeline.yaml
@@ -35,6 +35,7 @@ periodics:
       - --deployment=kops
       - --provider=aws
       - --cluster=e2e-kops-pipeline-updown-kopsmaster.test-cncf-aws.k8s.io
+      - --kops-args=--networking=calico
       - --kops-ssh-user=ubuntu
       - --kops-nodes=4
       - --extract=release/latest-1.20
@@ -88,6 +89,7 @@ periodics:
       - --deployment=kops
       - --provider=aws
       - --cluster=e2e-kops-pipeline-updown-kops119.test-cncf-aws.k8s.io
+      - --kops-args=--networking=calico
       - --kops-ssh-user=ubuntu
       - --kops-nodes=4
       - --extract=release/stable-1.19
@@ -141,6 +143,7 @@ periodics:
       - --deployment=kops
       - --provider=aws
       - --cluster=e2e-kops-pipeline-updown-kops118.test-cncf-aws.k8s.io
+      - --kops-args=--networking=calico
       - --kops-ssh-user=ubuntu
       - --kops-nodes=4
       - --extract=release/stable-1.18

--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -80,7 +80,7 @@ presubmits:
         - --cluster=
         - --kops-ssh-user=ubuntu
         - --env=KUBE_SSH_USER=ubuntu
-        - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest-1.19.txt
+        - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt
         - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
         - --env=KOPS_RUN_TOO_NEW_VERSION=1
         - --extract=release/latest-1.19
@@ -164,7 +164,7 @@ presubmits:
         - --cluster=
         - --kops-ssh-user=ubuntu
         - --env=KUBE_SSH_USER=ubuntu
-        - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest-1.19.txt
+        - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt
         - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
         - --env=KOPS_RUN_TOO_NEW_VERSION=1
         - --extract=release/latest-1.19


### PR DESCRIPTION
Changing the default container runtime to containerd and switching to k8s 1.20 as stable requires a few tweaks.
/cc @olemarkus @rifelpet 