### PR TITLE
re-add support for match-title in pr creator

### DIFF
--- a/robots/pr-creator/main.go
+++ b/robots/pr-creator/main.go
@@ -43,6 +43,7 @@ type options struct {
 
 	title      string
 	headBranch string
+	matchTitle string
 	body       string
 }
 
@@ -78,7 +79,8 @@ func optionsFromFlags() options {
 	fs.BoolVar(&o.confirm, "confirm", false, "Set to mutate github instead of a dry run")
 	fs.BoolVar(&o.local, "local", false, "Allow source to be local-branch instead of remote-user:branch")
 	fs.StringVar(&o.title, "title", "", "Title of PR")
-	fs.StringVar(&o.headBranch, "head-branch", "", "Reuse any self-authored open PR from this branch")
+	fs.StringVar(&o.headBranch, "head-branch", "", "Reuse any self-authored open PR from this branch. This takes priority over match-title")
+	fs.StringVar(&o.matchTitle, "match-title", "", "Reuse any self-autohred open PR that matches this title. If both this and head-branch are set, this will be overwritten by head-branch")
 	fs.StringVar(&o.body, "body", "", "Body of PR")
 	fs.Parse(os.Args[1:])
 	return o
@@ -100,7 +102,14 @@ func main() {
 		logrus.WithError(err).Fatal("Failed to create github client")
 	}
 
-	n, err := updater.EnsurePR(o.org, o.repo, o.title, o.body, o.source, o.branch, o.headBranch, o.allowMods, gc)
+	var queryTokensString string
+	// Prioritize using headBranch as it is less flakey
+	if o.headBranch != "" {
+		queryTokensString = "head:" + o.headBranch
+	} else {
+		queryTokensString = "in:title " + o.matchTitle
+	}
+	n, err := updater.EnsurePRWithQueryTokens(o.org, o.repo, o.title, o.body, o.source, o.branch, queryTokensString, o.allowMods, gc)
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to ensure PR exists.")
 	}


### PR DESCRIPTION
We removed match-title from the pr creator in favor of headBranch, not realizing it was being used outside of test-infra and needed to be backwards compatible. This change re-adds support for match-title while keeping the updater library backwards compatible as well.