### PR TITLE
[Kettle] Catch and log the chunks that fail for future debugging

### DIFF
--- a/kettle/stream.py
+++ b/kettle/stream.py
@@ -100,9 +100,9 @@ def retry(func, *args, **kwargs):
             traceback.print_exc()
             time.sleep(1.4 ** attempt)
         except api_exceptions.BadRequest as err:
-            args_str = ','.join(map(str,args))
-            kwargs_str = ','.join('{}={}'.format(k,v) for k,v in kwargs.items())
-            print(f"Error running {func.__name__}({','.join([args_str,kwargs_str])}) : {err}")
+            args_str = ','.join(map(str, args))
+            kwargs_str = ','.join('{}={}'.format(k, v) for k, v in kwargs.items())
+            print(f"Error running {func.__name__}({','.join([args_str, kwargs_str])}) : {err}")
             return None # Skip
     return func(*args, **kwargs)  # one last attempt
 

--- a/kettle/stream.py
+++ b/kettle/stream.py
@@ -95,10 +95,15 @@ def retry(func, *args, **kwargs):
     for attempt in range(20):
         try:
             return func(*args, **kwargs)
-        except (socket.error, google.cloud.exceptions.ServerError, api_exceptions.BadRequest):
+        except (socket.error, google.cloud.exceptions.ServerError):
             # retry with exponential backoff
             traceback.print_exc()
             time.sleep(1.4 ** attempt)
+        except api_exceptions.BadRequest as err:
+            args_str = ','.join(map(str,args))
+            kwargs_str = ','.join('{}={}'.format(k,v) for k,v in kwargs.items())
+            print(f"Error running {func.__name__}({','.join([args_str,kwargs_str])}) : {err}")
+            return None # Skip
     return func(*args, **kwargs)  # one last attempt
 
 


### PR DESCRIPTION
Follow-up to #20666

That change retried with the same chunk and would fail. Unfortunately this is not easy to debug. This change will skip that failure and  log the issue to help identify the problem. 
/area kettle