### PR TITLE
test(kubeflow): clean up no longer used tests

### DIFF
--- a/config/jobs/kubeflow/kubeflow-periodics.yaml
+++ b/config/jobs/kubeflow/kubeflow-periodics.yaml
@@ -1,28 +1,4 @@
-#******************************************************************************
-# kubeflow/kfctl
-#******************************************************************************
-# These tests are named kubeflow even though they are for the kfctl repo
-# because that used to be the repo that had our main E2E tests for kubeflow
 periodics:
-- name: kubeflow-periodic-1-1
-  cluster: kubeflow
-  interval: 8h
-  labels:
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: gcr.io/kubeflow-ci/test-worker:latest
-      imagePullPolicy: Always
-      env:
-      - name: REPO_OWNER
-        value: kubeflow
-      - name: REPO_NAME
-        value: kfctl
-      - name: BRANCH_NAME
-        value: v1.1-branch
-  annotations:
-    testgrid-dashboards: sig-big-data
-    description: Periodic testing of Kubeflow on the 1-0 release
 #******************************************************************************
 # kubeflow/kubeflow
 #******************************************************************************
@@ -48,26 +24,6 @@ periodics:
     # TODO: use a public email group
     testgrid-alert-email: kubeflow-engineering@google.com
     testgrid-num-failures-to-alert: "3"
-
-- name: kubeflow-kubeflow-periodic-1-1
-  cluster: kubeflow
-  interval: 8h
-  labels:
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: gcr.io/kubeflow-ci/test-worker:latest
-      imagePullPolicy: Always
-      env:
-      - name: REPO_OWNER
-        value: kubeflow
-      - name: REPO_NAME
-        value: kfctl
-      - name: BRANCH_NAME
-        value: v1.1-branch
-  annotations:
-    testgrid-dashboards: sig-big-data
-    description: Periodic testing of Kubeflow on the 1-1 branch
 
 #******************************************************************************
 # kubeflow/gcp-blueprints
@@ -120,47 +76,6 @@ periodics:
     testgrid-alert-email: kubeflow-engineering@google.com
     testgrid-num-failures-to-alert: "3"
 #******************************************************************************
-# kubeflow/manifests
-#******************************************************************************
-- name: kubeflow-manifests-periodic-1-1
-  cluster: kubeflow
-  interval: 8h
-  labels:
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: gcr.io/kubeflow-ci/test-worker:latest
-      imagePullPolicy: Always
-      env:
-      - name: REPO_OWNER
-        value: kubeflow
-      - name: REPO_NAME
-        value: manifests
-      - name: BRANCH_NAME
-        value: v1.1-branch
-  annotations:
-    testgrid-dashboards: sig-big-data
-    description: Periodic testing of Kubeflow/manifests on the master branch.
-- name: kubeflow-manifests-periodic-master
-  cluster: kubeflow
-  interval: 8h
-  labels:
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: gcr.io/kubeflow-ci/test-worker:latest
-      imagePullPolicy: Always
-      env:
-      - name: REPO_OWNER
-        value: kubeflow
-      - name: REPO_NAME
-        value: manifests
-      - name: BRANCH_NAME
-        value: master
-  annotations:
-    testgrid-dashboards: sig-big-data
-    description: Periodic testing of Kubeflow/manifests on the master branch.
-#******************************************************************************
 # kubeflow/examples
 #******************************************************************************
 - name: kubeflow-examples-periodic
@@ -207,28 +122,6 @@ periodics:
     description: Periodic job to run kfp functional test
     testgrid-alert-email: kubeflow-pipelines+test@google.com
     testgrid-num-failures-to-alert: "5"
-#******************************************************************************
-# kubeflow/kfctl
-#******************************************************************************
-- name: kubeflow-kfctl-periodic
-  cluster: kubeflow
-  interval: 8h
-  labels:
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: gcr.io/kubeflow-ci/test-worker:latest
-      imagePullPolicy: Always
-      env:
-      - name: REPO_OWNER
-        value: kubeflow
-      - name: REPO_NAME
-        value: kfctl
-      - name: BRANCH_NAME
-        value: master
-  annotations:
-    testgrid-dashboards: sig-big-data
-    description: Periodic testing of Kubeflow kfctl
 - name: kubeflow-periodic-project-cleanup
   cluster: kubeflow
   interval: 1h

--- a/config/jobs/kubeflow/kubeflow-postsubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-postsubmits.yaml
@@ -81,71 +81,6 @@ postsubmits:
     annotations:
       testgrid-dashboards: sig-big-data
       description: Postsubmit kubeflow/testing.
-  kubeflow/caffe2-operator:
-  - name: kubeflow-caffe2-operator-postsubmit
-    cluster: kubeflow
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Postsubmit kubeflow/caffe2-operator.
-  kubeflow/mpi-operator:
-  - name: kubeflow-mpi-operator-postsubmit
-    cluster: kubeflow
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Postsubmit tests for kubeflow/mpi-operator.
-  kubeflow/chainer-operator:
-  - name: kubeflow-chainer-operator-postsubmit
-    cluster: kubeflow
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Postsubmit tests for kubeflow/chainer-operator.
-  kubeflow/mxnet-operator:
-  - name: kubeflow-mxnet-operator-postsubmit
-    cluster: kubeflow
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Postsubmit kubeflow/mxnet-operator.
-  kubeflow/arena:
-  - name: kubeflow-arena-postsubmit
-    cluster: kubeflow
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Postsubmit tests for kubeflow/arena.
   kubeflow/pipelines:
   - name: kubeflow-pipeline-postsubmit-standalone-component-test
     cluster: kubeflow
@@ -238,16 +173,3 @@ postsubmits:
       description: Postsubmit tests for kubeflow/pipeline.
       testgrid-alert-email: kubeflow-pipelines+test@google.com
       testgrid-num-failures-to-alert: "5"
-  kubeflow/xgboost-operator:
-  - name: kubeflow-xgboost-operator-postsubmit
-    cluster: kubeflow
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Postsubmit tests for kubeflow/xgboost-operator.

--- a/config/jobs/kubeflow/kubeflow-postsubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-postsubmits.yaml
@@ -55,19 +55,6 @@ postsubmits:
       testgrid-alert-email: kubeflow-engineering@google.com
       testgrid-num-failures-to-alert: "3"
 
-  kubeflow/reporting:
-  - name: kubeflow-reporting-postsubmit
-    cluster: kubeflow
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Postsubmit kubeflow/reporting.
   kubeflow/website:
   - name: kubeflow-website-postsubmit
     cluster: kubeflow
@@ -94,32 +81,6 @@ postsubmits:
     annotations:
       testgrid-dashboards: sig-big-data
       description: Postsubmit kubeflow/testing.
-  kubeflow/tf-operator:
-  - name: kubeflow-tf-operator-postsubmit
-    cluster: kubeflow
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Postsubmit kubeflow/tf-operator.
-  kubeflow/experimental-seldon:
-  - name: kubeflow-experimental-seldon-postsubmit
-    cluster: kubeflow
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Postsubmit kubeflow/experimental-seldon.
   kubeflow/caffe2-operator:
   - name: kubeflow-caffe2-operator-postsubmit
     cluster: kubeflow
@@ -133,19 +94,6 @@ postsubmits:
     annotations:
       testgrid-dashboards: sig-big-data
       description: Postsubmit kubeflow/caffe2-operator.
-  kubeflow/kubebench:
-  - name: kubeflow-kubebench-postsubmit
-    cluster: kubeflow
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Postsubmit tests for kubeflow/kubebench.
   kubeflow/mpi-operator:
   - name: kubeflow-mpi-operator-postsubmit
     cluster: kubeflow

--- a/config/jobs/kubeflow/kubeflow-presubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-presubmits.yaml
@@ -96,34 +96,6 @@ presubmits:
       testgrid-dashboards: sig-big-data
       description: Presubmits for kubeflow/testing.
       testgrid-num-columns-recent: '30'
-  kubeflow/arena:
-  - name: kubeflow-arena-presubmit
-    cluster: kubeflow
-    always_run: true         # Run for every PR, or only when requested.
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Presubmit tests for kubeflow/arena.
-      testgrid-num-columns-recent: '30'
-  kubeflow/fairing:
-  - name: kubeflow-fairing-presubmit
-    cluster: kubeflow
-    always_run: true
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Presubmit tests for kubeflow/fairing.
-      testgrid-num-columns-recent: '30'
   kubeflow/pipelines:
   - name: kubeflow-pipeline-frontend-test
     cluster: kubeflow

--- a/config/jobs/kubeflow/kubeflow-presubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-presubmits.yaml
@@ -55,20 +55,6 @@ presubmits:
       testgrid-dashboards: sig-big-data
       description: Presubmit tests for Kubeflow.
       testgrid-num-columns-recent: '30'
-  kubeflow/reporting:
-  - name: kubeflow-reporting-presubmit
-    cluster: kubeflow
-    always_run: true         # Run for every PR, or only when requested.
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Presubmits for kubeflow/reporting.
-      testgrid-num-columns-recent: '30'
   kubeflow/website:
   - name: kubeflow-website-presubmit
     cluster: kubeflow
@@ -110,34 +96,6 @@ presubmits:
       testgrid-dashboards: sig-big-data
       description: Presubmits for kubeflow/testing.
       testgrid-num-columns-recent: '30'
-  kubeflow/experimental-seldon:
-  - name: kubeflow-experimental-seldon-presubmit
-    cluster: kubeflow
-    always_run: true         # Run for every PR, or only when requested.
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Presubmits for kubeflow/experimental-seldon.
-      testgrid-num-columns-recent: '30'
-  kubeflow/kubebench:
-  - name: kubeflow-kubebench-presubmit
-    cluster: kubeflow
-    always_run: true         # Run for every PR, or only when requested.
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Presubmit tests for kubeflow/kubebench.
-      testgrid-num-columns-recent: '30'
   kubeflow/arena:
   - name: kubeflow-arena-presubmit
     cluster: kubeflow
@@ -165,20 +123,6 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-big-data
       description: Presubmit tests for kubeflow/fairing.
-      testgrid-num-columns-recent: '30'
-  kubeflow/metadata:
-  - name: kubeflow-metadata-presubmit
-    cluster: kubeflow
-    always_run: true
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Presubmit tests for kubeflow/metadata.
       testgrid-num-columns-recent: '30'
   kubeflow/pipelines:
   - name: kubeflow-pipeline-frontend-test

--- a/config/testgrids/kubeflow/kubeflow.yaml
+++ b/config/testgrids/kubeflow/kubeflow.yaml
@@ -8,20 +8,12 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_gcp-blueprints/kubeflow-gcp-blueprints-postsubmit
 - name: kubeflow-mxnet-operator-postsubmit
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_mxnet-operator/kubeflow-mxnet-operator-postsubmit
-- name: kubeflow-reporting-postsubmit
-  gcs_prefix: kubernetes-jenkins/logs/kubeflow_reporting/kubeflow-reporting-postsubmit
 - name: kubeflow-testing-postsubmit
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_testing/kubeflow-testing-postsubmit
-- name: kubeflow-tf-operator-postsubmit
-  gcs_prefix: kubernetes-jenkins/logs/kubeflow_tf-operator/kubeflow-tf-operator-postsubmit
-- name: kubeflow-experimental-seldon-postsubmit
-  gcs_prefix: kubernetes-jenkins/logs/kubeflow_experimental-seldon/kubeflow-experimental-seldon-postsubmit
 - name: kubeflow-caffe2-operator-postsubmit
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_caffe2-operator/kubeflow-caffe2-operator-postsubmit
 - name: kubeflow-website-postsubmit
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_website/kubeflow-website-postsubmit
-- name: kubeflow-kubebench-postsubmit
-  gcs_prefix: kubernetes-jenkins/logs/kubeflow_kubebench/kubeflow-kubebench-postsubmit
 - name: kubeflow-mpi-operator-postsubmit
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_mpi-operator/kubeflow-mpi-operator-postsubmit
 - name: kubeflow-chainer-operator-postsubmit

--- a/config/testgrids/kubeflow/kubeflow.yaml
+++ b/config/testgrids/kubeflow/kubeflow.yaml
@@ -6,19 +6,7 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_examples/kubeflow-examples-postsubmit
 - name: kubeflow-gcp-blueprints-postsubmit
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_gcp-blueprints/kubeflow-gcp-blueprints-postsubmit
-- name: kubeflow-mxnet-operator-postsubmit
-  gcs_prefix: kubernetes-jenkins/logs/kubeflow_mxnet-operator/kubeflow-mxnet-operator-postsubmit
 - name: kubeflow-testing-postsubmit
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_testing/kubeflow-testing-postsubmit
-- name: kubeflow-caffe2-operator-postsubmit
-  gcs_prefix: kubernetes-jenkins/logs/kubeflow_caffe2-operator/kubeflow-caffe2-operator-postsubmit
 - name: kubeflow-website-postsubmit
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_website/kubeflow-website-postsubmit
-- name: kubeflow-mpi-operator-postsubmit
-  gcs_prefix: kubernetes-jenkins/logs/kubeflow_mpi-operator/kubeflow-mpi-operator-postsubmit
-- name: kubeflow-chainer-operator-postsubmit
-  gcs_prefix: kubernetes-jenkins/logs/kubeflow_chainer-operator/kubeflow-chainer-operator-postsubmit
-- name: kubeflow-arena-postsubmit
-  gcs_prefix: kubernetes-jenkins/logs/kubeflow_arena/kubeflow-arena-postsubmit
-- name: kubeflow-xgboost-operator-postsubmit
-  gcs_prefix: kubernetes-jenkins/logs/kubeflow_xgboost-operator/kubeflow-xgboost-operator-postsubmit


### PR DESCRIPTION
Part of https://github.com/kubernetes/test-infra/issues/14343
/assign @chaodaiG @jlewi 

Before moving tests for other kubeflow repos, let me first clean up ones that we no longer use.