### PR TITLE
Fix containerd node conformance periodic job

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -51,6 +51,7 @@ periodics:
       - --root=/go/src
       - --upload=gs://kubernetes-jenkins/logs
       - --scenario=execute
+      - --
       - --env=DEPLOY_DIR=containerd/master
       - /go/src/github.com/containerd/containerd/test/build.sh
   annotations:
@@ -292,7 +293,7 @@ periodics:
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
-      - --repo=github.com/containerd/cri=master
+      - --repo=github.com/containerd/containerd=master
       - --timeout=90
       - --scenario=kubernetes_e2e
       - --
@@ -403,24 +404,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd, sig-node-cos
     testgrid-tab-name: soak-cos-gce
-- name: ci-cri-containerd-build
-  interval: 30m
-  labels:
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-master
-      args:
-      - --repo=github.com/containerd/cri=master
-      - --root=/go/src
-      - --upload=gs://kubernetes-jenkins/logs
-      - --scenario=execute
-      - --
-      - ./test/build.sh
-  annotations:
-    testgrid-dashboards: sig-node-containerd
-    testgrid-tab-name: build
-    description: "builds master branch of upstream cri for containerd"
 - name: ci-cri-containerd-windows-build
   interval: 30m
   labels:

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -51,7 +51,7 @@ periodics:
       - --root=/go/src
       - --upload=gs://kubernetes-jenkins/logs
       - --scenario=execute
-      - --
+      - --env=DEPLOY_DIR=containerd/master
       - /go/src/github.com/containerd/containerd/test/build.sh
   annotations:
     testgrid-dashboards: sig-node-containerd
@@ -231,7 +231,7 @@ periodics:
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
-      - --repo=github.com/containerd/cri=master
+      - --repo=github.com/containerd/containerd=master
       - --timeout=90
       - --scenario=kubernetes_e2e
       - --


### PR DESCRIPTION

- Update the containerd repo location for job `ci-containerd-node-e2e`
- Add deploy_dir env for containerd build job
- Remove  `ci-cri-containerd-build` job as `ci-containerd-build` already testing containerd build and now containerd cri repo is merged with containerd repo.
