### PR TITLE
Adds periodic job to test CAPI workload cluster upgrades

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
@@ -1,0 +1,162 @@
+periodics:
+- name: periodic-cluster-api-e2e-workload-upgrade-1-17-1-18-main
+  interval: 24h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api
+    base_ref: master
+    path_alias: sigs.k8s.io/cluster-api
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-cc9840e-1.19
+      args:
+        - runner.sh
+        - "./scripts/ci-e2e.sh"
+      env:
+        - name: KUBERNETES_VERSION_UPGRADE_FROM
+          value: "stable-1.17"
+        - name: KUBERNETES_VERSION_UPGRADE_TO
+          value: "stable-1.18"
+        - name: ETCD_VERSION_UPGRADE_TO
+          value: "3.4.3-0"
+        - name: COREDNS_VERSION_UPGRADE_TO
+          value: "1.6.7"
+        - name: GINKGO_FOCUS
+          value: "\\[K8s-Upgrade\\]"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+    testgrid-tab-name: capi-e2e-main-1-17-1-18
+    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    testgrid-num-failures-to-alert: "2"
+
+- name: periodic-cluster-api-e2e-workload-upgrade-1-18-1-19-main
+  interval: 24h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api
+    base_ref: master
+    path_alias: sigs.k8s.io/cluster-api
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-cc9840e-1.19
+      args:
+        - runner.sh
+        - "./scripts/ci-e2e.sh"
+      env:
+        - name: KUBERNETES_VERSION_UPGRADE_FROM
+          value: "stable-1.18"
+        - name: KUBERNETES_VERSION_UPGRADE_TO
+          value: "stable-1.19"
+        - name: ETCD_VERSION_UPGRADE_TO
+          value: "3.4.13-0"
+        - name: COREDNS_VERSION_UPGRADE_TO
+          value: "1.7.0"
+        - name: GINKGO_FOCUS
+          value: "\\[K8s-Upgrade\\]"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+    testgrid-tab-name: capi-e2e-main-1-18-1-19
+    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    testgrid-num-failures-to-alert: "2"
+
+- name: periodic-cluster-api-e2e-workload-upgrade-1-19-1-20-main
+  interval: 24h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api
+    base_ref: master
+    path_alias: sigs.k8s.io/cluster-api
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-cc9840e-1.19
+      args:
+        - runner.sh
+        - "./scripts/ci-e2e.sh"
+      env:
+        - name: KUBERNETES_VERSION_UPGRADE_FROM
+          value: "stable-1.19"
+        - name: KUBERNETES_VERSION_UPGRADE_TO
+          value: "stable-1.20"
+        - name: ETCD_VERSION_UPGRADE_TO
+          value: "3.4.13-0"
+        - name: COREDNS_VERSION_UPGRADE_TO
+          value: "1.7.0"
+        - name: GINKGO_FOCUS
+          value: "\\[K8s-Upgrade\\]"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+    testgrid-tab-name: capi-e2e-main-1-19-1-20
+    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    testgrid-num-failures-to-alert: "2"
+
+- name: periodic-cluster-api-e2e-workload-upgrade-1-20-latest-main
+  interval: 24h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api
+    base_ref: master
+    path_alias: sigs.k8s.io/cluster-api
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-cc9840e-1.19
+      args:
+        - runner.sh
+        - "./scripts/ci-e2e.sh"
+      env:
+        - name: BUILD_NODE_IMAGE_TAG
+          value: "ci/latest"
+        - name: KUBERNETES_VERSION_UPGRADE_FROM
+          value: "stable-1.20"
+        - name: KUBERNETES_VERSION_UPGRADE_TO
+          value: "ci/latest"
+        - name: ETCD_VERSION_UPGRADE_TO
+          value: "3.4.13-0"
+        - name: COREDNS_VERSION_UPGRADE_TO
+          value: "1.8.0"
+        - name: GINKGO_FOCUS
+          value: "\\[K8s-Upgrade\\]"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+    testgrid-tab-name: capi-e2e-main-1-20-latest
+    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    testgrid-num-failures-to-alert: "2"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -39,6 +39,9 @@ periodics:
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
+        env:
+          - name: GINKGO_SKIP
+            value: "\\[K8s-Upgrade\\]"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -149,6 +149,12 @@ presubmits:
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
+        env:
+          # Since the PR-Blocking tests are run as part of the cluster-api-test-main job
+          # and the upgrade tests are being run as part of the periodic upgrade jobs.
+          # This jobs ends up running all the other tests in the E2E suite
+          - name: GINKGO_SKIP
+            value: "\\[PR-Blocking\\] \\[K8s-Upgrade\\]"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -194,7 +200,7 @@ presubmits:
           - name: COREDNS_VERSION_UPGRADE_TO
             value: "1.7.0"
           - name: GINKGO_FOCUS
-            value: "\\[Periodic-K8SVersion\\]"
+            value: "\\[K8s-Upgrade\\]"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true


### PR DESCRIPTION
This patch adds new periodic prow jobs to test CAPI workload cluster upgrades between different supported kubernetes versions.

Fixes: https://github.com/kubernetes-sigs/cluster-api/issues/4043