### PR TITLE
Update kubernetes/org job configs post default-branch-rename

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -5,7 +5,6 @@ postsubmits:
     decorate: true
     branches:
     - ^main$
-    - ^master$
     max_concurrency: 1
     spec:
       containers:
@@ -785,7 +784,7 @@ periodics:
   extra_refs:
   - org: kubernetes
     repo: org
-    base_ref: master
+    base_ref: main
   spec:
     containers:
     - image: launcher.gcr.io/google/bazel:0.29.1

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -328,7 +328,7 @@ milestone_applier:
     release-1.18: v1.18
     release-1.17: v1.17
   kubernetes/org:
-    master: v1.21
+    main: v1.21
   kubernetes/release:
     master: v1.21
   kubernetes/sig-release:


### PR DESCRIPTION
Part of issue to rename default branch: https://github.com/kubernetes/org/issues/2466

Followup to pre-rename PRs:
- kubernetes/test-infra#20665
- https://github.com/kubernetes/test-infra/pull/20664

/hold
waiting on https://github.com/kubernetes/org/pull/2473 to merge so I can see milestone_applier try its thing