### PR TITLE
kubernetes-csi: fix snapshotter for periodic on-kubernetes-1-20

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
@@ -476,7 +476,7 @@ periodics:
       - name: CSI_PROW_KUBERNETES_VERSION
         value: "release-1.20"
       - name: CSI_SNAPSHOTTER_VERSION
-        value: "v3.0.3"
+        value: "v4.0.0"
       - name: CSI_PROW_BUILD_JOB
         value: "false"
       - name: CSI_PROW_DEPLOYMENT
@@ -610,7 +610,7 @@ periodics:
       - name: CSI_PROW_KUBERNETES_VERSION
         value: "release-1.20"
       - name: CSI_SNAPSHOTTER_VERSION
-        value: "v3.0.3"
+        value: "v4.0.0"
       - name: CSI_PROW_BUILD_JOB
         value: "false"
       - name: CSI_PROW_DEPLOYMENT
@@ -698,7 +698,7 @@ periodics:
       - name: CSI_PROW_KUBERNETES_VERSION
         value: "release-1.20"
       - name: CSI_SNAPSHOTTER_VERSION
-        value: "v3.0.3"
+        value: "v4.0.0"
       - name: CSI_PROW_BUILD_JOB
         value: "false"
       - name: CSI_PROW_DEPLOYMENT


### PR DESCRIPTION
Those jobs use the release-1.20 branch and that wasn't detected as
Kubernetes 1.20 where we want to use the v4.0.0 snapshotter.