### PR TITLE
Automatically determine bazel version to install

### DIFF
--- a/prow/test/integration/test.sh
+++ b/prow/test/integration/test.sh
@@ -19,6 +19,8 @@ set -o pipefail
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd -P )"
 
+BAZEL_VERSION="$(cat "$CURRENT_DIR"/../../../.bazelversion)"
+
 function dump_prow_pod_log() {
   local log_dir="${ARTIFACTS}/prow_pod_logs"
   if [[ -n "${ARTIFACTS:-}" && -d "${ARTIFACTS}" ]]; then
@@ -37,12 +39,12 @@ if ! which kind >/dev/null 2>&1; then
 fi
 
 # TODO(chaodaiG): remove this once bazel is installed in test image
-if ! which bazel >/dev/null 2>&1 || [[ "$(bazel --version)" != "bazel 3.1.0" ]]; then
+if ! which bazel >/dev/null 2>&1 || [[ "$(bazel --version)" != "bazel $BAZEL_VERSION" ]]; then
   echo "Install bazel for prow"
   mkdir -p "/usr/local/lib/bazel/bin"
   pushd "/usr/local/lib/bazel/bin" >/dev/null
-  curl -LO https://releases.bazel.build/3.1.0/release/bazel-3.1.0-linux-x86_64
-  chmod +x bazel-3.1.0-linux-x86_64
+  curl -LO https://releases.bazel.build/${BAZEL_VERSION}/release/bazel-${BAZEL_VERSION}-linux-x86_64
+  chmod +x bazel-${BAZEL_VERSION}-linux-x86_64
   popd
 fi
 


### PR DESCRIPTION
We need to run whatever is in `.bazelversion`, not 3.0.0