### PR TITLE
feat(github): add AddLabels function to RepositoryClient interface

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -159,6 +159,7 @@ type RepositoryClient interface {
 	DeleteRepoLabel(org, repo, label string) error
 	GetRepoLabels(org, repo string) ([]Label, error)
 	AddLabel(org, repo string, number int, label string) error
+	AddLabels(org, repo string, number int, labels ...string) error
 	RemoveLabel(org, repo string, number int, label string) error
 	GetFile(org, repo, filepath, commit string) ([]byte, error)
 	GetDirectory(org, repo, dirpath, commit string) ([]DirectoryContent, error)
@@ -2463,14 +2464,21 @@ func (c *client) GetIssueLabels(org, repo string, number int) ([]Label, error) {
 //
 // See https://developer.github.com/v3/issues/labels/#add-labels-to-an-issue
 func (c *client) AddLabel(org, repo string, number int, label string) error {
-	durationLogger := c.log("AddLabel", org, repo, number, label)
+	return c.AddLabels(org, repo, number, label)
+}
+
+// AddLabels adds one or more labels to org/repo#number, returning an error on a bad response code.
+//
+// See https://developer.github.com/v3/issues/labels/#add-labels-to-an-issue
+func (c *client) AddLabels(org, repo string, number int, labels ...string) error {
+	durationLogger := c.log("AddLabels", org, repo, number, labels)
 	defer durationLogger()
 
 	_, err := c.request(&request{
 		method:      http.MethodPost,
 		path:        fmt.Sprintf("/repos/%s/%s/issues/%d/labels", org, repo, number),
 		org:         org,
-		requestBody: []string{label},
+		requestBody: labels,
 		exitCodes:   []int{200},
 	}, nil)
 	return err

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -623,6 +623,36 @@ func TestAddLabel(t *testing.T) {
 	}
 }
 
+func TestAddLabels(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("Bad method: %s", r.Method)
+		}
+		if r.URL.Path != "/repos/k8s/kuber/issues/5/labels" {
+			t.Errorf("Bad request path: %s", r.URL.Path)
+		}
+		b, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("Could not read request body: %v", err)
+		}
+		var ls []string
+		if err := json.Unmarshal(b, &ls); err != nil {
+			t.Errorf("Could not unmarshal request: %v", err)
+		} else if len(ls) != 2 {
+			t.Errorf("Wrong length labels: %v", ls)
+		} else if ls[0] != "foo" {
+			t.Errorf("Wrong label: %s", ls[0])
+		} else if ls[1] != "bar" {
+			t.Errorf("Wrong label: %s", ls[1])
+		}
+	}))
+	defer ts.Close()
+	c := getClient(ts.URL)
+	if err := c.AddLabels("k8s", "kuber", 5, "foo", "bar"); err != nil {
+		t.Errorf("Didn't expect error: %v", err)
+	}
+}
+
 func TestRemoveLabel(t *testing.T) {
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodDelete {

--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -373,6 +373,29 @@ func (f *FakeClient) AddLabel(owner, repo string, number int, label string) erro
 	return fmt.Errorf("cannot add %v to %s/%s/#%d", label, owner, repo, number)
 }
 
+// AddLabels adds a list of labels
+func (f *FakeClient) AddLabels(owner, repo string, number int, labels ...string) error {
+	for _, label := range labels {
+		labelString := fmt.Sprintf("%s/%s#%d:%s", owner, repo, number, label)
+		if sets.NewString(f.IssueLabelsAdded...).Has(labelString) {
+			return fmt.Errorf("cannot add %v to %s/%s/#%d", label, owner, repo, number)
+		}
+
+		if f.RepoLabelsExisting == nil {
+			f.IssueLabelsAdded = append(f.IssueLabelsAdded, labelString)
+			continue
+		}
+		for _, l := range f.RepoLabelsExisting {
+			if label == l {
+				f.IssueLabelsAdded = append(f.IssueLabelsAdded, labelString)
+				continue
+			}
+		}
+		return fmt.Errorf("cannot add %v to %s/%s/#%d", label, owner, repo, number)
+	}
+	return nil
+}
+
 // RemoveLabel removes a label
 func (f *FakeClient) RemoveLabel(owner, repo string, number int, label string) error {
 	labelString := fmt.Sprintf("%s/%s#%d:%s", owner, repo, number, label)

--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -356,21 +356,7 @@ func (f *FakeClient) GetIssueLabels(owner, repo string, number int) ([]github.La
 
 // AddLabel adds a label
 func (f *FakeClient) AddLabel(owner, repo string, number int, label string) error {
-	labelString := fmt.Sprintf("%s/%s#%d:%s", owner, repo, number, label)
-	if sets.NewString(f.IssueLabelsAdded...).Has(labelString) {
-		return fmt.Errorf("cannot add %v to %s/%s/#%d", label, owner, repo, number)
-	}
-	if f.RepoLabelsExisting == nil {
-		f.IssueLabelsAdded = append(f.IssueLabelsAdded, labelString)
-		return nil
-	}
-	for _, l := range f.RepoLabelsExisting {
-		if label == l {
-			f.IssueLabelsAdded = append(f.IssueLabelsAdded, labelString)
-			return nil
-		}
-	}
-	return fmt.Errorf("cannot add %v to %s/%s/#%d", label, owner, repo, number)
+	return f.AddLabels(owner, repo, number, label)
 }
 
 // AddLabels adds a list of labels
@@ -385,13 +371,18 @@ func (f *FakeClient) AddLabels(owner, repo string, number int, labels ...string)
 			f.IssueLabelsAdded = append(f.IssueLabelsAdded, labelString)
 			continue
 		}
+
+		var repoLabelExists bool
 		for _, l := range f.RepoLabelsExisting {
 			if label == l {
 				f.IssueLabelsAdded = append(f.IssueLabelsAdded, labelString)
-				continue
+				repoLabelExists = true
+				break
 			}
 		}
-		return fmt.Errorf("cannot add %v to %s/%s/#%d", label, owner, repo, number)
+		if !repoLabelExists {
+			return fmt.Errorf("cannot add %v to %s/%s/#%d", label, owner, repo, number)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Add a method to the GitHub client RepositoryClient interface to add multiple labels to a PR with a single API call.

Signed-off-by: Trevor Wood <Trevor.G.Wood@gmail.com>