### PR TITLE
Run kubernetes 1.20 build job on k8s-infra-prow-build

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
@@ -156,6 +156,7 @@ periodics:
     testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
     testgrid-dashboards: sig-release-1.20-blocking
     testgrid-tab-name: build-1.20
+  cluster: k8s-infra-prow-build
   interval: 1h
   labels:
     preset-dind-enabled: "true"


### PR DESCRIPTION
This should have been caught by tests, but they are currently
in log-instead-of-fail mode because of some outstanding jobs.
I'll open a followup PR to propose making the tests blocking


```
$ go test -v -count=1 ./config/tests/jobs/...
...
=== RUN   TestKubernetesReleaseBlockingJobsShouldRunOnK8sInfraProwBuild
    jobs_test.go:1049: ci-kubernetes-build: should run on cluster: k8s-infra-prow-build, found: default
    jobs_test.go:1049: ci-kubernetes-build-1-19: should run on cluster: k8s-infra-prow-build, found: default
    jobs_test.go:1049: ci-kubernetes-build-1-20: should run on cluster: k8s-infra-prow-build, found: default
    jobs_test.go:1049: ci-kubernetes-build-1-20-canary: should run on cluster: k8s-infra-prow-build, found: default # <-- caught here
    jobs_test.go:1049: ci-kubernetes-build-stable2: should run on cluster: k8s-infra-prow-build, found: default
    jobs_test.go:1049: ci-kubernetes-build-stable3: should run on cluster: k8s-infra-prow-build, found: default
    jobs_test.go:1049: periodic-kubernetes-bazel-build-1-17: should run on cluster: k8s-infra-prow-build, found: default
    jobs_test.go:1049: periodic-kubernetes-bazel-build-1-18: should run on cluster: k8s-infra-prow-build, found: default
    jobs_test.go:1049: periodic-kubernetes-bazel-build-1-19: should run on cluster: k8s-infra-prow-build, found: default
    jobs_test.go:1049: periodic-kubernetes-bazel-build-1-20: should run on cluster: k8s-infra-prow-build, found: default
    jobs_test.go:1049: periodic-kubernetes-bazel-build-master: should run on cluster: k8s-infra-prow-build, found: default
--- PASS: TestKubernetesReleaseBlockingJobsShouldRunOnK8sInfraProwBuild (0.02s)
```