### PR TITLE
Add 'DefaultServiceAccountName' field to decoration config.

### DIFF
--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -344,10 +344,13 @@ type DecorationConfig struct {
 	GCSConfiguration *GCSConfiguration `json:"gcs_configuration,omitempty"`
 	// GCSCredentialsSecret is the name of the Kubernetes secret
 	// that holds GCS push credentials.
-	GCSCredentialsSecret string `json:"gcs_credentials_secret,omitempty"`
+	GCSCredentialsSecret *string `json:"gcs_credentials_secret,omitempty"`
 	// S3CredentialsSecret is the name of the Kubernetes secret
 	// that holds blob storage push credentials.
-	S3CredentialsSecret string `json:"s3_credentials_secret,omitempty"`
+	S3CredentialsSecret *string `json:"s3_credentials_secret,omitempty"`
+	// DefaultServiceAccountName is the name of the Kubernetes service account
+	// that should be used by the pod if one is not specified in the podspec.
+	DefaultServiceAccountName *string `json:"default_service_account_name,omitempty"`
 	// SSHKeySecrets are the names of Kubernetes secrets that contain
 	// SSK keys which should be used during the cloning process.
 	SSHKeySecrets []string `json:"ssh_key_secrets,omitempty"`
@@ -434,11 +437,14 @@ func (d *DecorationConfig) ApplyDefault(def *DecorationConfig) *DecorationConfig
 	if merged.GracePeriod == nil {
 		merged.GracePeriod = def.GracePeriod
 	}
-	if merged.GCSCredentialsSecret == "" {
+	if merged.GCSCredentialsSecret == nil {
 		merged.GCSCredentialsSecret = def.GCSCredentialsSecret
 	}
-	if merged.S3CredentialsSecret == "" {
+	if merged.S3CredentialsSecret == nil {
 		merged.S3CredentialsSecret = def.S3CredentialsSecret
+	}
+	if merged.DefaultServiceAccountName == nil {
+		merged.DefaultServiceAccountName = def.DefaultServiceAccountName
 	}
 	if len(merged.SSHKeySecrets) == 0 {
 		merged.SSHKeySecrets = def.SSHKeySecrets

--- a/prow/apis/prowjobs/v1/types_test.go
+++ b/prow/apis/prowjobs/v1/types_test.go
@@ -23,8 +23,12 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/google/gofuzz"
+	fuzz "github.com/google/gofuzz"
 )
+
+func pStr(str string) *string {
+	return &str
+}
 
 func TestDecorationDefaultingDoesntOverwrite(t *testing.T) {
 	truth := true
@@ -97,7 +101,17 @@ func TestDecorationDefaultingDoesntOverwrite(t *testing.T) {
 		{
 			name: "gcs secret name provided",
 			provided: &DecorationConfig{
-				GCSCredentialsSecret: "somethingSecret",
+				GCSCredentialsSecret: pStr("somethingSecret"),
+			},
+			expected: func(orig, def *DecorationConfig) *DecorationConfig {
+				def.GCSCredentialsSecret = orig.GCSCredentialsSecret
+				return def
+			},
+		},
+		{
+			name: "gcs secret name unset",
+			provided: &DecorationConfig{
+				GCSCredentialsSecret: pStr(""),
 			},
 			expected: func(orig, def *DecorationConfig) *DecorationConfig {
 				def.GCSCredentialsSecret = orig.GCSCredentialsSecret
@@ -107,10 +121,30 @@ func TestDecorationDefaultingDoesntOverwrite(t *testing.T) {
 		{
 			name: "s3 secret name provided",
 			provided: &DecorationConfig{
-				S3CredentialsSecret: "overwritten",
+				S3CredentialsSecret: pStr("overwritten"),
 			},
 			expected: func(orig, def *DecorationConfig) *DecorationConfig {
 				def.S3CredentialsSecret = orig.S3CredentialsSecret
+				return def
+			},
+		},
+		{
+			name: "s3 secret name unset",
+			provided: &DecorationConfig{
+				S3CredentialsSecret: pStr(""),
+			},
+			expected: func(orig, def *DecorationConfig) *DecorationConfig {
+				def.S3CredentialsSecret = orig.S3CredentialsSecret
+				return def
+			},
+		},
+		{
+			name: "default service account name provided",
+			provided: &DecorationConfig{
+				DefaultServiceAccountName: pStr("gcs-upload-sa"),
+			},
+			expected: func(orig, def *DecorationConfig) *DecorationConfig {
+				def.DefaultServiceAccountName = orig.DefaultServiceAccountName
 				return def
 			},
 		},
@@ -193,8 +227,8 @@ func TestDecorationDefaultingDoesntOverwrite(t *testing.T) {
 					DefaultOrg:   "org",
 					DefaultRepo:  "repo",
 				},
-				GCSCredentialsSecret: "secretName",
-				S3CredentialsSecret:  "s3-secret",
+				GCSCredentialsSecret: pStr("secretName"),
+				S3CredentialsSecret:  pStr("s3-secret"),
 				SSHKeySecrets:        []string{"first", "second"},
 				SSHHostFingerprints:  []string{"primero", "segundo"},
 				SkipCloning:          &truth,

--- a/prow/apis/prowjobs/v1/zz_generated.deepcopy.go
+++ b/prow/apis/prowjobs/v1/zz_generated.deepcopy.go
@@ -56,6 +56,21 @@ func (in *DecorationConfig) DeepCopyInto(out *DecorationConfig) {
 		*out = new(GCSConfiguration)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.GCSCredentialsSecret != nil {
+		in, out := &in.GCSCredentialsSecret, &out.GCSCredentialsSecret
+		*out = new(string)
+		**out = **in
+	}
+	if in.S3CredentialsSecret != nil {
+		in, out := &in.S3CredentialsSecret, &out.S3CredentialsSecret
+		*out = new(string)
+		**out = **in
+	}
+	if in.DefaultServiceAccountName != nil {
+		in, out := &in.DefaultServiceAccountName, &out.DefaultServiceAccountName
+		*out = new(string)
+		**out = **in
+	}
 	if in.SSHKeySecrets != nil {
 		in, out := &in.SSHKeySecrets, &out.SSHKeySecrets
 		*out = make([]string, len(*in))

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -49,6 +49,10 @@ import (
 	"k8s.io/test-infra/prow/pod-utils/downwardapi"
 )
 
+func pStr(str string) *string {
+	return &str
+}
+
 func TestDefaultJobBase(t *testing.T) {
 	bar := "bar"
 	filled := JobBase{
@@ -490,7 +494,7 @@ periodics:
 					DefaultOrg:   "kubernetes",
 					DefaultRepo:  "kubernetes",
 				},
-				GCSCredentialsSecret: "default-service-account",
+				GCSCredentialsSecret: pStr("default-service-account"),
 			},
 		},
 		{
@@ -538,7 +542,7 @@ periodics:
 					DefaultOrg:   "kubernetes",
 					DefaultRepo:  "kubernetes",
 				},
-				GCSCredentialsSecret: "default-service-account",
+				GCSCredentialsSecret: pStr("default-service-account"),
 			},
 		},
 		{
@@ -598,7 +602,7 @@ periodics:
 					DefaultOrg:   "kubernetes",
 					DefaultRepo:  "kubernetes",
 				},
-				GCSCredentialsSecret: "explicit-service-account",
+				GCSCredentialsSecret: pStr("explicit-service-account"),
 			},
 		},
 		{
@@ -653,7 +657,7 @@ periodics:
 					DefaultRepo:  "kubernetes",
 					MediaTypes:   map[string]string{"log": "text/plain"},
 				},
-				GCSCredentialsSecret: "explicit-service-account",
+				GCSCredentialsSecret: pStr("explicit-service-account"),
 			},
 		},
 	}
@@ -1123,7 +1127,7 @@ func TestValidateDecoration(t *testing.T) {
 			Entrypoint: "enter-me",
 			Sidecar:    "official-drink-of-the-org",
 		},
-		GCSCredentialsSecret: "upload-secret",
+		GCSCredentialsSecret: pStr("upload-secret"),
 		GCSConfiguration: &prowjobv1.GCSConfiguration{
 			PathStrategy: prowjobv1.PathStrategyExplicit,
 			DefaultOrg:   "so-org",
@@ -1232,7 +1236,7 @@ func TestValidateMultipleContainers(t *testing.T) {
 			Entrypoint: "enter-me",
 			Sidecar:    "official-drink-of-the-org",
 		},
-		GCSCredentialsSecret: "upload-secret",
+		GCSCredentialsSecret: pStr("upload-secret"),
 		GCSConfiguration: &prowjobv1.GCSConfiguration{
 			PathStrategy: prowjobv1.PathStrategyExplicit,
 			DefaultOrg:   "so-org",
@@ -3616,7 +3620,7 @@ func TestSetDecorationDefaults(t *testing.T) {
 									DefaultOrg:   "org",
 									DefaultRepo:  "repo",
 								},
-								GCSCredentialsSecret: "credentials-gcs",
+								GCSCredentialsSecret: pStr("credentials-gcs"),
 							},
 						},
 					},
@@ -3635,7 +3639,7 @@ func TestSetDecorationDefaults(t *testing.T) {
 					DefaultOrg:   "org",
 					DefaultRepo:  "repo",
 				},
-				GCSCredentialsSecret: "credentials-gcs",
+				GCSCredentialsSecret: pStr("credentials-gcs"),
 			},
 		},
 		{
@@ -3659,7 +3663,7 @@ func TestSetDecorationDefaults(t *testing.T) {
 									DefaultOrg:   "org",
 									DefaultRepo:  "repo",
 								},
-								GCSCredentialsSecret: "credentials-gcs",
+								GCSCredentialsSecret: pStr("credentials-gcs"),
 							},
 							"org/repo": {
 								GCSConfiguration: &prowapi.GCSConfiguration{
@@ -3686,7 +3690,7 @@ func TestSetDecorationDefaults(t *testing.T) {
 					DefaultOrg:   "org-by-repo",
 					DefaultRepo:  "repo-by-repo",
 				},
-				GCSCredentialsSecret: "credentials-gcs",
+				GCSCredentialsSecret: pStr("credentials-gcs"),
 			},
 		},
 		{
@@ -3707,7 +3711,7 @@ func TestSetDecorationDefaults(t *testing.T) {
 						DefaultOrg:   "org-from-ps",
 						DefaultRepo:  "repo-from-ps",
 					},
-					GCSCredentialsSecret: "credentials-gcs-from-ps",
+					GCSCredentialsSecret: pStr("credentials-gcs-from-ps"),
 				},
 			},
 			config: &Config{
@@ -3727,7 +3731,7 @@ func TestSetDecorationDefaults(t *testing.T) {
 									DefaultOrg:   "org",
 									DefaultRepo:  "repo",
 								},
-								GCSCredentialsSecret: "credentials-gcs",
+								GCSCredentialsSecret: pStr("credentials-gcs"),
 							},
 						},
 					},
@@ -3746,7 +3750,7 @@ func TestSetDecorationDefaults(t *testing.T) {
 					DefaultOrg:   "org-from-ps",
 					DefaultRepo:  "repo-from-ps",
 				},
-				GCSCredentialsSecret: "credentials-gcs-from-ps",
+				GCSCredentialsSecret: pStr("credentials-gcs-from-ps"),
 			},
 		},
 		{
@@ -3767,7 +3771,7 @@ func TestSetDecorationDefaults(t *testing.T) {
 						DefaultOrg:   "org-from-ps",
 						DefaultRepo:  "repo-from-ps",
 					},
-					GCSCredentialsSecret: "credentials-gcs-from-ps",
+					GCSCredentialsSecret: pStr("credentials-gcs-from-ps"),
 				},
 			},
 			config: &Config{
@@ -3787,7 +3791,7 @@ func TestSetDecorationDefaults(t *testing.T) {
 									DefaultOrg:   "org",
 									DefaultRepo:  "repo",
 								},
-								GCSCredentialsSecret: "credentials-gcs",
+								GCSCredentialsSecret: pStr("credentials-gcs"),
 							},
 							"org/repo": {
 								UtilityImages: &prowapi.UtilityImages{
@@ -3802,7 +3806,7 @@ func TestSetDecorationDefaults(t *testing.T) {
 									DefaultOrg:   "org-test",
 									DefaultRepo:  "repo-test",
 								},
-								GCSCredentialsSecret: "credentials-gcs",
+								GCSCredentialsSecret: pStr("credentials-gcs"),
 							},
 						},
 					},
@@ -3821,7 +3825,7 @@ func TestSetDecorationDefaults(t *testing.T) {
 					DefaultOrg:   "org-from-ps",
 					DefaultRepo:  "repo-from-ps",
 				},
-				GCSCredentialsSecret: "credentials-gcs-from-ps",
+				GCSCredentialsSecret: pStr("credentials-gcs-from-ps"),
 			},
 		},
 		{
@@ -3845,7 +3849,7 @@ func TestSetDecorationDefaults(t *testing.T) {
 									DefaultOrg:   "org",
 									DefaultRepo:  "repo",
 								},
-								GCSCredentialsSecret: "credentials-gcs",
+								GCSCredentialsSecret: pStr("credentials-gcs"),
 							},
 							"org/repo": {
 								UtilityImages: &prowapi.UtilityImages{
@@ -3860,7 +3864,7 @@ func TestSetDecorationDefaults(t *testing.T) {
 									DefaultOrg:   "org-by-repo",
 									DefaultRepo:  "repo-by-repo",
 								},
-								GCSCredentialsSecret: "credentials-gcs-by-repo",
+								GCSCredentialsSecret: pStr("credentials-gcs-by-repo"),
 							},
 						},
 					},
@@ -3879,7 +3883,7 @@ func TestSetDecorationDefaults(t *testing.T) {
 					DefaultOrg:   "org-by-repo",
 					DefaultRepo:  "repo-by-repo",
 				},
-				GCSCredentialsSecret: "credentials-gcs-by-repo",
+				GCSCredentialsSecret: pStr("credentials-gcs-by-repo"),
 			},
 		},
 		{
@@ -3903,7 +3907,7 @@ func TestSetDecorationDefaults(t *testing.T) {
 									DefaultOrg:   "org",
 									DefaultRepo:  "repo",
 								},
-								GCSCredentialsSecret: "credentials-gcs",
+								GCSCredentialsSecret: pStr("credentials-gcs"),
 							},
 							"org": {
 								UtilityImages: &prowapi.UtilityImages{
@@ -3918,7 +3922,7 @@ func TestSetDecorationDefaults(t *testing.T) {
 									DefaultOrg:   "org-by-org",
 									DefaultRepo:  "repo-by-org",
 								},
-								GCSCredentialsSecret: "credentials-gcs-by-org",
+								GCSCredentialsSecret: pStr("credentials-gcs-by-org"),
 							},
 						},
 					},
@@ -3937,7 +3941,7 @@ func TestSetDecorationDefaults(t *testing.T) {
 					DefaultOrg:   "org-by-org",
 					DefaultRepo:  "repo-by-org",
 				},
-				GCSCredentialsSecret: "credentials-gcs-by-org",
+				GCSCredentialsSecret: pStr("credentials-gcs-by-org"),
 			},
 		},
 		{
@@ -3961,7 +3965,7 @@ func TestSetDecorationDefaults(t *testing.T) {
 									DefaultOrg:   "org-by-*",
 									DefaultRepo:  "repo-by-*",
 								},
-								GCSCredentialsSecret: "credentials-gcs-by-*",
+								GCSCredentialsSecret: pStr("credentials-gcs-by-*"),
 							},
 						},
 					},
@@ -3980,7 +3984,7 @@ func TestSetDecorationDefaults(t *testing.T) {
 					DefaultOrg:   "org-by-*",
 					DefaultRepo:  "repo-by-*",
 				},
-				GCSCredentialsSecret: "credentials-gcs-by-*",
+				GCSCredentialsSecret: pStr("credentials-gcs-by-*"),
 			},
 		},
 
@@ -4005,7 +4009,7 @@ func TestSetDecorationDefaults(t *testing.T) {
 									DefaultOrg:   "org-by-*",
 									DefaultRepo:  "repo-by-*",
 								},
-								GCSCredentialsSecret: "credentials-gcs-by-*",
+								GCSCredentialsSecret: pStr("credentials-gcs-by-*"),
 							},
 							"org": {
 								UtilityImages: &prowapi.UtilityImages{
@@ -4020,7 +4024,7 @@ func TestSetDecorationDefaults(t *testing.T) {
 									DefaultOrg:   "org-by-org",
 									DefaultRepo:  "repo-by-org",
 								},
-								GCSCredentialsSecret: "credentials-gcs-by-org",
+								GCSCredentialsSecret: pStr("credentials-gcs-by-org"),
 							},
 							"org/repo": {
 								UtilityImages: &prowapi.UtilityImages{
@@ -4035,7 +4039,7 @@ func TestSetDecorationDefaults(t *testing.T) {
 									DefaultOrg:   "org-by-org-repo",
 									DefaultRepo:  "repo-by-org-repo",
 								},
-								GCSCredentialsSecret: "credentials-gcs-by-org-repo",
+								GCSCredentialsSecret: pStr("credentials-gcs-by-org-repo"),
 							},
 						},
 					},
@@ -4054,7 +4058,7 @@ func TestSetDecorationDefaults(t *testing.T) {
 					DefaultOrg:   "org-by-org-repo",
 					DefaultRepo:  "repo-by-org-repo",
 				},
-				GCSCredentialsSecret: "credentials-gcs-by-org-repo",
+				GCSCredentialsSecret: pStr("credentials-gcs-by-org-repo"),
 			},
 		},
 
@@ -4079,7 +4083,7 @@ func TestSetDecorationDefaults(t *testing.T) {
 									DefaultOrg:   "org-by-*",
 									DefaultRepo:  "repo-by-*",
 								},
-								GCSCredentialsSecret: "credentials-gcs-by-*",
+								GCSCredentialsSecret: pStr("credentials-gcs-by-*"),
 							},
 							"org": {
 								UtilityImages: &prowapi.UtilityImages{
@@ -4094,7 +4098,7 @@ func TestSetDecorationDefaults(t *testing.T) {
 									DefaultOrg:   "org-by-org",
 									DefaultRepo:  "repo-by-org",
 								},
-								GCSCredentialsSecret: "credentials-gcs-by-org",
+								GCSCredentialsSecret: pStr("credentials-gcs-by-org"),
 							},
 						},
 					},
@@ -4113,7 +4117,7 @@ func TestSetDecorationDefaults(t *testing.T) {
 					DefaultOrg:   "org-by-org",
 					DefaultRepo:  "repo-by-org",
 				},
-				GCSCredentialsSecret: "credentials-gcs-by-org",
+				GCSCredentialsSecret: pStr("credentials-gcs-by-org"),
 			},
 		},
 		{
@@ -4138,7 +4142,7 @@ func TestSetDecorationDefaults(t *testing.T) {
 									DefaultOrg:   "org",
 									DefaultRepo:  "repo",
 								},
-								GCSCredentialsSecret: "credentials-gcs",
+								GCSCredentialsSecret: pStr("credentials-gcs"),
 							},
 						},
 					},
@@ -4157,7 +4161,7 @@ func TestSetDecorationDefaults(t *testing.T) {
 					DefaultOrg:   "org",
 					DefaultRepo:  "repo",
 				},
-				GCSCredentialsSecret: "credentials-gcs",
+				GCSCredentialsSecret: pStr("credentials-gcs"),
 			},
 		},
 		{
@@ -4183,7 +4187,7 @@ func TestSetDecorationDefaults(t *testing.T) {
 									DefaultOrg:   "org",
 									DefaultRepo:  "repo",
 								},
-								GCSCredentialsSecret: "credentials-gcs",
+								GCSCredentialsSecret: pStr("credentials-gcs"),
 							},
 						},
 					},
@@ -4238,7 +4242,7 @@ func TestSetPeriodicDecorationDefaults(t *testing.T) {
 									DefaultOrg:   "org-by-*",
 									DefaultRepo:  "repo-by-*",
 								},
-								GCSCredentialsSecret: "credentials-gcs-by-*",
+								GCSCredentialsSecret: pStr("credentials-gcs-by-*"),
 							},
 						},
 					},
@@ -4258,7 +4262,7 @@ func TestSetPeriodicDecorationDefaults(t *testing.T) {
 					DefaultOrg:   "org-by-*",
 					DefaultRepo:  "repo-by-*",
 				},
-				GCSCredentialsSecret: "credentials-gcs-by-*",
+				GCSCredentialsSecret: pStr("credentials-gcs-by-*"),
 			},
 		},
 		{
@@ -4280,7 +4284,7 @@ func TestSetPeriodicDecorationDefaults(t *testing.T) {
 									DefaultOrg:   "org-by-*",
 									DefaultRepo:  "repo-by-*",
 								},
-								GCSCredentialsSecret: "credentials-gcs-by-*",
+								GCSCredentialsSecret: pStr("credentials-gcs-by-*"),
 							},
 							"org": {
 								UtilityImages: &prowapi.UtilityImages{
@@ -4295,7 +4299,7 @@ func TestSetPeriodicDecorationDefaults(t *testing.T) {
 									DefaultOrg:   "org-by-org",
 									DefaultRepo:  "repo-by-org",
 								},
-								GCSCredentialsSecret: "credentials-gcs-by-org",
+								GCSCredentialsSecret: pStr("credentials-gcs-by-org"),
 							},
 						},
 					},
@@ -4323,7 +4327,7 @@ func TestSetPeriodicDecorationDefaults(t *testing.T) {
 					DefaultOrg:   "org-by-org",
 					DefaultRepo:  "repo-by-org",
 				},
-				GCSCredentialsSecret: "credentials-gcs-by-org",
+				GCSCredentialsSecret: pStr("credentials-gcs-by-org"),
 			},
 		},
 		{
@@ -4345,7 +4349,7 @@ func TestSetPeriodicDecorationDefaults(t *testing.T) {
 									DefaultOrg:   "org-by-*",
 									DefaultRepo:  "repo-by-*",
 								},
-								GCSCredentialsSecret: "credentials-gcs-by-*",
+								GCSCredentialsSecret: pStr("credentials-gcs-by-*"),
 							},
 							"org/repo": {
 								UtilityImages: &prowapi.UtilityImages{
@@ -4360,7 +4364,7 @@ func TestSetPeriodicDecorationDefaults(t *testing.T) {
 									DefaultOrg:   "org-by-org-repo",
 									DefaultRepo:  "repo-by-org-repo",
 								},
-								GCSCredentialsSecret: "credentials-gcs-by-org-repo",
+								GCSCredentialsSecret: pStr("credentials-gcs-by-org-repo"),
 							},
 						},
 					},
@@ -4388,7 +4392,7 @@ func TestSetPeriodicDecorationDefaults(t *testing.T) {
 					DefaultOrg:   "org-by-org-repo",
 					DefaultRepo:  "repo-by-org-repo",
 				},
-				GCSCredentialsSecret: "credentials-gcs-by-org-repo",
+				GCSCredentialsSecret: pStr("credentials-gcs-by-org-repo"),
 			},
 		},
 		{
@@ -4413,7 +4417,7 @@ func TestSetPeriodicDecorationDefaults(t *testing.T) {
 									DefaultOrg:   "org-by-*",
 									DefaultRepo:  "repo-by-*",
 								},
-								GCSCredentialsSecret: "credentials-gcs-by-*",
+								GCSCredentialsSecret: pStr("credentials-gcs-by-*"),
 							},
 						},
 					},
@@ -4432,7 +4436,7 @@ func TestSetPeriodicDecorationDefaults(t *testing.T) {
 					DefaultOrg:   "org-by-*",
 					DefaultRepo:  "repo-by-*",
 				},
-				GCSCredentialsSecret: "credentials-gcs-by-*",
+				GCSCredentialsSecret: pStr("credentials-gcs-by-*"),
 			},
 		},
 		{
@@ -4458,7 +4462,7 @@ func TestSetPeriodicDecorationDefaults(t *testing.T) {
 									DefaultOrg:   "org-by-*",
 									DefaultRepo:  "repo-by-*",
 								},
-								GCSCredentialsSecret: "credentials-gcs-by-*",
+								GCSCredentialsSecret: pStr("credentials-gcs-by-*"),
 							},
 						},
 					},

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -482,6 +482,10 @@ plank:
             # a git http.cookiefile, which should be used during the cloning process.
             cookiefile_secret: ' '
 
+            # DefaultServiceAccountName is the name of the Kubernetes service account
+            # that should be used by the pod if one is not specified in the podspec.
+            default_service_account_name: ""
+
             # GCSConfiguration holds options for pushing logs and
             # artifacts to GCS from a job.
             gcs_configuration:
@@ -523,7 +527,7 @@ plank:
 
             # GCSCredentialsSecret is the name of the Kubernetes secret
             # that holds GCS push credentials.
-            gcs_credentials_secret: ' '
+            gcs_credentials_secret: ""
 
             # GracePeriod is how long the pod utilities will wait
             # after sending SIGINT to send SIGKILL when aborting
@@ -566,7 +570,7 @@ plank:
 
             # S3CredentialsSecret is the name of the Kubernetes secret
             # that holds blob storage push credentials.
-            s3_credentials_secret: ' '
+            s3_credentials_secret: ""
 
             # SkipCloning determines if we should clone source code in the
             # initcontainers for jobs that specify refs

--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -539,12 +539,12 @@ func BlobStorageOptions(dc prowapi.DecorationConfig, localMode bool) ([]coreapi.
 
 	var volumes []coreapi.Volume
 	var mounts []coreapi.VolumeMount
-	if dc.GCSCredentialsSecret != "" {
+	if dc.GCSCredentialsSecret != nil && *dc.GCSCredentialsSecret != "" {
 		volumes = append(volumes, coreapi.Volume{
 			Name: gcsCredentialsMountName,
 			VolumeSource: coreapi.VolumeSource{
 				Secret: &coreapi.SecretVolumeSource{
-					SecretName: dc.GCSCredentialsSecret,
+					SecretName: *dc.GCSCredentialsSecret,
 				},
 			},
 		})
@@ -554,12 +554,12 @@ func BlobStorageOptions(dc prowapi.DecorationConfig, localMode bool) ([]coreapi.
 		})
 		opt.StorageClientOptions.GCSCredentialsFile = fmt.Sprintf("%s/service-account.json", gcsCredentialsMountPath)
 	}
-	if dc.S3CredentialsSecret != "" {
+	if dc.S3CredentialsSecret != nil && *dc.S3CredentialsSecret != "" {
 		volumes = append(volumes, coreapi.Volume{
 			Name: s3CredentialsMountName,
 			VolumeSource: coreapi.VolumeSource{
 				Secret: &coreapi.SecretVolumeSource{
-					SecretName: dc.S3CredentialsSecret,
+					SecretName: *dc.S3CredentialsSecret,
 				},
 			},
 		})
@@ -744,6 +744,11 @@ func decorate(spec *coreapi.PodSpec, pj *prowapi.ProwJob, rawEnv map[string]stri
 	if spec.TerminationGracePeriodSeconds == nil && pj.Spec.DecorationConfig.GracePeriod != nil {
 		gracePeriodSeconds := int64(pj.Spec.DecorationConfig.GracePeriod.Seconds())
 		spec.TerminationGracePeriodSeconds = &gracePeriodSeconds
+	}
+
+	defaultSA := pj.Spec.DecorationConfig.DefaultServiceAccountName
+	if spec.ServiceAccountName == "" && defaultSA != nil {
+		spec.ServiceAccountName = *defaultSA
 	}
 
 	return nil

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_2.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_2.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     created-by-prow: "true"
     needstobe: inherited
-    prow.k8s.io/build-id: "blabla"
+    prow.k8s.io/build-id: blabla
     prow.k8s.io/id: pod
     prow.k8s.io/job: job-name
     prow.k8s.io/refs.org: org-name

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_3.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_3.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     created-by-prow: "true"
     needstobe: inherited
-    prow.k8s.io/build-id: "blabla"
+    prow.k8s.io/build-id: blabla
     prow.k8s.io/id: pod
     prow.k8s.io/job: job-name
     prow.k8s.io/refs.org: org-name

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_4.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_4.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     created-by-prow: "true"
     needstobe: inherited
-    prow.k8s.io/build-id: "blabla"
+    prow.k8s.io/build-id: blabla
     prow.k8s.io/id: pod
     prow.k8s.io/job: job-name
     prow.k8s.io/refs.org: org-name

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_5.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_5.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     created-by-prow: "true"
     needstobe: inherited
-    prow.k8s.io/build-id: "blabla"
+    prow.k8s.io/build-id: blabla
     prow.k8s.io/id: pod
     prow.k8s.io/job: job-name
     prow.k8s.io/type: periodic

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_6.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_6.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     created-by-prow: "true"
     needstobe: inherited
-    prow.k8s.io/build-id: "blabla"
+    prow.k8s.io/build-id: blabla
     prow.k8s.io/id: pod
     prow.k8s.io/job: job-name
     prow.k8s.io/refs.org: org-name

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_7.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_7.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     created-by-prow: "true"
     needstobe: inherited
-    prow.k8s.io/build-id: "blabla"
+    prow.k8s.io/build-id: blabla
     prow.k8s.io/id: pod
     prow.k8s.io/job: job-name
     prow.k8s.io/refs.org: org-name

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_8.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_8.yaml
@@ -34,7 +34,7 @@ spec:
     - name: JOB_NAME
       value: job-name
     - name: JOB_SPEC
-      value: '{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"},"decoration_config":{"timeout":"2h0m0s","grace_period":"10s","utility_images":{"clonerefs":"clonerefs:tag","initupload":"initupload:tag","entrypoint":"entrypoint:tag","sidecar":"sidecar:tag"},"gcs_configuration":{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","mediaTypes":{"log":"text/plain"}},"gcs_credentials_secret":"secret-name","cookiefile_secret":"yummy/.gitcookies"}}'
+      value: '{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"},"decoration_config":{"timeout":"2h0m0s","grace_period":"10s","utility_images":{"clonerefs":"clonerefs:tag","initupload":"initupload:tag","entrypoint":"entrypoint:tag","sidecar":"sidecar:tag"},"gcs_configuration":{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","mediaTypes":{"log":"text/plain"}},"default_service_account_name":"default-SA","cookiefile_secret":"yummy/.gitcookies"}}'
     - name: JOB_TYPE
       value: presubmit
     - name: PROW_JOB_ID
@@ -71,9 +71,9 @@ spec:
     - /sidecar
     env:
     - name: JOB_SPEC
-      value: '{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"},"decoration_config":{"timeout":"2h0m0s","grace_period":"10s","utility_images":{"clonerefs":"clonerefs:tag","initupload":"initupload:tag","entrypoint":"entrypoint:tag","sidecar":"sidecar:tag"},"gcs_configuration":{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","mediaTypes":{"log":"text/plain"}},"gcs_credentials_secret":"secret-name","cookiefile_secret":"yummy/.gitcookies"}}'
+      value: '{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"},"decoration_config":{"timeout":"2h0m0s","grace_period":"10s","utility_images":{"clonerefs":"clonerefs:tag","initupload":"initupload:tag","entrypoint":"entrypoint:tag","sidecar":"sidecar:tag"},"gcs_configuration":{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","mediaTypes":{"log":"text/plain"}},"default_service_account_name":"default-SA","cookiefile_secret":"yummy/.gitcookies"}}'
     - name: SIDECAR_OPTIONS
-      value: '{"gcs_options":{"items":["/logs/artifacts"],"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","mediaTypes":{"log":"text/plain"},"gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false},"entries":[{"args":["/bin/thing","some","args"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}]}'
+      value: '{"gcs_options":{"items":["/logs/artifacts"],"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","mediaTypes":{"log":"text/plain"},"dry_run":false},"entries":[{"args":["/bin/thing","some","args"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}]}'
     image: sidecar:tag
     name: sidecar
     resources: {}
@@ -81,8 +81,6 @@ spec:
     volumeMounts:
     - mountPath: /logs
       name: logs
-    - mountPath: /secrets/gcs
-      name: gcs-credentials
   initContainers:
   - args:
     - --cookiefile=/secrets/cookiefile/.gitcookies
@@ -109,9 +107,9 @@ spec:
     - /initupload
     env:
     - name: INITUPLOAD_OPTIONS
-      value: '{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","mediaTypes":{"log":"text/plain"},"gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false,"log":"/logs/clone.json"}'
+      value: '{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","mediaTypes":{"log":"text/plain"},"dry_run":false,"log":"/logs/clone.json"}'
     - name: JOB_SPEC
-      value: '{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"},"decoration_config":{"timeout":"2h0m0s","grace_period":"10s","utility_images":{"clonerefs":"clonerefs:tag","initupload":"initupload:tag","entrypoint":"entrypoint:tag","sidecar":"sidecar:tag"},"gcs_configuration":{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","mediaTypes":{"log":"text/plain"}},"gcs_credentials_secret":"secret-name","cookiefile_secret":"yummy/.gitcookies"}}'
+      value: '{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"},"decoration_config":{"timeout":"2h0m0s","grace_period":"10s","utility_images":{"clonerefs":"clonerefs:tag","initupload":"initupload:tag","entrypoint":"entrypoint:tag","sidecar":"sidecar:tag"},"gcs_configuration":{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","mediaTypes":{"log":"text/plain"}},"default_service_account_name":"default-SA","cookiefile_secret":"yummy/.gitcookies"}}'
     image: initupload:tag
     name: initupload
     resources: {}
@@ -119,8 +117,6 @@ spec:
     volumeMounts:
     - mountPath: /logs
       name: logs
-    - mountPath: /secrets/gcs
-      name: gcs-credentials
   - args:
     - /entrypoint
     - /tools/entrypoint
@@ -134,15 +130,13 @@ spec:
     - mountPath: /tools
       name: tools
   restartPolicy: Never
+  serviceAccountName: default-SA
   terminationGracePeriodSeconds: 10
   volumes:
   - emptyDir: {}
     name: logs
   - emptyDir: {}
     name: tools
-  - name: gcs-credentials
-    secret:
-      secretName: secret-name
   - emptyDir: {}
     name: clonerefs-tmp
   - name: cookiefile


### PR DESCRIPTION
This will allow us to specify a default K8s service account to apply to ProwJob pods that don't specify their own in the podspec. In particular, this will be used to default the service account to one with sufficient permissions (via GCP Workload Identity) for the pod utilities to upload results to GCS.
DD: https://docs.google.com/document/d/1VtamQuaR-TFVud3NjCRUV8Nqtp4WmBK1na7fNNiYHXU/edit?ts=600ae8e0&resourcekey=0-VXcyCZ9kcLJxQnnrUx4p0Q#heading=h.6dyyhz5krl9v

/assign @chaodaiG @alvaroaleman 