### PR TITLE
Add custom-metrics-apiserver presubmits

### DIFF
--- a/config/jobs/kubernetes-sigs/custom-metrics-apiserver/OWNERS
+++ b/config/jobs/kubernetes-sigs/custom-metrics-apiserver/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- s-urbaniak
+- luxas
+- kawych

--- a/config/jobs/kubernetes-sigs/custom-metrics-apiserver/custom-metrics-apiserver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/custom-metrics-apiserver/custom-metrics-apiserver-presubmits.yaml
@@ -1,0 +1,38 @@
+presubmits:
+  kubernetes-sigs/custom-metrics-apiserver:
+  - name: pull-custom-metrics-apiserver-verify
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/custom-metrics-apiserver
+    spec:
+      containers:
+      - image: golang:1.15
+        command:
+        - make verify && git diff --exit-code
+    annotations:
+      testgrid-dashboards: sig-instrumentation-custom-metrics-apiserver
+      testgrid-tab-name: pr-verify
+  - name: pull-custom-metrics-apiserver-build-test-adapter
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/custom-metrics-apiserver
+    spec:
+      containers:
+      - image: golang:1.15
+        command:
+        - make build-test-adapter
+    annotations:
+      testgrid-dashboards: sig-instrumentation-custom-metrics-apiserver
+      testgrid-tab-name: pr-build-test-adapter
+  - name: pull-custom-metrics-apiserver-test
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/custom-metrics-apiserver
+    spec:
+      containers:
+      - image: golang:1.15
+        command:
+        - make test
+    annotations:
+      testgrid-dashboards: sig-instrumentation-custom-metrics-apiserver
+      testgrid-tab-name: pr-test

--- a/config/testgrids/kubernetes/sig-instrumentation/config.yaml
+++ b/config/testgrids/kubernetes/sig-instrumentation/config.yaml
@@ -4,6 +4,7 @@ dashboard_groups:
   - sig-instrumentation-tests
   - sig-instrumentation-image-pushes
   - sig-instrumentation-metrics-server
+  - sig-instrumentation-custom-metrics-apiserver
 
 dashboards:
 - name: sig-instrumentation-tests
@@ -22,3 +23,4 @@ dashboards:
       description: sig-instrumentation gce elasticsearch logging e2e tests for master branch
 - name: sig-instrumentation-image-pushes
 - name: sig-instrumentation-metrics-server
+- name: sig-instrumentation-custom-metrics-apiserver


### PR DESCRIPTION
/cc @s-urbaniak
/cc @brancz can you please have a look from a sig-instrumentation standpoint as this PR adds custom-metrics-apiserver to the sig testgrid.