### PR TITLE
Config: Insert git sha when using configupdater

### DIFF
--- a/prow/cmd/config-bootstrapper/main_test.go
+++ b/prow/cmd/config-bootstrapper/main_test.go
@@ -69,6 +69,7 @@ func testRun(clients localgit.Clients, t *testing.T) {
 	if err := lg.AddCommit("openshift", "release", map[string][]byte{
 		"config/foo.yaml": []byte(`#foo.yaml`),
 		"config/bar.yaml": []byte(`#bar.yaml`),
+		"VERSION":         []byte("some-git-sha"),
 	}); err != nil {
 		t.Fatalf("Add commit: %v", err)
 	}
@@ -131,6 +132,7 @@ func testRun(clients localgit.Clients, t *testing.T) {
 						Namespace: defaultNamespace,
 					},
 					Data: map[string]string{
+						"VERSION":  "some-git-sha",
 						"foo.yaml": "#foo.yaml",
 						"bar.yaml": "#bar.yaml",
 					},
@@ -179,6 +181,7 @@ func testRun(clients localgit.Clients, t *testing.T) {
 						Namespace: defaultNamespace,
 					},
 					Data: map[string]string{
+						"VERSION":  "some-git-sha",
 						"foo.yaml": "#foo.yaml",
 						"bar.yaml": "#bar.yaml",
 					},
@@ -189,6 +192,7 @@ func testRun(clients localgit.Clients, t *testing.T) {
 						Namespace: defaultNamespace,
 					},
 					Data: map[string]string{
+						"VERSION":        "some-git-sha",
 						"other-foo.yaml": "#other-foo.yaml",
 					},
 				},
@@ -198,6 +202,7 @@ func testRun(clients localgit.Clients, t *testing.T) {
 						Namespace: defaultNamespace,
 					},
 					Data: map[string]string{
+						"VERSION":        "some-git-sha",
 						"other-bar.yaml": "#other-bar.yaml",
 					},
 				},

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -1663,6 +1663,7 @@ func TestValidConfigLoading(t *testing.T) {
 	var testCases = []struct {
 		name               string
 		prowConfig         string
+		versionFileContent string
 		jobConfigs         []string
 		expectError        bool
 		expectPodNameSpace string
@@ -2294,6 +2295,16 @@ in_repo_config:
 				return nil
 			},
 		},
+		{
+			name:               "Version file sets the version",
+			versionFileContent: "some-git-sha",
+			verify: func(c *Config) error {
+				if c.ConfigVersionSHA != "some-git-sha" {
+					return fmt.Errorf("expected value of ConfigVersionSH field to be 'some-git-sha', was %q", c.ConfigVersionSHA)
+				}
+				return nil
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -2309,6 +2320,13 @@ in_repo_config:
 			prowConfig := filepath.Join(prowConfigDir, "config.yaml")
 			if err := ioutil.WriteFile(prowConfig, []byte(tc.prowConfig), 0666); err != nil {
 				t.Fatalf("fail to write prow config: %v", err)
+			}
+
+			if tc.versionFileContent != "" {
+				versionFile := filepath.Join(prowConfigDir, "VERSION")
+				if err := ioutil.WriteFile(versionFile, []byte(tc.versionFileContent), 0600); err != nil {
+					t.Fatalf("failed to write prow version file: %v", err)
+				}
 			}
 
 			jobConfig := ""

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -219,6 +219,10 @@ branch-protection:
           - ""
         users:
           - ""
+
+
+# The git sha from which this config was generated
+config_version_sha: ' '
 deck:
     # AdditionalAllowedBuckets is a list of storage buckets to allow in artifact requests
     # (in addition to those listed in the GCSConfiguration).

--- a/prow/plugins/updateconfig/updateconfig.go
+++ b/prow/plugins/updateconfig/updateconfig.go
@@ -98,7 +98,7 @@ func (g *OSFileGetter) GetFile(filename string) ([]byte, error) {
 // Update updates the configmap with the data from the identified files.
 // Existing configmap keys that are not included in the updates are left alone
 // unless bootstrap is true in which case they are deleted.
-func Update(fg FileGetter, kc corev1.ConfigMapInterface, name, namespace string, updates []ConfigMapUpdate, bootstrap bool, metrics *prometheus.GaugeVec, logger *logrus.Entry) error {
+func Update(fg FileGetter, kc corev1.ConfigMapInterface, name, namespace string, updates []ConfigMapUpdate, bootstrap bool, metrics *prometheus.GaugeVec, logger *logrus.Entry, sha string) error {
 	cm, getErr := kc.Get(context.TODO(), name, metav1.GetOptions{})
 	isNotFound := errors.IsNotFound(getErr)
 	if getErr != nil && !isNotFound {
@@ -115,6 +115,9 @@ func Update(fg FileGetter, kc corev1.ConfigMapInterface, name, namespace string,
 	}
 	if cm.Data == nil || bootstrap {
 		cm.Data = map[string]string{}
+	}
+	if sha != "" {
+		cm.Data[config.ConfigVersionFileName] = sha
 	}
 	if cm.BinaryData == nil || bootstrap {
 		cm.BinaryData = map[string][]byte{}
@@ -335,7 +338,7 @@ func handle(gc githubClient, gitClient git.ClientFactory, kc corev1.ConfigMapsGe
 			errs = append(errs, err)
 			continue
 		}
-		if err := Update(&OSFileGetter{Root: gitRepo.Directory()}, configMapClient, cm.Name, cm.Namespace, data, bootstrapMode, metrics, logger); err != nil {
+		if err := Update(&OSFileGetter{Root: gitRepo.Directory()}, configMapClient, cm.Name, cm.Namespace, data, bootstrapMode, metrics, logger, *pr.MergeSHA); err != nil {
 			errs = append(errs, err)
 			continue
 		}

--- a/prow/plugins/updateconfig/updateconfig_test.go
+++ b/prow/plugins/updateconfig/updateconfig_test.go
@@ -229,6 +229,7 @@ func testUpdateConfig(clients localgit.Clients, t *testing.T) {
 						Namespace: defaultNamespace,
 					},
 					Data: map[string]string{
+						"VERSION":     "12345",
 						"config.yaml": "old-config",
 					},
 				},
@@ -240,6 +241,7 @@ func testUpdateConfig(clients localgit.Clients, t *testing.T) {
 						Namespace: defaultNamespace,
 					},
 					Data: map[string]string{
+						"VERSION":     "12345",
 						"config.yaml": "new-config",
 					},
 				},
@@ -275,6 +277,7 @@ func testUpdateConfig(clients localgit.Clients, t *testing.T) {
 					},
 					Data: map[string]string{
 						"config.yaml": "new-config",
+						"VERSION":     "12345",
 					},
 				},
 			},
@@ -309,6 +312,7 @@ func testUpdateConfig(clients localgit.Clients, t *testing.T) {
 					},
 					Data: map[string]string{
 						"test-key": "new-plugins",
+						"VERSION":  "12345",
 					},
 				},
 			},
@@ -343,6 +347,7 @@ func testUpdateConfig(clients localgit.Clients, t *testing.T) {
 					},
 					Data: map[string]string{
 						"resources.yaml": "new-boskos-config",
+						"VERSION":        "12345",
 					},
 				},
 			},
@@ -403,6 +408,7 @@ func testUpdateConfig(clients localgit.Clients, t *testing.T) {
 					},
 					Data: map[string]string{
 						"config.yaml": "new-config",
+						"VERSION":     "12345",
 					},
 				},
 				{
@@ -412,6 +418,7 @@ func testUpdateConfig(clients localgit.Clients, t *testing.T) {
 					},
 					Data: map[string]string{
 						"test-key": "new-plugins",
+						"VERSION":  "12345",
 					},
 				},
 				{
@@ -421,6 +428,7 @@ func testUpdateConfig(clients localgit.Clients, t *testing.T) {
 					},
 					Data: map[string]string{
 						"resources.yaml": "new-boskos-config",
+						"VERSION":        "12345",
 					},
 				},
 			},
@@ -461,6 +469,7 @@ func testUpdateConfig(clients localgit.Clients, t *testing.T) {
 					Data: map[string]string{
 						"foo.yaml": "new-foo-config",
 						"bar.yaml": "new-bar-config",
+						"VERSION":  "12345",
 					},
 				},
 			},
@@ -498,6 +507,7 @@ func testUpdateConfig(clients localgit.Clients, t *testing.T) {
 					Data: map[string]string{
 						"foo.yaml": "new-foo-config",
 						"bar.yaml": "old-bar-config",
+						"VERSION":  "12345",
 					},
 				},
 			},
@@ -533,6 +543,7 @@ func testUpdateConfig(clients localgit.Clients, t *testing.T) {
 					},
 					Data: map[string]string{
 						"bar.yaml": "old-bar-config",
+						"VERSION":  "12345",
 					},
 				},
 			},
@@ -570,6 +581,7 @@ func testUpdateConfig(clients localgit.Clients, t *testing.T) {
 					Data: map[string]string{
 						"fejta.yaml":    "old-fejta-config",
 						"krzyzacy.yaml": "new-krzyzacy-config",
+						"VERSION":       "12345",
 					},
 				},
 			},
@@ -606,6 +618,7 @@ func testUpdateConfig(clients localgit.Clients, t *testing.T) {
 					},
 					Data: map[string]string{
 						"fejtabot.yaml": "new-fejtabot-config",
+						"VERSION":       "54321",
 					},
 				},
 			},
@@ -654,6 +667,7 @@ func testUpdateConfig(clients localgit.Clients, t *testing.T) {
 						"fejta.yaml":    "new-fejta-config",
 						"krzyzacy.yaml": "old-krzyzacy-config",
 						"added.yaml":    "new-added-config",
+						"VERSION":       "12345",
 					},
 				},
 			},
@@ -679,6 +693,7 @@ func testUpdateConfig(clients localgit.Clients, t *testing.T) {
 					},
 					Data: map[string]string{
 						"config.yaml": "new-config",
+						"VERSION":     "12345",
 					},
 				},
 			},
@@ -704,6 +719,9 @@ func testUpdateConfig(clients localgit.Clients, t *testing.T) {
 					},
 					BinaryData: map[string][]byte{
 						"config.yaml": {31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 202, 75, 45, 215, 77, 206, 207, 75, 203, 76, 7, 4, 0, 0, 255, 255, 84, 214, 231, 87, 10, 0, 0, 0},
+					},
+					Data: map[string]string{
+						"VERSION": "12345",
 					},
 				},
 			},
@@ -747,6 +765,9 @@ func testUpdateConfig(clients localgit.Clients, t *testing.T) {
 					BinaryData: map[string][]byte{
 						"config.yaml": {31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 202, 75, 45, 215, 77, 206, 207, 75, 203, 76, 7, 4, 0, 0, 255, 255, 84, 214, 231, 87, 10, 0, 0, 0},
 					},
+					Data: map[string]string{
+						"VERSION": "12345",
+					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -755,6 +776,7 @@ func testUpdateConfig(clients localgit.Clients, t *testing.T) {
 					},
 					Data: map[string]string{
 						"plugins.yaml": "new-plugins",
+						"VERSION":      "12345",
 					},
 				},
 			},
@@ -798,6 +820,9 @@ func testUpdateConfig(clients localgit.Clients, t *testing.T) {
 					BinaryData: map[string][]byte{
 						"config.yaml": {31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 202, 75, 45, 215, 77, 206, 207, 75, 203, 76, 7, 4, 0, 0, 255, 255, 84, 214, 231, 87, 10, 0, 0, 0},
 					},
+					Data: map[string]string{
+						"VERSION": "12345",
+					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -806,6 +831,7 @@ func testUpdateConfig(clients localgit.Clients, t *testing.T) {
 					},
 					Data: map[string]string{
 						"plugins.yaml": "new-plugins",
+						"VERSION":      "12345",
 					},
 				},
 			},
@@ -848,6 +874,7 @@ func testUpdateConfig(clients localgit.Clients, t *testing.T) {
 					},
 					Data: map[string]string{
 						"config.yaml": "new-config",
+						"VERSION":     "12345",
 					},
 					BinaryData: map[string][]byte{
 						"binary.yaml": []byte("new-binary\x00\xFF\xFF"),
@@ -894,6 +921,9 @@ func testUpdateConfig(clients localgit.Clients, t *testing.T) {
 					BinaryData: map[string][]byte{
 						"becoming-binary.yaml": []byte("now-binary\x00\xFF\xFF"),
 					},
+					Data: map[string]string{
+						"VERSION": "12345",
+					},
 				},
 			},
 			config: &plugins.ConfigUpdater{
@@ -935,6 +965,7 @@ func testUpdateConfig(clients localgit.Clients, t *testing.T) {
 					},
 					Data: map[string]string{
 						"becoming-text.yaml": "now-text",
+						"VERSION":            "12345",
 					},
 					BinaryData: map[string][]uint8{},
 				},
@@ -989,6 +1020,7 @@ func testUpdateConfig(clients localgit.Clients, t *testing.T) {
 					},
 					Data: map[string]string{
 						"becoming-text.yaml": "now-text",
+						"VERSION":            "12345",
 					},
 				},
 			},
@@ -1032,6 +1064,9 @@ func testUpdateConfig(clients localgit.Clients, t *testing.T) {
 					BinaryData: map[string][]byte{
 						"config.yaml": {31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 202, 75, 45, 215, 77, 206, 207, 75, 203, 76, 7, 4, 0, 0, 255, 255, 84, 214, 231, 87, 10, 0, 0, 0},
 					},
+					Data: map[string]string{
+						"VERSION": "12345",
+					},
 				},
 			},
 			config: &plugins.ConfigUpdater{
@@ -1074,6 +1109,7 @@ func testUpdateConfig(clients localgit.Clients, t *testing.T) {
 					},
 					Data: map[string]string{
 						"config.yaml": "new-config",
+						"VERSION":     "12345",
 					},
 				},
 			},
@@ -1345,6 +1381,7 @@ func testUpdate(clients localgit.Clients, t *testing.T) {
 				},
 				Data: map[string]string{
 					"foo.yaml": "new-foo-config",
+					"VERSION":  "12345",
 				},
 			},
 		},
@@ -1375,6 +1412,7 @@ func testUpdate(clients localgit.Clients, t *testing.T) {
 					Namespace: defaultNamespace,
 				},
 				Data: map[string]string{
+					"VERSION":  "12345",
 					"foo.yaml": "new-foo-config",
 					"bar.yaml": "old-bar-config",
 				},
@@ -1437,7 +1475,7 @@ func testUpdate(clients localgit.Clients, t *testing.T) {
 			t.Errorf("Failed to checkout 12345: %v.", err)
 			continue
 		}
-		if err := Update(&OSFileGetter{Root: gitRepo.Directory()}, configMapClient, tc.expectedConfigMap.Name, tc.expectedConfigMap.Namespace, tc.updates, tc.bootstrap, nil, log); err != nil {
+		if err := Update(&OSFileGetter{Root: gitRepo.Directory()}, configMapClient, tc.expectedConfigMap.Name, tc.expectedConfigMap.Namespace, tc.updates, tc.bootstrap, nil, log, "12345"); err != nil {
 			t.Errorf("%s: unexpected error updating: %s", tc.name, err)
 			continue
 		}

--- a/prow/statusreconciler/controller_test.go
+++ b/prow/statusreconciler/controller_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/yaml"
@@ -239,8 +240,8 @@ func TestAddedBlockingPresubmits(t *testing.T) {
 			if err := yaml.Unmarshal([]byte(testCase.new), &newConfig); err != nil {
 				t.Fatalf("%s: could not unmarshal new config: %v", testCase.name, err)
 			}
-			if actual, expected := addedBlockingPresubmits(oldConfig, newConfig), testCase.expected; !reflect.DeepEqual(actual, expected) {
-				t.Errorf("%s: did not get correct added presubmits: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
+			if actual, _ := addedBlockingPresubmits(oldConfig, newConfig, logrusEntry()); !reflect.DeepEqual(actual, testCase.expected) {
+				t.Errorf("%s: did not get correct added presubmits: %v", testCase.name, diff.ObjectReflectDiff(actual, testCase.expected))
 			}
 		})
 	}
@@ -389,8 +390,8 @@ func TestRemovedBlockingPresubmits(t *testing.T) {
 			if err := yaml.Unmarshal([]byte(testCase.new), &newConfig); err != nil {
 				t.Fatalf("%s: could not unmarshal new config: %v", testCase.name, err)
 			}
-			if actual, expected := removedBlockingPresubmits(oldConfig, newConfig), testCase.expected; !reflect.DeepEqual(actual, expected) {
-				t.Errorf("%s: did not get correct removed presubmits: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
+			if actual, _ := removedBlockingPresubmits(oldConfig, newConfig, logrusEntry()); !reflect.DeepEqual(actual, testCase.expected) {
+				t.Errorf("%s: did not get correct removed presubmits: %v", testCase.name, diff.ObjectReflectDiff(actual, testCase.expected))
 			}
 		})
 	}
@@ -542,8 +543,8 @@ func TestMigratedBlockingPresubmits(t *testing.T) {
 			if err := yaml.Unmarshal([]byte(testCase.new), &newConfig); err != nil {
 				t.Fatalf("%s: could not unmarshal new config: %v", testCase.name, err)
 			}
-			if actual, expected := migratedBlockingPresubmits(oldConfig, newConfig), testCase.expected; !reflect.DeepEqual(actual, expected) {
-				t.Errorf("%s: did not get correct removed presubmits: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
+			if actual, _ := migratedBlockingPresubmits(oldConfig, newConfig, logrusEntry()); !reflect.DeepEqual(actual, testCase.expected) {
+				t.Errorf("%s: did not get correct removed presubmits: %v", testCase.name, diff.ObjectReflectDiff(actual, testCase.expected))
 			}
 		})
 	}
@@ -1130,7 +1131,7 @@ func TestControllerReconcile(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			controller, check := testCase.generator()
-			err := controller.reconcile(delta)
+			err := controller.reconcile(delta, logrusEntry())
 			if err == nil && testCase.expectErr {
 				t.Errorf("expected an error, but got none")
 			}
@@ -1140,6 +1141,10 @@ func TestControllerReconcile(t *testing.T) {
 			check(t)
 		})
 	}
+}
+
+func logrusEntry() *logrus.Entry {
+	return logrus.NewEntry(logrus.StandardLogger())
 }
 
 func checkTriggerer(t *testing.T, triggerer fakeProwJobTriggerer, expectedCreatedJobs map[prKey]sets.String) {


### PR DESCRIPTION
This change makes the configupdater always add a key named VERSION to
the configmap which contains the git sha that triggered said update.
The configloading in turn will pick it up if present. This allows
components to include the config version in their logs, which can be
useful for debugging.

The second commit shows the reason I started thinking about this, namely the fact that the statusreconciler log is near useless, it tells us what it did but not for what config version, which makes debugging issues impossible and forces us to guess (ref https://github.com/kubernetes/test-infra/pull/20498#issuecomment-763139545)

This is technically a breaking change in that we now always include a key in the configmaps that we didn't include before (but won't override if it gets populated). This is fine for prow itself, as it only looks at all files in the context of job configs and there it ignores files that do not end with `.yaml` or `.yml`: https://github.com/kubernetes/test-infra/blob/6a328dba0fabd4a5b11ccf6d245c513bb528e2e8/prow/config/config.go#L1026

If someone uses the configupdater for something other than the prow config and then looks at all files and expects all of them to have a certain format, that would break now. But this seems rather unlikely to me. WDYT @fejta ?

/assign @fejta 