### PR TITLE
[tide] Allow PRs to be picked for batch while still pending tests

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -577,6 +577,8 @@ tide:
   - labels: [ "kind/flake", "priority/critical-urgent" ]
   - labels: [ "kind/failing-test", "priority/critical-urgent" ]
   - labels: [ "kind/bug", "priority/critical-urgent" ]
+  # this will allow tide to pick PRs for batch builds while still pending tests
+  # batch_allow_pending: false
 
 push_gateway:
   endpoint: pushgateway

--- a/prow/cmd/tide/config.md
+++ b/prow/cmd/tide/config.md
@@ -10,6 +10,7 @@ To deploy Tide for your organization or repository, please see [how to get start
 
 The following configuration fields are available:
 
+* `batch_allow_pending`: Boolean that allows tide to pick PRs for batch that have pending tests.
 * `sync_period`: The field specifies how often Tide will sync jobs with GitHub. Defaults to 1m.
 * `status_update_period`: The field specifies how often Tide will update GitHub status contexts.
    Defaults to the value of `sync_period`.

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1781,6 +1781,11 @@ func parseProwConfig(c *Config) error {
 		c.Sinker.TerminatedPodTTL = &metav1.Duration{Duration: c.Sinker.MaxPodAge.Duration}
 	}
 
+	if c.Tide.BatchAllowPending == nil {
+		batchAllowPending := false
+		c.Tide.BatchAllowPending = &batchAllowPending
+	}
+
 	if c.Tide.SyncPeriod == nil {
 		c.Tide.SyncPeriod = &metav1.Duration{Duration: time.Minute}
 	}

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -721,6 +721,11 @@ tide:
     batch_size_limit:
         "": 0
 
+    # BatchAllowPending is a config that allows tide to select PRs that still have pending tests,
+    # this is intended to increase the likelihood of batch PRs.
+    # Note that failed or error status contexts will still preclude PR from being in a batch.
+    batch_skip_tests: false
+
     # BlockerLabel is an optional label that is used to identify merge blocking
     # GitHub issues.
     # Leave this blank to disable this feature and save 1 API token per sync loop.

--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -155,6 +155,11 @@ type Tide struct {
 	// Priority is an ordered list of sets of labels that would be prioritized before other PRs
 	// PRs should match all labels contained in a set to be prioritized
 	Priority []TidePriority `json:"priority,omitempty"`
+
+	// BatchAllowPending is a config that allows tide to select PRs that still have pending tests,
+	// this is intended to increase the likelihood of batch PRs.
+	// Note that failed or error status contexts will still preclude PR from being in a batch.
+	BatchAllowPending *bool `json:"batch_skip_tests,omitempty"`
 }
 
 func (t *Tide) BatchSizeLimit(repo OrgRepo) int {

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -778,6 +778,23 @@ func isPassingTests(log *logrus.Entry, ghc githubClient, pr PullRequest, cc cont
 	return len(unsuccessful) == 0
 }
 
+// isFailingTests returns whether one or more contexts are failing.
+func isFailingTests(log *logrus.Entry, ghc githubClient, pr PullRequest, cc contextChecker) bool {
+	log = log.WithFields(pr.logFields())
+	contexts, err := headContexts(log, ghc, &pr)
+	if err != nil {
+		log.WithError(err).Error("Getting head commit status contexts.")
+		// If we can't get the status of the commit, assume that it is failing.
+		return true
+	}
+	for _, ctx := range unsuccessfulContexts(contexts, cc, log) {
+		if ctx.State == githubql.StatusStateFailure || ctx.State == githubql.StatusStateError {
+			return true
+		}
+	}
+	return false
+}
+
 // unsuccessfulContexts determines which contexts from the list that we care about are
 // failed. For instance, we do not care about our own context.
 // If the branchProtection is set to only check for required checks, we will skip
@@ -1011,9 +1028,10 @@ func (c *Controller) pickBatch(sp subpool, cc map[int]contextChecker) ([]PullReq
 	// we must choose the oldest PRs for the batch
 	sort.Slice(sp.prs, func(i, j int) bool { return sp.prs[i].Number < sp.prs[j].Number })
 
+	batchAllowPending := (c.config().Tide.BatchAllowPending != nil && *c.config().Tide.BatchAllowPending)
 	var candidates []PullRequest
 	for _, pr := range sp.prs {
-		if isPassingTests(sp.log, c.ghc, pr, cc[int(pr.Number)]) {
+		if (batchAllowPending && !isFailingTests(sp.log, c.ghc, pr, cc[int(pr.Number)])) || isPassingTests(sp.log, c.ghc, pr, cc[int(pr.Number)]) {
 			candidates = append(candidates, pr)
 		}
 	}

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -817,6 +817,14 @@ func TestPickBatchV2(t *testing.T) {
 	testPickBatch(localgit.NewV2, t)
 }
 
+func TestPickBatchAllowPending(t *testing.T) {
+	testPickBatchAllowPending(localgit.New, t)
+}
+
+func TestPickBatchAllowPendingV2(t *testing.T) {
+	testPickBatchAllowPending(localgit.NewV2, t)
+}
+
 func testPickBatch(clients localgit.Clients, t *testing.T) {
 	lg, gc, err := clients()
 	if err != nil {
@@ -962,6 +970,130 @@ func testPickBatch(clients localgit.Clients, t *testing.T) {
 	}
 	if !equality.Semantic.DeepEqual(presubmits, ca.Config().PresubmitsStatic["o/r"]) {
 		t.Errorf("resolving presubmits failed, diff:\n%v\n", diff.ObjectReflectDiff(presubmits, ca.Config().PresubmitsStatic["o/r"]))
+	}
+	for _, testpr := range testprs {
+		var found bool
+		for _, pr := range prs {
+			if int(pr.Number) == testpr.number {
+				found = true
+				break
+			}
+		}
+		if found && !testpr.included {
+			t.Errorf("PR %d should not be picked.", testpr.number)
+		} else if !found && testpr.included {
+			t.Errorf("PR %d should be picked.", testpr.number)
+		}
+	}
+}
+
+func testPickBatchAllowPending(clients localgit.Clients, t *testing.T) {
+	lg, gc, err := clients()
+	if err != nil {
+		t.Fatalf("Error making local git: %v", err)
+	}
+	defer gc.Clean()
+	defer lg.Clean()
+	if err := lg.MakeFakeRepo("o", "r"); err != nil {
+		t.Fatalf("Error making fake repo: %v", err)
+	}
+	if err := lg.AddCommit("o", "r", map[string][]byte{"foo": []byte("foo")}); err != nil {
+		t.Fatalf("Adding initial commit: %v", err)
+	}
+	testprs := []struct {
+		files    map[string][]byte
+		success  bool
+		number   int
+		pending  bool
+		included bool
+	}{
+		{
+			files:    map[string][]byte{"bar": []byte("ok")},
+			success:  true,
+			pending:  false,
+			number:   0,
+			included: true,
+		},
+		{
+			files:    map[string][]byte{"foo": []byte("ok")},
+			success:  false,
+			pending:  true,
+			number:   1,
+			included: true,
+		},
+		{
+			files:    map[string][]byte{"foo": []byte("ok")},
+			success:  false,
+			pending:  false,
+			number:   2,
+			included: false,
+		},
+	}
+	sp := subpool{
+		log:    logrus.WithField("component", "tide"),
+		org:    "o",
+		repo:   "r",
+		branch: "master",
+		sha:    "master",
+	}
+	for _, testpr := range testprs {
+		if err := lg.CheckoutNewBranch("o", "r", fmt.Sprintf("pr-%d", testpr.number)); err != nil {
+			t.Fatalf("Error checking out new branch: %v", err)
+		}
+		if err := lg.AddCommit("o", "r", testpr.files); err != nil {
+			t.Fatalf("Error adding commit: %v", err)
+		}
+		if err := lg.Checkout("o", "r", "master"); err != nil {
+			t.Fatalf("Error checking out master: %v", err)
+		}
+		oid := githubql.String(fmt.Sprintf("origin/pr-%d", testpr.number))
+		var pr PullRequest
+		pr.Number = githubql.Int(testpr.number)
+		pr.HeadRefOID = oid
+		pr.Commits.Nodes = []struct {
+			Commit Commit
+		}{{Commit: Commit{OID: oid}}}
+		pr.Commits.Nodes[0].Commit.Status.Contexts = append(pr.Commits.Nodes[0].Commit.Status.Contexts, Context{State: githubql.StatusStateSuccess})
+		if !testpr.success {
+			pr.Commits.Nodes[0].Commit.Status.Contexts[0].State = githubql.StatusStateFailure
+		}
+		if testpr.pending {
+			pr.Commits.Nodes[0].Commit.Status.Contexts[0].State = githubql.StatusStatePending
+		}
+		sp.prs = append(sp.prs, pr)
+	}
+	ca := &config.Agent{}
+	batchAllowPending := true
+	ca.Set(&config.Config{
+		ProwConfig: config.ProwConfig{
+			Tide: config.Tide{
+				BatchSizeLimitMap: map[string]int{"*": 5},
+				BatchAllowPending: &batchAllowPending,
+			},
+		},
+		JobConfig: config.JobConfig{
+			PresubmitsStatic: map[string][]config.Presubmit{
+				"o/r": {{
+					AlwaysRun: true,
+					JobBase: config.JobBase{
+						Name: "my-presubmit",
+					},
+				}},
+			},
+		},
+	})
+	c := &Controller{
+		logger: logrus.WithField("component", "tide"),
+		gc:     gc,
+		config: ca.Config,
+	}
+	prs, _, err := c.pickBatch(sp, map[int]contextChecker{
+		0: &config.TideContextPolicy{},
+		1: &config.TideContextPolicy{},
+		2: &config.TideContextPolicy{},
+	})
+	if err != nil {
+		t.Fatalf("Error from pickBatch: %v", err)
 	}
 	for _, testpr := range testprs {
 		var found bool


### PR DESCRIPTION
Allows tide to select PRs without the need for a first successful presubmit(s) build, this is intended to increase the likelihood of batch PRs. This logic disqualifies any failed individual builds and just include pending or passing.

Primary usecase is where teams have quick fixes that can be added to batch while still pending their individual builds (where build times are longer than usual).

Introducing a boolean config `batchAllowPending`, if set to `true` while enable this functionality.