### PR TITLE
Check leaked resources in presubmits

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -28,6 +28,7 @@ presubmits:
         - --timeout=120
         - --scenario=kubernetes_e2e
         - --
+        - --check-leaked-resources
         - --build=bazel
         - --cluster=
         - --extract=local
@@ -427,6 +428,7 @@ presubmits:
         - --timeout=120
         - --scenario=kubernetes_e2e
         - --
+        - --check-leaked-resources
         - --cluster=
         - --extract=ci/latest
         - --gcp-nodes=100


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/98757

It's a second time some change in kubernetes/kubernetes makes our periodic job fail on diffResources. The reason for that is that k/k presubmit doesn't run diffResources tests, so we will not block such changes.

This PR enables leaked resources checking in both k/k and perf-tests presubmits to match our CI job.

/assign @wojtek-t @jkaniuk @mm4tt 