### PR TITLE
Upload git dir for scl-image-builder image build

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
@@ -189,4 +189,5 @@ postsubmits:
               - --project=k8s-staging-scl-image-builder
               - --scratch-bucket=gs://k8s-staging-scl-image-builder-gcb
               - --env-passthrough=PULL_BASE_REF
+              - --with-git-dir
               - .


### PR DESCRIPTION
When building the container image for kubernetes-sigs/image-builder, the
Makefile expects to be able to interact with git commands, so the git
directory needs to be uploaded with it.

/assign @dims