### PR TITLE
Renaming extra bump files to match python import style.

### DIFF
--- a/config/prow/autobump-config.yaml
+++ b/config/prow/autobump-config.yaml
@@ -14,8 +14,8 @@ includedConfigPaths:
 excludedConfigPaths:
   - "config/prow-staging"
 extraFiles:
-  - "config/jobs/kubernetes/kops/build-grid.py"
-  - "config/jobs/kubernetes/kops/build-pipeline.py"
+  - "config/jobs/kubernetes/kops/build_grid.py"
+  - "config/jobs/kubernetes/kops/build_pipeline.py"
   - "releng/generate_tests.py"
   - "images/kubekins-e2e/Dockerfile"
 targetVersion: "latest"


### PR DESCRIPTION
Reasons:
https://github.com/kubernetes/test-infra/commit/2ee1a26ed170eceaf068ca433da1f8c1fb44817c