### PR TITLE
Update Kops python file name autobump references

### DIFF
--- a/config/prow/autobump-config.yaml
+++ b/config/prow/autobump-config.yaml
@@ -14,8 +14,8 @@ includedConfigPaths:
 excludedConfigPaths:
   - "config/prow-staging"
 extraFiles:
-  - "config/jobs/kubernetes/kops/build-grid.py"
-  - "config/jobs/kubernetes/kops/build-pipeline.py"
+  - "config/jobs/kubernetes/kops/build_grid.py"
+  - "config/jobs/kubernetes/kops/build_pipeline.py"
   - "releng/generate_tests.py"
   - "images/kubekins-e2e/Dockerfile"
 targetVersion: "latest"


### PR DESCRIPTION
These were renamed in https://github.com/kubernetes/test-infra/pull/20685 but I forgot to update their references here.

We will be adding more of these soon, would a PR to have autobump support glob patterns here be accepted? 