### PR TITLE
Prow integration test: add more scenarios for sinker test

### DIFF
--- a/prow/test/integration/test/sinker_test.go
+++ b/prow/test/integration/test/sinker_test.go
@@ -19,7 +19,6 @@ package integration
 import (
 	"context"
 	"fmt"
-	"log"
 	"testing"
 	"time"
 
@@ -27,7 +26,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	prowjobv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -35,94 +33,36 @@ func TestDeletePod(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name             string
-		notCreatedByProw bool
-		jobStartTime     v1.Time
-		jobFinishTime    v1.Time
-		hasCR            bool
-		wantJobDeleted   bool
-		wantPodDeleted   bool
+		name           string
+		prowjob        *prowjobv1.ProwJob
+		pod            *corev1.Pod
+		prowjobDeleted bool
+		wantJobDeleted bool
+		wantPodDeleted bool
 	}{
 		{
-			name:           "running-pod",
-			jobStartTime:   v1.NewTime(time.Now().Add(-1 * time.Minute)),
-			hasCR:          true,
-			wantPodDeleted: false,
-		},
-		{
-			name:           "orphaned-pod",
-			jobStartTime:   v1.NewTime(time.Now().Add(-1 * time.Minute)),
-			hasCR:          false,
-			wantPodDeleted: true,
-		},
-		{
-			name:           "ttl-deleted",
-			jobStartTime:   v1.NewTime(time.Now().Add(-32 * time.Minute)),
-			jobFinishTime:  v1.NewTime(time.Now().Add(-31 * time.Minute)),
-			hasCR:          true,
-			wantPodDeleted: true,
-		},
-		{
-			name:           "max-prow-job-age",
-			jobStartTime:   v1.NewTime(time.Now().Add(-49 * time.Hour)),
-			jobFinishTime:  v1.NewTime(time.Now().Add(-48 * time.Hour)),
-			hasCR:          true,
-			wantJobDeleted: true,
-			wantPodDeleted: true,
-		},
-		{
-			name:             "orphaned-pod-not-prowpod",
-			notCreatedByProw: true,
-			wantPodDeleted:   false,
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			resourceName := fmt.Sprintf("%s-%s", tt.name, RandomString(t))
-
-			clusterContext := getClusterContext()
-			t.Logf("Creating client for cluster: %s", clusterContext)
-
-			kubeClient, err := NewClients("", clusterContext)
-			if err != nil {
-				t.Fatalf("Failed creating clients for cluster %q: %v", clusterContext, err)
-			}
-
-			ctx := context.Background()
-
-			prowjob := prowjobv1.ProwJob{
+			name: "running-pod",
+			prowjob: &prowjobv1.ProwJob{
 				ObjectMeta: v1.ObjectMeta{
-					Annotations: map[string]string{
-						"prow.k8s.io/job": resourceName,
-					},
 					Labels: map[string]string{
-						"created-by-prow":  "true",
-						"prow.k8s.io/type": "periodic",
-						"name":             resourceName,
+						"created-by-prow": "true",
 					},
-					Name:      resourceName,
 					Namespace: defaultNamespace,
 				},
 				Spec: prowjobv1.ProwJobSpec{
-					Type:      prowjobv1.PeriodicJob,
 					Namespace: testpodNamespace,
-					Job:       resourceName,
 				},
 				Status: prowjobv1.ProwJobStatus{
-					State: prowjobv1.TriggeredState,
+					State:     prowjobv1.TriggeredState,
+					StartTime: v1.NewTime(time.Now().Add(-1 * time.Minute)),
 				},
-			}
-
-			pod := corev1.Pod{
+			},
+			pod: &corev1.Pod{
 				ObjectMeta: v1.ObjectMeta{
-					Name:      resourceName,
-					Namespace: testpodNamespace,
 					Labels: map[string]string{
-						"name": resourceName,
+						"created-by-prow": "true",
 					},
+					Namespace: testpodNamespace,
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -136,73 +76,215 @@ func TestDeletePod(t *testing.T) {
 						},
 					},
 				},
+			},
+			prowjobDeleted: false,
+			wantPodDeleted: false,
+		},
+		{
+			name: "orphaned-pod",
+			prowjob: &prowjobv1.ProwJob{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{
+						"created-by-prow": "true",
+					},
+					Namespace: defaultNamespace,
+				},
+				Spec: prowjobv1.ProwJobSpec{
+					Namespace: testpodNamespace,
+				},
+				Status: prowjobv1.ProwJobStatus{
+					State:     prowjobv1.TriggeredState,
+					StartTime: v1.NewTime(time.Now().Add(-1 * time.Minute)),
+				},
+			},
+			pod: &corev1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{
+						"created-by-prow": "true",
+					},
+					Namespace: testpodNamespace,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "alpine",
+							Image: "localhost:5000/alpine",
+							Args: []string{
+								"sleep",
+								"1000000",
+							},
+						},
+					},
+				},
+			},
+			prowjobDeleted: true,
+			wantPodDeleted: true,
+		},
+		{
+			name: "ttl-deleted",
+			prowjob: &prowjobv1.ProwJob{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{
+						"created-by-prow": "true",
+					},
+					Namespace: defaultNamespace,
+				},
+				Spec: prowjobv1.ProwJobSpec{
+					Namespace: testpodNamespace,
+				},
+				Status: prowjobv1.ProwJobStatus{
+					State:          prowjobv1.TriggeredState,
+					StartTime:      v1.NewTime(time.Now().Add(-32 * time.Minute)),
+					CompletionTime: &v1.Time{Time: time.Now().Add(-31 * time.Minute)},
+				},
+			},
+			pod: &corev1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{
+						"created-by-prow": "true",
+					},
+					Namespace: testpodNamespace,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "alpine",
+							Image: "localhost:5000/alpine",
+							Args: []string{
+								"sleep",
+								"1000000",
+							},
+						},
+					},
+				},
+			},
+			prowjobDeleted: false,
+			wantJobDeleted: false,
+			wantPodDeleted: true,
+		},
+		{
+			name: "max-prow-job-age",
+			prowjob: &prowjobv1.ProwJob{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{
+						"created-by-prow": "true",
+					},
+					Namespace: defaultNamespace,
+				},
+				Spec: prowjobv1.ProwJobSpec{
+					Namespace: testpodNamespace,
+				},
+				Status: prowjobv1.ProwJobStatus{
+					State:          prowjobv1.TriggeredState,
+					StartTime:      v1.NewTime(time.Now().Add(-50 * time.Hour)),
+					CompletionTime: &v1.Time{Time: time.Now().Add(-49 * time.Hour)},
+				},
+			},
+			pod: &corev1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{
+						"created-by-prow": "true",
+					},
+					Namespace: testpodNamespace,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "alpine",
+							Image: "localhost:5000/alpine",
+							Args: []string{
+								"sleep",
+								"1000000",
+							},
+						},
+					},
+				},
+			},
+			prowjobDeleted: false,
+			wantPodDeleted: true,
+		},
+		{
+			name:    "orphaned-pod-not-prowjob",
+			prowjob: nil,
+			pod: &corev1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: testpodNamespace,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "alpine",
+							Image: "localhost:5000/alpine",
+							Args: []string{
+								"sleep",
+								"1000000",
+							},
+						},
+					},
+				},
+			},
+			prowjobDeleted: false,
+			wantPodDeleted: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			prowjob, pod := tt.prowjob, tt.pod
+			// The name of prowjob and pod is derived from the test name,
+			// doing it here to avoid repeated declaration in tests.
+			resourceName := fmt.Sprintf("%s-%s", tt.name, RandomString(t))
+			if prowjob != nil {
+				prowjob.ObjectMeta.Labels["name"] = resourceName
+				prowjob.ObjectMeta.Name = resourceName
 			}
-			if !tt.notCreatedByProw {
-				pod.ObjectMeta.Labels["created-by-prow"] = "true"
+			pod.ObjectMeta.Name = resourceName
+			clusterContext := getClusterContext()
+			t.Logf("Creating client for cluster: %s", clusterContext)
+
+			kubeClient, err := NewClients("", clusterContext)
+			if err != nil {
+				t.Fatalf("Failed creating clients for cluster %q: %v", clusterContext, err)
 			}
+
+			ctx := context.Background()
 
 			t.Cleanup(func() {
-				kubeClient.Delete(ctx, &prowjob)
-				kubeClient.Delete(ctx, &pod)
+				if prowjob != nil {
+					kubeClient.Delete(ctx, prowjob)
+				}
+				kubeClient.Delete(ctx, pod)
 			})
 
-			if !tt.notCreatedByProw {
-				t.Logf("Creating prowjob: %s", resourceName)
-				if err := kubeClient.Create(ctx, &prowjob); err != nil {
+			if tt.prowjob != nil {
+				t.Logf("Creating prowjob: %s", prowjob.Name)
+				if err := kubeClient.Create(ctx, prowjob); err != nil {
 					t.Fatalf("Failed creating prowjob: %v", err)
 				}
-				t.Logf("Finished creating prowjob: %s", resourceName)
-				// Make sure pod is running
-				p := &prowjobv1.ProwJob{}
-				if err := kubeClient.Get(ctx, client.ObjectKey{
-					Name:      resourceName,
-					Namespace: defaultNamespace,
-				}, p); err != nil {
-					log.Fatalf("Prowjob %q not exist: %v", resourceName, err)
-				}
+				t.Logf("Finished creating prowjob: %s", prowjob.Name)
 			}
 
 			// Create pod
-			t.Logf("Creating pod: %s", resourceName)
-			if err := kubeClient.Create(ctx, &pod); err != nil {
+			t.Logf("Creating pod: %s", pod.Name)
+			if err := kubeClient.Create(ctx, pod); err != nil {
 				t.Fatalf("Failed creating pod: %v", err)
 			}
-			t.Logf("Finished creating pod: %s", resourceName)
+			t.Logf("Finished creating pod: %s", pod.Name)
 
-			// Make sure pod is running
-			t.Logf("Make sure pod is running: %s", resourceName)
-			if err = wait.Poll(time.Second, time.Minute, func() (bool, error) {
-				p := &corev1.Pod{}
-				if err := kubeClient.Get(ctx, client.ObjectKey{
-					Name:      resourceName,
-					Namespace: testpodNamespace,
-				}, p); err != nil {
-					return false, fmt.Errorf("Failed getting pod: %v", err)
-				}
-				return (p.Status.Phase == corev1.PodRunning), nil
-			}); err != nil {
-				t.Fatalf("Pod was not created successfully: %v", err)
-			}
-			t.Logf("Pod is running: %s", resourceName)
-
-			if !tt.notCreatedByProw {
-				// Patch prowjob to make it stale if needed
-				prowjob.Status.StartTime = tt.jobStartTime
-				prowjob.Status.CompletionTime = &tt.jobFinishTime
-				if err := kubeClient.Update(ctx, &prowjob); err != nil {
-					t.Fatalf("Failed updating prowjob %q: %v", resourceName, err)
-				}
-				// Delete prowjob if CR isn't supposed to have existed
-				if !tt.hasCR {
-					if err := kubeClient.Delete(ctx, &prowjob); err != nil {
-						t.Fatalf("Failed deleting prowjob: %v", err)
-					}
+			// Delete prowjob to make pod orphan
+			if tt.prowjobDeleted {
+				t.Logf("Deleting prowjob %s to make the pod %s orphan", prowjob.Name, pod.Name)
+				if err := kubeClient.Delete(ctx, prowjob); err != nil {
+					t.Fatalf("Failed deleting prowjob %s: %v", prowjob.Name, err)
 				}
 			}
 
-			// Make sure pod is deleted, it'll take roughly 2 minutes
+			// Make sure pod is deleted, it'll take roughly 3 minutes
 			// Don't care about the outcome, will check later
-			t.Logf("Wait for sinker deleting pod or timeout in 2 minutes: %s", resourceName)
+			t.Logf("Wait for sinker deleting pod or timeout in 3 minutes: %s", pod.Name)
 			var exist bool
 			wait.Poll(time.Second, 2*time.Minute, func() (bool, error) {
 				exist = false
@@ -212,7 +294,7 @@ func TestDeletePod(t *testing.T) {
 					return false, err
 				}
 				for _, p := range pods.Items {
-					if p.Name == resourceName {
+					if p.Name == pod.Name {
 						exist = true
 					}
 				}
@@ -222,21 +304,21 @@ func TestDeletePod(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			t.Logf("Pod %s exist: %v", resourceName, exist)
+			t.Logf("Pod %s exist: %v", pod.Name, exist)
 			if want, got := tt.wantPodDeleted, !exist; want != got {
-				t.Fatalf("Want deleted: %v. Got deleted: %v", want, got)
+				t.Fatalf("Want pod deleted: %v. Got deleted: %v", want, got)
 			}
 
 			// Check for prowjob deletion.
-			{
+			if prowjob != nil {
 				exist = false
 				pjs := &prowjobv1.ProwJobList{}
 				err = kubeClient.List(ctx, pjs, ctrlruntimeclient.InNamespace(defaultNamespace))
 				if err != nil {
-					log.Fatalf("Failed listing prowjobs: %v", err)
+					t.Fatalf("Failed listing prowjobs: %v", err)
 				}
 				for _, pj := range pjs.Items {
-					if pj.Name == resourceName {
+					if pj.Name == prowjob.Name {
 						exist = true
 					}
 				}


### PR DESCRIPTION
Following up https://github.com/kubernetes/test-infra/pull/20451#discussion_r556998226, adding:

1. completed, non-orphaned pods are deleted after the terminatedPodTTL expires.
1. pods not created by prow are not deleted.
1. prowjobs (not pods) are deleted after maxProwJobAge has passed.

/assign @cjwagner 
/cc @alvaroaleman 