### PR TITLE
releng: update pull-release-image-kube-cross to set the cluster where it should run

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -85,11 +85,12 @@ presubmits:
       testgrid-num-columns-recent: '30'
   - name: pull-release-image-kube-cross
     optional: true
+    cluster: k8s-infra-prow-build
     decorate: true
     run_if_changed: '^images\/build\/cross\/'
     path_alias: k8s.io/release
     spec:
-      serviceAccountName: gcb-builder
+      serviceAccountName: gcb-builder-releng-test
       containers:
         - image: gcr.io/k8s-testimages/image-builder:v20210204-b06ec78
           command:
@@ -102,6 +103,13 @@ presubmits:
           env:
             - name: LOG_TO_STDOUT
               value: "y"
+          resources:
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
     annotations:
       testgrid-dashboards: sig-release-releng-presubmits
       testgrid-tab-name: release-image-kube-cross


### PR DESCRIPTION
follow up of https://github.com/kubernetes/test-infra/pull/20689

the default cluster does not have the service account that is needed for this job, so adding the cluster that contains the setup

The error when the job tried to run

```
Pod can not be created: pods "63ae2683-6532-11eb-82fa-d61530c4f03a" ... count test-pods/gcb-builder: serviceaccount "gcb-builder" not found
```

/assign @saschagrunert @hasheddan @xmudrii @puerco 
cc: @kubernetes/release-engineering 