### PR TITLE
Make prometheus alerts rule for ci absent configurable

### DIFF
--- a/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
@@ -26,6 +26,19 @@ local config = {
     ],
   },
 
+  ciAbsents: {
+    components: [
+      comps.crier,
+      comps.deck,
+      comps.ghproxy,
+      comps.hook,
+      comps.horologium,
+      comps.prowControllerManager,
+      comps.sinker,
+      comps.tide,
+    ],
+  },
+
   // Heartbeat jobs
   heartbeatJobs: [
     {name: 'ci-test-infra-prow-checkconfig', interval: '5m', alertInterval: '20m'},

--- a/config/prow/cluster/monitoring/mixins/prometheus/ci_absent_alerts.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/ci_absent_alerts.libsonnet
@@ -1,6 +1,5 @@
 {
   prometheusAlerts+:: {
-    local comps = $._config.components,
     groups+: [
       {
         name: 'ci-absent',
@@ -19,16 +18,7 @@
               message: '@test-infra-oncall The service %s has been down for 5 minutes.' % name,
             },
           }
-          for name in [
-              comps.crier,
-              comps.deck,
-              comps.ghproxy,
-              comps.hook,
-              comps.horologium,
-              comps.prowControllerManager,
-              comps.sinker,
-              comps.tide,
-          ]
+          for name in $._config.ciAbsents.components
         ],
       },
     ],


### PR DESCRIPTION
Not all prow instances have the same set of core components to be monitored, make this configurable so it's easier to upgrade.