### PR TITLE
releng: Re-enable a bootstrap build job for K8s Infra

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -67,6 +67,46 @@ periodics:
     testgrid-tab-name: build-master
     testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
 
+- name: ci-kubernetes-build-k8s-infra
+  interval: 1h
+  cluster: k8s-infra-prow-build
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/bootstrap:v20210108-5927ee692c
+      args:
+      - --repo=k8s.io/kubernetes
+      - --repo=k8s.io/release
+      - --root=/go/src
+      - --timeout=240
+      - --scenario=kubernetes_build
+      - --
+      - --allow-dup
+      - --extra-version-markers=k8s-master
+      - --registry=gcr.io/k8s-staging-ci-images
+      - --release=k8s-release-dev
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          cpu: "7"
+          memory: "34Gi"
+        requests:
+          cpu: "7"
+          memory: "34Gi"
+  rerun_auth_config:
+    github_team_ids:
+      - 2241179 # release-managers
+  annotations:
+    fork-per-release: "true"
+    fork-per-release-replacements: "k8s-master -> k8s-beta"
+    testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-testing-canaries
+    testgrid-tab-name: build-k8s-infra-master
+    testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
+
 - name: ci-kubernetes-build-canary
   interval: 1h
   cluster: k8s-infra-prow-build


### PR DESCRIPTION
This is somewhat of a partial revert of https://github.com/kubernetes/test-infra/pull/20663 to re-enable the previous bootstrap-driven K8s Infra build "canary" job with the following adjustments:
- Job renamed to `ci-kubernetes-build-k8s-infra`
- Adjusted limits for K8s Infra (based on previous PR feedback)
- Fork annotations (so it doesn't get missed when we cut 1.21 RC... though we should have the new jobs ironed out well before that)

Signed-off-by: Stephen Augustus <foo@auggie.dev>

ref: https://github.com/kubernetes/kubernetes/issues/98646, https://github.com/kubernetes/test-infra/pull/20663, https://github.com/kubernetes/release/issues/1711, https://kubernetes.slack.com/archives/C09QZ4DQB/p1612269558032700

/assign @hasheddan @saschagrunert 
cc: @kubernetes/release-engineering @kubernetes/ci-signal @neolit123 
/priority critical-urgent