### PR TITLE
Mkpj doesn't fetch github when running at local mode

### DIFF
--- a/prow/cmd/mkpj/main.go
+++ b/prow/cmd/mkpj/main.go
@@ -247,7 +247,10 @@ func main() {
 	if job.Name == "" {
 		logrus.Fatalf("Job %s not found.", o.jobName)
 	}
-	if pjs.Refs != nil {
+	// local mode runs with phaino, which uses local source code instead of cloing, so
+	// no need to fetch refs from github.
+	// Aside, this also makes mkpj usable for source control system other than github.
+	if pjs.Refs != nil && !o.local {
 		o.org = pjs.Refs.Org
 		o.repo = pjs.Refs.Repo
 		if len(pjs.Refs.Pulls) != 0 {
@@ -278,6 +281,10 @@ func main() {
 }
 
 func splitRepoName(repo string) (string, string, error) {
+	// Normalize repo name to remove http:// or https://, this is the case for some
+	// of the gerrit instances.
+	repo = strings.TrimPrefix(repo, "http://")
+	repo = strings.TrimPrefix(repo, "https://")
 	s := strings.SplitN(repo, "/", 2)
 	if len(s) != 2 {
 		return "", "", fmt.Errorf("repo %s cannot be split into org/repo", repo)

--- a/prow/cmd/mkpj/main_test.go
+++ b/prow/cmd/mkpj/main_test.go
@@ -124,5 +124,67 @@ func TestDefaultBaseRef(t *testing.T) {
 			}
 		})
 	}
+}
 
+func TestSplitRepoName(t *testing.T) {
+	tests := []struct {
+		name     string
+		full     string
+		wantOrg  string
+		wantRepo string
+		wantErr  bool
+	}{
+		{
+			name:     "github repo",
+			full:     "orgA/repoB",
+			wantOrg:  "orgA",
+			wantRepo: "repoB",
+			wantErr:  false,
+		},
+		{
+			name:     "ref name with http://",
+			full:     "http://orgA/repoB",
+			wantOrg:  "orgA",
+			wantRepo: "repoB",
+			wantErr:  false,
+		},
+		{
+			name:     "ref name with https://",
+			full:     "https://orgA/repoB",
+			wantOrg:  "orgA",
+			wantRepo: "repoB",
+			wantErr:  false,
+		},
+		{
+			name:     "repo name contains /",
+			full:     "orgA/repoB/subC",
+			wantOrg:  "orgA",
+			wantRepo: "repoB/subC",
+			wantErr:  false,
+		},
+		{
+			name:     "invalid",
+			full:     "repoB",
+			wantOrg:  "",
+			wantRepo: "",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			gotOrg, gotRepo, err := splitRepoName(tt.full)
+			if gotOrg != tt.wantOrg {
+				t.Errorf("org mismatch. Want: %v, got: %v", tt.wantOrg, gotOrg)
+			}
+			if gotRepo != tt.wantRepo {
+				t.Errorf("repo mismatch. Want: %v, got: %v", tt.wantRepo, gotRepo)
+			}
+			gotErr := (err != nil)
+			if gotErr != (tt.wantErr && gotErr) {
+				t.Errorf("err mismatch. Want: %v, got: %v", tt.wantErr, gotErr)
+			}
+		})
+	}
 }


### PR DESCRIPTION
One of the use case of mkpj is to couple with phaino, when --local is passed in as param. Since phaino utilized pre-checked out source code, instead of source code clone or checkout, there is no need to fetch github for a presubmit or postsubmit job.

This change also makes it possible for source control system other than github to use mkpj + phaino for running prow jobs locally