### PR TITLE
prow/cmd/exporter fix prow_job_runtime_seconds metric and docs

### DIFF
--- a/prow/cmd/exporter/README.md
+++ b/prow/cmd/exporter/README.md
@@ -9,7 +9,6 @@ metrics are not directly related to a specific prow-component.
 |----------------------|-------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | prow_job_labels      | Gauge       | `job_name`=&lt;prow_job-name&gt; <br> `job_namespace`=&lt;prow_job-namespace&gt; <br> `job_agent`=&lt;prow_job-agent&gt; <br> `label_PROW_JOB_LABEL_KEY`=&lt;PROW_JOB_LABEL_VALUE&gt;                 |
 | prow_job_annotations | Gauge       | `job_name`=&lt;prow_job-name&gt; <br> `job_namespace`=&lt;prow_job-namespace&gt; <br> `job_agent`=&lt;prow_job-agent&gt; <br> `annotation_PROW_JOB_ANNOTATION_KEY`=&lt;PROW_JOB_ANNOTATION_VALUE&gt;  |
-| prow_job_annotations | Gauge       | `job_name`=&lt;prow_job-name&gt; <br> `job_namespace`=&lt;prow_job-namespace&gt; <br> `job_agent`=&lt;prow_job-agent&gt; <br> `annotation_PROW_JOB_ANNOTATION_KEY`=&lt;PROW_JOB_ANNOTATION_VALUE&gt;  |
 | prow_job_runtime_seconds     | Histogram     | `job_name`=&lt;prow_job-name&gt; <br> `job_namespace`=&lt;prow_job-namespace&gt; <br> `type`=&lt;prow_job-type&gt; <br> `last_state`=&lt;last-state&gt; <br> `state`=&lt;state&gt; <br> `org`=&lt;org&gt; <br> `repo`=&lt;repo&gt; <br> `base_ref`=&lt;base_ref&gt; <br>  |
 
 For example, the metric `prow_job_labels` is similar to `kube_pod_labels` defined

--- a/prow/cmd/exporter/main.go
+++ b/prow/cmd/exporter/main.go
@@ -93,11 +93,10 @@ func main() {
 	informerFactory := prowjobinformer.NewSharedInformerFactoryWithOptions(pjClientset, 0, prowjobinformer.WithNamespace(cfg().ProwJobNamespace))
 	pjLister := informerFactory.Prow().V1().ProwJobs().Lister()
 
-	prometheus.MustRegister(prowjobs.NewProwJobLifecycleHistogramVec(informerFactory.Prow().V1().ProwJobs().Informer()))
-
 	go informerFactory.Start(interrupts.Context().Done())
 
 	registry := mustRegister("exporter", pjLister)
+	registry.MustRegister(prowjobs.NewProwJobLifecycleHistogramVec(informerFactory.Prow().V1().ProwJobs().Informer()))
 
 	// Expose prometheus metrics
 	metrics.ExposeMetricsWithRegistry("exporter", cfg().PushGateway, o.instrumentationOptions.MetricsPort, registry, nil)


### PR DESCRIPTION
* Fixes the docs, the line for `prow_job_annotations` was duplicated in [this commit](https://github.com/Daimler/test-infra/commit/3b8c5cf4fa00a404daa13a4c05d9240b7f08e23b#diff-1fbf75a3aec0d12d094aa0bbbff32630f675a25108233bff64ac4b24782f461c) which I think was by accident.
* Also fixes the registration of the `prow_job_runtime_seconds` histogram metric. It was registered in prometheus `DefaultRegisterer` instead of the exporters `registry` and because of that never exposed in the `/metrics` endpoint.

<sup>
Christian Schlotter <christian.schlotter@daimler.com>, Daimler TSS GmbH, 
<a href="https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md">Imprint</a>
</sup>
