### PR TITLE
releng: add presubmit job to test kube cross image builder

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -83,6 +83,30 @@ presubmits:
       testgrid-tab-name: release-verify
       testgrid-alert-email: release-managers+alerts@kubernetes.io
       testgrid-num-columns-recent: '30'
+  - name: pull-release-image-kube-cross
+    optional: false
+    decorate: true
+    run_if_changed: '^images\/build\/cross\/'
+    path_alias: k8s.io/release
+    spec:
+      serviceAccountName: gcb-builder
+      containers:
+        - image: gcr.io/k8s-testimages/image-builder:v20200901-ab141a0
+          command:
+            - /run.sh
+          args:
+            - --project=k8s-staging-releng-test
+            - --scratch-bucket=gs://k8s-staging-releng-test
+            - --build-dir=.
+            - images/build/cross
+          env:
+            - name: LOG_TO_STDOUT
+              value: "y"
+    annotations:
+      testgrid-dashboards: sig-release-releng-presubmits
+      testgrid-tab-name: release-image-kube-cross
+      testgrid-alert-email: release-managers+alerts@kubernetes.io
+      testgrid-num-columns-recent: '30'
 periodics:
 # package tests
 - name: periodic-release-verify-packages-debs


### PR DESCRIPTION
Adding the first job to test if the setup is correct and not to make big changes 😄
If works fine will add the other jobs in a follow-up PR(s)

This PR adds a pre-submit job to test the image build for kube cross

Part of https://github.com/kubernetes/release/issues/1850

/assign @justaugustus @saschagrunert @hasheddan 
cc @kubernetes/release-engineering 