### PR TITLE
Prepare config-forker for unique names in prow, second try

### DIFF
--- a/releng/config-forker/BUILD.bazel
+++ b/releng/config-forker/BUILD.bazel
@@ -40,6 +40,8 @@ go_test(
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
+        "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/util/diff:go_default_library",
     ],

--- a/releng/config-forker/README.md
+++ b/releng/config-forker/README.md
@@ -35,6 +35,19 @@ For all jobs:
 - If the `testgrid-tab-name` annotation is specified, references to `master` are changed to `1.15`.
 - If the `description` annotation is specified, it is removed (for now).
 
+For presubmits only:
+
+- If `name` has no `-master` ending, then `-1.15` will be appended.
+- If `name` has a `-master` ending, it is replaced with `1.15`.
+- If `context` is unset and `name` has no `-master` ending, it will be set to the original `name` without appending `-1.15`.
+- If `context` is unset and `name` has a `-master` ending, it will be set to the `name`, including the `-1.15` suffix.
+- If `context` is set and it has a `-master` ending, it is replaced with `-1.15`.
+- If `context` is set and it has no `-master` ending, it will be taken over unmodified.
+
+The `context` is modified in a way to report the same context name on different branches if `-master` was not included
+in the original context. If `-master` was included (either in an explicit context value, or inferred from the job name),
+it gets added to the context.
+
 For presubmits and postsubmits:
 
 - `skip_branches` will be deleted

--- a/releng/config-forker/main.go
+++ b/releng/config-forker/main.go
@@ -85,6 +85,8 @@ func generatePresubmits(c config.JobConfig, version string) (map[string][]config
 			p := presubmit
 			p.SkipBranches = nil
 			p.Branches = []string{"release-" + version}
+			p.Context = generatePresubmitContextVariant(p.Name, p.Context, version)
+			p.Name = generatePresubmitNameVariant(p.Name, version)
 			if p.Spec != nil {
 				for i := range p.Spec.Containers {
 					c := &p.Spec.Containers[i]
@@ -347,6 +349,23 @@ func generateNameVariant(name, version string, generic bool) string {
 	}
 	if !strings.HasSuffix(name, "-master") {
 		return name + suffix
+	}
+	return strings.ReplaceAll(name, "-master", suffix)
+}
+
+func generatePresubmitNameVariant(name, version string) string {
+	suffix := "-" + version
+	if !strings.HasSuffix(name, "-master") {
+		return name + suffix
+	}
+	return strings.ReplaceAll(name, "-master", suffix)
+}
+
+func generatePresubmitContextVariant(name, context, version string) string {
+	suffix := "-" + version
+
+	if context != "" {
+		return strings.ReplaceAll(context, "-master", suffix)
 	}
 	return strings.ReplaceAll(name, "-master", suffix)
 }

--- a/releng/config-forker/main_test.go
+++ b/releng/config-forker/main_test.go
@@ -20,6 +20,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
@@ -490,6 +492,39 @@ func TestGeneratePresubmits(t *testing.T) {
 			},
 			{
 				JobBase: config.JobBase{
+					Name:        "pull-kubernetes-e2e-branch-in-name-master",
+					Annotations: map[string]string{forkAnnotation: "true"},
+				},
+				Brancher: config.Brancher{
+					SkipBranches: []string{`release-\d\.\d`},
+				},
+			},
+			{
+				JobBase: config.JobBase{
+					Name:        "pull-kubernetes-e2e-keep-context",
+					Annotations: map[string]string{forkAnnotation: "true"},
+				},
+				Brancher: config.Brancher{
+					SkipBranches: []string{`release-\d\.\d`},
+				},
+				Reporter: config.Reporter{
+					Context: "mycontext",
+				},
+			},
+			{
+				JobBase: config.JobBase{
+					Name:        "pull-kubernetes-e2e-replace-context",
+					Annotations: map[string]string{forkAnnotation: "true"},
+				},
+				Brancher: config.Brancher{
+					SkipBranches: []string{`release-\d\.\d`},
+				},
+				Reporter: config.Reporter{
+					Context: "mycontext-master",
+				},
+			},
+			{
+				JobBase: config.JobBase{
 					Name: "pull-replace-some-things",
 					Annotations: map[string]string{
 						forkAnnotation:                 "true",
@@ -524,16 +559,55 @@ func TestGeneratePresubmits(t *testing.T) {
 		"kubernetes/kubernetes": {
 			{
 				JobBase: config.JobBase{
-					Name:        "pull-kubernetes-e2e",
+					Name:        "pull-kubernetes-e2e-1.15",
 					Annotations: map[string]string{},
 				},
 				Brancher: config.Brancher{
 					Branches: []string{"release-1.15"},
 				},
+				Reporter: config.Reporter{
+					Context: "pull-kubernetes-e2e",
+				},
 			},
 			{
 				JobBase: config.JobBase{
-					Name: "pull-replace-some-things",
+					Name:        "pull-kubernetes-e2e-branch-in-name-1.15",
+					Annotations: map[string]string{},
+				},
+				Brancher: config.Brancher{
+					Branches: []string{"release-1.15"},
+				},
+				Reporter: config.Reporter{
+					Context: "pull-kubernetes-e2e-branch-in-name-1.15",
+				},
+			},
+			{
+				JobBase: config.JobBase{
+					Name:        "pull-kubernetes-e2e-keep-context-1.15",
+					Annotations: map[string]string{},
+				},
+				Brancher: config.Brancher{
+					Branches: []string{"release-1.15"},
+				},
+				Reporter: config.Reporter{
+					Context: "mycontext",
+				},
+			},
+			{
+				JobBase: config.JobBase{
+					Name:        "pull-kubernetes-e2e-replace-context-1.15",
+					Annotations: map[string]string{},
+				},
+				Brancher: config.Brancher{
+					Branches: []string{"release-1.15"},
+				},
+				Reporter: config.Reporter{
+					Context: "mycontext-1.15",
+				},
+			},
+			{
+				JobBase: config.JobBase{
+					Name: "pull-replace-some-things-1.15",
 					Annotations: map[string]string{
 						"some-annotation": "yup",
 					},
@@ -550,6 +624,9 @@ func TestGeneratePresubmits(t *testing.T) {
 				Brancher: config.Brancher{
 					Branches: []string{"release-1.15"},
 				},
+				Reporter: config.Reporter{
+					Context: "pull-replace-some-things",
+				},
 			},
 		},
 	}
@@ -560,7 +637,7 @@ func TestGeneratePresubmits(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(result, expected) {
-		t.Errorf("Result does not match expected. Difference:\n%s", diff.ObjectDiff(expected, result))
+		t.Errorf("Result does not match expected. Difference:\n%s", cmp.Diff(expected, result, cmpopts.IgnoreUnexported(config.Brancher{}, config.RegexpChangeMatcher{}, config.Presubmit{})))
 	}
 }
 


### PR DESCRIPTION
Create unique names on forked jobs and modify the reporting context in
an expected way. If the original context did not include `-master`, keep
it in the original state, to not invent new context values on release
branches. Otherwise replace -master with the version to make the github
context distinct from the master jobs.

This is another try to bring in https://github.com/kubernetes/test-infra/pull/19009 after it had to be reverted in https://github.com/kubernetes/test-infra/pull/20079.