### PR TITLE
Clean and update Metrics Query and Filter

### DIFF
--- a/metrics/configs/build-stats.yaml
+++ b/metrics/configs/build-stats.yaml
@@ -22,6 +22,7 @@ query: |
   )
   where day is not null
   order by day
+
 jqfilter: |
   ([(.[] | .day|tonumber)] | max) as $newestday |
   [(.[] | select((.day|tonumber)==$newestday) | {

--- a/metrics/configs/flakes-config.yaml
+++ b/metrics/configs/flakes-config.yaml
@@ -85,9 +85,9 @@ query: |
   order by flakes desc, commit_consistency, build_consistency, job /* flakiest jobs first */
 
 jqfilter: |
-  [(.[] | select(.job | contains("pr:")) | {(.job): {
+  [(.[] | {(.job): {
       consistency: (.commit_consistency|tonumber),
       flakes: (.flakes|tonumber),
-      flakiest: ([(.flakiest[] | select(.flakes|tonumber >= 4) | {
+      test_flakes: ([(.flakiest[] | {
         (.name): (.flakes|tonumber)}) ])| add
   }})] | add

--- a/metrics/configs/flakes-config.yaml
+++ b/metrics/configs/flakes-config.yaml
@@ -58,14 +58,14 @@ query: |
             ifnull(repo_commit, version) version, /* git version, empty for ci  */
             if(substr(job, 0, 3) = 'pr:',
               regexp_extract(
-                ifnull(repos, (select i.value from t.metadata i where i.key = 'repos')),
+                repo,
                 r'[^,]+,\d+:([a-f0-9]+)"'
               ),
               ifnull(repo_commit, version)
             ) commit,  /* repo commit for PR or version for CI */
             result,  /* SUCCESS if the build passed */
             test  /* repeated tuple of tests */
-          from(
+          from (
                 select *,
                        ifnull(b.repos, (select i.value from b.metadata i where i.key = 'repos')) repo from `k8s-gubernator.build.week` as b
           ) as t

--- a/metrics/configs/flakes-daily-config.yaml
+++ b/metrics/configs/flakes-daily-config.yaml
@@ -41,18 +41,17 @@ query: |
             job,
             if(substr(job, 0, 3) = 'pr:',
               regexp_extract(
-                (
-                  select i.value
-                  from t.metadata i
-                  where i.key = 'repos'
-                ),
+                repo,
                 r'[^,]+,\d+:([a-f0-9]+)"'
               ),
               version
             ) commit,  /* repo commit for PR or version for CI */
             result,  /* SUCCESS if the build passed */
             date_trunc(date(started), DAY) day
-          FROM `k8s-gubernator.build.all` as t
+          from (
+                select *,
+                       ifnull(b.repos, (select i.value from b.metadata i where i.key = 'repos')) repo from `k8s-gubernator.build.all` as b
+          ) as t
           where
             /* Select results that have occurred on or after the day of <LAST_DATA_TIME> (those results were
                for the day before), but don't include results from today, only return results for complete days. */
@@ -60,13 +59,7 @@ query: |
             and datetime(started) < datetime_trunc(current_datetime(), DAY) /* Drop results from partial day */
             and (
               (substr(job, 0, 3) = 'ci-' and version != 'unknown') or
-              exists(
-                select as struct
-                  i
-                from t.metadata i
-                where i.key = 'repos' and
-                array_length(split(replace(i.value,', ', ''), ',')) = 2 /*serial pr jobs only (# of PR refs +1 == 2)*/
-              )
+              array_length(split(replace(t.repo,', ', ''), ',')) = 2 /*serial pr jobs only (# of PR refs +1 == 2)*/
             )
         )
         group by job, day, commit

--- a/metrics/configs/presubmit-health.yaml
+++ b/metrics/configs/presubmit-health.yaml
@@ -59,6 +59,7 @@ query: |
   ORDER BY
     day DESC,
     pr_failure_perc DESC
+
 jqfilter: |
   ([(.[] | .day|tonumber)] | max) as $newestday |
   [(.[] | select((.day|tonumber)==$newestday) | {


### PR DESCRIPTION
- Remove filtering of non-pr jobs as well as show all flake tests
- Align formatting on all configs
- Update Flakes-Daily to also include PodUtils

This will update results to look like:
```
{
  "pr:pull-kubernetes-e2e-gce-ubuntu-containerd": {
    "consistency": 0.933,
    "flakes": 25,
    "flakiest": {
      "[k8s.io] [sig-node] NodeProblemDetector [DisabledForLargeClusters] should run without error": 6,
      "[sig-network] Conntrack should be able to preserve UDP traffic when server pod cycles for a NodePort service": 5,
      "[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: tmpfs] [Testpattern: Pre-provisioned PV (default fs)] volumes should store data": 3,
      "[sig-storage] PersistentVolumes-local  [Volume type: dir] One pod requesting one prebound PVC should be able to mount volume and write from pod1": 3,
      "[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: blockfs] [Testpattern: Pre-provisioned PV (default fs)] subPath should support existing directory": 2,
      "Build": 2,
      "[sig-storage] PersistentVolumes-local  [Volume type: blockfswithformat] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2": 2,
      "[sig-storage] In-tree Volumes [Driver: hostPathSymlink] [Testpattern: Inline-volume (default fs)] subPath should support file as subpath [LinuxOnly]": 2,
      "[sig-network] Networking Granular Checks: Services should function for service endpoints using hostNetwork": 2,
      "[k8s.io] Container Lifecycle Hook when create a pod with lifecycle hook should execute poststart exec hook properly [NodeConformance] [Conformance]": 2
    }
  },
  "ci-kubernetes-e2e-gci-gce-slow": {
    "consistency": 0.611,
    "flakes": 21,
    "flakiest": {
      "[sig-storage] In-tree Volumes [Driver: gluster] [Testpattern: Pre-provisioned PV (default fs)] volumeIO should write files of various sizes, verify size, validate content [Slow][LinuxOnly]": 6,
      "[sig-storage] In-tree Volumes [Driver: gluster] [Testpattern: Inline-volume (default fs)] volumeIO should write files of various sizes, verify size, validate content [Slow][LinuxOnly]": 4,
      "[sig-storage] PersistentVolumes-local  StatefulSet with pod affinity [Slow] should use volumes on one node when pod management is parallel and pod has affinity": 3,
      "[sig-storage] PersistentVolumes-local  StatefulSet with pod affinity [Slow] should use volumes on one node when pod has affinity": 3,
      "Timeout": 2,
      "[sig-storage] In-tree Volumes [Driver: nfs] [Testpattern: Dynamic PV (filesystem volmode)] multiVolume [Slow] should access to two volumes with the same volume mode and retain data across pod recreation on the same node [LinuxOnly]": 1,
      "[sig-storage] CSI Volumes [Driver: csi-hostpath] [Testpattern: Dynamic PV (block volmode)] provisioning should provision storage with pvc data source in parallel [Slow]": 1,
      "[sig-network] ESIPP [Slow] should work for type=LoadBalancer": 1,
      "[sig-storage] PersistentVolumes-local  StatefulSet with pod affinity [Slow] should use volumes spread across nodes when pod has anti-affinity": 1,
      "[sig-storage] In-tree Volumes [Driver: gcepd] [Testpattern: Dynamic PV (filesystem volmode)] multiVolume [Slow] should access to two volumes with the same volume mode and retain data across pod recreation on the same node [LinuxOnly]": 1
    }
  },
  "ci-kubernetes-e2e-gci-gce-single-flake-attempt": {
    "consistency": 0.672,
    "flakes": 20,
    "flakiest": {
      "[sig-auth] Metadata Concealment should run a check-metadata-concealment job to completion": 4,
      "[k8s.io] [sig-node] NodeProblemDetector [DisabledForLargeClusters] should run without error": 4,
      "Up": 3,
      "[sig-apps] Deployment should not disrupt a cloud load-balancer's connectivity during rollout": 2,
      "[k8s.io] Probing container should *not* be restarted with a tcp:8080 liveness probe [NodeConformance] [Conformance]": 2,
      "[k8s.io] NodeLease when the NodeLease feature is enabled the kubelet should report node status infrequently": 2,
      "[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: block] [Testpattern: Pre-provisioned PV (default fs)] volumes should store data": 2,
      "[sig-cli] Kubectl Port forwarding With a server listening on 0.0.0.0 that expects a client request should support a client that connects, sends DATA, and disconnects": 2,
      "[sig-cli] Kubectl client Simple pod should return command exit codes": 1,
      "[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] One pod requesting one prebound PVC should be able to mount volume and read from pod1": 1
    }
  },
  "ci-kubernetes-e2e-gci-gce-proto": {
    "consistency": 0.689,
    "flakes": 19,
    "flakiest": {
      "[sig-network] Services should have session affinity timeout work for NodePort service [LinuxOnly] [Conformance]": 3,
      "[k8s.io] [sig-node] NodeProblemDetector [DisabledForLargeClusters] should run without error": 2,
      "[sig-network] Services should be able to change the type from NodePort to ExternalName [Conformance]": 2,
      "[sig-auth] Metadata Concealment should run a check-metadata-concealment job to completion": 2,
      "[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] One pod requesting one prebound PVC should be able to mount volume and write from pod1": 2,
      "[sig-network] EndpointSliceMirroring should mirror a custom Endpoints resource through create update and delete": 1,
      "[sig-network] Services should be able to change the type from ClusterIP to ExternalName [Conformance]": 1,
      "[sig-storage] In-tree Volumes [Driver: gluster] [Testpattern: Inline-volume (default fs)] volumes should store data": 1,
      "[k8s.io] NodeLease when the NodeLease feature is enabled the kubelet should report node status infrequently": 1,
      "[sig-storage] In-tree Volumes [Driver: hostPathSymlink] [Testpattern: Inline-volume (default fs)] subPath should support readOnly file specified in the volumeMount [LinuxOnly]": 1
    }
  },
  "ci-kubernetes-e2e-gci-gce-flaky-repro": {
    "consistency": 0.705,
    "flakes": 18,
    "flakiest": {
      "[sig-api-machinery] CustomResourcePublishOpenAPI [Privileged:ClusterAdmin] [Flaky] kubectl explain works for CR with the same resource name as built-in object.": 21,
      "[sig-network] Services should have session affinity timeout work for NodePort service [LinuxOnly] [Conformance]": 2,
      "[sig-cli] Kubectl client Simple pod should support inline execution and attach": 2,
      "[k8s.io] NodeLease when the NodeLease feature is enabled the kubelet should report node status infrequently": 2,
      "[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (active) client pod, the NFS mount and the pod's UID directory should be removed.": 2,
      "[k8s.io] [sig-node] NodeProblemDetector [DisabledForLargeClusters] should run without error": 2,
      "[sig-network] Networking Granular Checks: Services should update endpoints: udp": 2,
      "[sig-network] Conntrack should be able to preserve UDP traffic when server pod cycles for a NodePort service": 2,
      "Timeout": 2,
      "[sig-api-machinery] ResourceQuota should create a ResourceQuota and capture the life of a service. [Conformance]": 1
    }
  }
}

```
/area Metrics

@BenTheElder @spiffxp @amwat Should I change "flakiest" to something like "test flakes"?