### PR TITLE
ci-kubernetes-build-canary: Adjust CPU request/limit to 7

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -95,10 +95,10 @@ periodics:
         privileged: true
       resources:
         limits:
-          cpu: 7300m
+          cpu: "7"
           memory: "34Gi"
         requests:
-          cpu: 7300m
+          cpu: "7"
           memory: "34Gi"
   rerun_auth_config:
     github_team_ids:


### PR DESCRIPTION
May resolve https://github.com/kubernetes/test-infra/issues/20670#issuecomment-770085903.
Part of https://github.com/kubernetes/release/issues/1711.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @hasheddan @puerco 
cc: @kubernetes/release-engineering 
