### PR TITLE
Add Gardener test results for kubernetes v1.20

### DIFF
--- a/config/testgrids/conformance/conformance-all.yaml
+++ b/config/testgrids/conformance/conformance-all.yaml
@@ -26,6 +26,21 @@ dashboards:
       description: Runs conformance tests using kubetest against kubernetes from the release-1.16 branch with cloud-provider-openstack
       test_group_name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.16
 
+    - name: Gardener, v1.20 AWS
+      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)"
+      test_group_name: ci-gardener-e2e-conformance-aws-v1.20
+    - name: Gardener, v1.20 GCE
+      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)"
+      test_group_name: ci-gardener-e2e-conformance-gce-v1.20
+    - name: Gardener, v1.20 OpenStack
+      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Openstack"
+      test_group_name: ci-gardener-e2e-conformance-openstack-v1.20
+    - name: Gardener, v1.20 Azure
+      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure"
+      test_group_name: ci-gardener-e2e-conformance-azure-v1.20
+    - name: Gardener, v1.20 Alibaba Cloud
+      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud"
+      test_group_name: ci-gardener-e2e-conformance-alicloud-v1.20
     - name: Gardener, v1.19 AWS
       description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)"
       test_group_name: ci-gardener-e2e-conformance-aws-v1.19
@@ -153,6 +168,31 @@ dashboards:
 # Gardener Conformance Dashboard
 - name: conformance-gardener
   dashboard_tab:
+    - name: Gardener, v1.20 AWS
+      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)"
+      test_group_name: ci-gardener-e2e-conformance-aws-v1.20
+      alert_options:
+        alert_mail_to_addresses: gardener-oq@listserv.sap.com
+    - name: Gardener, v1.20 GCE
+      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)"
+      test_group_name: ci-gardener-e2e-conformance-gce-v1.20
+      alert_options:
+        alert_mail_to_addresses: gardener-oq@listserv.sap.com
+    - name: Gardener, v1.20 OpenStack
+      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Openstack"
+      test_group_name: ci-gardener-e2e-conformance-openstack-v1.20
+      alert_options:
+        alert_mail_to_addresses: gardener-oq@listserv.sap.com
+    - name: Gardener, v1.20 Azure
+      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure"
+      test_group_name: ci-gardener-e2e-conformance-azure-v1.20
+      alert_options:
+        alert_mail_to_addresses: gardener-oq@listserv.sap.com
+    - name: Gardener, v1.20 Alibaba Cloud
+      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud"
+      test_group_name: ci-gardener-e2e-conformance-alicloud-v1.20
+      alert_options:
+        alert_mail_to_addresses: gardener-oq@listserv.sap.com
     - name: Gardener, v1.19 AWS
       description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)"
       test_group_name: ci-gardener-e2e-conformance-aws-v1.19

--- a/config/testgrids/gardener/config.yaml
+++ b/config/testgrids/gardener/config.yaml
@@ -13,6 +13,11 @@ dashboards:
 - name: gardener-all
   dashboard_tab:
     # GCE
+    - name: Gardener, v1.20 GCE
+      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)
+      test_group_name: ci-gardener-e2e-gce-v1.20
+      alert_options:
+        alert_mail_to_addresses: gardener-oq@listserv.sap.com
     - name: Gardener, v1.19 GCE
       description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)
       test_group_name: ci-gardener-e2e-gce-v1.19
@@ -35,6 +40,11 @@ dashboards:
         alert_mail_to_addresses: gardener-oq@listserv.sap.com
 
     # AWS
+    - name: Gardener, v1.20 AWS
+      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)
+      test_group_name: ci-gardener-e2e-aws-v1.20
+      alert_options:
+        alert_mail_to_addresses: gardener-oq@listserv.sap.com
     - name: Gardener, v1.19 AWS
       description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)
       test_group_name: ci-gardener-e2e-aws-v1.19
@@ -57,6 +67,11 @@ dashboards:
         alert_mail_to_addresses: gardener-oq@listserv.sap.com
 
     #Alicloud
+    - name: Gardener, v1.20 Alicloud
+      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud (Alicloud)
+      test_group_name: ci-gardener-e2e-alicloud-v1.20
+      alert_options:
+        alert_mail_to_addresses: gardener-oq@listserv.sap.com
     - name: Gardener, v1.19 Alicloud
       description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud (Alicloud)
       test_group_name: ci-gardener-e2e-alicloud-v1.19
@@ -79,6 +94,11 @@ dashboards:
         alert_mail_to_addresses: gardener-oq@listserv.sap.com
 
     # Azure
+    - name: Gardener, v1.20 Azure
+      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure
+      test_group_name: ci-gardener-e2e-azure-v1.20
+      alert_options:
+        alert_mail_to_addresses: gardener-oq@listserv.sap.com
     - name: Gardener, v1.19 Azure
       description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure
       test_group_name: ci-gardener-e2e-azure-v1.19
@@ -101,6 +121,11 @@ dashboards:
         alert_mail_to_addresses: gardener-oq@listserv.sap.com
 
     # Openstack
+    - name: Gardener, v1.20 OpenStack
+      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on OpenStack
+      test_group_name: ci-gardener-e2e-openstack-v1.20
+      alert_options:
+        alert_mail_to_addresses: gardener-oq@listserv.sap.com
     - name: Gardener, v1.19 OpenStack
       description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on OpenStack
       test_group_name: ci-gardener-e2e-openstack-v1.19
@@ -125,6 +150,11 @@ dashboards:
   # Gardener AWS Dashboard
 - name: gardener-aws
   dashboard_tab:
+    - name: Gardener, v1.20 AWS
+      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)
+      test_group_name: ci-gardener-e2e-aws-v1.20
+      alert_options:
+        alert_mail_to_addresses: gardener-oq@listserv.sap.com
     - name: Gardener, v1.19 AWS
       description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)
       test_group_name: ci-gardener-e2e-aws-v1.19
@@ -149,6 +179,11 @@ dashboards:
   # Gardener GCE Dashboard
 - name: gardener-gce
   dashboard_tab:
+    - name: Gardener, v1.20 GCE
+      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)
+      test_group_name: ci-gardener-e2e-gce-v1.20
+      alert_options:
+        alert_mail_to_addresses: gardener-oq@listserv.sap.com
     - name: Gardener, v1.19 GCE
       description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)
       test_group_name: ci-gardener-e2e-gce-v1.19
@@ -173,6 +208,11 @@ dashboards:
   # Gardener Alicloud Dashboard
 - name: gardener-alicloud
   dashboard_tab:
+    - name: Gardener, v1.20 Alicloud
+      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud (Alicloud)
+      test_group_name: ci-gardener-e2e-alicloud-v1.20
+      alert_options:
+        alert_mail_to_addresses: gardener-oq@listserv.sap.com
     - name: Gardener, v1.19 Alicloud
       description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud (Alicloud)
       test_group_name: ci-gardener-e2e-alicloud-v1.19
@@ -197,6 +237,11 @@ dashboards:
   # Gardener Azure Dashboard
 - name: gardener-azure
   dashboard_tab:
+    - name: Gardener, v1.20 Azure
+      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure
+      test_group_name: ci-gardener-e2e-azure-v1.20
+      alert_options:
+        alert_mail_to_addresses: gardener-oq@listserv.sap.com
     - name: Gardener, v1.19 Azure
       description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure
       test_group_name: ci-gardener-e2e-azure-v1.19
@@ -221,6 +266,11 @@ dashboards:
   # Gardener OpenStack Dashboard
 - name: gardener-openstack
   dashboard_tab:
+    - name: Gardener, v1.20 OpenStack
+      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on OpenStack
+      test_group_name: ci-gardener-e2e-openstack-v1.20
+      alert_options:
+        alert_mail_to_addresses: gardener-oq@listserv.sap.com
     - name: Gardener, v1.19 OpenStack
       description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on OpenStack
       test_group_name: ci-gardener-e2e-openstack-v1.19
@@ -244,6 +294,26 @@ dashboards:
 
 test_groups:
 # Gardener Conformance Test Groups
+- name: ci-gardener-e2e-conformance-aws-v1.20
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-aws-v1.20
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-conformance-gce-v1.20
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-gce-v1.20
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-conformance-openstack-v1.20
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-openstack-v1.20
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-conformance-azure-v1.20
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-azure-v1.20
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-conformance-alicloud-v1.20
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-alicloud-v1.20
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
 - name: ci-gardener-e2e-conformance-aws-v1.19
   gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-aws-v1.19
   alert_stale_results_hours: 168
@@ -326,6 +396,26 @@ test_groups:
   num_failures_to_alert: 1
 
 # Gardener General Test Groups
+- name: ci-gardener-e2e-aws-v1.20
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-aws-v1.20
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-gce-v1.20
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-gce-v1.20
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-openstack-v1.20
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-openstack-v1.20
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-azure-v1.20
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-azure-v1.20
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
+- name: ci-gardener-e2e-alicloud-v1.20
+  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-alicloud-v1.20
+  alert_stale_results_hours: 168
+  num_failures_to_alert: 1
 - name: ci-gardener-e2e-aws-v1.19
   gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-aws-v1.19
   alert_stale_results_hours: 168


### PR DESCRIPTION
Adds gardener test results for new kubernetes version 1.20 to the testgrid.

cc @schrodit 