### PR TITLE
releng(kubekins): Update Golang versions to go1.15.7

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -1,20 +1,20 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.15.5
+    GO_VERSION: 1.15.7
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
     UPGRADE_DOCKER: 'true'
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.15.5
+    GO_VERSION: 1.15.7
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   master:
     CONFIG: master
-    GO_VERSION: 1.15.5
+    GO_VERSION: 1.15.7
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
Part of https://github.com/kubernetes/release/issues/1851.
`k/k` go1.15.7 PR has merged https://github.com/kubernetes/kubernetes/pull/98363

/assign @hasheddan @saschagrunert @puerco @xmudrii @ameukam 
cc: @kubernetes/release-engineering