### PR TITLE
Auto milestone kubernetes/org PRs

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -327,6 +327,8 @@ milestone_applier:
     release-1.19: v1.19
     release-1.18: v1.18
     release-1.17: v1.17
+  kubernetes/org:
+    master: v1.21
   kubernetes/release:
     master: v1.21
   kubernetes/sig-release:


### PR DESCRIPTION
I'm adding this in to get a better sense of how this commonly-used plugin will work after renaming the kubernetes/org default branch (ref: https://github.com/kubernetes/org/issues/2466)

It might be nice to keep around for quick measure of PR's in this repo per kubernetes/kubernetes release lifecycle, but I can also see kicking it out since a lot of work in here is independent of that.

/cc @mrbobbytables @cblecker 