### PR TITLE
aws-encryption-provider: update to go 1.15

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-encryption-provider/presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-encryption-provider/presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     max_concurrency: 5
     spec:
       containers:
-      - image: golang:1.13
+      - image: golang:1.15
         args:
         - make
         - lint
@@ -24,7 +24,7 @@ presubmits:
     max_concurrency: 5
     spec:
       containers:
-      - image: golang:1.13
+      - image: golang:1.15
         args:
         - make
         - test


### PR DESCRIPTION
As suggested in https://github.com/kubernetes-sigs/aws-encryption-provider/pull/72#discussion_r568246547.