### PR TITLE
disable parallel test runs to prevent test skips

### DIFF
--- a/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml
@@ -196,7 +196,7 @@ periodics:
       # Skipping "Should recreate evicted statefulset" because of an issue in dockershim for dualstack
       # Suggested fix - https://github.com/kubernetes/kubernetes/pull/94382
       - --test_args=--ginkgo.focus=\[Feature:IPv6DualStackAlphaFeature\]|\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\]|Should.recreate.evicted.statefulset
-      - --ginkgo-parallel=20
+      - --ginkgo-parallel=1
       securityContext:
         privileged: true
   annotations:
@@ -248,7 +248,7 @@ periodics:
       # Skipping "Should recreate evicted statefulset" because of an issue in dockershim for dualstack
       # Suggested fix - https://github.com/kubernetes/kubernetes/pull/94382
       - --test_args=--ginkgo.focus=\[Feature:IPv6DualStackAlphaFeature\]|\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\]|Should.recreate.evicted.statefulset
-      - --ginkgo-parallel=20
+      - --ginkgo-parallel=1
       securityContext:
         privileged: true
   annotations:


### PR DESCRIPTION
Running in parallel causes some of the tests to be skipped because of unavailable nodes. So setting `--ginkgo-parallel=1` to ensure all the dual-stack tests are run. 

```bash
[36m[1mS [SKIPPING] [25.828 seconds][0m
[sig-network] [Feature:IPv6DualStackAlphaFeature] [LinuxOnly]
[90m/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:23[0m
  Granular Checks: Services Secondary IP Family
  [90m/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/dual_stack.go:443[0m
    [36m[1mshould function for node-Service: udp [It][0m
    [90m/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/dual_stack.go:482[0m

    [36mRequires at least 2 nodes (not -1)[0m

    /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/network/utils.go:753
```

We can optimize the # in a follow up PR to reduce the time taken to run the tests. 

/assign @aojea 
cc @lachie83 @bridgetkromhout 