### PR TITLE
Fix Autobumper PR summary for image bumps with variants

### DIFF
--- a/experiment/autobumper/bumper/bumper.go
+++ b/experiment/autobumper/bumper/bumper.go
@@ -745,6 +745,16 @@ func commitToRef(commit string) string {
 	return tag
 }
 
+func formatVariant(variant string) string {
+	if variant == "" {
+		return ""
+	}
+	if strings.HasPrefix(variant, "-") {
+		variant = variant[1:]
+	}
+	return fmt.Sprintf("(%s)", variant)
+}
+
 func generateSummary(name, repo, prefix string, summarise bool, images map[string]string) string {
 	type delta struct {
 		oldCommit string
@@ -772,7 +782,7 @@ func generateSummary(name, repo, prefix string, summarise bool, images map[strin
 			newCommit: newCommit,
 			oldDate:   oldDate,
 			newDate:   newDate,
-			variant:   oldVariant,
+			variant:   formatVariant(oldVariant),
 			component: componentFromName(image),
 		}
 		versions[k] = append(versions[k], d)


### PR DESCRIPTION
In https://github.com/kubernetes/test-infra/pull/20649#issue-563516326 the PR summary says that the k8s-testimages images that have been updated are:
"launcher.gcr.io/google/bazel-kubernetes-master, launcher.gcr.io/google/bazel-org, launcher.gcr.io/google/bazel-test-infra"
These are all the same image "launcher.gcr.io/google/bazel" but with different variants (kubernetes-master, org and test-infra)
The PR summary is taking images that look like this:
gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:v20210128-721ee66-org
removing the tag (:v20210128-721ee66) and calling that the image which is making multiple variants of the same image look like different images.

This change puts parens around the variants to more clearly distinguish that they are different variants of the same image rather than different images