### PR TITLE
Prep kubernetes/k8s.io for default branch rename

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-infra-tools.yaml
+++ b/config/jobs/image-pushing/k8s-staging-infra-tools.yaml
@@ -7,6 +7,7 @@ postsubmits:
       decorate: true
       run_if_changed: "^dns/octodns-docker/"
       branches:
+        - ^main$
         - ^master$
       spec:
         serviceAccountName: gcb-builder

--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -10,6 +10,7 @@ presubmits:
     run_if_changed: 'k8s.gcr.io/((images/.*/images\.yaml)|(manifests/.*/promoter-manifest\.yaml))'
     max_concurrency: 10
     branches:
+    - ^main$
     - ^master$
     spec:
       containers:
@@ -51,6 +52,7 @@ presubmits:
     run_if_changed: '^infra/gcp/backup_tools/'
     max_concurrency: 1
     branches:
+    - ^main$
     - ^master$
     spec:
       serviceAccountName: k8s-infra-gcr-promoter-test

--- a/config/jobs/kubernetes/wg-k8s-infra/k8sio-presubmit.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/k8sio-presubmit.yaml
@@ -8,6 +8,7 @@ presubmits:
     path_alias: k8s.io/k8s.io
     run_if_changed: "^groups/"
     branches:
+    - ^main$
     - ^master$
     spec:
       containers:

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -9,6 +9,7 @@ postsubmits:
     # one).
     max_concurrency: 1
     branches:
+    - ^main$
     - ^master$
     spec:
       serviceAccountName: k8s-infra-gcr-promoter
@@ -40,7 +41,7 @@ periodics:
   # into /home/prow/go/src/github.com/kubernetes/k8s.io.
   - org: kubernetes
     repo: k8s.io
-    base_ref: master
+    base_ref: main
   spec:
     # The k8s-artifacts-prod name was chosen in
     # https://github.com/kubernetes/k8s.io/pull/695.
@@ -68,7 +69,7 @@ periodics:
   extra_refs:
   - org: kubernetes
     repo: k8s.io
-    base_ref: master
+    base_ref: main
   spec:
     serviceAccountName: k8s-infra-gcr-promoter-bak
     containers:

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
@@ -11,7 +11,7 @@ periodics:
   extra_refs:
   - org: kubernetes
     repo: k8s.io
-    base_ref: master
+    base_ref: main
   spec:
     serviceAccountName: gsuite-groups-manager
     containers:
@@ -30,6 +30,9 @@ postsubmits:
     decorate: true
     max_concurrency: 1
     run_if_changed: '^groups/groups.yaml'
+    branches:
+    - ^main$
+    - ^master$
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: wg-k8s-infra-k8sio
@@ -51,6 +54,7 @@ postsubmits:
     max_concurrency: 1
     run_if_changed: "^dns/zone-configs/"
     branches:
+    - ^main$
     - ^master$
     annotations:
       testgrid-create-test-group: 'true'
@@ -72,6 +76,7 @@ postsubmits:
     max_concurrency: 1
     run_if_changed: "^infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/"
     branches:
+    - ^main$
     - ^master$
     annotations:
       testgrid-create-test-group: 'true'
@@ -96,6 +101,7 @@ postsubmits:
     max_concurrency: 1
     run_if_changed: "^infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/"
     branches:
+    - ^main$
     - ^master$
     annotations:
       testgrid-create-test-group: 'true'

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -336,6 +336,7 @@ milestone_applier:
   kubernetes/test-infra:
     master: v1.21
   kubernetes/k8s.io:
+    main: v1.21
     master: v1.21
   kubernetes/kops:
     master: v1.20


### PR DESCRIPTION
Part of https://github.com/kubernetes/k8s.io/issues/1597

/hold
The periodic changes here are disruptive, they will break until the branch is renamed. Will remove the hold when it's not late on a friday.