### PR TITLE
sig-windows: change ginkgo parallel to 4

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.19-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.19-windows.yaml
@@ -273,7 +273,7 @@ periodics:
       - --aksengine-deploy-custom-k8s
       # Specific test args
       - --test_args=--node-os-distro=windows --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-scheduling\].SchedulerPreemption --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Slow\]|Guestbook.application.should.create.and.stop.a.working.application
-      - --ginkgo-parallel=8
+      - --ginkgo-parallel=4
       securityContext:
         privileged: true
   annotations:

--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
@@ -362,7 +362,7 @@ periodics:
       - --aksengine-deploy-custom-k8s
       # Specific test args
       - --test_args=--node-os-distro=windows --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-scheduling\].SchedulerPreemption --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
-      - --ginkgo-parallel=8
+      - --ginkgo-parallel=4
       securityContext:
         privileged: true
   annotations:
@@ -470,7 +470,7 @@ periodics:
       - --aksengine-deploy-custom-k8s
       # Specific test args
       - --test_args=--node-os-distro=windows --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-scheduling\].SchedulerPreemption --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Slow\]|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
-      - --ginkgo-parallel=8
+      - --ginkgo-parallel=4
       securityContext:
         privileged: true
   annotations:


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

Modified various job configs to use `--ginkgo-parallel=4` to make them consistent across all sig-windows jobs.

/assign @jsturtevant @marosset 