### PR TITLE
Kops - make the Windows GitHub Actions job blocking

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -248,6 +248,7 @@ branch-protection:
             contexts:
             - build-linux-amd64
             - build-macos-amd64
+            - build-windows-amd64
             - verify
         kubelet:
           restrictions:


### PR DESCRIPTION
This job has been stable since its inception months ago. Given our desire to increase windows support going forward I think it makes sense to have the job be required for PRs. This also helps with consistency by having all of our GHA jobs be blocking.