### PR TITLE
Fix upstream bumps not showing correct commit diff

### DIFF
--- a/experiment/autobumper/bumper/bumper.go
+++ b/experiment/autobumper/bumper/bumper.go
@@ -477,7 +477,7 @@ func upstreamImageVersionResolver(
 	}
 
 	return func(imageHost, imageName, currentTag string) (string, error) {
-		imageFullPath := imageHost + "/" + imageName + "/" + currentTag
+		imageFullPath := imageHost + "/" + imageName + ":" + currentTag
 		for prefix, version := range upstreamVersions {
 			if strings.HasPrefix(imageFullPath, prefix) {
 				imageBumperCli.AddToCache(imageFullPath, version)


### PR DESCRIPTION
The PR Summary generates the commit diff by using the images map created during the image bump. The upstreamImageResolver was creating this map incorrectly breaking this part of the pr summary when targetVersion was upstream