### PR TITLE
Reenable OOM tracker in 5k scalability job

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -87,8 +87,6 @@ periodics:
       - --gcp-zone=us-east1-b
       - --provider=gce
       - --metadata-sources=cl2-metadata.json
-      # TODO(https://github.com/kubernetes/perf-tests/issues/1536): Reenable oom tracker.
-      - --env=CL2_ENABLE_CLUSTER_OOMS_TRACKER=false
       - --env=CL2_LOAD_TEST_THROUGHPUT=50
       - --env=CL2_DELETE_TEST_THROUGHPUT=30
       # Overrides CONTROLLER_MANAGER_TEST_ARGS from preset-e2e-scalability-periodics.


### PR DESCRIPTION
https://github.com/kubernetes/perf-tests/issues/1536 is fixed, time to reenable the measurement in our 5k test job.

/sig scalability
/assign @jkaniuk 