### PR TITLE
[Kettle] Handle case when build table is empty

### DIFF
--- a/kettle/make_json.py
+++ b/kettle/make_json.py
@@ -293,8 +293,10 @@ def main(db, opts, outfile):
 
     if opts.assert_oldest:
         oldest = db.get_oldest_emitted(incremental_table)
+        if oldest is None:
+            return 1 # if the table is empty, allow cycle
         if oldest < time.time() - opts.assert_oldest * SECONDS_PER_DAY:
-            return 1
+            return 1 # if table is outdated, allow cycle
         return 0
 
     if opts.reset_emitted:


### PR DESCRIPTION
In monitoring Kettle last night I saw a new failure

```
Traceback (most recent call last):
  File "make_json.py", line 328, in <module>
    sys.exit(main(DB, OPTIONS, sys.stdout))
  File "make_json.py", line 296, in main
    if oldest < time.time() - opts.assert_oldest * SECONDS_PER_DAY:
TypeError: '<' not supported between instances of 'NoneType' and 'float'
```
This should not impact the behavior much as far as I understand, but want to target this behavior so there are no stacks in prod

/area kettle
/type bug
