### PR TITLE
Deck: Omit managed fields when sending data to frontend

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -798,6 +798,7 @@ func handleProwJobs(ja *jobs.JobAgent, log *logrus.Entry) http.HandlerFunc {
 
 		if set := sets.NewString(strings.Split(omit, ",")...); set.Len() > 0 {
 			for i := range jobs {
+				jobs[i].ManagedFields = nil
 				if set.Has(Annotations) {
 					jobs[i].Annotations = nil
 				}


### PR DESCRIPTION
For openshift, this more than halves the data sent over the wire, from
43MB to 20MB (uncompressed). For prow.k8s.io this will not make a
difference, as it runs on a kube version that is too old to have managed
fields.

This is especially important since the frontend ends up processing all of this data in JS.