### PR TITLE
Fix sig-node containerd-build periodic job

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -48,12 +48,11 @@ periodics:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20210108-3c85f1a-master
       args:
       - --repo=github.com/containerd/containerd=master
-      - --repo=github.com/containerd/cri=master
       - --root=/go/src
       - --upload=gs://kubernetes-jenkins/logs
       - --scenario=execute
       - --
-      - /go/src/github.com/containerd/cri/test/containerd/build.sh
+      - /go/src/github.com/containerd/containerd/test/build.sh
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-build


### PR DESCRIPTION
The Job https://testgrid.k8s.io/sig-node-containerd#containerd-build is failing with `cannot open /go/src/github.com/containerd/containerd/vendor.conf (No such file or directory)
W0120 ` because it uses a deprecated repo https://github.com/containerd/cri . This repo is now merged with  https://github.com/containerd/containerd. 

This PR updates the build script location.

Signed-off-by: Aditi Sharma <adi.sky17@gmail.com>