### PR TITLE
update image used by cluster-api-provider-azure

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
@@ -15,7 +15,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.19
         command:
         - "runner.sh"
         - "./scripts/ci-conformance.sh"
@@ -47,7 +47,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.19
         command:
         - "runner.sh"
         - "./scripts/ci-conformance.sh"
@@ -83,7 +83,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.19
       command:
       - "runner.sh"
       - "./scripts/ci-e2e.sh"
@@ -114,7 +114,7 @@ periodics:
       path_alias: k8s.io/test-infra
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.19
       command:
       - runner.sh
       - bash
@@ -151,7 +151,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.19
       command:
       - "runner.sh"
       - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-postsubmits.yaml
@@ -14,7 +14,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.19
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.19
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -21,7 +21,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.19
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -42,7 +42,7 @@ presubmits:
       preset-azure-anonymous-pull: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.19
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -73,7 +73,7 @@ presubmits:
       preset-azure-anonymous-pull: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.19
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -105,7 +105,7 @@ presubmits:
       preset-azure-anonymous-pull: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.19
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -138,7 +138,7 @@ presubmits:
       preset-azure-anonymous-pull: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.19
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -161,7 +161,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.19
         command:
         - "runner.sh"
         - "make"
@@ -184,7 +184,7 @@ presubmits:
       preset-azure-cred-only: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.19
         command:
         - "runner.sh"
         - "./scripts/ci-conformance.sh"
@@ -213,7 +213,7 @@ presubmits:
       preset-azure-cred-only: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.18
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.19
           command:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"
@@ -243,7 +243,7 @@ presubmits:
       - command:
         - runner.sh
         - ./scripts/ci-apidiff.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.19
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: pr-apidiff
@@ -259,7 +259,7 @@ presubmits:
       path_alias: k8s.io/test-infra
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-77bfce8-1.19
         command:
         - runner.sh
         - bash


### PR DESCRIPTION
in prep for v1alpha4 when we will have to use go1.15

/cc @CecileRobertMichon 