### PR TITLE
Disable branch protection on gh-pages for cloud-provider-openstack

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -184,6 +184,10 @@ branch-protection:
           branches:
             gh-pages:
               protect: false
+        cloud-provider-openstack:
+          branches:
+            gh-pages:
+              protect: false
         cluster-bootstrap:
           restrictions:
             users: []


### PR DESCRIPTION
We need to disable branch protection on gh-pages branch for chart-releaser-action to function correctly.