### PR TITLE
Tide: Add github apps support in the sync controller

### DIFF
--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -125,7 +125,13 @@ func main() {
 	cfg := configAgent.Config
 
 	secretAgent := &secret.Agent{}
-	if err := secretAgent.Start([]string{o.github.TokenPath}); err != nil {
+	var token string
+	if o.github.TokenPath != "" {
+		token = o.github.TokenPath
+	} else {
+		token = o.github.AppPrivateKeyPath
+	}
+	if err := secretAgent.Start([]string{token}); err != nil {
 		logrus.WithError(err).Fatal("Error starting secrets agent.")
 	}
 
@@ -163,7 +169,7 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Error constructing mgr.")
 	}
-	c, err := tide.NewController(githubSync, githubStatus, mgr, cfg, git.ClientFactoryFrom(gitClient), o.maxRecordsPerPool, opener, o.historyURI, o.statusURI, nil)
+	c, err := tide.NewController(githubSync, githubStatus, mgr, cfg, git.ClientFactoryFrom(gitClient), o.maxRecordsPerPool, opener, o.historyURI, o.statusURI, nil, o.github.AppPrivateKeyPath != "")
 	if err != nil {
 		logrus.WithError(err).Fatal("Error creating Tide controller.")
 	}

--- a/prow/tide/blockers/blockers.go
+++ b/prow/tide/blockers/blockers.go
@@ -33,7 +33,7 @@ var (
 )
 
 type githubClient interface {
-	Query(context.Context, interface{}, map[string]interface{}) error
+	QueryWithGitHubAppsSupport(ctx context.Context, q interface{}, vars map[string]interface{}, org string) error
 }
 
 // Blocker specifies an issue number that should block tide from merging.
@@ -146,7 +146,8 @@ func search(ctx context.Context, ghc githubClient, log *logrus.Entry, q string) 
 	var remaining int
 	for {
 		sq := searchQuery{}
-		if err := ghc.Query(ctx, &sq, vars); err != nil {
+		// TODO alvaroaleman: Add github apps support
+		if err := ghc.QueryWithGitHubAppsSupport(ctx, &sq, vars, ""); err != nil {
 			return nil, err
 		}
 		totalCost += int(sq.RateLimit.Cost)

--- a/prow/tide/search.go
+++ b/prow/tide/search.go
@@ -27,7 +27,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type querier func(ctx context.Context, result interface{}, vars map[string]interface{}) error
+type querier func(ctx context.Context, q interface{}, vars map[string]interface{}, org string) error
 
 func datedQuery(q string, start, end time.Time) string {
 	return fmt.Sprintf("%s %s", q, dateToken(start, end))
@@ -40,7 +40,7 @@ func floor(t time.Time) time.Time {
 	return t
 }
 
-func search(query querier, log *logrus.Entry, q string, start, end time.Time) ([]PullRequest, error) {
+func search(query querier, log *logrus.Entry, q string, start, end time.Time, org string) ([]PullRequest, error) {
 	start = floor(start)
 	end = floor(end)
 	log = log.WithFields(logrus.Fields{
@@ -61,7 +61,7 @@ func search(query querier, log *logrus.Entry, q string, start, end time.Time) ([
 	ctx := context.Background()
 	for {
 		log.Debug("Sending query")
-		if err := query(ctx, &sq, vars); err != nil {
+		if err := query(ctx, &sq, vars, org); err != nil {
 			if cursor != nil {
 				err = fmt.Errorf("cursor: %q, err: %v", *cursor, err)
 			}

--- a/prow/tide/search_test.go
+++ b/prow/tide/search_test.go
@@ -137,7 +137,7 @@ func TestSearch(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			var i int
-			querier := func(_ context.Context, result interface{}, actual map[string]interface{}) error {
+			querier := func(_ context.Context, result interface{}, actual map[string]interface{}, _ string) error {
 				expected := map[string]interface{}{
 					"query":        githubql.String(tc.q),
 					"searchCursor": tc.cursors[i],
@@ -155,7 +155,7 @@ func TestSearch(t *testing.T) {
 				*ret = sq
 				return nil
 			}
-			prs, err := search(querier, logrus.WithField("test", tc.name), q, tc.start, tc.end)
+			prs, err := search(querier, logrus.WithField("test", tc.name), q, tc.start, tc.end, "")
 			switch {
 			case err != nil:
 				if !tc.err {

--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -558,7 +558,8 @@ func (sc *statusController) search() []PullRequest {
 		sc.PreviousQuery = query
 	}
 
-	prs, err := search(sc.ghc.Query, sc.logger, query, sc.LatestPR.Time, now)
+	// TODO @alvaroaleman: Add github apps support
+	prs, err := search(sc.ghc.QueryWithGitHubAppsSupport, sc.logger, query, sc.LatestPR.Time, now, "")
 	log.WithField("duration", time.Since(now).String()).Debugf("Found %d open PRs.", len(prs))
 	if err != nil {
 		log := log.WithError(err)


### PR DESCRIPTION
This PR adds GitHub apps support for the Tide sync controller. Behavior
when not using GitHub apps should be unchanged.

The feature is not usable yet, because the tide status controller and
blocker search do not have support yet. I will create follow-ups for
those soon.