### PR TITLE
Add image pushing job for Image Builder

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
@@ -167,3 +167,26 @@ postsubmits:
               - --scratch-bucket=gs://k8s-staging-capi-openstack-gcb
               - --env-passthrough=PULL_BASE_REF
               - .
+  kubernetes-sigs/image-builder:
+    - name: post-image-builder-push-images
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        # this is the name of some testgrid dashboard to report to.
+        testgrid-dashboards: sig-cluster-lifecycle-image-pushes
+      decorate: true
+      branches:
+        - ^master$
+        # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200901-ab141a0
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR images are pushed to.
+              - --project=k8s-staging-scl-image-builder
+              - --scratch-bucket=gs://k8s-staging-scl-image-builder-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - .


### PR DESCRIPTION
Adds a post-submit job for pushing images for scl-image-builder. 
This change is a part of the addition of image promotion process to publish container images in the image-builder repository. [(Merged Image-builder PR here)](https://github.com/kubernetes-sigs/image-builder/pull/450)