### PR TITLE
Plank: Default to sane pod pending and scheduling timeouts

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -127,7 +127,8 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
- - *January 1, 2021* Support for `whitelist` and `branch_whitelist` fields in Slack merge warning configuration is discontinued. You can use `exempt_users` and `exempt_branches` fields instead. 
+ - *January 24th, 2021* Planks Pod pending and Pod scheduling timeout defaults where changed from 24h each to the more reasonable 10 minutes/5 minutes, respectively.
+ - *January 1, 2021* Support for `whitelist` and `branch_whitelist` fields in Slack merge warning configuration is discontinued. You can use `exempt_users` and `exempt_branches` fields instead.
  - *November 24, 2020* The `requiresig` plugin has been removed in favor of the `require-matching-label` plugin
     which provides equivalent functionality ([example plugin config](https://github.com/kubernetes/test-infra/blob/e42b0745404017bc71c668da0342ef6857d87fa9/config/prow/plugins.yaml#L494-L498))
  - *November 14, 2020* The `whitelist` and `branch_whitelist` fields in Slack merge warning were deprecated on *August 22, 2020* in favor of the new `exempt_users` and `exempt_branches` fields. The support for these fields shall be stopped in *January 2021*.

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1622,7 +1622,7 @@ func parseProwConfig(c *Config) error {
 	}
 
 	if c.Plank.PodPendingTimeout == nil {
-		c.Plank.PodPendingTimeout = &metav1.Duration{Duration: 24 * time.Hour}
+		c.Plank.PodPendingTimeout = &metav1.Duration{Duration: 10 * time.Minute}
 	}
 
 	if c.Plank.PodRunningTimeout == nil {
@@ -1630,7 +1630,7 @@ func parseProwConfig(c *Config) error {
 	}
 
 	if c.Plank.PodUnscheduledTimeout == nil {
-		c.Plank.PodUnscheduledTimeout = &metav1.Duration{Duration: 24 * time.Hour}
+		c.Plank.PodUnscheduledTimeout = &metav1.Duration{Duration: 5 * time.Minute}
 	}
 
 	if c.Gerrit.TickInterval == nil {


### PR DESCRIPTION
Currently, Plank defaults the pod pending and scheduling timeouts to 24
hours. This is unreasonably long and delays feedback in case of
misconfigureed jobs.

This change defaults the Pending timeout which includes everything after
scheduling completed until the Pod enters Running (Volume setup, image
pulling) to 10 minutes and the timeout for scheduling to five minutes.
Scheduling will include time to scale up the cluster, if needed.

Fixes https://github.com/kubernetes/test-infra/issues/20170
/assign @MushuEE @cjwagner 