### PR TITLE
Enable release notes for CAPA

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -975,6 +975,7 @@ plugins:
   kubernetes-sigs/cluster-api-provider-aws:
   - milestone
   - override
+  - release-note
 
   kubernetes-sigs/cluster-api-provider-azure:
   - milestone


### PR DESCRIPTION
Signed-off-by: Richard Case <198425+richardcase@users.noreply.github.com>

This adds the `release-note` plugin to `cluster-api-provider-aws`.

/cc @randomvariable 