### PR TITLE
Allow unit tests to pass when init.defaultBranch is set.

### DIFF
--- a/prow/cmd/config-bootstrapper/main_test.go
+++ b/prow/cmd/config-bootstrapper/main_test.go
@@ -37,6 +37,7 @@ import (
 
 var (
 	defaultNamespace = "default"
+	defaultBranch    = localgit.DefaultBranch("")
 )
 
 func TestRun(t *testing.T) {
@@ -62,7 +63,7 @@ func testRun(clients localgit.Clients, t *testing.T) {
 	if err := lg.MakeFakeRepo("openshift", "release"); err != nil {
 		t.Fatalf("Making fake repo: %v", err)
 	}
-	if err := lg.Checkout("openshift", "release", "master"); err != nil {
+	if err := lg.Checkout("openshift", "release", defaultBranch); err != nil {
 		t.Fatalf("Checkout new branch: %v", err)
 	}
 
@@ -77,7 +78,7 @@ func testRun(clients localgit.Clients, t *testing.T) {
 	if err := lg.MakeFakeRepo("openshift", "other"); err != nil {
 		t.Fatalf("Making fake repo: %v", err)
 	}
-	if err := lg.Checkout("openshift", "other", "master"); err != nil {
+	if err := lg.Checkout("openshift", "other", defaultBranch); err != nil {
 		t.Fatalf("Checkout new branch: %v", err)
 	}
 

--- a/prow/config/inrepoconfig_test.go
+++ b/prow/config/inrepoconfig_test.go
@@ -25,6 +25,8 @@ import (
 	"k8s.io/test-infra/prow/kube"
 )
 
+var defaultBranch = localgit.DefaultBranch("")
+
 func TestDefaultProwYAMLGetter(t *testing.T) {
 	testDefaultProwYAMLGetter(localgit.New, t)
 }
@@ -347,7 +349,7 @@ func testDefaultProwYAMLGetter(clients localgit.Clients, t *testing.T) {
 				}
 			}
 
-			baseSHA, err := lg.RevParse(org, repo, "master")
+			baseSHA, err := lg.RevParse(org, repo, defaultBranch)
 			if err != nil {
 				t.Fatalf("failed to get baseSHA: %v", err)
 			}

--- a/prow/git/git_test.go
+++ b/prow/git/git_test.go
@@ -30,6 +30,8 @@ import (
 	"k8s.io/test-infra/prow/github"
 )
 
+var defaultBranch = localgit.DefaultBranch("")
+
 func TestClone(t *testing.T) {
 	testClone(localgit.New, t)
 }
@@ -204,12 +206,12 @@ func testMergeCommitsExistBetween(clients localgit.Clients, t *testing.T) {
 			}
 		}
 		mergeMaster = func() {
-			if _, err := lg.Merge("foo", "bar", "master"); err != nil {
+			if _, err := lg.Merge("foo", "bar", defaultBranch); err != nil {
 				t.Fatalf("Rebasing commit: %v", err)
 			}
 		}
 		rebaseMaster = func() {
-			if _, err := lg.Rebase("foo", "bar", "master"); err != nil {
+			if _, err := lg.Rebase("foo", "bar", defaultBranch); err != nil {
 				t.Fatalf("Rebasing commit: %v", err)
 			}
 		}
@@ -248,7 +250,7 @@ func testMergeCommitsExistBetween(clients localgit.Clients, t *testing.T) {
 		checkoutPR(tt.prNum)
 	}
 	// switch back to master and create a new commit 'ouch'
-	checkoutBranch("master")
+	checkoutBranch(defaultBranch)
 	addCommit("ouch")
 	masterSHA, err := lg.RevParse("foo", "bar", "HEAD")
 	if err != nil {
@@ -386,14 +388,14 @@ func testMergeAndCheckout(clients localgit.Clients, t *testing.T) {
 				commitsToMerge = append(commitsToMerge, headRef)
 			}
 			if len(tc.prBranches) > 0 {
-				if err := lg.Checkout(org, repo, "master"); err != nil {
+				if err := lg.Checkout(org, repo, defaultBranch); err != nil {
 					t.Fatalf("failed to run git checkout master: %v", err)
 				}
 			}
 
 			var baseSHA string
 			if tc.setBaseSHA {
-				baseSHA, err = lg.RevParse(org, repo, "master")
+				baseSHA, err = lg.RevParse(org, repo, defaultBranch)
 				if err != nil {
 					t.Fatalf("failed to run git rev-parse master: %v", err)
 				}

--- a/prow/plugins/mergecommitblocker/mergecommitblocker_test.go
+++ b/prow/plugins/mergecommitblocker/mergecommitblocker_test.go
@@ -27,6 +27,8 @@ import (
 	"k8s.io/test-infra/prow/labels"
 )
 
+var defaultBranch = localgit.DefaultBranch("")
+
 type strSet map[string]struct{}
 
 type fakeGHClient struct {
@@ -125,12 +127,12 @@ func testHandle(clients localgit.Clients, t *testing.T) {
 			}
 		}
 		mergeMaster = func() {
-			if _, err := lg.Merge("foo", "bar", "master"); err != nil {
+			if _, err := lg.Merge("foo", "bar", defaultBranch); err != nil {
 				t.Fatalf("Rebasing commit: %v", err)
 			}
 		}
 		rebaseMaster = func() {
-			if _, err := lg.Rebase("foo", "bar", "master"); err != nil {
+			if _, err := lg.Rebase("foo", "bar", defaultBranch); err != nil {
 				t.Fatalf("Rebasing commit: %v", err)
 			}
 		}
@@ -202,7 +204,7 @@ func testHandle(clients localgit.Clients, t *testing.T) {
 		checkoutPR(tt.prNum)
 	}
 	// switch back to master and create a new commit 'ouch'
-	checkoutBranch("master")
+	checkoutBranch(defaultBranch)
 	addCommit("ouch")
 	masterSHA, err := lg.RevParse("foo", "bar", "HEAD")
 	if err != nil {

--- a/prow/plugins/updateconfig/updateconfig_test.go
+++ b/prow/plugins/updateconfig/updateconfig_test.go
@@ -43,46 +43,48 @@ import (
 
 const defaultNamespace = "default"
 
+var defaultBranch = localgit.DefaultBranch("")
+
 var remoteFiles = map[string]map[string]string{
 	"prow/config.yaml": {
-		"master": "old-config",
-		"12345":  "new-config",
+		defaultBranch: "old-config",
+		"12345":       "new-config",
 	},
 	"prow/binary.yaml": {
-		"master": "old-binary\x00\xFF\xFF",
-		"12345":  "new-binary\x00\xFF\xFF",
+		defaultBranch: "old-binary\x00\xFF\xFF",
+		"12345":       "new-binary\x00\xFF\xFF",
 	},
 	"prow/becoming-binary.yaml": {
-		"master": "not-yet-binary",
-		"12345":  "now-binary\x00\xFF\xFF",
+		defaultBranch: "not-yet-binary",
+		"12345":       "now-binary\x00\xFF\xFF",
 	},
 	"prow/becoming-text.yaml": {
-		"master": "not-yet-text\x00\xFF\xFF",
-		"12345":  "now-text",
+		defaultBranch: "not-yet-text\x00\xFF\xFF",
+		"12345":       "now-text",
 	},
 	"prow/plugins.yaml": {
-		"master": "old-plugins",
-		"12345":  "new-plugins",
+		defaultBranch: "old-plugins",
+		"12345":       "new-plugins",
 	},
 	"boskos/resources.yaml": {
-		"master": "old-boskos-config",
-		"12345":  "new-boskos-config",
+		defaultBranch: "old-boskos-config",
+		"12345":       "new-boskos-config",
 	},
 	"config/foo.yaml": {
-		"master": "old-foo-config",
-		"12345":  "new-foo-config",
+		defaultBranch: "old-foo-config",
+		"12345":       "new-foo-config",
 	},
 	"config/bar.yaml": {
-		"master": "old-bar-config",
-		"12345":  "new-bar-config",
+		defaultBranch: "old-bar-config",
+		"12345":       "new-bar-config",
 	},
 	"dir/subdir/fejta.yaml": {
-		"master": "old-fejta-config",
-		"12345":  "new-fejta-config",
+		defaultBranch: "old-fejta-config",
+		"12345":       "new-fejta-config",
 	},
 	"dir/subdir/fejtaverse/krzyzacy.yaml": {
-		"master": "old-krzyzacy-config",
-		"12345":  "new-krzyzacy-config",
+		defaultBranch: "old-krzyzacy-config",
+		"12345":       "new-krzyzacy-config",
 	},
 	"dir/subdir/fejtaverse/fejtabot.yaml": {
 		"54321": "new-fejtabot-config",
@@ -91,7 +93,7 @@ var remoteFiles = map[string]map[string]string{
 		"12345": "new-added-config",
 	},
 	"dir/subdir/fejtaverse/sig-bar/removed.yaml": {
-		"master": "old-removed-config",
+		defaultBranch: "old-removed-config",
 	},
 }
 
@@ -103,10 +105,10 @@ func setupLocalGitRepo(clients localgit.Clients, t *testing.T, org, repo string)
 	if err := lg.MakeFakeRepo(org, repo); err != nil {
 		t.Fatalf("Making fake repo: %v", err)
 	}
-	if err := lg.Checkout(org, repo, "master"); err != nil {
+	if err := lg.Checkout(org, repo, defaultBranch); err != nil {
 		t.Fatalf("Checkout new branch: %v", err)
 	}
-	if err := lg.AddCommit(org, repo, getFileMap("master")); err != nil {
+	if err := lg.AddCommit(org, repo, getFileMap(defaultBranch)); err != nil {
 		t.Fatalf("Add commit: %v", err)
 	}
 	if err := lg.CheckoutNewBranch(org, repo, "12345"); err != nil {
@@ -115,7 +117,7 @@ func setupLocalGitRepo(clients localgit.Clients, t *testing.T, org, repo string)
 	if err := lg.AddCommit(org, repo, getFileMap("12345")); err != nil {
 		t.Fatalf("Add commit: %v", err)
 	}
-	if err := lg.Checkout(org, repo, "master"); err != nil {
+	if err := lg.Checkout(org, repo, defaultBranch); err != nil {
 		t.Fatalf("Checkout new branch: %v", err)
 	}
 	if err := lg.CheckoutNewBranch(org, repo, "54321"); err != nil {
@@ -124,7 +126,7 @@ func setupLocalGitRepo(clients localgit.Clients, t *testing.T, org, repo string)
 	if err := lg.AddCommit(org, repo, getFileMap("54321")); err != nil {
 		t.Fatalf("Add commit: %v", err)
 	}
-	if err := lg.Checkout(org, repo, "master"); err != nil {
+	if err := lg.Checkout(org, repo, defaultBranch); err != nil {
 		t.Fatalf("Checkout new branch: %v", err)
 	}
 	return c

--- a/prow/plugins/verify-owners/verify-owners_test.go
+++ b/prow/plugins/verify-owners/verify-owners_test.go
@@ -43,6 +43,8 @@ import (
 	"k8s.io/test-infra/prow/repoowners"
 )
 
+var defaultBranch = localgit.DefaultBranch("")
+
 var ownerFiles = map[string][]byte{
 	"emptyApprovers": []byte(`approvers:
 reviewers:
@@ -461,7 +463,7 @@ func testHandle(clients localgit.Clients, t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			pr := i + 1
 			// make sure we're on master before branching
-			if err := lg.Checkout("org", "repo", "master"); err != nil {
+			if err := lg.Checkout("org", "repo", defaultBranch); err != nil {
 				t.Fatalf("Switching to master branch: %v", err)
 			}
 			if len(test.filesRemoved) > 0 {
@@ -490,7 +492,7 @@ func testHandle(clients localgit.Clients, t *testing.T) {
 				t.Fatalf("Getting commit SHA: %v", err)
 			}
 			if len(test.filesChangedAfterPR) > 0 {
-				if err := lg.Checkout("org", "repo", "master"); err != nil {
+				if err := lg.Checkout("org", "repo", defaultBranch); err != nil {
 					t.Fatalf("Switching to master branch: %v", err)
 				}
 				if err := addFilesToRepo(lg, test.filesChangedAfterPR, test.addedContent); err != nil {
@@ -501,7 +503,7 @@ func testHandle(clients localgit.Clients, t *testing.T) {
 				PullRequest: github.PullRequest{
 					User: github.User{Login: "author"},
 					Base: github.PullRequestBranch{
-						Ref: "master",
+						Ref: defaultBranch,
 					},
 					Head: github.PullRequestBranch{
 						SHA: sha,
@@ -513,7 +515,7 @@ func testHandle(clients localgit.Clients, t *testing.T) {
 			fghc.PullRequests = map[int]*github.PullRequest{}
 			fghc.PullRequests[pr] = &github.PullRequest{
 				Base: github.PullRequestBranch{
-					Ref: "master",
+					Ref: defaultBranch,
 				},
 			}
 
@@ -623,7 +625,7 @@ func testParseOwnersFile(clients localgit.Clients, t *testing.T) {
 				t.Fatalf("Making fake repo: %v", err)
 			}
 			// make sure we're on master before branching
-			if err := lg.Checkout("org", "repo", "master"); err != nil {
+			if err := lg.Checkout("org", "repo", defaultBranch); err != nil {
 				t.Fatalf("Switching to master branch: %v", err)
 			}
 			if err := lg.CheckoutNewBranch("org", "repo", fmt.Sprintf("pull/%d/head", pr)); err != nil {
@@ -1042,7 +1044,7 @@ func testNonCollaborators(clients localgit.Clients, t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			pr := i + 1
 			// make sure we're on master before branching
-			if err := lg.Checkout("org", "repo", "master"); err != nil {
+			if err := lg.Checkout("org", "repo", defaultBranch); err != nil {
 				t.Fatalf("Switching to master branch: %v", err)
 			}
 			if err := lg.CheckoutNewBranch("org", "repo", fmt.Sprintf("pull/%d/head", pr)); err != nil {
@@ -1078,7 +1080,7 @@ func testNonCollaborators(clients localgit.Clients, t *testing.T) {
 				PullRequest: github.PullRequest{
 					User: github.User{Login: "author"},
 					Base: github.PullRequestBranch{
-						Ref: "master",
+						Ref: defaultBranch,
 					},
 					Head: github.PullRequestBranch{
 						SHA: sha,
@@ -1242,7 +1244,7 @@ func testHandleGenericComment(clients localgit.Clients, t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			pr := i + 1
 			// make sure we're on master before branching
-			if err := lg.Checkout("org", "repo", "master"); err != nil {
+			if err := lg.Checkout("org", "repo", defaultBranch); err != nil {
 				t.Fatalf("Switching to master branch: %v", err)
 			}
 			if len(test.filesRemoved) > 0 {
@@ -1284,7 +1286,7 @@ func testHandleGenericComment(clients localgit.Clients, t *testing.T) {
 					SHA: sha,
 				},
 				Base: github.PullRequestBranch{
-					Ref: "master",
+					Ref: defaultBranch,
 				},
 			}
 
@@ -1354,7 +1356,7 @@ func testOwnersRemoval(clients localgit.Clients, t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			pr := i + 1
 			// make sure we're on master before branching
-			if err := lg.Checkout("org", "repo", "master"); err != nil {
+			if err := lg.Checkout("org", "repo", defaultBranch); err != nil {
 				t.Fatalf("Switching to master branch: %v", err)
 			}
 			pullFiles := map[string][]byte{}
@@ -1387,7 +1389,7 @@ func testOwnersRemoval(clients localgit.Clients, t *testing.T) {
 				PullRequest: github.PullRequest{
 					User: github.User{Login: "author"},
 					Base: github.PullRequestBranch{
-						Ref: "master",
+						Ref: defaultBranch,
 					},
 					Head: github.PullRequestBranch{
 						SHA: sha,

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -56,6 +56,8 @@ import (
 	"k8s.io/test-infra/prow/tide/history"
 )
 
+var defaultBranch = localgit.DefaultBranch("")
+
 func testPullsMatchList(t *testing.T, test string, actual []PullRequest, expected []int) {
 	if len(actual) != len(expected) {
 		t.Errorf("Wrong size for case %s. Got PRs %+v, wanted numbers %v.", test, actual, expected)
@@ -644,19 +646,19 @@ func TestDividePool(t *testing.T) {
 			org:    "k",
 			repo:   "t-i",
 			number: 5,
-			branch: "master",
+			branch: defaultBranch,
 		},
 		{
 			org:    "k",
 			repo:   "t-i",
 			number: 6,
-			branch: "master",
+			branch: defaultBranch,
 		},
 		{
 			org:    "k",
 			repo:   "k",
 			number: 123,
-			branch: "master",
+			branch: defaultBranch,
 		},
 		{
 			org:    "k",
@@ -676,14 +678,14 @@ func TestDividePool(t *testing.T) {
 			jobType: prowapi.PresubmitJob,
 			org:     "k",
 			repo:    "t-i",
-			baseRef: "master",
+			baseRef: defaultBranch,
 			baseSHA: "123",
 		},
 		{
 			jobType: prowapi.BatchJob,
 			org:     "k",
 			repo:    "t-i",
-			baseRef: "master",
+			baseRef: defaultBranch,
 			baseSHA: "123",
 		},
 		{
@@ -700,21 +702,21 @@ func TestDividePool(t *testing.T) {
 			jobType: prowapi.PresubmitJob,
 			org:     "k",
 			repo:    "t-i",
-			baseRef: "master",
+			baseRef: defaultBranch,
 			baseSHA: "abc",
 		},
 		{
 			jobType: prowapi.PresubmitJob,
 			org:     "o",
 			repo:    "t-i",
-			baseRef: "master",
+			baseRef: defaultBranch,
 			baseSHA: "123",
 		},
 		{
 			jobType: prowapi.PresubmitJob,
 			org:     "k",
 			repo:    "other",
-			baseRef: "master",
+			baseRef: defaultBranch,
 			baseSHA: "123",
 		},
 	}
@@ -896,8 +898,8 @@ func testPickBatch(clients localgit.Clients, t *testing.T) {
 		log:    logrus.WithField("component", "tide"),
 		org:    "o",
 		repo:   "r",
-		branch: "master",
-		sha:    "master",
+		branch: defaultBranch,
+		sha:    defaultBranch,
 	}
 	for _, testpr := range testprs {
 		if err := lg.CheckoutNewBranch("o", "r", fmt.Sprintf("pr-%d", testpr.number)); err != nil {
@@ -906,7 +908,7 @@ func testPickBatch(clients localgit.Clients, t *testing.T) {
 		if err := lg.AddCommit("o", "r", testpr.files); err != nil {
 			t.Fatalf("Error adding commit: %v", err)
 		}
-		if err := lg.Checkout("o", "r", "master"); err != nil {
+		if err := lg.Checkout("o", "r", defaultBranch); err != nil {
 			t.Fatalf("Error checking out master: %v", err)
 		}
 		oid := githubql.String(fmt.Sprintf("origin/pr-%d", testpr.number))
@@ -1397,8 +1399,8 @@ func testTakeAction(clients localgit.Clients, t *testing.T) {
 					Refs: &prowapi.Refs{
 						Org:     "o",
 						Repo:    "r",
-						BaseRef: "master",
-						BaseSHA: "master",
+						BaseRef: defaultBranch,
+						BaseSHA: defaultBranch,
 						Pulls: []prowapi.Pull{
 							{Number: 1, SHA: "origin/pr-1"},
 							{Number: 3, SHA: "origin/pr-3"},
@@ -1434,8 +1436,8 @@ func testTakeAction(clients localgit.Clients, t *testing.T) {
 					Refs: &prowapi.Refs{
 						Org:     "o",
 						Repo:    "r",
-						BaseRef: "master",
-						BaseSHA: "master",
+						BaseRef: defaultBranch,
+						BaseSHA: defaultBranch,
 						Pulls: []prowapi.Pull{
 							{Number: 1, SHA: "origin/pr-1"},
 							{Number: 3, SHA: "origin/pr-3"},
@@ -1475,8 +1477,8 @@ func testTakeAction(clients localgit.Clients, t *testing.T) {
 					Refs: &prowapi.Refs{
 						Org:     "o",
 						Repo:    "r",
-						BaseRef: "master",
-						BaseSHA: "master",
+						BaseRef: defaultBranch,
+						BaseSHA: defaultBranch,
 						Pulls: []prowapi.Pull{
 							{Number: 1, SHA: "origin/pr-1"},
 							{Number: 3, SHA: "origin/pr-3"},
@@ -1631,8 +1633,8 @@ func testTakeAction(clients localgit.Clients, t *testing.T) {
 				},
 				org:    "o",
 				repo:   "r",
-				branch: "master",
-				sha:    "master",
+				branch: defaultBranch,
+				sha:    defaultBranch,
 			}
 			genPulls := func(nums []int) []PullRequest {
 				var prs []PullRequest
@@ -1643,7 +1645,7 @@ func testTakeAction(clients localgit.Clients, t *testing.T) {
 					if err := lg.AddCommit("o", "r", map[string][]byte{fmt.Sprintf("%d", i): []byte("WOW")}); err != nil {
 						t.Fatalf("Error adding commit: %v", err)
 					}
-					if err := lg.Checkout("o", "r", "master"); err != nil {
+					if err := lg.Checkout("o", "r", defaultBranch); err != nil {
 						t.Fatalf("Error checking out master: %v", err)
 					}
 					oid := githubql.String(fmt.Sprintf("origin/pr-%d", i))
@@ -2713,7 +2715,7 @@ func TestPresubmitsByPull(t *testing.T) {
 					Reporter:  config.Reporter{Context: "presubmit"},
 					AlwaysRun: true,
 					Brancher: config.Brancher{
-						Branches: []string{"master", "dev"},
+						Branches: []string{defaultBranch, "dev"},
 					},
 				},
 				{
@@ -2724,7 +2726,7 @@ func TestPresubmitsByPull(t *testing.T) {
 				Reporter:  config.Reporter{Context: "presubmit"},
 				AlwaysRun: true,
 				Brancher: config.Brancher{
-					Branches: []string{"master", "dev"},
+					Branches: []string{defaultBranch, "dev"},
 				},
 			}}},
 		},
@@ -2901,7 +2903,7 @@ func TestPresubmitsByPull(t *testing.T) {
 		cfgAgent := &config.Agent{}
 		cfgAgent.Set(cfg)
 		sp := &subpool{
-			branch: "master",
+			branch: defaultBranch,
 			sha:    "master-sha",
 			prs:    append(tc.prs, samplePR),
 		}
@@ -3323,12 +3325,12 @@ func TestPresubmitsForBatch(t *testing.T) {
 			jobs: []config.Presubmit{{
 				AlwaysRun: true,
 				Reporter:  config.Reporter{Context: "foo"},
-				Brancher:  config.Brancher{Branches: []string{"master"}},
+				Brancher:  config.Brancher{Branches: []string{defaultBranch}},
 			}},
 			expected: []config.Presubmit{{
 				AlwaysRun: true,
 				Reporter:  config.Reporter{Context: "foo"},
-				Brancher:  config.Brancher{Branches: []string{"master"}},
+				Brancher:  config.Brancher{Branches: []string{defaultBranch}},
 			}},
 		},
 		{
@@ -3476,7 +3478,7 @@ func TestPresubmitsForBatch(t *testing.T) {
 				logger: logrus.WithField("test", tc.name),
 			}
 
-			presubmits, err := c.presubmitsForBatch(tc.prs, "org", "repo", "baseSHA", "master")
+			presubmits, err := c.presubmitsForBatch(tc.prs, "org", "repo", "baseSHA", defaultBranch)
 			if err != nil {
 				t.Fatalf("failed to get presubmits for batch: %v", err)
 			}


### PR DESCRIPTION
Currently a lot of unit tests expect the default branch to be master. This is now a runtime
configurable variable, often configured to main. Update tests to handle this situation --
note that one test was behaving oddly with this, so configured this branch to force master as the initial branch.

