### PR TITLE
Allow pod utilities to upload to GCS with implicit Workload Identity credentials rather than service account secret.

### DIFF
--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -484,9 +484,10 @@ func (d *DecorationConfig) Validate() error {
 	if d.GCSConfiguration == nil {
 		return errors.New("GCS upload configuration is not specified")
 	}
-	if d.GCSCredentialsSecret == "" && d.S3CredentialsSecret == "" {
-		return errors.New("neither GCS nor S3 credential secret are specified")
-	}
+	// Intentionally allow d.GCSCredentialsSecret and d.S3CredentialsSecret to
+	// be unset in which case we assume GCS permissions are provided by GKE
+	// Workload Identity: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
+
 	if err := d.GCSConfiguration.Validate(); err != nil {
 		return fmt.Errorf("GCS configuration is invalid: %v", err)
 	}


### PR DESCRIPTION
Initial work for: [PodUtil support for GKE Workload Identity + Cluster scoped decoration config](https://docs.google.com/document/d/1VtamQuaR-TFVud3NjCRUV8Nqtp4WmBK1na7fNNiYHXU/edit?usp=sharing&resourcekey=0-VXcyCZ9kcLJxQnnrUx4p0Q). (That doc mainly covers related config changes that will be made separately from this PR.)

It looks like the decoration logic already omits the credential secret volume[mount] and argument when the field `gcs_decoration_secret` field is omitted ([source](https://github.com/kubernetes/test-infra/blob/5eb1563809dec48dfa1b337959c608f9c28a8816/prow/pod-utils/decorate/podspec.go#L542-L556)). Additionally, the generic opener used by the pod utils for opening GCS/S3/local files already supports sourcing GCS credentials from the environment/metadata server if possible. ([source1](https://github.com/kubernetes/test-infra/blob/5eb1563809dec48dfa1b337959c608f9c28a8816/prow/pod-utils/gcs/upload.go#L57)) ([source2](https://github.com/kubernetes/test-infra/blob/5eb1563809dec48dfa1b337959c608f9c28a8816/prow/io/opener.go#L123-L128)) I knew we had this for our core Prow components, but didn't realize we used the same "opener" for the pod utils 👍 .

So it seems like we have already implemented the support we need for this and just need to remove the no-longer-applicable config validation.
/assign @alvaroaleman @chaodaiG 
/cc @fejta 