### PR TITLE
Directly write to gzip from make_json

### DIFF
--- a/kettle/stream.py
+++ b/kettle/stream.py
@@ -100,8 +100,8 @@ def retry(func, *args, **kwargs):
             traceback.print_exc()
             time.sleep(1.4 ** attempt)
         except api_exceptions.BadRequest as err:
-            args_str = ','.join(map(str, args))
-            kwargs_str = ','.join('{}={}'.format(k, v) for k, v in kwargs.items())
+            args_str = ','.join(map(str, args)).encode('utf-8')
+            kwargs_str = ','.join('{}={}'.format(k, v) for k, v in kwargs.items()).encode('utf-8')
             print(f"Error running {func.__name__}({','.join([args_str, kwargs_str])}) : {err}")
             return None # Skip
     return func(*args, **kwargs)  # one last attempt

--- a/kettle/update.py
+++ b/kettle/update.py
@@ -62,21 +62,21 @@ def main():
         mj_ext = ' --reset-emitted'
 
     if os.getenv('DEPLOYMENT', 'staging') == "prod":
-        call(f'{mj_cmd} {mj_ext} --days {DAY} | pv | gzip > build_day.json.gz')
+        call(f'{mj_cmd} {mj_ext} --days {DAY} --out-file build_day.json.gz')
         call(f'{bq_cmd} {bq_ext} k8s-gubernator:build.day build_day.json.gz schema.json')
 
-        call(f'{mj_cmd} {mj_ext} --days {WEEK} | pv | gzip > build_week.json.gz')
+        call(f'{mj_cmd} {mj_ext} --days {WEEK} --out-file build_week.json.gz')
         call(f'{bq_cmd} {bq_ext} k8s-gubernator:build.week build_week.json.gz schema.json')
 
         # TODO: (MushuEE) #20024, remove 30 day limit once issue with all uploads is found
-        call(f'{mj_cmd} --days {MONTH} | pv | gzip > build_all.json.gz')
+        call(f'{mj_cmd} --days {MONTH} --out-file build_all.json.gz')
         call(f'{bq_cmd} k8s-gubernator:build.all build_all.json.gz schema.json')
 
         call(f'python3 stream.py --poll {SUB_PATH} ' \
              f'--dataset k8s-gubernator:build ' \
              f'--tables all:{MONTH} day:{DAY} week:{WEEK} --stop_at=1')
     else:
-        call(f'{mj_cmd} | pv | gzip > build_staging.json.gz')
+        call(f'{mj_cmd} --out-file build_staging.json.gz')
         call(f'{bq_cmd} k8s-gubernator:build.staging build_staging.json.gz schema.json')
         call(f'python3 stream.py --poll {SUB_PATH} ' \
              f'--dataset k8s-gubernator:build --tables staging:0 --stop_at=1')


### PR DESCRIPTION
Kettle currently runs something like `pypy3 make_json.py --days {DAY} | pv | gzip > build_day.json.gz`, tons of data is sent to stdout and I have a suspicion is contributing to the recent lockups we have been seeing.

This change writes the data directly to the `.gz` byte encoded file.

/hold complete staging testing