### PR TITLE
Plank: don't requeue when build cluster doesn't exist

### DIFF
--- a/prow/plank/BUILD.bazel
+++ b/prow/plank/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "controller_test.go",
+        "error_test.go",
         "reconciler_test.go",
     ],
     embed = [":go_default_library"],
@@ -49,6 +50,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "controller.go",
+        "error.go",
         "reconciler.go",
     ],
     importpath = "k8s.io/test-infra/prow/plank",

--- a/prow/plank/error.go
+++ b/prow/plank/error.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plank
+
+import "errors"
+
+var ClusterClientNotExistError *clusterClientNotExistError
+
+type clusterClientNotExistError struct{}
+
+func (ce *clusterClientNotExistError) Error() string {
+	return "Cluster client not exist"
+}
+
+func (ce *clusterClientNotExistError) Unwrap() error {
+	return errors.New("Cluster client not exist")
+}

--- a/prow/plank/error.go
+++ b/prow/plank/error.go
@@ -16,16 +16,29 @@ limitations under the License.
 
 package plank
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
-var ClusterClientNotExistError *clusterClientNotExistError
-
-type clusterClientNotExistError struct{}
-
-func (ce *clusterClientNotExistError) Error() string {
-	return "Cluster client not exist"
+type nonRetryableError struct {
+	err error
 }
 
-func (ce *clusterClientNotExistError) Unwrap() error {
-	return errors.New("Cluster client not exist")
+func (ne nonRetryableError) Error() string {
+	return fmt.Sprintf("nonretryable error: %s", ne.err.Error())
+}
+
+func (nonRetryableError) Is(err error) bool {
+	_, ok := err.(nonRetryableError)
+	return ok
+}
+
+// TerminalError wraps an error and return a nonRetryableError error
+func TerminalError(err error) error {
+	return &nonRetryableError{err: err}
+}
+
+func IsTerminalError(err error) bool {
+	return errors.Is(err, nonRetryableError{})
 }

--- a/prow/plank/error_test.go
+++ b/prow/plank/error_test.go
@@ -18,46 +18,40 @@ package plank
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 )
 
-func TestCustomError(t *testing.T) {
+func TestTerminalError(t *testing.T) {
 	tests := []struct {
-		name      string
-		gotErr    error
-		wantErr   error
-		wantMatch bool
+		name       string
+		gotErr     error
+		isTerminal bool
 	}{
 		{
-			name:      "same error",
-			gotErr:    ClusterClientNotExistError,
-			wantErr:   ClusterClientNotExistError,
-			wantMatch: true,
+			name:       "nil",
+			gotErr:     TerminalError(nil),
+			isTerminal: true,
 		},
 		{
-			name:      "wrap error",
-			gotErr:    fmt.Errorf("wrapping %w", ClusterClientNotExistError),
-			wantErr:   ClusterClientNotExistError,
-			wantMatch: true,
+			name:       "wrap error",
+			gotErr:     TerminalError(errors.New("ramdom error")),
+			isTerminal: true,
 		},
 		{
-			name:      "not random error",
-			gotErr:    errors.New("random error"),
-			wantErr:   ClusterClientNotExistError,
-			wantMatch: false,
+			name:       "not nil",
+			gotErr:     nil,
+			isTerminal: false,
 		},
 		{
-			name:      "not nil",
-			gotErr:    nil,
-			wantErr:   ClusterClientNotExistError,
-			wantMatch: false,
+			name:       "not random error",
+			gotErr:     errors.New("random error"),
+			isTerminal: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, want := errors.Is(tt.gotErr, tt.wantErr), tt.wantMatch
+			got, want := IsTerminalError(tt.gotErr), tt.isTerminal
 			if got != want {
 				t.Fatalf("Error matching not expected. want match: %v. got match: %v", want, got)
 			}

--- a/prow/plank/error_test.go
+++ b/prow/plank/error_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plank
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestCustomError(t *testing.T) {
+	tests := []struct {
+		name      string
+		gotErr    error
+		wantErr   error
+		wantMatch bool
+	}{
+		{
+			name:      "same error",
+			gotErr:    ClusterClientNotExistError,
+			wantErr:   ClusterClientNotExistError,
+			wantMatch: true,
+		},
+		{
+			name:      "wrap error",
+			gotErr:    fmt.Errorf("wrapping %w", ClusterClientNotExistError),
+			wantErr:   ClusterClientNotExistError,
+			wantMatch: true,
+		},
+		{
+			name:      "not random error",
+			gotErr:    errors.New("random error"),
+			wantErr:   ClusterClientNotExistError,
+			wantMatch: false,
+		},
+		{
+			name:      "not nil",
+			gotErr:    nil,
+			wantErr:   ClusterClientNotExistError,
+			wantMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, want := errors.Is(tt.gotErr, tt.wantErr), tt.wantMatch
+			if got != want {
+				t.Fatalf("Error matching not expected. want match: %v. got match: %v", want, got)
+			}
+		})
+	}
+}

--- a/prow/test/integration/test/BUILD.bazel
+++ b/prow/test/integration/test/BUILD.bazel
@@ -43,11 +43,8 @@ go_library(
     srcs = ["setup.go"],
     importpath = "k8s.io/test-infra/prow/test/integration/test",
     deps = [
-        "@io_k8s_client_go//kubernetes:go_default_library",
         "@io_k8s_client_go//plugin/pkg/client/auth/oidc:go_default_library",
-        "@io_k8s_client_go//rest:go_default_library",
         "@io_k8s_client_go//tools/clientcmd:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
-        "@io_k8s_sigs_controller_runtime//pkg/manager:go_default_library",
     ],
 )


### PR DESCRIPTION
Plank loads build clusters at start up, and stores them in memory. If a build cluster is not found in this map, then it will not find it in next reconcilation cycle. There is no reason to requeue prowjobs failed with this reason since it's bound to failure

Fixes https://github.com/kubernetes/test-infra/issues/20595