### PR TITLE
kops - Set cluster name in upgrade test

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -395,6 +395,8 @@ periodics:
       env:
       - name: CLOUD_PROVIDER
         value: aws
+      - name: CLUSTER_NAME
+        value: e2e-f9b0e6b3f9-bb3c3.test-cncf-aws.k8s.io
       securityContext:
         privileged: true
       resources:


### PR DESCRIPTION
The script requires one be set, so this uses the same name that kubetest2-kops would use itself