### PR TITLE
Add support to autobumper for multiple repos with the same name

### DIFF
--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -342,6 +342,17 @@ type Repo struct {
 	// is being used, if listing a team's repos this will be for the
 	// team's privilege level in the repo
 	Permissions RepoPermissions `json:"permissions"`
+	Parent      ParentRepo      `json:"parent"`
+}
+
+// ParentRepo contains a small subsection of general repository information: it
+// just includes the information needed to confirm that a parent repo exists
+// and what the name of that repo is.
+type ParentRepo struct {
+	Owner    User   `json:"owner"`
+	Name     string `json:"name"`
+	FullName string `json:"full_name"`
+	HTMLURL  string `json:"html_url"`
 }
 
 // Repo contains detailed repository information, including items


### PR DESCRIPTION
The autobumper would run into issues if we wanted to bump a repo with a name that was already in use by the robot's GH account. This change allows configuring the name of the repo we wish the robot to use for the remote fork and will create the fork if it does not exist. 