### PR TITLE
Remove leading args forgotten while migrating to podutils

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -22,13 +22,6 @@ presubmits:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
         args:
-        - --timeout=170
-        - --root=/go/src
-        - --repo=k8s.io/kubernetes=$(PULL_REFS)
-        - --repo=k8s.io/release
-        - --upload=gs://kubernetes-jenkins/pr-logs
-        - --scenario=kubernetes_e2e
-        - --
         - --build=bazel
         - --extract=local
         - --env=ALLOW_PRIVILEGED=true


### PR DESCRIPTION
Signed-off-by: Ricardo Pchevuzinske Katz <ricardo.katz@gmail.com>

While migrating a sig-net job to podutils, I've forgotten the leading args on command :/

/kind bug