### PR TITLE
fix: add privileged true for dind

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -91,6 +91,9 @@ presubmits:
           - -c
           - >-
             make container image-scan
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, provider-azure-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-image-scan
@@ -416,6 +419,9 @@ periodics:
         - -c
         - >-
           make container image-scan
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
   annotations:
     testgrid-dashboards: sig-auth-secrets-store-csi-driver, provider-azure-periodic
     testgrid-tab-name: secrets-store-csi-driver-image-scan


### PR DESCRIPTION
Without `privileged`, docker fails to start:

```
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
```

https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_secrets-store-csi-driver/441/pull-secrets-store-csi-driver-image-scan/1355293755996901376/build-log.txt