### PR TITLE
Prow integration test: deflake sinker test by waiting on an earlier signal of pod deletion

### DIFF
--- a/prow/test/integration/test/sinker_test.go
+++ b/prow/test/integration/test/sinker_test.go
@@ -282,11 +282,11 @@ func TestDeletePod(t *testing.T) {
 				}
 			}
 
-			// Make sure pod is deleted, it'll take roughly 3 minutes
+			// Make sure pod is deleted, it'll take roughly 1 minutes
 			// Don't care about the outcome, will check later
-			t.Logf("Wait for sinker deleting pod or timeout in 3 minutes: %s", pod.Name)
+			t.Logf("Wait for sinker deleting pod or timeout in 1 minutes: %s", pod.Name)
 			var exist bool
-			wait.Poll(time.Second, 2*time.Minute, func() (bool, error) {
+			wait.Poll(time.Second, 1*time.Minute, func() (bool, error) {
 				exist = false
 				pods := &corev1.PodList{}
 				err = kubeClient.List(ctx, pods, ctrlruntimeclient.InNamespace(testpodNamespace))
@@ -296,6 +296,9 @@ func TestDeletePod(t *testing.T) {
 				for _, p := range pods.Items {
 					if p.Name == pod.Name {
 						exist = true
+						if p.ObjectMeta.DeletionTimestamp != nil { // Pod scheduled to deletion
+							exist = false
+						}
 					}
 				}
 				return !exist, nil


### PR DESCRIPTION
sinker test was found flaky in https://github.com/kubernetes/test-infra/pull/20522#issuecomment-764008120, which was likely due to the fact of pod deletion takes various amount of time. Try to deflake this by determining pod deletion based on the existence of `ObjectMeta.DeletionTimestamp`, this had worked pretty well during my local testing. By the way reducing the time of waiting from 2 minutes to 1 minute to make the test shorter, we can make this longer if this turned out to be flaky.