### PR TITLE
kops: move grid to alpha channel

### DIFF
--- a/config/jobs/kubernetes/kops/build_grid.py
+++ b/config/jobs/kubernetes/kops/build_grid.py
@@ -242,6 +242,7 @@ def build_test(cloud='aws',
                networking=None,
                container_runtime=None,
                k8s_version='latest',
+               kops_channel='alpha',
                kops_version=None,
                kops_zones=None,
                name_override=None,
@@ -299,6 +300,9 @@ def build_test(cloud='aws',
         raise Exception('missing required k8s_version')
 
     kops_args = ""
+    if kops_channel:
+        kops_args = kops_args + " --channel=" + kops_channel
+
     if networking:
         kops_args = kops_args + " --networking=" + networking
 
@@ -419,6 +423,7 @@ def build_test(cloud='aws',
         'k8s_version': k8s_version,
         'kops_version': kops_version,
         'container_runtime': container_runtime,
+        'kops_channel': kops_channel,
     }
     if feature_flags:
         spec['feature_flags'] = ','.join(feature_flags)
@@ -594,6 +599,7 @@ def generate_distros():
                        networking='calico',
                        container_runtime='containerd',
                        k8s_version='stable',
+                       kops_channel='stable',
                        name_override='kops-aws-distro-image' + distro,
                        extra_dashboards=['kops-distros'],
                        interval='8h',

--- a/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
@@ -2,7 +2,7 @@
 # 10 jobs, total of 16 runs per week
 periodics:
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "stable", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "stable", "kops_channel": "stable", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-aws-distro-imagedebian9
   interval: '8h'
   labels:
@@ -58,13 +58,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: stable
+    test.kops.k8s.io/kops_channel: stable
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-distros, kops-k8s-stable, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-imagedebian9
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "stable", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "stable", "kops_channel": "stable", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-aws-distro-imagedebian10
   interval: '8h'
   labels:
@@ -120,13 +121,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: stable
+    test.kops.k8s.io/kops_channel: stable
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-distros, kops-k8s-stable, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-imagedebian10
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "stable", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "stable", "kops_channel": "stable", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-aws-distro-imageubuntu1804
   interval: '8h'
   labels:
@@ -182,13 +184,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: stable
+    test.kops.k8s.io/kops_channel: stable
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-distros, kops-k8s-stable, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-imageubuntu1804
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "stable", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "stable", "kops_channel": "stable", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-aws-distro-imageubuntu2004
   interval: '8h'
   labels:
@@ -244,13 +247,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: stable
+    test.kops.k8s.io/kops_channel: stable
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-distros, kops-k8s-stable, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-imageubuntu2004
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "stable", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "stable", "kops_channel": "stable", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-aws-distro-imagecentos7
   interval: '8h'
   labels:
@@ -306,13 +310,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: centos7
     test.kops.k8s.io/k8s_version: stable
+    test.kops.k8s.io/kops_channel: stable
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-centos7, kops-distros, kops-k8s-stable, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-imagecentos7
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "centos8", "k8s_version": "stable", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "centos8", "k8s_version": "stable", "kops_channel": "stable", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-aws-distro-imagecentos8
   interval: '8h'
   labels:
@@ -368,13 +373,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: centos8
     test.kops.k8s.io/k8s_version: stable
+    test.kops.k8s.io/kops_channel: stable
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-centos8, kops-distros, kops-k8s-stable, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-imagecentos8
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "stable", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "stable", "kops_channel": "stable", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-aws-distro-imageamazonlinux2
   interval: '8h'
   labels:
@@ -430,13 +436,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: stable
+    test.kops.k8s.io/kops_channel: stable
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-distros, kops-k8s-stable, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-imageamazonlinux2
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "stable", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "stable", "kops_channel": "stable", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-aws-distro-imagerhel7
   interval: '8h'
   labels:
@@ -492,13 +499,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: stable
+    test.kops.k8s.io/kops_channel: stable
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-distros, kops-k8s-stable, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-imagerhel7
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "stable", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "stable", "kops_channel": "stable", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-aws-distro-imagerhel8
   interval: '8h'
   labels:
@@ -554,13 +562,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: stable
+    test.kops.k8s.io/kops_channel: stable
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-distros, kops-k8s-stable, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-imagerhel8
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "stable", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "stable", "kops_channel": "stable", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-aws-distro-imageflatcar
   interval: '8h'
   labels:
@@ -616,6 +625,7 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: stable
+    test.kops.k8s.io/kops_channel: stable
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-distros, kops-k8s-stable, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -2,7 +2,7 @@
 # 640 jobs, total of 1120 runs per week
 periodics:
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-amzn2-k17-docker
   cron: '19 9 * * 6'
   labels:
@@ -27,7 +27,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -47,13 +47,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": null}
 - name: e2e-kops-grid-amzn2-k17-ko18-docker
   cron: '41 2 * * 4'
   labels:
@@ -78,7 +79,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -98,13 +99,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-amzn2, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-amzn2-k17-ko19-docker
   cron: '51 20 * * 0'
   labels:
@@ -129,7 +131,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -149,13 +151,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-amzn2, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-amzn2-k18-docker
   cron: '23 5 * * 4'
   labels:
@@ -180,7 +183,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -200,13 +203,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": null}
 - name: e2e-kops-grid-amzn2-k18-ko18-docker
   cron: '48 7 * * 2'
   labels:
@@ -231,7 +235,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -251,13 +255,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-amzn2, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-amzn2-k18-ko19-docker
   cron: '38 1 * * 6'
   labels:
@@ -282,7 +287,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -302,13 +307,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-amzn2, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-amzn2-k19-docker
   cron: '37 3 * * 3'
   labels:
@@ -333,7 +339,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -353,13 +359,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-amzn2-k19-ko19-docker
   cron: '3 20 * * 0'
   labels:
@@ -384,7 +391,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -404,13 +411,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-amzn2, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-amzn2-k20-docker
   cron: '35 5 * * 0'
   labels:
@@ -435,7 +443,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -455,13 +463,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-deb9-k17-docker
   cron: '44 18 * * 5'
   labels:
@@ -486,7 +495,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -506,13 +515,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": null}
 - name: e2e-kops-grid-deb9-k17-ko18-docker
   cron: '39 14 * * 3'
   labels:
@@ -537,7 +547,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -557,13 +567,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-deb9, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-deb9-k17-ko19-docker
   cron: '41 8 * * 4'
   labels:
@@ -588,7 +599,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -608,13 +619,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb9, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-deb9-k18-docker
   cron: '52 14 * * 1'
   labels:
@@ -639,7 +651,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -659,13 +671,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": null}
 - name: e2e-kops-grid-deb9-k18-ko18-docker
   cron: '10 11 * * 6'
   labels:
@@ -690,7 +703,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -710,13 +723,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-deb9, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-deb9-k18-ko19-docker
   cron: '20 21 * * 6'
   labels:
@@ -741,7 +755,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -761,13 +775,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb9, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-deb9-k19-docker
   cron: '54 8 * * 1'
   labels:
@@ -792,7 +807,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -812,13 +827,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-deb9-k19-ko19-docker
   cron: '49 16 * * 0'
   labels:
@@ -843,7 +859,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -863,13 +879,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb9, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-deb9-k20-docker
   cron: '0 6 * * 5'
   labels:
@@ -894,7 +911,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -914,13 +931,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-deb10-k17-docker
   cron: '27 17 * * 4'
   labels:
@@ -945,7 +963,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -965,13 +983,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": null}
 - name: e2e-kops-grid-deb10-k17-ko18-docker
   cron: '18 5 * * 4'
   labels:
@@ -996,7 +1015,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -1016,13 +1035,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-deb10, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-deb10-k17-ko19-docker
   cron: '0 3 * * 1'
   labels:
@@ -1047,7 +1067,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -1067,13 +1087,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb10, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-deb10-k18-docker
   cron: '39 13 * * 2'
   labels:
@@ -1098,7 +1119,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -1118,13 +1139,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": null}
 - name: e2e-kops-grid-deb10-k18-ko18-docker
   cron: '55 0 * * 2'
   labels:
@@ -1149,7 +1171,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -1169,13 +1191,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-deb10, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-deb10-k18-ko19-docker
   cron: '53 14 * * 6'
   labels:
@@ -1200,7 +1223,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -1220,13 +1243,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb10, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-deb10-k19-docker
   cron: '45 11 * * 1'
   labels:
@@ -1251,7 +1275,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -1271,13 +1295,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-deb10-k19-ko19-docker
   cron: '32 19 * * 2'
   labels:
@@ -1302,7 +1327,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -1322,13 +1347,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb10, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-deb10-k20-docker
   cron: '19 13 * * 5'
   labels:
@@ -1353,7 +1379,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -1373,13 +1399,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-flatcar-k17-docker
   cron: '43 21 * * 3'
   labels:
@@ -1404,7 +1431,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -1424,13 +1451,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": null}
 - name: e2e-kops-grid-flatcar-k17-ko18-docker
   cron: '38 10 * * 5'
   labels:
@@ -1455,7 +1483,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -1475,13 +1503,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-flatcar, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-flatcar-k17-ko19-docker
   cron: '12 20 * * 0'
   labels:
@@ -1506,7 +1535,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -1526,13 +1555,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-flatcar, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-flatcar-k18-docker
   cron: '43 1 * * 0'
   labels:
@@ -1557,7 +1587,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -1577,13 +1607,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": null}
 - name: e2e-kops-grid-flatcar-k18-ko18-docker
   cron: '43 23 * * 3'
   labels:
@@ -1608,7 +1639,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -1628,13 +1659,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-flatcar, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-flatcar-k18-ko19-docker
   cron: '1 9 * * 6'
   labels:
@@ -1659,7 +1691,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -1679,13 +1711,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-flatcar, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-flatcar-k19-docker
   cron: '57 7 * * 6'
   labels:
@@ -1710,7 +1743,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -1730,13 +1763,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-flatcar-k19-ko19-docker
   cron: '16 12 * * 6'
   labels:
@@ -1761,7 +1795,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -1781,13 +1815,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-flatcar, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-flatcar-k20-docker
   cron: '15 9 * * 5'
   labels:
@@ -1812,7 +1847,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -1832,13 +1867,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-rhel7-k17-docker
   cron: '5 7 * * 4'
   labels:
@@ -1863,7 +1899,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -1883,13 +1919,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": null}
 - name: e2e-kops-grid-rhel7-k17-ko18-docker
   cron: '34 17 * * 5'
   labels:
@@ -1914,7 +1951,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -1934,13 +1971,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-rhel7, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-rhel7-k17-ko19-docker
   cron: '48 23 * * 3'
   labels:
@@ -1965,7 +2003,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -1985,13 +2023,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel7, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-rhel7-k18-docker
   cron: '5 11 * * 3'
   labels:
@@ -2016,7 +2055,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -2036,13 +2075,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": null}
 - name: e2e-kops-grid-rhel7-k18-ko18-docker
   cron: '51 12 * * 4'
   labels:
@@ -2067,7 +2107,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -2087,13 +2127,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-rhel7, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-rhel7-k18-ko19-docker
   cron: '49 2 * * 2'
   labels:
@@ -2118,7 +2159,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -2138,13 +2179,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel7, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-rhel7-k19-docker
   cron: '3 21 * * 6'
   labels:
@@ -2169,7 +2211,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -2189,13 +2231,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-rhel7-k19-ko19-docker
   cron: '28 23 * * 1'
   labels:
@@ -2220,7 +2263,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -2240,13 +2283,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel7, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-rhel7-k20-docker
   cron: '13 3 * * 3'
   labels:
@@ -2271,7 +2315,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -2291,13 +2335,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-rhel8-k17-docker
   cron: '40 6 * * 2'
   labels:
@@ -2322,7 +2367,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -2342,13 +2387,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": null}
 - name: e2e-kops-grid-rhel8-k17-ko18-docker
   cron: '55 4 * * 1'
   labels:
@@ -2373,7 +2419,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -2393,13 +2439,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-rhel8, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-rhel8-k17-ko19-docker
   cron: '25 18 * * 1'
   labels:
@@ -2424,7 +2471,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -2444,13 +2491,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel8, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-rhel8-k18-docker
   cron: '32 2 * * 1'
   labels:
@@ -2475,7 +2523,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -2495,13 +2543,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": null}
 - name: e2e-kops-grid-rhel8-k18-ko18-docker
   cron: '54 9 * * 1'
   labels:
@@ -2526,7 +2575,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -2546,13 +2595,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-rhel8, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-rhel8-k18-ko19-docker
   cron: '32 23 * * 5'
   labels:
@@ -2577,7 +2627,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -2597,13 +2647,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel8, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-rhel8-k19-docker
   cron: '26 20 * * 6'
   labels:
@@ -2628,7 +2679,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -2648,13 +2699,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-rhel8-k19-ko19-docker
   cron: '1 2 * * 3'
   labels:
@@ -2679,7 +2731,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -2699,13 +2751,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel8, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-rhel8-k20-docker
   cron: '48 10 * * 0'
   labels:
@@ -2730,7 +2783,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -2750,13 +2803,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-u1804-k17-docker
   cron: '9 3 * * 2'
   labels:
@@ -2781,7 +2835,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -2801,13 +2855,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": null}
 - name: e2e-kops-grid-u1804-k17-ko18-docker
   cron: '26 13 * * 1'
   labels:
@@ -2832,7 +2887,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -2852,13 +2907,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-u1804, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u1804-k17-ko19-docker
   cron: '8 11 * * 3'
   labels:
@@ -2883,7 +2939,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -2903,13 +2959,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u1804, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-u1804-k18-docker
   cron: '25 15 * * 3'
   labels:
@@ -2934,7 +2991,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -2954,13 +3011,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": null}
 - name: e2e-kops-grid-u1804-k18-ko18-docker
   cron: '51 16 * * 4'
   labels:
@@ -2985,7 +3043,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -3005,13 +3063,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-u1804, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u1804-k18-ko19-docker
   cron: '41 14 * * 3'
   labels:
@@ -3036,7 +3095,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -3056,13 +3115,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u1804, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-u1804-k19-docker
   cron: '23 9 * * 2'
   labels:
@@ -3087,7 +3147,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -3107,13 +3167,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u1804-k19-ko19-docker
   cron: '28 19 * * 6'
   labels:
@@ -3138,7 +3199,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -3158,13 +3219,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u1804, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-u1804-k20-docker
   cron: '49 15 * * 6'
   labels:
@@ -3189,7 +3251,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -3209,13 +3271,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-u2004-k17-docker
   cron: '54 12 * * *'
   labels:
@@ -3240,7 +3303,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -3260,13 +3323,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": null}
 - name: e2e-kops-grid-u2004-k17-ko18-docker
   cron: '9 18 * * *'
   labels:
@@ -3291,7 +3355,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -3311,13 +3375,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-u2004, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u2004-k17-ko19-docker
   cron: '51 20 * * *'
   labels:
@@ -3342,7 +3407,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -3362,13 +3427,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u2004, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-u2004-k18-docker
   cron: '46 0 * * *'
   labels:
@@ -3393,7 +3459,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -3413,13 +3479,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": null}
 - name: e2e-kops-grid-u2004-k18-ko18-docker
   cron: '0 23 * * *'
   labels:
@@ -3444,7 +3511,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -3464,13 +3531,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-u2004, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u2004-k18-ko19-docker
   cron: '22 1 * * *'
   labels:
@@ -3495,7 +3563,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -3515,13 +3583,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u2004, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-u2004-k19-docker
   cron: '36 6 * * *'
   labels:
@@ -3546,7 +3615,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -3566,13 +3635,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u2004-k19-ko19-docker
   cron: '35 20 * * *'
   labels:
@@ -3597,7 +3667,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -3617,13 +3687,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u2004, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-u2004-k20-docker
   cron: '10 0 * * *'
   labels:
@@ -3648,7 +3719,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker
+      - --kops-args=--channel=alpha --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -3668,13 +3739,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k17-docker
   cron: '21 17 * * 6'
   labels:
@@ -3699,7 +3771,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -3719,13 +3791,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k17-ko18-docker
   cron: '31 0 * * 5'
   labels:
@@ -3750,7 +3823,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -3770,13 +3843,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-amzn2, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k17-ko19-docker
   cron: '45 6 * * 3'
   labels:
@@ -3801,7 +3875,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -3821,13 +3895,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-amzn2, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k18-docker
   cron: '13 21 * * 5'
   labels:
@@ -3852,7 +3927,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -3872,13 +3947,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k18-ko18-docker
   cron: '6 13 * * 0'
   labels:
@@ -3903,7 +3979,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -3923,13 +3999,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-amzn2, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k18-ko19-docker
   cron: '40 19 * * 5'
   labels:
@@ -3954,7 +4031,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -3974,13 +4051,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-amzn2, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k19-docker
   cron: '19 3 * * 6'
   labels:
@@ -4005,7 +4083,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -4025,13 +4103,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k19-ko19-docker
   cron: '9 22 * * 3'
   labels:
@@ -4056,7 +4135,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -4076,13 +4155,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-amzn2, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k20-docker
   cron: '29 5 * * 3'
   labels:
@@ -4107,7 +4187,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -4127,13 +4207,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-k17-docker
   cron: '57 6 * * 6'
   labels:
@@ -4158,7 +4239,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -4178,13 +4259,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-k17-ko18-docker
   cron: '31 3 * * 3'
   labels:
@@ -4209,7 +4291,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -4229,13 +4311,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-deb9, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-k17-ko19-docker
   cron: '9 5 * * 1'
   labels:
@@ -4260,7 +4343,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -4280,13 +4363,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb9, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-k18-docker
   cron: '33 2 * * 1'
   labels:
@@ -4311,7 +4395,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -4331,13 +4415,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-k18-ko18-docker
   cron: '58 22 * * 2'
   labels:
@@ -4362,7 +4447,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -4382,13 +4467,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-deb9, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-k18-ko19-docker
   cron: '0 0 * * 2'
   labels:
@@ -4413,7 +4499,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -4433,13 +4519,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb9, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-k19-docker
   cron: '7 4 * * 5'
   labels:
@@ -4464,7 +4551,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -4484,13 +4571,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-k19-ko19-docker
   cron: '25 5 * * 0'
   labels:
@@ -4515,7 +4603,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -4535,13 +4623,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb9, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-k20-docker
   cron: '9 2 * * 5'
   labels:
@@ -4566,7 +4655,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -4586,13 +4675,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k17-docker
   cron: '1 9 * * 2'
   labels:
@@ -4617,7 +4707,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -4637,13 +4727,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k17-ko18-docker
   cron: '28 15 * * 5'
   labels:
@@ -4668,7 +4759,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -4688,13 +4779,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-deb10, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k17-ko19-docker
   cron: '34 9 * * 4'
   labels:
@@ -4719,7 +4811,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -4739,13 +4831,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb10, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k18-docker
   cron: '53 21 * * 5'
   labels:
@@ -4770,7 +4863,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -4790,13 +4883,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k18-ko18-docker
   cron: '5 2 * * 0'
   labels:
@@ -4821,7 +4915,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -4841,13 +4935,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-deb10, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k18-ko19-docker
   cron: '55 12 * * 5'
   labels:
@@ -4872,7 +4967,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -4892,13 +4987,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb10, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k19-docker
   cron: '27 11 * * 4'
   labels:
@@ -4923,7 +5019,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -4943,13 +5039,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k19-ko19-docker
   cron: '34 17 * * 5'
   labels:
@@ -4974,7 +5071,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -4994,13 +5091,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb10, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k20-docker
   cron: '57 21 * * 2'
   labels:
@@ -5025,7 +5123,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -5045,13 +5143,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k17-docker
   cron: '21 19 * * 5'
   labels:
@@ -5076,7 +5175,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -5096,13 +5195,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k17-ko18-docker
   cron: '40 16 * * 0'
   labels:
@@ -5127,7 +5227,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -5147,13 +5247,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-flatcar, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k17-ko19-docker
   cron: '50 6 * * 5'
   labels:
@@ -5178,7 +5279,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -5198,13 +5299,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-flatcar, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k18-docker
   cron: '49 23 * * 0'
   labels:
@@ -5229,7 +5331,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -5249,13 +5351,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k18-ko18-docker
   cron: '13 21 * * 4'
   labels:
@@ -5280,7 +5383,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -5300,13 +5403,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-flatcar, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k18-ko19-docker
   cron: '51 11 * * 6'
   labels:
@@ -5331,7 +5435,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -5351,13 +5455,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-flatcar, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k19-docker
   cron: '15 9 * * 5'
   labels:
@@ -5382,7 +5487,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -5402,13 +5507,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k19-ko19-docker
   cron: '42 22 * * 6'
   labels:
@@ -5433,7 +5539,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -5453,13 +5559,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-flatcar, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k20-docker
   cron: '29 15 * * 1'
   labels:
@@ -5484,7 +5591,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -5504,13 +5611,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-k17-docker
   cron: '23 23 * * 1'
   labels:
@@ -5535,7 +5643,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -5555,13 +5663,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-k17-ko18-docker
   cron: '20 19 * * 3'
   labels:
@@ -5586,7 +5695,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -5606,13 +5715,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-rhel7, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-k17-ko19-docker
   cron: '54 13 * * 2'
   labels:
@@ -5637,7 +5747,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -5657,13 +5767,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel7, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-k18-docker
   cron: '23 19 * * 0'
   labels:
@@ -5688,7 +5799,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -5708,13 +5819,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-k18-ko18-docker
   cron: '57 6 * * 4'
   labels:
@@ -5739,7 +5851,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -5759,13 +5871,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-rhel7, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-k18-ko19-docker
   cron: '47 8 * * 4'
   labels:
@@ -5790,7 +5903,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -5810,13 +5923,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel7, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-k19-docker
   cron: '45 5 * * 4'
   labels:
@@ -5841,7 +5955,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -5861,13 +5975,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-k19-ko19-docker
   cron: '30 13 * * 2'
   labels:
@@ -5892,7 +6007,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -5912,13 +6027,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel7, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-k20-docker
   cron: '59 11 * * 0'
   labels:
@@ -5943,7 +6059,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -5963,13 +6079,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k17-docker
   cron: '50 6 * * 3'
   labels:
@@ -5994,7 +6111,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -6014,13 +6131,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k17-ko18-docker
   cron: '21 14 * * 2'
   labels:
@@ -6045,7 +6163,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -6065,13 +6183,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-rhel8, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k17-ko19-docker
   cron: '59 16 * * 0'
   labels:
@@ -6096,7 +6215,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -6116,13 +6235,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel8, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k18-docker
   cron: '54 2 * * 3'
   labels:
@@ -6147,7 +6267,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -6167,13 +6287,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k18-ko18-docker
   cron: '12 19 * * 2'
   labels:
@@ -6198,7 +6319,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -6218,13 +6339,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-rhel8, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k18-ko19-docker
   cron: '42 5 * * 3'
   labels:
@@ -6249,7 +6371,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -6269,13 +6391,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel8, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k19-docker
   cron: '20 12 * * 4'
   labels:
@@ -6300,7 +6423,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -6320,13 +6443,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k19-ko19-docker
   cron: '19 0 * * 6'
   labels:
@@ -6351,7 +6475,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -6371,13 +6495,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel8, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k20-docker
   cron: '18 2 * * 2'
   labels:
@@ -6402,7 +6527,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -6422,13 +6547,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-k17-docker
   cron: '23 3 * * 3'
   labels:
@@ -6453,7 +6579,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -6473,13 +6599,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-k17-ko18-docker
   cron: '12 15 * * 0'
   labels:
@@ -6504,7 +6631,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -6524,13 +6651,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-u1804, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-k17-ko19-docker
   cron: '38 1 * * 0'
   labels:
@@ -6555,7 +6683,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -6575,13 +6703,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u1804, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-k18-docker
   cron: '7 7 * * 4'
   labels:
@@ -6606,7 +6735,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -6626,13 +6755,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-k18-ko18-docker
   cron: '45 2 * * 1'
   labels:
@@ -6657,7 +6787,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -6677,13 +6807,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-u1804, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-k18-ko19-docker
   cron: '3 20 * * 4'
   labels:
@@ -6708,7 +6839,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -6728,13 +6859,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u1804, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-k19-docker
   cron: '57 17 * * 1'
   labels:
@@ -6759,7 +6891,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -6779,13 +6911,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-k19-ko19-docker
   cron: '50 17 * * 1'
   labels:
@@ -6810,7 +6943,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -6830,13 +6963,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u1804, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-k20-docker
   cron: '23 23 * * 3'
   labels:
@@ -6861,7 +6995,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -6881,13 +7015,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k17-docker
   cron: '8 20 * * *'
   labels:
@@ -6912,7 +7047,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -6932,13 +7067,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k17-ko18-docker
   cron: '31 0 * * *'
   labels:
@@ -6963,7 +7099,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -6983,13 +7119,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-u2004, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k17-ko19-docker
   cron: '53 22 * * *'
   labels:
@@ -7014,7 +7151,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -7034,13 +7171,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u2004, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k18-docker
   cron: '48 0 * * *'
   labels:
@@ -7065,7 +7203,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -7085,13 +7223,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k18-ko18-docker
   cron: '38 5 * * *'
   labels:
@@ -7116,7 +7255,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -7136,13 +7275,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-u2004, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k18-ko19-docker
   cron: '20 3 * * *'
   labels:
@@ -7167,7 +7307,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -7187,13 +7327,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u2004, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k19-docker
   cron: '14 6 * * *'
   labels:
@@ -7218,7 +7359,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -7238,13 +7379,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k19-ko19-docker
   cron: '21 22 * * *'
   labels:
@@ -7269,7 +7411,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -7289,13 +7431,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u2004, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k20-docker
   cron: '28 16 * * *'
   labels:
@@ -7320,7 +7463,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -7340,13 +7483,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k17-docker
   cron: '31 3 * * 0'
   labels:
@@ -7371,7 +7515,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -7391,13 +7535,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k17-ko18-docker
   cron: '9 22 * * 3'
   labels:
@@ -7422,7 +7567,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -7442,13 +7587,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-amzn2, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k17-ko19-docker
   cron: '59 0 * * 3'
   labels:
@@ -7473,7 +7619,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -7493,13 +7639,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-amzn2, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k18-docker
   cron: '27 7 * * 1'
   labels:
@@ -7524,7 +7671,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -7544,13 +7691,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k18-ko18-docker
   cron: '32 19 * * 3'
   labels:
@@ -7575,7 +7723,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -7595,13 +7743,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-amzn2, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k18-ko19-docker
   cron: '58 13 * * 1'
   labels:
@@ -7626,7 +7775,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -7646,13 +7795,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-amzn2, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k19-docker
   cron: '41 17 * * 5'
   labels:
@@ -7677,7 +7827,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -7697,13 +7847,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k19-ko19-docker
   cron: '39 16 * * 1'
   labels:
@@ -7728,7 +7879,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -7748,13 +7899,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-amzn2, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k20-docker
   cron: '43 15 * * 2'
   labels:
@@ -7779,7 +7931,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -7799,13 +7951,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb9-k17-docker
   cron: '41 18 * * 3'
   labels:
@@ -7830,7 +7983,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -7850,13 +8003,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb9-k17-ko18-docker
   cron: '17 9 * * 1'
   labels:
@@ -7881,7 +8035,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -7901,13 +8055,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-deb9, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb9-k17-ko19-docker
   cron: '35 7 * * 4'
   labels:
@@ -7932,7 +8087,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -7952,13 +8107,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb9, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb9-k18-docker
   cron: '37 22 * * 0'
   labels:
@@ -7983,7 +8139,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -8003,13 +8159,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb9-k18-ko18-docker
   cron: '24 12 * * 1'
   labels:
@@ -8034,7 +8191,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -8054,13 +8211,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-deb9, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb9-k18-ko19-docker
   cron: '22 18 * * 4'
   labels:
@@ -8085,7 +8243,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -8105,13 +8263,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb9, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb9-k19-docker
   cron: '27 0 * * 2'
   labels:
@@ -8136,7 +8295,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -8156,13 +8315,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb9-k19-ko19-docker
   cron: '7 15 * * 1'
   labels:
@@ -8187,7 +8347,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -8207,13 +8367,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb9, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb9-k20-docker
   cron: '53 22 * * 2'
   labels:
@@ -8238,7 +8399,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -8258,13 +8419,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k17-docker
   cron: '15 11 * * 2'
   labels:
@@ -8289,7 +8451,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -8309,13 +8471,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k17-ko18-docker
   cron: '42 1 * * 5'
   labels:
@@ -8340,7 +8503,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -8360,13 +8523,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-deb10, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k17-ko19-docker
   cron: '28 7 * * 6'
   labels:
@@ -8391,7 +8555,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -8411,13 +8575,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb10, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k18-docker
   cron: '11 23 * * 0'
   labels:
@@ -8442,7 +8607,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -8462,13 +8627,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k18-ko18-docker
   cron: '31 4 * * 2'
   labels:
@@ -8493,7 +8659,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -8513,13 +8679,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-deb10, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k18-ko19-docker
   cron: '45 10 * * 4'
   labels:
@@ -8544,7 +8711,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -8564,13 +8731,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb10, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k19-docker
   cron: '29 1 * * 2'
   labels:
@@ -8595,7 +8763,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -8615,13 +8783,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k19-ko19-docker
   cron: '56 7 * * 5'
   labels:
@@ -8646,7 +8815,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -8666,13 +8835,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb10, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k20-docker
   cron: '23 15 * * 2'
   labels:
@@ -8697,7 +8867,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -8717,13 +8887,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar-k17-docker
   cron: '33 11 * * 5'
   labels:
@@ -8748,7 +8919,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -8768,13 +8939,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar-k17-ko18-docker
   cron: '30 22 * * 2'
   labels:
@@ -8799,7 +8971,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -8819,13 +8991,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-flatcar, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar-k17-ko19-docker
   cron: '0 0 * * 0'
   labels:
@@ -8850,7 +9023,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -8870,13 +9043,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-flatcar, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar-k18-docker
   cron: '57 7 * * 2'
   labels:
@@ -8901,7 +9075,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -8921,13 +9095,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar-k18-ko18-docker
   cron: '11 11 * * 5'
   labels:
@@ -8952,7 +9127,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -8972,13 +9147,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-flatcar, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar-k18-ko19-docker
   cron: '29 21 * * 4'
   labels:
@@ -9003,7 +9179,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -9023,13 +9199,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-flatcar, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar-k19-docker
   cron: '59 17 * * 0'
   labels:
@@ -9054,7 +9231,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -9074,13 +9251,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar-k19-ko19-docker
   cron: '40 8 * * 0'
   labels:
@@ -9105,7 +9283,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -9125,13 +9303,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-flatcar, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar-k20-docker
   cron: '49 23 * * 3'
   labels:
@@ -9156,7 +9335,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -9176,13 +9355,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel7-k17-docker
   cron: '29 21 * * 3'
   labels:
@@ -9207,7 +9387,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -9227,13 +9407,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel7-k17-ko18-docker
   cron: '42 13 * * 2'
   labels:
@@ -9258,7 +9439,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -9278,13 +9459,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-rhel7, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel7-k17-ko19-docker
   cron: '40 3 * * 5'
   labels:
@@ -9309,7 +9491,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -9329,13 +9511,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel7, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel7-k18-docker
   cron: '25 17 * * 2'
   labels:
@@ -9360,7 +9543,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -9380,13 +9563,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel7-k18-ko18-docker
   cron: '15 0 * * 0'
   labels:
@@ -9411,7 +9595,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -9431,13 +9615,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-rhel7, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel7-k18-ko19-docker
   cron: '45 14 * * 2'
   labels:
@@ -9462,7 +9647,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -9482,13 +9667,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel7, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel7-k19-docker
   cron: '3 15 * * 1'
   labels:
@@ -9513,7 +9699,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -9533,13 +9719,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel7-k19-ko19-docker
   cron: '44 19 * * 3'
   labels:
@@ -9564,7 +9751,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -9584,13 +9771,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel7, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel7-k20-docker
   cron: '29 17 * * 5'
   labels:
@@ -9615,7 +9803,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -9635,13 +9823,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k17-docker
   cron: '24 20 * * 1'
   labels:
@@ -9666,7 +9855,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -9686,13 +9875,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k17-ko18-docker
   cron: '59 0 * * 2'
   labels:
@@ -9717,7 +9907,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -9737,13 +9927,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-rhel8, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k17-ko19-docker
   cron: '37 22 * * 1'
   labels:
@@ -9768,7 +9959,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -9788,13 +9979,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel8, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k18-docker
   cron: '32 16 * * 3'
   labels:
@@ -9819,7 +10011,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -9839,13 +10031,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k18-ko18-docker
   cron: '2 21 * * 4'
   labels:
@@ -9870,7 +10063,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -9890,13 +10083,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-rhel8, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k18-ko19-docker
   cron: '16 11 * * 1'
   labels:
@@ -9921,7 +10115,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -9941,13 +10135,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel8, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k19-docker
   cron: '18 6 * * 0'
   labels:
@@ -9972,7 +10167,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -9992,13 +10187,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k19-ko19-docker
   cron: '5 14 * * 6'
   labels:
@@ -10023,7 +10219,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -10043,13 +10239,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel8, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k20-docker
   cron: '48 0 * * 6'
   labels:
@@ -10074,7 +10271,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -10094,13 +10291,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1804-k17-docker
   cron: '57 17 * * 2'
   labels:
@@ -10125,7 +10323,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -10145,13 +10343,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1804-k17-ko18-docker
   cron: '42 17 * * 3'
   labels:
@@ -10176,7 +10375,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -10196,13 +10395,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-u1804, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1804-k17-ko19-docker
   cron: '0 15 * * 2'
   labels:
@@ -10227,7 +10427,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -10247,13 +10447,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u1804, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1804-k18-docker
   cron: '13 21 * * 3'
   labels:
@@ -10278,7 +10479,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -10298,13 +10499,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1804-k18-ko18-docker
   cron: '19 4 * * 0'
   labels:
@@ -10329,7 +10531,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -10349,13 +10551,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-u1804, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1804-k18-ko19-docker
   cron: '13 18 * * 4'
   labels:
@@ -10380,7 +10583,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -10400,13 +10603,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u1804, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1804-k19-docker
   cron: '23 11 * * 1'
   labels:
@@ -10431,7 +10635,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -10451,13 +10655,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1804-k19-ko19-docker
   cron: '52 23 * * 0'
   labels:
@@ -10482,7 +10687,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -10502,13 +10707,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u1804, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1804-k20-docker
   cron: '5 21 * * 5'
   labels:
@@ -10533,7 +10739,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -10553,13 +10759,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k17-docker
   cron: '42 6 * * *'
   labels:
@@ -10584,7 +10791,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -10604,13 +10811,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k17-ko18-docker
   cron: '9 6 * * *'
   labels:
@@ -10635,7 +10843,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -10655,13 +10863,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-u2004, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k17-ko19-docker
   cron: '15 0 * * *'
   labels:
@@ -10686,7 +10895,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -10706,13 +10915,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u2004, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k18-docker
   cron: '26 10 * * *'
   labels:
@@ -10737,7 +10947,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -10757,13 +10967,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k18-ko18-docker
   cron: '56 3 * * *'
   labels:
@@ -10788,7 +10999,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -10808,13 +11019,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-u2004, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k18-ko19-docker
   cron: '38 13 * * *'
   labels:
@@ -10839,7 +11051,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -10859,13 +11071,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u2004, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k19-docker
   cron: '36 4 * * *'
   labels:
@@ -10890,7 +11103,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -10910,13 +11123,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k19-ko19-docker
   cron: '43 8 * * *'
   labels:
@@ -10941,7 +11155,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -10961,13 +11175,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u2004, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k20-docker
   cron: '2 10 * * *'
   labels:
@@ -10992,7 +11207,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=cilium --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -11012,13 +11227,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k17-docker
   cron: '56 15 * * 5'
   labels:
@@ -11043,7 +11259,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -11063,13 +11279,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k17-ko18-docker
   cron: '7 0 * * 3'
   labels:
@@ -11094,7 +11311,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -11114,13 +11331,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-amzn2, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k17-ko19-docker
   cron: '53 14 * * 5'
   labels:
@@ -11145,7 +11363,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -11165,13 +11383,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-amzn2, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k18-docker
   cron: '40 11 * * 5'
   labels:
@@ -11196,7 +11415,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -11216,13 +11435,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k18-ko18-docker
   cron: '26 5 * * 1'
   labels:
@@ -11247,7 +11467,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -11267,13 +11487,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-amzn2, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k18-ko19-docker
   cron: '0 3 * * 1'
   labels:
@@ -11298,7 +11519,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -11318,13 +11539,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-amzn2, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k19-docker
   cron: '6 13 * * 5'
   labels:
@@ -11349,7 +11571,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -11369,13 +11591,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k19-ko19-docker
   cron: '13 6 * * 2'
   labels:
@@ -11400,7 +11623,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -11420,13 +11643,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-amzn2, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k20-docker
   cron: '16 11 * * 3'
   labels:
@@ -11451,7 +11675,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -11471,13 +11695,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-k17-docker
   cron: '51 19 * * 3'
   labels:
@@ -11502,7 +11727,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -11522,13 +11747,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-k17-ko18-docker
   cron: '3 0 * * 0'
   labels:
@@ -11553,7 +11779,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -11573,13 +11799,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-deb9, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-k17-ko19-docker
   cron: '49 6 * * 3'
   labels:
@@ -11604,7 +11831,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -11624,13 +11851,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb9, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-k18-docker
   cron: '23 23 * * 2'
   labels:
@@ -11655,7 +11883,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -11675,13 +11903,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-k18-ko18-docker
   cron: '26 13 * * 6'
   labels:
@@ -11706,7 +11935,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -11726,13 +11955,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-deb9, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-k18-ko19-docker
   cron: '48 11 * * 0'
   labels:
@@ -11757,7 +11987,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -11777,13 +12007,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb9, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-k19-docker
   cron: '57 9 * * 3'
   labels:
@@ -11808,7 +12039,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -11828,13 +12059,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-k19-ko19-docker
   cron: '41 14 * * 4'
   labels:
@@ -11859,7 +12091,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -11879,13 +12111,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb9, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-k20-docker
   cron: '43 7 * * 3'
   labels:
@@ -11910,7 +12143,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -11930,13 +12163,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k17-docker
   cron: '36 15 * * 1'
   labels:
@@ -11961,7 +12195,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -11981,13 +12215,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k17-ko18-docker
   cron: '48 7 * * 6'
   labels:
@@ -12012,7 +12247,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -12032,13 +12267,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-deb10, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k17-ko19-docker
   cron: '54 17 * * 3'
   labels:
@@ -12063,7 +12299,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -12083,13 +12319,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb10, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k18-docker
   cron: '12 11 * * 4'
   labels:
@@ -12114,7 +12351,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -12134,13 +12371,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k18-ko18-docker
   cron: '21 18 * * 5'
   labels:
@@ -12165,7 +12403,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -12185,13 +12423,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-deb10, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k18-ko19-docker
   cron: '35 4 * * 3'
   labels:
@@ -12216,7 +12455,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -12236,13 +12475,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb10, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k19-docker
   cron: '14 5 * * 4'
   labels:
@@ -12267,7 +12507,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -12287,13 +12527,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k19-ko19-docker
   cron: '34 9 * * 5'
   labels:
@@ -12318,7 +12559,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -12338,13 +12579,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb10, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k20-docker
   cron: '52 3 * * 5'
   labels:
@@ -12369,7 +12611,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -12389,13 +12631,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k17-docker
   cron: '43 10 * * 0'
   labels:
@@ -12420,7 +12663,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -12440,13 +12683,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k17-ko18-docker
   cron: '43 7 * * 4'
   labels:
@@ -12471,7 +12715,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -12491,13 +12735,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-flatcar, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k17-ko19-docker
   cron: '1 9 * * 4'
   labels:
@@ -12522,7 +12767,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -12542,13 +12787,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-flatcar, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k18-docker
   cron: '31 14 * * 6'
   labels:
@@ -12573,7 +12819,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -12593,13 +12839,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k18-ko18-docker
   cron: '6 18 * * 3'
   labels:
@@ -12624,7 +12871,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -12644,13 +12891,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-flatcar, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k18-ko19-docker
   cron: '4 12 * * 3'
   labels:
@@ -12675,7 +12923,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -12695,13 +12943,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-flatcar, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k19-docker
   cron: '13 16 * * 6'
   labels:
@@ -12726,7 +12975,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -12746,13 +12995,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k19-ko19-docker
   cron: '29 9 * * 5'
   labels:
@@ -12777,7 +13027,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -12797,13 +13047,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-flatcar, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k20-docker
   cron: '39 22 * * 3'
   labels:
@@ -12828,7 +13079,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -12848,13 +13099,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-k17-docker
   cron: '42 9 * * 3'
   labels:
@@ -12879,7 +13131,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -12899,13 +13151,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-k17-ko18-docker
   cron: '12 11 * * 4'
   labels:
@@ -12930,7 +13183,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -12950,13 +13203,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-rhel7, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-k17-ko19-docker
   cron: '42 5 * * 1'
   labels:
@@ -12981,7 +13235,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -13001,13 +13255,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel7, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-k18-docker
   cron: '6 5 * * 4'
   labels:
@@ -13032,7 +13287,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -13052,13 +13307,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-k18-ko18-docker
   cron: '9 14 * * 4'
   labels:
@@ -13083,7 +13339,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -13103,13 +13359,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-rhel7, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-k18-ko19-docker
   cron: '31 8 * * 0'
   labels:
@@ -13134,7 +13391,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -13154,13 +13411,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel7, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-k19-docker
   cron: '16 11 * * 2'
   labels:
@@ -13185,7 +13443,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -13205,13 +13463,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-k19-ko19-docker
   cron: '30 21 * * 4'
   labels:
@@ -13236,7 +13495,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -13256,13 +13515,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel7, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-k20-docker
   cron: '38 13 * * 2'
   labels:
@@ -13287,7 +13547,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -13307,13 +13567,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k17-docker
   cron: '43 16 * * 4'
   labels:
@@ -13338,7 +13599,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -13358,13 +13619,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k17-ko18-docker
   cron: '25 14 * * 0'
   labels:
@@ -13389,7 +13651,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -13409,13 +13671,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-rhel8, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k17-ko19-docker
   cron: '7 0 * * 4'
   labels:
@@ -13440,7 +13703,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -13460,13 +13723,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel8, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k18-docker
   cron: '7 12 * * 1'
   labels:
@@ -13491,7 +13755,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -13511,13 +13775,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k18-ko18-docker
   cron: '16 19 * * 5'
   labels:
@@ -13542,7 +13807,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -13562,13 +13827,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-rhel8, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k18-ko19-docker
   cron: '14 13 * * 0'
   labels:
@@ -13593,7 +13859,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -13613,13 +13879,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel8, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k19-docker
   cron: '9 18 * * 6'
   labels:
@@ -13644,7 +13911,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -13664,13 +13931,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k19-ko19-docker
   cron: '3 8 * * 3'
   labels:
@@ -13695,7 +13963,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -13715,13 +13983,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel8, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k20-docker
   cron: '59 4 * * 4'
   labels:
@@ -13746,7 +14015,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -13766,13 +14035,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-k17-docker
   cron: '22 5 * * 6'
   labels:
@@ -13797,7 +14067,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -13817,13 +14087,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-k17-ko18-docker
   cron: '56 7 * * 1'
   labels:
@@ -13848,7 +14119,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -13868,13 +14139,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-u1804, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-k17-ko19-docker
   cron: '22 17 * * 5'
   labels:
@@ -13899,7 +14171,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -13919,13 +14191,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u1804, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-k18-docker
   cron: '2 9 * * 6'
   labels:
@@ -13950,7 +14223,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -13970,13 +14243,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-k18-ko18-docker
   cron: '25 2 * * 1'
   labels:
@@ -14001,7 +14275,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -14021,13 +14295,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-u1804, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-k18-ko19-docker
   cron: '7 20 * * 3'
   labels:
@@ -14052,7 +14327,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -14072,13 +14347,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u1804, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-k19-docker
   cron: '40 7 * * 4'
   labels:
@@ -14103,7 +14379,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -14123,13 +14399,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-k19-ko19-docker
   cron: '10 1 * * 2'
   labels:
@@ -14154,7 +14431,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -14174,13 +14451,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u1804, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-k20-docker
   cron: '34 17 * * 0'
   labels:
@@ -14205,7 +14483,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -14225,13 +14503,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k17-docker
   cron: '49 18 * * *'
   labels:
@@ -14256,7 +14535,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -14276,13 +14555,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k17-ko18-docker
   cron: '47 0 * * *'
   labels:
@@ -14307,7 +14587,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -14327,13 +14607,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-u2004, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k17-ko19-docker
   cron: '9 6 * * *'
   labels:
@@ -14358,7 +14639,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -14378,13 +14659,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u2004, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k18-docker
   cron: '37 22 * * *'
   labels:
@@ -14409,7 +14691,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -14429,13 +14711,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k18-ko18-docker
   cron: '30 5 * * *'
   labels:
@@ -14460,7 +14743,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -14480,13 +14763,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-u2004, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k18-ko19-docker
   cron: '40 19 * * *'
   labels:
@@ -14511,7 +14795,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -14531,13 +14815,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u2004, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k19-docker
   cron: '39 0 * * *'
   labels:
@@ -14562,7 +14847,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -14582,13 +14867,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k19-ko19-docker
   cron: '33 22 * * *'
   labels:
@@ -14613,7 +14899,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -14633,13 +14919,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u2004, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k20-docker
   cron: '1 14 * * *'
   labels:
@@ -14664,7 +14951,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=flannel --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -14684,13 +14971,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k17-docker
   cron: '45 1 * * 0'
   labels:
@@ -14715,7 +15003,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -14735,13 +15023,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k17-ko18-docker
   cron: '49 18 * * 3'
   labels:
@@ -14766,7 +15055,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -14786,13 +15075,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-amzn2, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k17-ko19-docker
   cron: '19 12 * * 6'
   labels:
@@ -14817,7 +15107,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -14837,13 +15127,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-amzn2, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k18-docker
   cron: '45 5 * * 2'
   labels:
@@ -14868,7 +15159,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -14888,13 +15179,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k18-ko18-docker
   cron: '8 7 * * 6'
   labels:
@@ -14919,7 +15211,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -14939,13 +15231,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-amzn2, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k18-ko19-docker
   cron: '58 1 * * 2'
   labels:
@@ -14970,7 +15263,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -14990,13 +15283,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-amzn2, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k19-docker
   cron: '31 19 * * 6'
   labels:
@@ -15021,7 +15315,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -15041,13 +15335,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k19-ko19-docker
   cron: '31 4 * * 3'
   labels:
@@ -15072,7 +15367,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -15092,13 +15387,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-amzn2, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k20-docker
   cron: '41 21 * * 0'
   labels:
@@ -15123,7 +15419,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -15143,13 +15439,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-k17-docker
   cron: '59 0 * * 2'
   labels:
@@ -15174,7 +15471,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -15194,13 +15491,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-k17-ko18-docker
   cron: '48 0 * * 6'
   labels:
@@ -15225,7 +15523,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -15245,13 +15543,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-deb9, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-k17-ko19-docker
   cron: '30 22 * * 4'
   labels:
@@ -15276,7 +15575,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -15296,13 +15595,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb9, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-k18-docker
   cron: '23 4 * * 3'
   labels:
@@ -15327,7 +15627,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -15347,13 +15647,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-k18-ko18-docker
   cron: '41 5 * * 1'
   labels:
@@ -15378,7 +15679,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -15398,13 +15699,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-deb9, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-k18-ko19-docker
   cron: '55 11 * * 5'
   labels:
@@ -15429,7 +15731,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -15449,13 +15751,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb9, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-k19-docker
   cron: '5 10 * * 5'
   labels:
@@ -15480,7 +15783,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -15500,13 +15803,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-k19-ko19-docker
   cron: '10 6 * * 6'
   labels:
@@ -15531,7 +15835,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -15551,13 +15855,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb9, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-k20-docker
   cron: '39 20 * * 6'
   labels:
@@ -15582,7 +15887,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -15602,13 +15907,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k17-docker
   cron: '9 17 * * 2'
   labels:
@@ -15633,7 +15939,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -15653,13 +15959,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k17-ko18-docker
   cron: '2 5 * * 5'
   labels:
@@ -15684,7 +15991,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -15704,13 +16011,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-deb10, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k17-ko19-docker
   cron: '40 3 * * 4'
   labels:
@@ -15735,7 +16043,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -15755,13 +16063,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb10, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k18-docker
   cron: '1 21 * * 4'
   labels:
@@ -15786,7 +16095,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -15806,13 +16115,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k18-ko18-docker
   cron: '19 16 * * 4'
   labels:
@@ -15837,7 +16147,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -15857,13 +16167,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-deb10, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k18-ko19-docker
   cron: '41 6 * * 2'
   labels:
@@ -15888,7 +16199,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -15908,13 +16219,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb10, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k19-docker
   cron: '55 3 * * 0'
   labels:
@@ -15939,7 +16251,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -15959,13 +16271,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k19-ko19-docker
   cron: '28 11 * * 5'
   labels:
@@ -15990,7 +16303,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -16010,13 +16323,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb10, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k20-docker
   cron: '57 5 * * 4'
   labels:
@@ -16041,7 +16355,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=136693071363/debian-10-amd64-20201207-477
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -16061,13 +16375,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k17-docker
   cron: '58 16 * * 2'
   labels:
@@ -16092,7 +16407,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -16112,13 +16427,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k17-ko18-docker
   cron: '10 18 * * 0'
   labels:
@@ -16143,7 +16459,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -16163,13 +16479,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-flatcar, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k17-ko19-docker
   cron: '48 20 * * 5'
   labels:
@@ -16194,7 +16511,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -16214,13 +16531,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-flatcar, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k18-docker
   cron: '6 20 * * 0'
   labels:
@@ -16245,7 +16563,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -16265,13 +16583,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k18-ko18-docker
   cron: '51 7 * * 0'
   labels:
@@ -16296,7 +16615,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -16316,13 +16635,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-flatcar, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k18-ko19-docker
   cron: '41 1 * * 4'
   labels:
@@ -16347,7 +16667,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -16367,13 +16687,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-flatcar, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k19-docker
   cron: '28 2 * * 5'
   labels:
@@ -16398,7 +16719,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -16418,13 +16739,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k19-ko19-docker
   cron: '12 4 * * 6'
   labels:
@@ -16449,7 +16771,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -16469,13 +16791,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-flatcar, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k20-docker
   cron: '38 4 * * 0'
   labels:
@@ -16500,7 +16823,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=075585003325/Flatcar-stable-2605.11.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -16520,13 +16843,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-k17-docker
   cron: '19 23 * * 1'
   labels:
@@ -16551,7 +16875,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -16571,13 +16895,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-k17-ko18-docker
   cron: '22 9 * * 4'
   labels:
@@ -16602,7 +16927,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -16622,13 +16947,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-rhel7, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-k17-ko19-docker
   cron: '28 7 * * 3'
   labels:
@@ -16653,7 +16979,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -16673,13 +16999,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel7, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-k18-docker
   cron: '15 3 * * 0'
   labels:
@@ -16704,7 +17031,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -16724,13 +17051,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-k18-ko18-docker
   cron: '47 12 * * 1'
   labels:
@@ -16755,7 +17083,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -16775,13 +17103,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-rhel7, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-k18-ko19-docker
   cron: '9 18 * * 1'
   labels:
@@ -16806,7 +17135,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -16826,13 +17155,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel7, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-k19-docker
   cron: '45 5 * * 5'
   labels:
@@ -16857,7 +17187,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -16877,13 +17207,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-k19-ko19-docker
   cron: '0 23 * * 2'
   labels:
@@ -16908,7 +17239,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -16928,13 +17259,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel7, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-k20-docker
   cron: '23 3 * * 3'
   labels:
@@ -16959,7 +17291,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -16979,13 +17311,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k17-docker
   cron: '6 6 * * 5'
   labels:
@@ -17010,7 +17343,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -17030,13 +17363,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k17-ko18-docker
   cron: '23 20 * * 3'
   labels:
@@ -17061,7 +17395,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -17081,13 +17415,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-rhel8, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k17-ko19-docker
   cron: '25 2 * * 6'
   labels:
@@ -17112,7 +17447,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -17132,13 +17467,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel8, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k18-docker
   cron: '18 2 * * 1'
   labels:
@@ -17163,7 +17499,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -17183,13 +17519,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k18-ko18-docker
   cron: '54 1 * * 0'
   labels:
@@ -17214,7 +17551,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -17234,13 +17571,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-rhel8, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k18-ko19-docker
   cron: '48 15 * * 6'
   labels:
@@ -17265,7 +17603,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -17285,13 +17623,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel8, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k19-docker
   cron: '28 12 * * 6'
   labels:
@@ -17316,7 +17655,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -17336,13 +17675,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k19-ko19-docker
   cron: '41 10 * * 0'
   labels:
@@ -17367,7 +17707,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -17387,13 +17727,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel8, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k20-docker
   cron: '26 2 * * 1'
   labels:
@@ -17418,7 +17759,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -17438,13 +17779,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-k17-docker
   cron: '51 19 * * 0'
   labels:
@@ -17469,7 +17811,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -17489,13 +17831,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-k17-ko18-docker
   cron: '18 5 * * 6'
   labels:
@@ -17520,7 +17863,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -17540,13 +17883,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-u1804, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-k17-ko19-docker
   cron: '28 3 * * 1'
   labels:
@@ -17571,7 +17915,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -17591,13 +17935,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u1804, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-k18-docker
   cron: '31 7 * * 4'
   labels:
@@ -17622,7 +17967,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -17642,13 +17987,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-k18-ko18-docker
   cron: '39 8 * * 6'
   labels:
@@ -17673,7 +18019,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -17693,13 +18039,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-u1804, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-k18-ko19-docker
   cron: '41 14 * * 4'
   labels:
@@ -17724,7 +18071,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -17744,13 +18091,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u1804, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-k19-docker
   cron: '33 1 * * 3'
   labels:
@@ -17775,7 +18123,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -17795,13 +18143,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-k19-ko19-docker
   cron: '20 19 * * 2'
   labels:
@@ -17826,7 +18175,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -17846,13 +18195,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u1804, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-k20-docker
   cron: '55 15 * * 0'
   labels:
@@ -17877,7 +18227,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -17897,13 +18247,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k17-docker
   cron: '8 20 * * *'
   labels:
@@ -17928,7 +18279,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -17948,13 +18299,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.17, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k17-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.18", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k17-ko18-docker
   cron: '25 18 * * *'
   labels:
@@ -17979,7 +18331,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -17999,13 +18351,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-u2004, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k17-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k17-ko19-docker
   cron: '11 4 * * *'
   labels:
@@ -18030,7 +18383,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.17
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -18050,13 +18403,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u2004, kops-grid, kops-k8s-1.17, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k17-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k18-docker
   cron: '12 16 * * *'
   labels:
@@ -18081,7 +18435,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -18101,13 +18455,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.18, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.18", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k18-ko18-docker
   cron: '20 15 * * *'
   labels:
@@ -18132,7 +18487,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
@@ -18152,13 +18507,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.18'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.18, kops-distro-u2004, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k18-ko18-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k18-ko19-docker
   cron: '26 1 * * *'
   labels:
@@ -18183,7 +18539,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.18
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -18203,13 +18559,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u2004, kops-grid, kops-k8s-1.18, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k18-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k19-docker
   cron: '22 22 * * *'
   labels:
@@ -18234,7 +18591,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -18254,13 +18611,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.19, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k19-ko19-docker
   cron: '19 4 * * *'
   labels:
@@ -18285,7 +18643,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt
@@ -18305,13 +18663,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u2004, kops-grid, kops-k8s-1.19, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k19-ko19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k20-docker
   cron: '44 16 * * *'
   labels:
@@ -18336,7 +18695,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=25
-      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=kopeio --container-runtime=docker
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -18356,13 +18715,14 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k20-docker
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-amzn2-k17-containerd
   cron: '30 23 * * 2'
   labels:
@@ -18418,13 +18778,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-amzn2-k17-ko19-containerd
   cron: '6 12 * * 2'
   labels:
@@ -18480,13 +18841,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-amzn2, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-amzn2-k18-containerd
   cron: '27 22 * * 4'
   labels:
@@ -18542,13 +18904,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-amzn2-k18-ko19-containerd
   cron: '43 17 * * 5'
   labels:
@@ -18604,13 +18967,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-amzn2, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-amzn2-k19-containerd
   cron: '48 17 * * 2'
   labels:
@@ -18666,13 +19030,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-amzn2-k19-ko19-containerd
   cron: '48 18 * * 0'
   labels:
@@ -18728,13 +19093,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-amzn2, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-amzn2-k20-containerd
   cron: '39 14 * * 6'
   labels:
@@ -18790,13 +19156,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-deb9-k17-containerd
   cron: '45 5 * * 1'
   labels:
@@ -18852,13 +19219,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-deb9-k17-ko19-containerd
   cron: '52 11 * * 1'
   labels:
@@ -18914,13 +19282,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb9, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-deb9-k18-containerd
   cron: '40 4 * * 4'
   labels:
@@ -18976,13 +19345,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-deb9-k18-ko19-containerd
   cron: '45 14 * * 2'
   labels:
@@ -19038,13 +19408,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb9, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-deb9-k19-containerd
   cron: '3 3 * * 5'
   labels:
@@ -19100,13 +19471,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-deb9-k19-ko19-containerd
   cron: '54 13 * * 5'
   labels:
@@ -19162,13 +19534,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb9, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-deb9-k20-containerd
   cron: '52 12 * * 4'
   labels:
@@ -19224,13 +19597,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-deb10-k17-containerd
   cron: '39 6 * * 2'
   labels:
@@ -19286,13 +19660,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-deb10-k17-ko19-containerd
   cron: '12 22 * * 1'
   labels:
@@ -19348,13 +19723,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb10, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-deb10-k18-containerd
   cron: '38 7 * * 3'
   labels:
@@ -19410,13 +19786,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-deb10-k18-ko19-containerd
   cron: '49 3 * * 2'
   labels:
@@ -19472,13 +19849,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb10, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-deb10-k19-containerd
   cron: '29 0 * * 4'
   labels:
@@ -19534,13 +19912,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-deb10-k19-ko19-containerd
   cron: '6 16 * * 0'
   labels:
@@ -19596,13 +19975,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb10, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-deb10-k20-containerd
   cron: '34 15 * * 1'
   labels:
@@ -19658,13 +20038,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-flatcar-k17-containerd
   cron: '31 20 * * 2'
   labels:
@@ -19720,13 +20101,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-flatcar-k17-ko19-containerd
   cron: '3 19 * * 4'
   labels:
@@ -19782,13 +20164,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-flatcar, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-flatcar-k18-containerd
   cron: '14 5 * * 5'
   labels:
@@ -19844,13 +20227,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-flatcar-k18-ko19-containerd
   cron: '58 14 * * 5'
   labels:
@@ -19906,13 +20290,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-flatcar, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-flatcar-k19-containerd
   cron: '1 10 * * 0'
   labels:
@@ -19968,13 +20353,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-flatcar-k19-ko19-containerd
   cron: '13 5 * * 6'
   labels:
@@ -20030,13 +20416,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-flatcar, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-flatcar-k20-containerd
   cron: '2 21 * * 4'
   labels:
@@ -20092,13 +20479,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-rhel7-k17-containerd
   cron: '38 19 * * 0'
   labels:
@@ -20154,13 +20542,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-rhel7-k17-ko19-containerd
   cron: '30 8 * * 2'
   labels:
@@ -20216,13 +20605,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel7, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-rhel7-k18-containerd
   cron: '7 10 * * 4'
   labels:
@@ -20278,13 +20668,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-rhel7-k18-ko19-containerd
   cron: '43 21 * * 2'
   labels:
@@ -20340,13 +20731,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel7, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-rhel7-k19-containerd
   cron: '48 21 * * 6'
   labels:
@@ -20402,13 +20794,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-rhel7-k19-ko19-containerd
   cron: '28 14 * * 4'
   labels:
@@ -20464,13 +20857,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel7, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-rhel7-k20-containerd
   cron: '11 10 * * 4'
   labels:
@@ -20526,13 +20920,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-rhel8-k17-containerd
   cron: '12 1 * * 4'
   labels:
@@ -20588,13 +20983,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-rhel8-k17-ko19-containerd
   cron: '44 6 * * 1'
   labels:
@@ -20650,13 +21046,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel8, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-rhel8-k18-containerd
   cron: '25 0 * * 0'
   labels:
@@ -20712,13 +21109,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-rhel8-k18-ko19-containerd
   cron: '45 11 * * 5'
   labels:
@@ -20774,13 +21172,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel8, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-rhel8-k19-containerd
   cron: '22 15 * * 0'
   labels:
@@ -20836,13 +21235,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-rhel8-k19-ko19-containerd
   cron: '22 0 * * 6'
   labels:
@@ -20898,13 +21298,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel8, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-rhel8-k20-containerd
   cron: '13 0 * * 0'
   labels:
@@ -20960,13 +21361,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-u1804-k17-containerd
   cron: '11 6 * * 3'
   labels:
@@ -21022,13 +21424,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u1804-k17-ko19-containerd
   cron: '39 9 * * 4'
   labels:
@@ -21084,13 +21487,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u1804, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-u1804-k18-containerd
   cron: '14 23 * * 6'
   labels:
@@ -21146,13 +21550,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u1804-k18-ko19-containerd
   cron: '22 12 * * 3'
   labels:
@@ -21208,13 +21613,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u1804, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-u1804-k19-containerd
   cron: '37 16 * * 3'
   labels:
@@ -21270,13 +21676,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u1804-k19-ko19-containerd
   cron: '57 15 * * 2'
   labels:
@@ -21332,13 +21739,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u1804, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-u1804-k20-containerd
   cron: '30 7 * * 0'
   labels:
@@ -21394,13 +21802,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-u2004-k17-containerd
   cron: '14 19 * * *'
   labels:
@@ -21456,13 +21865,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u2004-k17-ko19-containerd
   cron: '29 23 * * *'
   labels:
@@ -21518,13 +21928,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u2004, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-u2004-k18-containerd
   cron: '23 10 * * *'
   labels:
@@ -21580,13 +21991,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u2004-k18-ko19-containerd
   cron: '8 2 * * *'
   labels:
@@ -21642,13 +22054,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u2004, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-u2004-k19-containerd
   cron: '24 21 * * *'
   labels:
@@ -21704,13 +22117,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u2004-k19-ko19-containerd
   cron: '3 9 * * *'
   labels:
@@ -21766,13 +22180,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u2004, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-u2004-k20-containerd
   cron: '55 18 * * *'
   labels:
@@ -21828,13 +22243,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k17-containerd
   cron: '34 10 * * 6'
   labels:
@@ -21890,13 +22306,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k17-ko19-containerd
   cron: '19 9 * * 3'
   labels:
@@ -21952,13 +22369,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-amzn2, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k18-containerd
   cron: '27 19 * * 4'
   labels:
@@ -22014,13 +22432,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k18-ko19-containerd
   cron: '26 12 * * 2'
   labels:
@@ -22076,13 +22495,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-amzn2, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k19-containerd
   cron: '32 20 * * 2'
   labels:
@@ -22138,13 +22558,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k19-ko19-containerd
   cron: '53 23 * * 6'
   labels:
@@ -22200,13 +22621,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-amzn2, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k20-containerd
   cron: '51 3 * * 4'
   labels:
@@ -22262,13 +22684,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-k17-containerd
   cron: '41 8 * * 5'
   labels:
@@ -22324,13 +22747,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-k17-ko19-containerd
   cron: '2 14 * * 6'
   labels:
@@ -22386,13 +22810,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb9, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-k18-containerd
   cron: '16 17 * * 5'
   labels:
@@ -22448,13 +22873,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-k18-ko19-containerd
   cron: '7 11 * * 1'
   labels:
@@ -22510,13 +22936,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb9, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-k19-containerd
   cron: '35 14 * * 3'
   labels:
@@ -22572,13 +22999,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-k19-ko19-containerd
   cron: '8 0 * * 6'
   labels:
@@ -22634,13 +23062,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb9, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-k20-containerd
   cron: '44 9 * * 5'
   labels:
@@ -22696,13 +23125,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k17-containerd
   cron: '23 11 * * 2'
   labels:
@@ -22758,13 +23188,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k17-ko19-containerd
   cron: '1 3 * * 0'
   labels:
@@ -22820,13 +23251,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb10, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k18-containerd
   cron: '10 10 * * 0'
   labels:
@@ -22882,13 +23314,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k18-ko19-containerd
   cron: '56 14 * * 2'
   labels:
@@ -22944,13 +23377,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb10, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k19-containerd
   cron: '5 21 * * 5'
   labels:
@@ -23006,13 +23440,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k19-ko19-containerd
   cron: '35 21 * * 3'
   labels:
@@ -23068,13 +23503,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb10, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k20-containerd
   cron: '6 10 * * 1'
   labels:
@@ -23130,13 +23566,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k17-containerd
   cron: '40 3 * * 3'
   labels:
@@ -23192,13 +23629,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k17-ko19-containerd
   cron: '48 1 * * 5'
   labels:
@@ -23254,13 +23692,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-flatcar, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k18-containerd
   cron: '29 18 * * 6'
   labels:
@@ -23316,13 +23755,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k18-ko19-containerd
   cron: '37 12 * * 0'
   labels:
@@ -23378,13 +23818,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-flatcar, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k19-containerd
   cron: '18 13 * * 2'
   labels:
@@ -23440,13 +23881,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k19-ko19-containerd
   cron: '22 15 * * 3'
   labels:
@@ -23502,13 +23944,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-flatcar, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k20-containerd
   cron: '21 2 * * 1'
   labels:
@@ -23564,13 +24007,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-k17-containerd
   cron: '30 6 * * 2'
   labels:
@@ -23626,13 +24070,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-k17-ko19-containerd
   cron: '27 21 * * 2'
   labels:
@@ -23688,13 +24133,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel7, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-k18-containerd
   cron: '11 23 * * 5'
   labels:
@@ -23750,13 +24196,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-k18-ko19-containerd
   cron: '50 0 * * 6'
   labels:
@@ -23812,13 +24259,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel7, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-k19-containerd
   cron: '4 16 * * 6'
   labels:
@@ -23874,13 +24322,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-k19-ko19-containerd
   cron: '37 3 * * 5'
   labels:
@@ -23936,13 +24385,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel7, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-k20-containerd
   cron: '59 23 * * 3'
   labels:
@@ -23998,13 +24448,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k17-containerd
   cron: '0 12 * * 2'
   labels:
@@ -24060,13 +24511,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k17-ko19-containerd
   cron: '29 19 * * 2'
   labels:
@@ -24122,13 +24574,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel8, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k18-containerd
   cron: '21 13 * * 4'
   labels:
@@ -24184,13 +24637,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k18-ko19-containerd
   cron: '24 22 * * 4'
   labels:
@@ -24246,13 +24700,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel8, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k19-containerd
   cron: '6 10 * * 0'
   labels:
@@ -24308,13 +24763,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k19-ko19-containerd
   cron: '51 5 * * 3'
   labels:
@@ -24370,13 +24826,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel8, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k20-containerd
   cron: '9 21 * * 4'
   labels:
@@ -24432,13 +24889,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-k17-containerd
   cron: '19 19 * * 5'
   labels:
@@ -24494,13 +24952,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-k17-ko19-containerd
   cron: '38 12 * * 3'
   labels:
@@ -24556,13 +25015,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u1804, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-k18-containerd
   cron: '18 18 * * 2'
   labels:
@@ -24618,13 +25078,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-k18-ko19-containerd
   cron: '23 17 * * 6'
   labels:
@@ -24680,13 +25141,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u1804, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-k19-containerd
   cron: '13 13 * * 2'
   labels:
@@ -24742,13 +25204,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-k19-ko19-containerd
   cron: '56 18 * * 0'
   labels:
@@ -24804,13 +25267,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u1804, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-k20-containerd
   cron: '18 18 * * 6'
   labels:
@@ -24866,13 +25330,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k17-containerd
   cron: '50 22 * * *'
   labels:
@@ -24928,13 +25393,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k17-ko19-containerd
   cron: '16 18 * * *'
   labels:
@@ -24990,13 +25456,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u2004, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k18-containerd
   cron: '15 7 * * *'
   labels:
@@ -25052,13 +25519,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k18-ko19-containerd
   cron: '5 7 * * *'
   labels:
@@ -25114,13 +25582,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u2004, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k19-containerd
   cron: '12 16 * * *'
   labels:
@@ -25176,13 +25645,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k19-ko19-containerd
   cron: '14 20 * * *'
   labels:
@@ -25238,13 +25708,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u2004, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k20-containerd
   cron: '39 23 * * *'
   labels:
@@ -25300,13 +25771,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k17-containerd
   cron: '40 16 * * 5'
   labels:
@@ -25362,13 +25834,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k17-ko19-containerd
   cron: '3 5 * * 6'
   labels:
@@ -25424,13 +25897,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-amzn2, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k18-containerd
   cron: '17 1 * * 1'
   labels:
@@ -25486,13 +25960,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k18-ko19-containerd
   cron: '22 8 * * 6'
   labels:
@@ -25548,13 +26023,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-amzn2, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k19-containerd
   cron: '10 14 * * 1'
   labels:
@@ -25610,13 +26086,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k19-ko19-containerd
   cron: '17 11 * * 5'
   labels:
@@ -25672,13 +26149,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-amzn2, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k20-containerd
   cron: '37 1 * * 5'
   labels:
@@ -25734,13 +26212,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb9-k17-containerd
   cron: '58 11 * * 1'
   labels:
@@ -25796,13 +26275,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb9-k17-ko19-containerd
   cron: '34 18 * * 5'
   labels:
@@ -25858,13 +26338,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb9, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb9-k18-containerd
   cron: '55 10 * * 2'
   labels:
@@ -25920,13 +26401,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb9-k18-ko19-containerd
   cron: '51 23 * * 3'
   labels:
@@ -25982,13 +26464,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb9, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb9-k19-containerd
   cron: '12 21 * * 1'
   labels:
@@ -26044,13 +26527,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb9-k19-ko19-containerd
   cron: '52 12 * * 4'
   labels:
@@ -26106,13 +26590,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb9, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb9-k20-containerd
   cron: '27 18 * * 6'
   labels:
@@ -26168,13 +26653,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb9-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k17-containerd
   cron: '1 17 * * 6'
   labels:
@@ -26230,13 +26716,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k17-ko19-containerd
   cron: '33 15 * * 6'
   labels:
@@ -26292,13 +26779,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb10, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k18-containerd
   cron: '12 0 * * 5'
   labels:
@@ -26354,13 +26842,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k18-ko19-containerd
   cron: '24 10 * * 6'
   labels:
@@ -26416,13 +26905,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb10, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k19-containerd
   cron: '19 23 * * 6'
   labels:
@@ -26478,13 +26968,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k19-ko19-containerd
   cron: '59 17 * * 1'
   labels:
@@ -26540,13 +27031,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb10, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k20-containerd
   cron: '40 0 * * 1'
   labels:
@@ -26602,13 +27094,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar-k17-containerd
   cron: '23 4 * * 0'
   labels:
@@ -26664,13 +27157,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar-k17-ko19-containerd
   cron: '47 18 * * 3'
   labels:
@@ -26726,13 +27220,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-flatcar, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar-k18-containerd
   cron: '50 21 * * 2'
   labels:
@@ -26788,13 +27283,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar-k18-ko19-containerd
   cron: '6 15 * * 3'
   labels:
@@ -26850,13 +27346,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-flatcar, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar-k19-containerd
   cron: '49 2 * * 1'
   labels:
@@ -26912,13 +27409,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar-k19-ko19-containerd
   cron: '41 4 * * 1'
   labels:
@@ -26974,13 +27472,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-flatcar, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar-k20-containerd
   cron: '10 21 * * 3'
   labels:
@@ -27036,13 +27535,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel7-k17-containerd
   cron: '40 12 * * 6'
   labels:
@@ -27098,13 +27598,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel7-k17-ko19-containerd
   cron: '11 1 * * 5'
   labels:
@@ -27160,13 +27661,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel7, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel7-k18-containerd
   cron: '1 5 * * 5'
   labels:
@@ -27222,13 +27724,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel7-k18-ko19-containerd
   cron: '34 4 * * 6'
   labels:
@@ -27284,13 +27787,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel7, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel7-k19-containerd
   cron: '46 10 * * 3'
   labels:
@@ -27346,13 +27850,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel7-k19-ko19-containerd
   cron: '57 15 * * 5'
   labels:
@@ -27408,13 +27913,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel7, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel7-k20-containerd
   cron: '1 5 * * 6'
   labels:
@@ -27470,13 +27976,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel7-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k17-containerd
   cron: '54 6 * * 5'
   labels:
@@ -27532,13 +28039,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k17-ko19-containerd
   cron: '9 23 * * 5'
   labels:
@@ -27594,13 +28102,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel8, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k18-containerd
   cron: '35 7 * * 0'
   labels:
@@ -27656,13 +28165,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k18-ko19-containerd
   cron: '44 18 * * 5'
   labels:
@@ -27718,13 +28228,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel8, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k19-containerd
   cron: '24 0 * * 4'
   labels:
@@ -27780,13 +28291,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k19-ko19-containerd
   cron: '35 17 * * 3'
   labels:
@@ -27842,13 +28354,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel8, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k20-containerd
   cron: '7 7 * * 4'
   labels:
@@ -27904,13 +28417,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1804-k17-containerd
   cron: '41 9 * * 6'
   labels:
@@ -27966,13 +28480,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1804-k17-ko19-containerd
   cron: '50 8 * * 6'
   labels:
@@ -28028,13 +28543,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u1804, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1804-k18-containerd
   cron: '24 16 * * 0'
   labels:
@@ -28090,13 +28606,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1804-k18-ko19-containerd
   cron: '47 5 * * 6'
   labels:
@@ -28152,13 +28669,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u1804, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1804-k19-containerd
   cron: '39 15 * * 1'
   labels:
@@ -28214,13 +28732,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1804-k19-ko19-containerd
   cron: '52 6 * * 3'
   labels:
@@ -28276,13 +28795,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u1804, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1804-k20-containerd
   cron: '0 16 * * 5'
   labels:
@@ -28338,13 +28858,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u1804-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k17-containerd
   cron: '52 12 * * *'
   labels:
@@ -28400,13 +28921,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k17-ko19-containerd
   cron: '4 22 * * *'
   labels:
@@ -28462,13 +28984,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u2004, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k18-containerd
   cron: '57 21 * * *'
   labels:
@@ -28524,13 +29047,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k18-ko19-containerd
   cron: '33 19 * * *'
   labels:
@@ -28586,13 +29110,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u2004, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k19-containerd
   cron: '46 18 * * *'
   labels:
@@ -28648,13 +29173,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k19-ko19-containerd
   cron: '54 0 * * *'
   labels:
@@ -28710,13 +29236,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u2004, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k20-containerd
   cron: '33 13 * * *'
   labels:
@@ -28772,13 +29299,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k17-containerd
   cron: '2 1 * * 3'
   labels:
@@ -28834,13 +29362,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k17-ko19-containerd
   cron: '4 2 * * 6'
   labels:
@@ -28896,13 +29425,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-amzn2, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k18-containerd
   cron: '59 8 * * 2'
   labels:
@@ -28958,13 +29488,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k18-ko19-containerd
   cron: '25 23 * * 4'
   labels:
@@ -29020,13 +29551,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-amzn2, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k19-containerd
   cron: '44 23 * * 0'
   labels:
@@ -29082,13 +29614,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k19-ko19-containerd
   cron: '46 20 * * 5'
   labels:
@@ -29144,13 +29677,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-amzn2, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k20-containerd
   cron: '35 8 * * 5'
   labels:
@@ -29206,13 +29740,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-k17-containerd
   cron: '52 12 * * 5'
   labels:
@@ -29268,13 +29803,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-k17-ko19-containerd
   cron: '58 8 * * 2'
   labels:
@@ -29330,13 +29866,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb9, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-k18-containerd
   cron: '45 5 * * 0'
   labels:
@@ -29392,13 +29929,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-k18-ko19-containerd
   cron: '39 13 * * 2'
   labels:
@@ -29454,13 +29992,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb9, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-k19-containerd
   cron: '10 10 * * 4'
   labels:
@@ -29516,13 +30055,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-k19-ko19-containerd
   cron: '44 14 * * 5'
   labels:
@@ -29578,13 +30118,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb9, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-k20-containerd
   cron: '53 21 * * 6'
   labels:
@@ -29640,13 +30181,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k17-containerd
   cron: '11 16 * * 5'
   labels:
@@ -29702,13 +30244,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k17-ko19-containerd
   cron: '50 8 * * 6'
   labels:
@@ -29764,13 +30307,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb10, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k18-containerd
   cron: '18 9 * * 1'
   labels:
@@ -29826,13 +30370,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k18-ko19-containerd
   cron: '11 13 * * 6'
   labels:
@@ -29888,13 +30433,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb10, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k19-containerd
   cron: '5 14 * * 5'
   labels:
@@ -29950,13 +30496,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k19-ko19-containerd
   cron: '20 14 * * 3'
   labels:
@@ -30012,13 +30559,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb10, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k20-containerd
   cron: '58 9 * * 5'
   labels:
@@ -30074,13 +30622,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k17-containerd
   cron: '55 3 * * 5'
   labels:
@@ -30136,13 +30685,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k17-ko19-containerd
   cron: '38 11 * * 6'
   labels:
@@ -30198,13 +30748,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-flatcar, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k18-containerd
   cron: '50 2 * * 1'
   labels:
@@ -30260,13 +30811,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k18-ko19-containerd
   cron: '19 14 * * 4'
   labels:
@@ -30322,13 +30874,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-flatcar, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k19-containerd
   cron: '21 21 * * 3'
   labels:
@@ -30384,13 +30937,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k19-ko19-containerd
   cron: '52 21 * * 2'
   labels:
@@ -30446,13 +31000,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-flatcar, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k20-containerd
   cron: '2 18 * * 5'
   labels:
@@ -30508,13 +31063,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-k17-containerd
   cron: '26 13 * * 4'
   labels:
@@ -30570,13 +31126,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-k17-ko19-containerd
   cron: '4 22 * * 6'
   labels:
@@ -30632,13 +31189,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel7, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-k18-containerd
   cron: '55 20 * * 4'
   labels:
@@ -30694,13 +31252,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-k18-ko19-containerd
   cron: '45 3 * * 6'
   labels:
@@ -30756,13 +31315,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel7, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-k19-containerd
   cron: '32 11 * * 4'
   labels:
@@ -30818,13 +31378,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-k19-ko19-containerd
   cron: '58 16 * * 0'
   labels:
@@ -30880,13 +31441,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel7, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-k20-containerd
   cron: '35 20 * * 4'
   labels:
@@ -30942,13 +31504,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k17-containerd
   cron: '4 23 * * 2'
   labels:
@@ -31004,13 +31567,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k17-ko19-containerd
   cron: '58 8 * * 0'
   labels:
@@ -31066,13 +31630,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel8, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k18-containerd
   cron: '29 14 * * 4'
   labels:
@@ -31128,13 +31693,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k18-ko19-containerd
   cron: '3 5 * * 2'
   labels:
@@ -31190,13 +31756,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel8, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k19-containerd
   cron: '46 9 * * 3'
   labels:
@@ -31252,13 +31819,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k19-ko19-containerd
   cron: '8 6 * * 1'
   labels:
@@ -31314,13 +31882,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel8, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k20-containerd
   cron: '41 6 * * 3'
   labels:
@@ -31376,13 +31945,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-k17-containerd
   cron: '59 0 * * 5'
   labels:
@@ -31438,13 +32008,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-k17-ko19-containerd
   cron: '33 23 * * 1'
   labels:
@@ -31500,13 +32071,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u1804, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-k18-containerd
   cron: '30 17 * * 1'
   labels:
@@ -31562,13 +32134,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-k18-ko19-containerd
   cron: '40 2 * * 3'
   labels:
@@ -31624,13 +32197,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u1804, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-k19-containerd
   cron: '17 14 * * 1'
   labels:
@@ -31686,13 +32260,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-k19-ko19-containerd
   cron: '11 1 * * 2'
   labels:
@@ -31748,13 +32323,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u1804, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-k20-containerd
   cron: '26 17 * * 6'
   labels:
@@ -31810,13 +32386,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k17-containerd
   cron: '6 21 * * *'
   labels:
@@ -31872,13 +32449,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k17-ko19-containerd
   cron: '23 17 * * *'
   labels:
@@ -31934,13 +32512,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u2004, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k18-containerd
   cron: '51 12 * * *'
   labels:
@@ -31996,13 +32575,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k18-ko19-containerd
   cron: '58 20 * * *'
   labels:
@@ -32058,13 +32638,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u2004, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k19-containerd
   cron: '8 3 * * *'
   labels:
@@ -32120,13 +32701,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k19-ko19-containerd
   cron: '29 23 * * *'
   labels:
@@ -32182,13 +32764,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u2004, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k20-containerd
   cron: '55 12 * * *'
   labels:
@@ -32244,13 +32827,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k17-containerd
   cron: '29 17 * * 0'
   labels:
@@ -32306,13 +32890,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k17-ko19-containerd
   cron: '3 1 * * 0'
   labels:
@@ -32368,13 +32953,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-amzn2, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k18-containerd
   cron: '56 0 * * 1'
   labels:
@@ -32430,13 +33016,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k18-ko19-containerd
   cron: '58 12 * * 0'
   labels:
@@ -32492,13 +33079,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-amzn2, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k19-containerd
   cron: '31 15 * * 6'
   labels:
@@ -32554,13 +33142,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k19-ko19-containerd
   cron: '25 15 * * 0'
   labels:
@@ -32616,13 +33205,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-amzn2, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k20-containerd
   cron: '48 0 * * 2'
   labels:
@@ -32678,13 +33268,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-k17-containerd
   cron: '5 4 * * 3'
   labels:
@@ -32740,13 +33331,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-k17-ko19-containerd
   cron: '41 21 * * 2'
   labels:
@@ -32802,13 +33394,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb9, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-k18-containerd
   cron: '28 13 * * 3'
   labels:
@@ -32864,13 +33457,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-k18-ko19-containerd
   cron: '40 0 * * 1'
   labels:
@@ -32926,13 +33520,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb9, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-k19-containerd
   cron: '51 2 * * 6'
   labels:
@@ -32988,13 +33583,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-k19-ko19-containerd
   cron: '59 3 * * 2'
   labels:
@@ -33050,13 +33646,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb9, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-k20-containerd
   cron: '28 5 * * 6'
   labels:
@@ -33112,13 +33709,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k17-containerd
   cron: '56 0 * * 5'
   labels:
@@ -33174,13 +33772,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k17-ko19-containerd
   cron: '57 11 * * 2'
   labels:
@@ -33236,13 +33835,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb10, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k18-containerd
   cron: '25 9 * * 5'
   labels:
@@ -33298,13 +33898,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k18-ko19-containerd
   cron: '4 14 * * 3'
   labels:
@@ -33360,13 +33961,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb10, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k19-containerd
   cron: '2 6 * * 3'
   labels:
@@ -33422,13 +34024,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k19-ko19-containerd
   cron: '11 21 * * 6'
   labels:
@@ -33484,13 +34087,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-deb10, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k20-containerd
   cron: '29 17 * * 2'
   labels:
@@ -33546,13 +34150,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k17-containerd
   cron: '34 5 * * 5'
   labels:
@@ -33608,13 +34213,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k17-ko19-containerd
   cron: '16 17 * * 0'
   labels:
@@ -33670,13 +34276,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-flatcar, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k18-containerd
   cron: '19 4 * * 3'
   labels:
@@ -33732,13 +34339,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k18-ko19-containerd
   cron: '41 4 * * 5'
   labels:
@@ -33794,13 +34402,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-flatcar, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k19-containerd
   cron: '8 11 * * 0'
   labels:
@@ -33856,13 +34465,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k19-ko19-containerd
   cron: '22 7 * * 5'
   labels:
@@ -33918,13 +34528,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-flatcar, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k20-containerd
   cron: '15 12 * * 6'
   labels:
@@ -33980,13 +34591,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-k17-containerd
   cron: '49 13 * * 3'
   labels:
@@ -34042,13 +34654,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-k17-ko19-containerd
   cron: '3 5 * * 5'
   labels:
@@ -34104,13 +34717,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel7, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-k18-containerd
   cron: '52 20 * * 6'
   labels:
@@ -34166,13 +34780,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-k18-ko19-containerd
   cron: '50 0 * * 6'
   labels:
@@ -34228,13 +34843,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel7, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-k19-containerd
   cron: '23 19 * * 3'
   labels:
@@ -34290,13 +34906,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-k19-ko19-containerd
   cron: '13 19 * * 1'
   labels:
@@ -34352,13 +34969,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel7, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-k20-containerd
   cron: '56 20 * * 0'
   labels:
@@ -34414,13 +35032,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-rhel7, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k17-containerd
   cron: '47 23 * * 2'
   labels:
@@ -34476,13 +35095,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k17-ko19-containerd
   cron: '29 19 * * 5'
   labels:
@@ -34538,13 +35158,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel8, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k18-containerd
   cron: '10 22 * * 5'
   labels:
@@ -34600,13 +35221,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k18-ko19-containerd
   cron: '0 6 * * 6'
   labels:
@@ -34662,13 +35284,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel8, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k19-containerd
   cron: '49 1 * * 0'
   labels:
@@ -34724,13 +35347,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k19-ko19-containerd
   cron: '19 5 * * 3'
   labels:
@@ -34786,13 +35410,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-rhel8, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k20-containerd
   cron: '18 6 * * 6'
   labels:
@@ -34848,13 +35473,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-k17-containerd
   cron: '52 16 * * 4'
   labels:
@@ -34910,13 +35536,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-k17-ko19-containerd
   cron: '10 4 * * 3'
   labels:
@@ -34972,13 +35599,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u1804, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-k18-containerd
   cron: '21 1 * * 5'
   labels:
@@ -35034,13 +35662,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-k18-ko19-containerd
   cron: '7 17 * * 6'
   labels:
@@ -35096,13 +35725,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u1804, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-k19-containerd
   cron: '18 6 * * 2'
   labels:
@@ -35158,13 +35788,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-k19-ko19-containerd
   cron: '12 10 * * 0'
   labels:
@@ -35220,13 +35851,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u1804, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-k20-containerd
   cron: '49 1 * * 1'
   labels:
@@ -35282,13 +35914,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k17-containerd
   cron: '57 13 * * *'
   labels:
@@ -35344,13 +35977,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.17, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k17-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k17-ko19-containerd
   cron: '40 2 * * *'
   labels:
@@ -35406,13 +36040,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u2004, kops-grid, kops-k8s-1.17, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k17-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k18-containerd
   cron: '8 20 * * *'
   labels:
@@ -35468,13 +36103,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.18, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k18-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k18-ko19-containerd
   cron: '5 15 * * *'
   labels:
@@ -35530,13 +36166,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u2004, kops-grid, kops-k8s-1.18, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k18-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k19-containerd
   cron: '43 11 * * *'
   labels:
@@ -35592,13 +36229,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k19-ko19-containerd
   cron: '26 4 * * *'
   labels:
@@ -35654,13 +36292,14 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.19'
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-1.19, kops-distro-u2004, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k20-containerd
   cron: '40 20 * * *'
   labels:
@@ -35716,6 +36355,7 @@ periodics:
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -2,7 +2,7 @@
 # 4 jobs, total of 28 runs per week
 periodics:
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--node-size=m6g.large --master-size=m6g.large --image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20210106", "k8s_version": "latest", "kops_version": null, "kops_zones": "us-east-2b", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--node-size=m6g.large --master-size=m6g.large --image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20210106", "k8s_version": "latest", "kops_channel": "alpha", "kops_version": null, "kops_zones": "us-east-2b", "networking": null}
 - name: e2e-kops-grid-scenario-arm64
   cron: '33 16 * * *'
   labels:
@@ -27,7 +27,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/latest
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker --node-size=m6g.large --master-size=m6g.large --image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20210106
+      - --kops-args=--channel=alpha --container-runtime=docker --node-size=m6g.large --master-size=m6g.large --image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20210106
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -49,6 +49,7 @@ periodics:
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/extra_flags: --node-size=m6g.large --master-size=m6g.large --image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20210106
     test.kops.k8s.io/k8s_version: latest
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/kops_zones: us-east-2b
     test.kops.k8s.io/networking: ''
@@ -56,7 +57,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-scenario-arm64
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--api-loadbalancer-type=public", "feature_flags": "UseServiceAccountIAM,PublicJWKS", "k8s_version": "latest", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--api-loadbalancer-type=public", "feature_flags": "UseServiceAccountIAM,PublicJWKS", "k8s_version": "latest", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-scenario-public-jwks
   cron: '53 4 * * *'
   labels:
@@ -81,7 +82,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/latest
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker --api-loadbalancer-type=public
+      - --kops-args=--channel=alpha --container-runtime=docker --api-loadbalancer-type=public
       - --kops-feature-flags=UseServiceAccountIAM,PublicJWKS
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
@@ -104,13 +105,14 @@ periodics:
     test.kops.k8s.io/extra_flags: --api-loadbalancer-type=public
     test.kops.k8s.io/feature_flags: UseServiceAccountIAM,PublicJWKS
     test.kops.k8s.io/k8s_version: latest
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-latest, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-scenario-public-jwks
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--override=cluster.spec.cloudControllerManager.cloudProvider=aws --override=cluster.spec.cloudConfig.awsEBSCSIDriver.enabled=true", "feature_flags": "EnableExternalCloudController,SpecOverrideFlag", "k8s_version": "1.19", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--override=cluster.spec.cloudControllerManager.cloudProvider=aws --override=cluster.spec.cloudConfig.awsEBSCSIDriver.enabled=true", "feature_flags": "EnableExternalCloudController,SpecOverrideFlag", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-scenario-aws-cloud-controller-manager
   cron: '28 22 * * *'
   labels:
@@ -135,7 +137,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.19
       - --ginkgo-parallel=25
-      - --kops-args=--container-runtime=docker --override=cluster.spec.cloudControllerManager.cloudProvider=aws --override=cluster.spec.cloudConfig.awsEBSCSIDriver.enabled=true
+      - --kops-args=--channel=alpha --container-runtime=docker --override=cluster.spec.cloudControllerManager.cloudProvider=aws --override=cluster.spec.cloudConfig.awsEBSCSIDriver.enabled=true
       - --kops-feature-flags=EnableExternalCloudController,SpecOverrideFlag
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
@@ -158,13 +160,14 @@ periodics:
     test.kops.k8s.io/extra_flags: --override=cluster.spec.cloudControllerManager.cloudProvider=aws --override=cluster.spec.cloudConfig.awsEBSCSIDriver.enabled=true
     test.kops.k8s.io/feature_flags: EnableExternalCloudController,SpecOverrideFlag
     test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.19, kops-latest, kops-misc, provider-aws-cloud-provider-aws, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-scenario-aws-cloud-controller-manager
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-scenario-serial-test-for-timeout
   cron: '14 0 * * *'
   labels:
@@ -189,7 +192,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable-1.20
       - --ginkgo-parallel=1
-      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-args=--channel=alpha --networking=calico --container-runtime=docker
       - --kops-image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -209,6 +212,7 @@ periodics:
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
     test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops


### PR DESCRIPTION
As discussed, we should get the (broad) grid on the alpha channel, to
give us earlier signal.

We can have PR tests and "headline" periodics on the stable channel.