### PR TITLE
Use prow_push bazel target consistently among prow image publish and prow test image publish

### DIFF
--- a/prow/test/integration/setup-prow.sh
+++ b/prow/test/integration/setup-prow.sh
@@ -28,7 +28,7 @@ if [[ "${CONTEXT}" != "kind-kind-prow-integration" ]]; then
 fi
 
 echo "Pushing prow images"
-bazel run //prow:testimage-push "$@"
+bazel run //prow:testimage-push --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64
 
 echo "Wait until nginx is ready"
 kubectl --context=${CONTEXT} wait --namespace ingress-nginx \


### PR DESCRIPTION
This could possibly mitigate the problem of bazel run hanging like in https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/test-infra/20611/pull-test-infra-integration/1354445650376265728