### PR TITLE
Kops - Specify SSH private key and user for e2e tests

### DIFF
--- a/config/jobs/kubernetes/kops/build-grid.py
+++ b/config/jobs/kubernetes/kops/build-grid.py
@@ -98,6 +98,11 @@ kubetest2_template = """
           --parallel 25 \\
           --skip-regex="{{skip_regex}}"
       image: {{e2e_image}}
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: {{kops_ssh_user}}
       resources:
         limits:
           memory: 2Gi

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -20489,6 +20489,11 @@ periodics:
           --parallel 25 \
           --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-1.17
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
       resources:
         limits:
           memory: 2Gi
@@ -20544,6 +20549,11 @@ periodics:
           --parallel 25 \
           --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-1.17
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
       resources:
         limits:
           memory: 2Gi
@@ -20599,6 +20609,11 @@ periodics:
           --parallel 25 \
           --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-1.18
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
       resources:
         limits:
           memory: 2Gi
@@ -20654,6 +20669,11 @@ periodics:
           --parallel 25 \
           --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-1.18
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
       resources:
         limits:
           memory: 2Gi
@@ -20709,6 +20729,11 @@ periodics:
           --parallel 25 \
           --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-1.19
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
       resources:
         limits:
           memory: 2Gi
@@ -20764,6 +20789,11 @@ periodics:
           --parallel 25 \
           --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-1.19
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
       resources:
         limits:
           memory: 2Gi
@@ -20819,6 +20849,11 @@ periodics:
           --parallel 25 \
           --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-1.20
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
       resources:
         limits:
           memory: 2Gi
@@ -23324,6 +23359,11 @@ periodics:
           --parallel 25 \
           --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-1.17
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
       resources:
         limits:
           memory: 2Gi
@@ -23379,6 +23419,11 @@ periodics:
           --parallel 25 \
           --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-1.17
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
       resources:
         limits:
           memory: 2Gi
@@ -23434,6 +23479,11 @@ periodics:
           --parallel 25 \
           --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-1.18
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
       resources:
         limits:
           memory: 2Gi
@@ -23489,6 +23539,11 @@ periodics:
           --parallel 25 \
           --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-1.18
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
       resources:
         limits:
           memory: 2Gi
@@ -23544,6 +23599,11 @@ periodics:
           --parallel 25 \
           --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-1.19
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
       resources:
         limits:
           memory: 2Gi
@@ -23599,6 +23659,11 @@ periodics:
           --parallel 25 \
           --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-1.19
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
       resources:
         limits:
           memory: 2Gi
@@ -23654,6 +23719,11 @@ periodics:
           --parallel 25 \
           --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-1.20
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
       resources:
         limits:
           memory: 2Gi
@@ -26159,6 +26229,11 @@ periodics:
           --parallel 25 \
           --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-1.17
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
       resources:
         limits:
           memory: 2Gi
@@ -26214,6 +26289,11 @@ periodics:
           --parallel 25 \
           --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-1.17
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
       resources:
         limits:
           memory: 2Gi
@@ -26269,6 +26349,11 @@ periodics:
           --parallel 25 \
           --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-1.18
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
       resources:
         limits:
           memory: 2Gi
@@ -26324,6 +26409,11 @@ periodics:
           --parallel 25 \
           --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-1.18
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
       resources:
         limits:
           memory: 2Gi
@@ -26379,6 +26469,11 @@ periodics:
           --parallel 25 \
           --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-1.19
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
       resources:
         limits:
           memory: 2Gi
@@ -26434,6 +26529,11 @@ periodics:
           --parallel 25 \
           --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-1.19
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
       resources:
         limits:
           memory: 2Gi
@@ -26489,6 +26589,11 @@ periodics:
           --parallel 25 \
           --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-1.20
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
       resources:
         limits:
           memory: 2Gi

--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -28,7 +28,7 @@ periodics:
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
       - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RunetimeHandler|Services.*functioning.*NodePort
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
@@ -67,7 +67,7 @@ periodics:
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
       - --kops-zones=eu-west-1a,eu-west-1b,eu-west-1c
       - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RunetimeHandler|Services.*functioning.*NodePort|
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
@@ -218,7 +218,7 @@ periodics:
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
       - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RunetimeHandler|Services.*functioning.*NodePort
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always


### PR DESCRIPTION
Certain tests are failing with kubetest2 because they're trying to use an ssh key file that doesnt exist: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/e2e-kops-grid-cilium-u2004-k18-containerd/1353824362930638848#1:build-log.txt%3A43181

`s: "failed running \"ls /proc/net/nf_conntrack\": error getting signer for provider skeleton: 'error reading SSH key /root/.ssh/id_rsa: 'open /root/.ssh/id_rsa: no such file or directory'' (exit code 0, stderr )",`

The e2e test suite uses an env var for determining the [SSH private key](https://github.com/kubernetes/kubernetes/blob/228d5f20028ced2ae0970466bbf9707a7c2528cc/test/e2e/framework/ssh/ssh.go#L57-L59) and the [SSH user](https://github.com/kubernetes/kubernetes/blob/228d5f20028ced2ae0970466bbf9707a7c2528cc/test/e2e/framework/ssh/ssh.go#L174). This adds those env vars to the kubetest2 grid jobs.


Also updating a few misc jobs that have failing Runtime tests after switching their runtime to containerd.
