### PR TITLE
Fixes to kubetest to run external e2e k8s tests

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -579,8 +579,8 @@ presubmits:
         - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/test/e2e/manifest/single-az.json
         - --aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz
         # Ginkgo specific args
-        - --ginkgo-focus='External.Storage.*disk.csi.azure.com'
-        - --ginkgo-skip='\[Disruptive\]|\[Slow\]|\[Feature:VolumeSnapshotDataSource\]'
+        - --ginkgo-focus=External.Storage.*disk.csi.azure.com
+        - --ginkgo-skip=\[Disruptive\]|\[Slow\]|\[Feature:VolumeSnapshotDataSource\]
         # Specific test args
         - --test-azure-disk-csi-driver
         - --run-external-e2e-ginkgo-test

--- a/kubetest/aksengine.go
+++ b/kubetest/aksengine.go
@@ -1298,6 +1298,12 @@ func (c *aksEngineDeployer) BuildTester(o *e2e.BuildTesterOptions) (e2e.Tester, 
 			if o.StorageTestDriverPath != "" {
 				t.StorageTestDriver = filepath.Join(util.K8sSigs(csiDriverName), o.StorageTestDriverPath)
 			}
+			t.KubeRoot = "."
+			kubeConfig := os.Getenv("KUBECONFIG")
+			if kubeConfig != "" {
+				t.Kubeconfig = kubeConfig
+			}
+			t.Provider = "azure"
 			return t, nil
 		} else {
 			return &GinkgoCSIDriverTester{


### PR DESCRIPTION
This PR handles the failures observed while running the ginkgo external e2e test as required in Issue#577[https://github.com/kubernetes-sigs/azuredisk-csi-driver/issues/577](url)

Fixes include:
- yaml file regex fix
- Setting mandatory fields for the GinkgoTester interface to pass the validation