### PR TITLE
labels_sync: allow setting org-level labels

### DIFF
--- a/label_sync/BUILD.bazel
+++ b/label_sync/BUILD.bazel
@@ -57,6 +57,10 @@ go_test(
         "//label_sync:test_examples",
     ],
     embed = [":go_default_library"],
+    deps = [
+        "@com_github_google_go_cmp//cmp:go_default_library",
+        "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
+    ],
 )
 
 filegroup(

--- a/label_sync/labels_example.yaml
+++ b/label_sync/labels_example.yaml
@@ -15,4 +15,16 @@ default:
     - name: dead-label
       description: Delete Me :)
       deleteAfter: 2017-01-01T13:00:00Z
+orgs:
+  org:
+    labels:
+      - color: green
+        name: sgtm
+        description: Sounds Good To Me
+repos:
+  org/repo:
+    labels:
+      - color: blue
+        name: tgtm
+        description: Tastes Good To Me
 ...


### PR DESCRIPTION
In OpenShift we cargo-culted us into thinking the tool actually supports
org-level labels but it doesn't. The *proper* structure for doing this
is probably more hierarchic (like some of the Prow plugins, e.g.
branch protector), but I wanted to avoid larger changes.