### PR TITLE
Use alternate internal comments/vars from whitelist/blacklist

### DIFF
--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -259,10 +259,10 @@ func (rac *RerunAuthConfig) Validate() error {
 		return nil
 	}
 
-	hasWhiteList := len(rac.GitHubUsers) > 0 || len(rac.GitHubTeamIDs) > 0 || len(rac.GitHubTeamSlugs) > 0 || len(rac.GitHubOrgs) > 0
+	hasAllowList := len(rac.GitHubUsers) > 0 || len(rac.GitHubTeamIDs) > 0 || len(rac.GitHubTeamSlugs) > 0 || len(rac.GitHubOrgs) > 0
 
-	// If a whitelist is specified, the user probably does not intend for anyone to be able to rerun any job.
-	if rac.AllowAnyone && hasWhiteList {
+	// If an allowlist is specified, the user probably does not intend for anyone to be able to rerun any job.
+	if rac.AllowAnyone && hasAllowList {
 		return errors.New("allow anyone is set to true and permitted users or groups are specified")
 	}
 

--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -409,10 +409,10 @@ func strictBranchesConfig(c config.ProwConfig) (*orgRepoConfig, error) {
 		// Done partitioning the repos.
 
 		if policyIsStrict(org.Policy) {
-			// This org is strict, record with repo exceptions (blacklist).
+			// This org is strict, record with repo exceptions ("denylist")
 			strictOrgExceptions[orgName] = nonStrictExplicitRepos
 		} else {
-			// The org is not strict, record member repos that are (whitelist).
+			// The org is not strict, record member repos that are allowed
 			strictRepos.Insert(strictExplicitRepos.UnsortedList()...)
 		}
 	}
@@ -621,11 +621,11 @@ func newOrgRepoConfig(orgExceptions map[string]sets.String, repos sets.String) *
 }
 
 // orgRepoConfig describes a set of repositories with an explicit
-// whitelist and a mapping of blacklists for owning orgs
+// allowlist and a mapping of denied repos for owning orgs
 type orgRepoConfig struct {
-	// orgExceptions holds explicit blacklists of repos for owning orgs
+	// orgExceptions holds explicit denylists of repos for owning orgs
 	orgExceptions map[string]sets.String
-	// repos is a whitelist of repos
+	// repos is an allowed list of repos
 	repos sets.String
 }
 
@@ -723,10 +723,10 @@ func (c *orgRepoConfig) union(c2 *orgRepoConfig) *orgRepoConfig {
 	}
 
 	for org, excepts1 := range c.orgExceptions {
-		// keep only items in both blacklists that are not in the
-		// explicit repo whitelists for the other configuration;
+		// keep only items in both denylists that are not in the
+		// explicit repo allowlist for the other configuration;
 		// we know from how the orgRepoConfigs are constructed that
-		// a org blacklist won't intersect it's own repo whitelist
+		// a org denylist won't intersect it's own repo allowlist
 		pruned := excepts1.Difference(c2.repos)
 		if excepts2, ok := c2.orgExceptions[org]; ok {
 			res.orgExceptions[org] = pruned.Intersection(excepts2.Difference(c.repos))
@@ -736,15 +736,15 @@ func (c *orgRepoConfig) union(c2 *orgRepoConfig) *orgRepoConfig {
 	}
 
 	for org, excepts2 := range c2.orgExceptions {
-		// update any blacklists not previously updated
+		// update any denylists not previously updated
 		if _, exists := res.orgExceptions[org]; !exists {
 			res.orgExceptions[org] = excepts2.Difference(c.repos)
 		}
 	}
 
-	// we need to prune out repos in the whitelists which are
+	// we need to prune out repos in the allowed lists which are
 	// covered by an org already; we know from above that no
-	// org blacklist in the result will contain a repo whitelist
+	// org denylist in the result will contain a repo allowlist
 	for _, repo := range c.repos.Union(c2.repos).UnsortedList() {
 		parts := strings.SplitN(repo, "/", 2)
 		if len(parts) != 2 {

--- a/prow/cmd/checkconfig/main_test.go
+++ b/prow/cmd/checkconfig/main_test.go
@@ -346,19 +346,19 @@ func TestOrgRepoUnion(t *testing.T) {
 			expected: newOrgRepoConfig(map[string]sets.String{"org": sets.NewString("org/repo"), "org2": sets.NewString()}, sets.NewString("4/1", "4/2", "5/1")),
 		},
 		{
-			name:     "keep only common blacklist items for an org",
+			name:     "keep only common denied items for an org",
 			a:        newOrgRepoConfig(map[string]sets.String{"org": sets.NewString("org/repo", "org/bar")}, sets.NewString()),
 			b:        newOrgRepoConfig(map[string]sets.String{"org": sets.NewString("org/repo", "org/foo")}, sets.NewString()),
 			expected: newOrgRepoConfig(map[string]sets.String{"org": sets.NewString("org/repo")}, sets.NewString()),
 		},
 		{
-			name:     "remove items from an org blacklist if they're in a repo whitelist",
+			name:     "remove items from an org denylist if they're in a repo allowlist",
 			a:        newOrgRepoConfig(map[string]sets.String{"org": sets.NewString("org/repo")}, sets.NewString()),
 			b:        newOrgRepoConfig(map[string]sets.String{}, sets.NewString("org/repo")),
 			expected: newOrgRepoConfig(map[string]sets.String{"org": sets.NewString()}, sets.NewString()),
 		},
 		{
-			name:     "remove repos when they're covered by an org whitelist",
+			name:     "remove repos when they're covered by an org allowlist",
 			a:        newOrgRepoConfig(map[string]sets.String{}, sets.NewString("4/1", "4/2", "4/3")),
 			b:        newOrgRepoConfig(map[string]sets.String{"4": sets.NewString("4/2")}, sets.NewString()),
 			expected: newOrgRepoConfig(map[string]sets.String{"4": sets.NewString()}, sets.NewString()),

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -391,20 +391,20 @@ type OwnersDirBlacklist struct {
 	IgnorePreconfiguredDefaults bool `json:"ignore_preconfigured_defaults,omitempty"`
 }
 
-// DirBlacklist returns regular expressions matching directories to ignore when
+// ListIgnoredDirs returns regular expressions matching directories to ignore when
 // searching for OWNERS{,_ALIAS} files in a repo.
-func (ownersDirBlacklist OwnersDirBlacklist) DirBlacklist(org, repo string) (blacklist []string) {
-	blacklist = append(blacklist, ownersDirBlacklist.Default...)
+func (ownersDirBlacklist OwnersDirBlacklist) ListIgnoredDirs(org, repo string) (ignorelist []string) {
+	ignorelist = append(ignorelist, ownersDirBlacklist.Default...)
 	if bl, ok := ownersDirBlacklist.Repos[org]; ok {
-		blacklist = append(blacklist, bl...)
+		ignorelist = append(ignorelist, bl...)
 	}
 	if bl, ok := ownersDirBlacklist.Repos[org+"/"+repo]; ok {
-		blacklist = append(blacklist, bl...)
+		ignorelist = append(ignorelist, bl...)
 	}
 
 	preconfiguredDefaults := []string{"\\.git$", "_output$", "vendor/.*/.*"}
 	if !ownersDirBlacklist.IgnorePreconfiguredDefaults {
-		blacklist = append(blacklist, preconfiguredDefaults...)
+		ignorelist = append(ignorelist, preconfiguredDefaults...)
 	}
 	return
 }

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -2687,7 +2687,7 @@ deck:
 			expectError: false,
 		},
 		{
-			name: "allow anyone and whitelist specified",
+			name: "allow anyone and allowed users specified",
 			prowConfig: `
 deck:
   rerun_auth_config:
@@ -2707,7 +2707,7 @@ deck:
 			expectError: false,
 		},
 		{
-			name: "allow anyone with empty whitelist",
+			name: "allow anyone with an empty allowlist",
 			prowConfig: `
 deck:
   rerun_auth_config:

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -237,7 +237,7 @@ func (br Brancher) RunsAgainstAllBranch() bool {
 	return len(br.SkipBranches) == 0 && len(br.Branches) == 0
 }
 
-// ShouldRun returns true if the input branch matches, given the whitelist/blacklist.
+// ShouldRun returns true if the input branch matches, given the allow/deny list.
 func (br Brancher) ShouldRun(branch string) bool {
 	if br.RunsAgainstAllBranch() {
 		return true

--- a/prow/external-plugins/cherrypicker/server.go
+++ b/prow/external-plugins/cherrypicker/server.go
@@ -213,7 +213,7 @@ func (s *Server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent
 		return s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(ic.Comment, resp))
 	}
 
-	// TODO: Use a whitelist for allowed base and target branches.
+	// TODO: Use an allowlist for allowed base and target branches.
 	if baseBranch == targetBranch {
 		resp := fmt.Sprintf("base branch (%s) needs to differ from target branch (%s)", baseBranch, targetBranch)
 		l.Info(resp)

--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -557,7 +557,7 @@ type ManagedColumn struct {
 
 // MergeWarning is a config for the slackevents plugin's manual merge warnings.
 // If a PR is pushed to any of the repos listed in the config then send messages
-// to the all the slack channels listed if pusher is NOT in the whitelist.
+// to the all the slack channels listed if pusher is NOT in the allowlist.
 type MergeWarning struct {
 	// Repos is either of the form org/repos or just org.
 	Repos []string `json:"repos,omitempty"`

--- a/prow/plugins/slackevents/slackevents_test.go
+++ b/prow/plugins/slackevents/slackevents_test.go
@@ -263,7 +263,7 @@ func TestComment(t *testing.T) {
 			commenter:        orgMember,
 		},
 		{
-			name:             "If multiple sigs mentioned, but only one channel is whitelisted, only send to one channel.",
+			name:             "If multiple sigs mentioned, but only one channel is allowed, only send to one channel.",
 			action:           github.GenericCommentActionCreated,
 			body:             "@kubernetes/sig-node-misc, @kubernetes/sig-testing-misc Message sent to multiple sigs.",
 			expectedMessages: map[string][]string{"sig-node": {"Message sent to multiple sigs."}},

--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -127,22 +127,22 @@ func requirementDiff(pr *PullRequest, q *config.TideQuery, cc contextChecker) (s
 
 	// Weight incorrect branches with very high diff so that we select the query
 	// for the correct branch.
-	targetBranchBlacklisted := false
+	targetBranchDenied := false
 	for _, excludedBranch := range q.ExcludedBranches {
 		if string(pr.BaseRef.Name) == excludedBranch {
-			targetBranchBlacklisted = true
+			targetBranchDenied = true
 			break
 		}
 	}
-	// if no whitelist is configured, the target is OK by default
-	targetBranchWhitelisted := len(q.IncludedBranches) == 0
+	// if no allowlist is configured, the target is OK by default
+	targetBranchAllowed := len(q.IncludedBranches) == 0
 	for _, includedBranch := range q.IncludedBranches {
 		if string(pr.BaseRef.Name) == includedBranch {
-			targetBranchWhitelisted = true
+			targetBranchAllowed = true
 			break
 		}
 	}
-	if targetBranchBlacklisted || !targetBranchWhitelisted {
+	if targetBranchDenied || !targetBranchAllowed {
 		diff += 1000
 		if desc == "" {
 			desc = fmt.Sprintf(" Merging to branch %s is forbidden.", pr.BaseRef.Name)

--- a/prow/tide/status_test.go
+++ b/prow/tide/status_test.go
@@ -44,8 +44,8 @@ func TestExpectedStatus(t *testing.T) {
 		name string
 
 		baseref           string
-		branchWhitelist   []string
-		branchBlacklist   []string
+		branchAllowList   []string
+		branchDenyList    []string
 		sameBranchReqs    bool
 		labels            []string
 		author            string
@@ -130,12 +130,12 @@ func TestExpectedStatus(t *testing.T) {
 			desc:  fmt.Sprintf(statusNotInPool, " Needs need-1 label."),
 		},
 		{
-			name:            "against excluded branch",
-			baseref:         "bad",
-			branchBlacklist: []string{"bad"},
-			sameBranchReqs:  true,
-			labels:          neededLabels,
-			inPool:          false,
+			name:           "against excluded branch",
+			baseref:        "bad",
+			branchDenyList: []string{"bad"},
+			sameBranchReqs: true,
+			labels:         neededLabels,
+			inPool:         false,
 
 			state: github.StatusPending,
 			desc:  fmt.Sprintf(statusNotInPool, " Merging to branch bad is forbidden."),
@@ -143,7 +143,7 @@ func TestExpectedStatus(t *testing.T) {
 		{
 			name:            "not against included branch",
 			baseref:         "bad",
-			branchWhitelist: []string{"good"},
+			branchAllowList: []string{"good"},
 			sameBranchReqs:  true,
 			labels:          neededLabels,
 			inPool:          false,
@@ -154,7 +154,7 @@ func TestExpectedStatus(t *testing.T) {
 		{
 			name:              "choose query for correct branch",
 			baseref:           "bad",
-			branchWhitelist:   []string{"good"},
+			branchAllowList:   []string{"good"},
 			author:            "batman",
 			firstQueryAuthor:  "batman",
 			secondQueryAuthor: "batman",
@@ -635,14 +635,14 @@ func TestExpectedStatus(t *testing.T) {
 				Milestone: "v1.0",
 			}
 			if tc.sameBranchReqs {
-				secondQuery.ExcludedBranches = tc.branchBlacklist
-				secondQuery.IncludedBranches = tc.branchWhitelist
+				secondQuery.ExcludedBranches = tc.branchDenyList
+				secondQuery.IncludedBranches = tc.branchAllowList
 			}
 			queriesByRepo := config.TideQueries{
 				config.TideQuery{
 					Orgs:             []string{""},
-					ExcludedBranches: tc.branchBlacklist,
-					IncludedBranches: tc.branchWhitelist,
+					ExcludedBranches: tc.branchDenyList,
+					IncludedBranches: tc.branchAllowList,
 					Labels:           neededLabels,
 					MissingLabels:    forbiddenLabels,
 					Author:           tc.firstQueryAuthor,


### PR DESCRIPTION
xref #19264

I tried to be context-sensitive in choosing new names, trying to best reflect the idea the comment/variable is trying to convey.

This PR doesn't cover files that change Prow Config options; those changes will require deprecations.