### PR TITLE
add ci-kubernetes-build-1-20-canary job

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
@@ -160,6 +160,42 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-service-account: "true"
+  name: ci-kubernetes-build-1-20-canary
+  rerun_auth_config:
+    github_team_ids:
+    - 2241179
+  spec:
+    containers:
+    - args:
+      - --repo=k8s.io/kubernetes=release-1.20
+      - --repo=k8s.io/release
+      - --root=/go/src
+      - --timeout=240
+      - --scenario=kubernetes_build
+      - --
+      - --release=k8s-release-dev
+      - --allow-dup
+      - --extra-version-markers=k8s-beta
+      - --registry=gcr.io/k8s-staging-ci-images
+      image: gcr.io/k8s-testimages/bootstrap:v20210108-5927ee692c
+      name: ""
+      resources:
+        limits:
+          cpu: 7300m
+          memory: 34Gi
+        requests:
+          cpu: 7300m
+          memory: 34Gi
+      securityContext:
+        privileged: true
+- annotations:
+    testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
+    testgrid-dashboards: sig-release-1.20-blocking, sig-testing-canaries
+    testgrid-tab-name: build-1.20-canary
+  interval: 1h
+  labels:
+    preset-dind-enabled: "true"
+    preset-service-account: "true"
   name: ci-kubernetes-build-1-20
   rerun_auth_config:
     github_team_ids:


### PR DESCRIPTION
Fix: kubernetes/kubeadm#2380
Ref: #19483 #19904

We seem to have forgotten to add the canary job for release-1.20 branch ?
Not sure if it will be possible to just discard the old `kubernetes-release-dev` bucket in 1.20.