### PR TITLE
Branchprotector: improve document by explicitly mark repo protected

### DIFF
--- a/prow/cmd/branchprotector/README.md
+++ b/prow/cmd/branchprotector/README.md
@@ -119,6 +119,7 @@ branch-protection:
       protect: false
       repos:
         protected-repo:
+          protect: true
           # Inherit protect-by-default config from parent
           # If protected, always require the tested status context
           required_status_checks:


### PR DESCRIPTION
The general rule for branchprotection setting says use parent value if child value is null, in current case it would inherit 'protect: false' from org, mark it protected to make it more explicit