### PR TITLE
Notify runner that the spell check passed

### DIFF
--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -63,3 +63,5 @@ find -L . -type f -not \( \
     -o -path '*/localdata/*' \
     \) -prune \
     \) -exec "$@" '{}' '+'
+
+echo 'PASS: No spelling issues detected'


### PR DESCRIPTION
Currently when running a passing `bazel run //hack:verify-spelling` results end as follows:
```
Executing tests from //hack:verify-spelling
-----------------------------------------------------------------------------
Validating spelling...
```
Then exits without letting the runner know there was a pass, it looks more like the execution ended abruptly.

This just prompts the user with a completion. 