### PR TITLE
increase node count for dualstack jobs

### DIFF
--- a/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml
@@ -131,7 +131,7 @@ periodics:
       # Azure-specific test args
       - --provider=skeleton
       - --deployment=aksengine
-      - --aksengine-agentpoolcount=2
+      - --aksengine-agentpoolcount=3
       - --aksengine-admin-username=azureuser
       - --aksengine-creds=$(AZURE_CREDENTIALS)
       - --aksengine-orchestratorRelease=1.20
@@ -182,7 +182,7 @@ periodics:
       # Azure-specific test args
       - --provider=skeleton
       - --deployment=aksengine
-      - --aksengine-agentpoolcount=2
+      - --aksengine-agentpoolcount=3
       - --aksengine-admin-username=azureuser
       - --aksengine-creds=$(AZURE_CREDENTIALS)
       - --aksengine-orchestratorRelease=1.20
@@ -234,7 +234,7 @@ periodics:
       # Azure-specific test args
       - --provider=skeleton
       - --deployment=aksengine
-      - --aksengine-agentpoolcount=2
+      - --aksengine-agentpoolcount=3
       - --aksengine-admin-username=azureuser
       - --aksengine-creds=$(AZURE_CREDENTIALS)
       - --aksengine-orchestratorRelease=1.20


### PR DESCRIPTION
- Increase node count to allow certain tests to be run for dual-stack jobs. 