### PR TITLE
Statusreconciler: add an option denylist-all

### DIFF
--- a/prow/statusreconciler/controller.go
+++ b/prow/statusreconciler/controller.go
@@ -293,6 +293,9 @@ func (c *Controller) retireRemovedContexts(retiredPresubmits map[string][]config
 			continue
 		}
 		org, repo := parts[0], parts[1]
+		if c.addedPresubmitDenylist.Has(org) || c.addedPresubmitDenylist.Has(orgrepo) {
+			continue
+		}
 		for _, presubmit := range presubmits {
 			log.WithFields(logrus.Fields{
 				"org":     org,
@@ -320,6 +323,9 @@ func (c *Controller) updateMigratedContexts(migrations map[string][]presubmitMig
 			continue
 		}
 		org, repo := parts[0], parts[1]
+		if c.addedPresubmitDenylist.Has(org) || c.addedPresubmitDenylist.Has(orgrepo) {
+			continue
+		}
 		for _, migration := range migrations {
 			log.WithFields(logrus.Fields{
 				"org":  org,

--- a/prow/statusreconciler/controller_test.go
+++ b/prow/statusreconciler/controller_test.go
@@ -867,7 +867,7 @@ func TestControllerReconcile(t *testing.T) {
 		expectErr bool
 	}{
 		{
-			name: "ignored org skips creation, still does retire and migrate",
+			name: "ignored org skips creation, retire and migrate",
 			generator: func() (Controller, func(*testing.T)) {
 				fpjt := newfakeProwJobTriggerer()
 				fghc := newFakeGitHubClient(orgRepoKey)
@@ -886,13 +886,13 @@ func TestControllerReconcile(t *testing.T) {
 				}
 				checker := func(t *testing.T) {
 					checkTriggerer(t, fpjt, map[prKey]sets.String{})
-					checkMigrator(t, fsm, map[orgRepo]sets.String{orgRepoKey: sets.NewString("required-job")}, map[orgRepo]migrationSet{orgRepoKey: {migrate: nil}})
+					checkMigrator(t, fsm, map[orgRepo]sets.String{orgRepoKey: sets.NewString()}, map[orgRepo]migrationSet{orgRepoKey: {}})
 				}
 				return controller, checker
 			},
 		},
 		{
-			name: "ignored org/repo skips creation, still does retire and migrate",
+			name: "ignored org/repo skips creation, retire and migrate",
 			generator: func() (Controller, func(*testing.T)) {
 				fpjt := newfakeProwJobTriggerer()
 				fghc := newFakeGitHubClient(orgRepoKey)
@@ -911,7 +911,7 @@ func TestControllerReconcile(t *testing.T) {
 				}
 				checker := func(t *testing.T) {
 					checkTriggerer(t, fpjt, map[prKey]sets.String{})
-					checkMigrator(t, fsm, map[orgRepo]sets.String{orgRepoKey: sets.NewString("required-job")}, map[orgRepo]migrationSet{orgRepoKey: {migrate: nil}})
+					checkMigrator(t, fsm, map[orgRepo]sets.String{orgRepoKey: sets.NewString()}, map[orgRepo]migrationSet{orgRepoKey: {}})
 				}
 				return controller, checker
 			},

--- a/prow/statusreconciler/controller_test.go
+++ b/prow/statusreconciler/controller_test.go
@@ -886,7 +886,7 @@ func TestControllerReconcile(t *testing.T) {
 				}
 				checker := func(t *testing.T) {
 					checkTriggerer(t, fpjt, map[prKey]sets.String{})
-					checkMigrator(t, fsm, map[orgRepo]sets.String{orgRepoKey: sets.NewString()}, map[orgRepo]migrationSet{orgRepoKey: {}})
+					checkMigrator(t, fsm, map[orgRepo]sets.String{orgRepoKey: sets.NewString("required-job")}, map[orgRepo]migrationSet{orgRepoKey: {migrate: nil}})
 				}
 				return controller, checker
 			},
@@ -908,6 +908,56 @@ func TestControllerReconcile(t *testing.T) {
 					githubClient:           &fghc,
 					statusMigrator:         &fsm,
 					trustedChecker:         &ftc,
+				}
+				checker := func(t *testing.T) {
+					checkTriggerer(t, fpjt, map[prKey]sets.String{})
+					checkMigrator(t, fsm, map[orgRepo]sets.String{orgRepoKey: sets.NewString("required-job")}, map[orgRepo]migrationSet{orgRepoKey: {migrate: nil}})
+				}
+				return controller, checker
+			},
+		},
+		{
+			name: "ignored all org skips creation, retire and migrate",
+			generator: func() (Controller, func(*testing.T)) {
+				fpjt := newfakeProwJobTriggerer()
+				fghc := newFakeGitHubClient(orgRepoKey)
+				fghc.prs[orgRepoKey] = []github.PullRequest{pr}
+				fghc.refs[orgRepoKey]["heads/"+pr.Base.Ref] = baseSha
+				fsm := newFakeMigrator(orgRepoKey)
+				ftc := newFakeTrustedChecker(orgRepoKey)
+				ftc.trusted[orgRepoKey][prAuthorKey] = true
+				controller := Controller{
+					continueOnError:           true,
+					addedPresubmitDenylistAll: sets.NewString("org"),
+					prowJobTriggerer:          &fpjt,
+					githubClient:              &fghc,
+					statusMigrator:            &fsm,
+					trustedChecker:            &ftc,
+				}
+				checker := func(t *testing.T) {
+					checkTriggerer(t, fpjt, map[prKey]sets.String{})
+					checkMigrator(t, fsm, map[orgRepo]sets.String{orgRepoKey: sets.NewString()}, map[orgRepo]migrationSet{orgRepoKey: {}})
+				}
+				return controller, checker
+			},
+		},
+		{
+			name: "ignored all org/repo skips creation, retire and migrate",
+			generator: func() (Controller, func(*testing.T)) {
+				fpjt := newfakeProwJobTriggerer()
+				fghc := newFakeGitHubClient(orgRepoKey)
+				fghc.prs[orgRepoKey] = []github.PullRequest{pr}
+				fghc.refs[orgRepoKey]["heads/"+pr.Base.Ref] = baseSha
+				fsm := newFakeMigrator(orgRepoKey)
+				ftc := newFakeTrustedChecker(orgRepoKey)
+				ftc.trusted[orgRepoKey][prAuthorKey] = true
+				controller := Controller{
+					continueOnError:           true,
+					addedPresubmitDenylistAll: sets.NewString("org/repo"),
+					prowJobTriggerer:          &fpjt,
+					githubClient:              &fghc,
+					statusMigrator:            &fsm,
+					trustedChecker:            &ftc,
 				}
 				checker := func(t *testing.T) {
 					checkTriggerer(t, fpjt, map[prKey]sets.String{})


### PR DESCRIPTION
Denylist is only used for triggerring new jobs, but not retire or migrate. This makes it impossible to stop statusreconciler from mark contexts as 'retired' when the workloads are moved from prow instance A to prow instance B.

Related: https://github.com/kubernetes/test-infra/issues/14343