### PR TITLE
Add postsubmit job for externalip-webhook repo

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-multitenancy.yaml
+++ b/config/jobs/image-pushing/k8s-staging-multitenancy.yaml
@@ -1,0 +1,23 @@
+postsubmits:
+  kubernetes-sigs/externalip-webhook:
+    - name: post-externalip-webhook-push-image
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: wg-multi-tenancy-externalip
+      decorate: true
+      always_run: true
+      branches:
+        - ^master$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200901-ab141a0
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-multitenancy
+              - --scratch-bucket=gs://k8s-staging-multitenancy-gcb
+              - .
+            env:
+              - name: LOG_TO_STDOUT
+                value: "y"

--- a/config/jobs/kubernetes-sigs/externalip-webhook/OWNERS
+++ b/config/jobs/kubernetes-sigs/externalip-webhook/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+- SaranBalaji90
+- tallclair
+approvers:
+- SaranBalaji90
+- tallclair

--- a/config/testgrids/kubernetes/wg-multi-tenancy/config.yaml
+++ b/config/testgrids/kubernetes/wg-multi-tenancy/config.yaml
@@ -3,7 +3,9 @@ dashboard_groups:
   dashboard_names:
     - wg-multi-tenancy-hnc
     - wg-multi-tenancy-mtb
+    - wg-multi-tenancy-externalip
 
 dashboards:
 - name: wg-multi-tenancy-hnc
 - name: wg-multi-tenancy-mtb
+- name: wg-multi-tenancy-externalip


### PR DESCRIPTION
Automating release for https://github.com/kubernetes-sigs/externalip-webhook which was created to address CVE-2020-855. 

Cloudbuild.yaml - https://github.com/kubernetes-sigs/externalip-webhook/pull/11/files

Currently repo is using k8s.gcr.io/multitenancy but this might move to sig-networking in future.

Thank you @saschagrunert for guiding with the onboarding process.