### PR TITLE
Revert "Merge pull request #20519 from lyzs90/clean-up-node-size-anno…

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -17,6 +17,11 @@ presets:
   # Turn on profiling for various components.
   - name: ETCD_TEST_ARGS
     value: "--enable-pprof"
+  # Number of bytes of an additional nodes objects annotation in a kubemark
+  # cluster. The annotation label is added to make nodes objects sizes similar
+  # to regular cluster nodes.
+  - name: KUBEMARK_NODE_OBJECT_SIZE_BYTES
+    value: 15000
   # Increase throughput in Kubemark master components and turn on profiling.
   - name: KUBEMARK_CONTROLLER_MANAGER_TEST_ARGS
     value: "--profiling --kube-api-qps=100 --kube-api-burst=100"


### PR DESCRIPTION
…tation"

This reverts commit b955f1e92413f9117f086038e8c8832be4aab4eb, reversing
changes made to 3579070677115da6390f7f19847f16e738ee45d7.

Reason: I forgot that we also run kubemark on older releases - https://k8s-testgrid.appspot.com/sig-scalability-kubemark#Summary&grid=beta, and this preset is global (for all tests, also older releases). While it's fine to stop setting for master tests, we shouldn't really change it for older releases.