### PR TITLE
Remove references to unused/non-existent projects

### DIFF
--- a/experiment/ci-janitor/main.go
+++ b/experiment/ci-janitor/main.go
@@ -53,7 +53,6 @@ var (
 		"k8s-jkns-pr-kubemark",
 		"k8s-jkns-pr-node-e2e",
 		"k8s-jkns-pr-gce-gpus",
-		"k8s-gke-gpu-pr",
 		"k8s-presubmit-scale",
 	}
 )

--- a/scenarios/kubernetes_janitor.py
+++ b/scenarios/kubernetes_janitor.py
@@ -103,8 +103,6 @@ PR_PROJECTS = {
     'k8s-jkns-pr-kubemark': 3,
     'k8s-jkns-pr-node-e2e': 3,
     'k8s-jkns-pr-gce-gpus': 3,
-    'k8s-gke-gpu-pr': 3,
-    'k8s-c8d-pr-node-e2e': 3,
 }
 
 SCALE_PROJECT = {
@@ -142,9 +140,6 @@ def check_ci_jobs():
             found = project
         if found:
             clean_project(found, clean_hours)
-
-    # Hard code node-ci project here
-    clean_project('k8s-jkns-ci-node-e2e')
 
 
 def main(mode, ratelimit, projects, age, artifacts, filt):


### PR DESCRIPTION
While doing some inventory for k8s-infra (ref: https://github.com/kubernetes/k8s.io/issues/1469) I noticed a couple of projects that were unused or no longer existed