### PR TITLE
prep kubernetes/org jobs for default branch rename

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -4,6 +4,7 @@ postsubmits:
     cluster: test-infra-trusted
     decorate: true
     branches:
+    - ^main$
     - ^master$
     max_concurrency: 1
     spec:


### PR DESCRIPTION
specificalky
- add main to any pre/postsubmit triggers that reference master
- try removing explicit master base_ref, see if that gets us default branch

Part of https://github.com/kubernetes/org/issues/2466