### PR TITLE
Approvers: Add AutoApproveUnownedSubfolders option

### DIFF
--- a/prow/plugins/approve/BUILD.bazel
+++ b/prow/plugins/approve/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
         "//prow/plugins/approve/approvers:go_default_library",
         "//prow/plugins/ownersconfig:go_default_library",
         "//prow/repoowners:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
         "@io_k8s_sigs_yaml//:go_default_library",

--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -27,10 +27,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
-	"sigs.k8s.io/yaml"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/yaml"
 
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
@@ -129,10 +130,14 @@ func newFakeGitHubClient(hasLabel, humanApproved bool, files []string, comments 
 }
 
 type fakeRepo struct {
-	approvers      map[string]layeredsets.String
-	leafApprovers  map[string]sets.String
+	approvers map[string]layeredsets.String
+	// directory -> approver
+	leafApprovers map[string]sets.String
+	// toApprove -> directoryWithOwnersFile
 	approverOwners map[string]string
-	dirBlacklist   []*regexp.Regexp
+	// dir -> allowed
+	autoApproveUnownedSubfolders map[string]bool
+	dirBlacklist                 []*regexp.Regexp
 }
 
 func (fr fakeRepo) Filenames() ownersconfig.Filenames {
@@ -150,6 +155,9 @@ func (fr fakeRepo) FindApproverOwnersForFile(path string) string {
 }
 func (fr fakeRepo) IsNoParentOwners(path string) bool {
 	return false
+}
+func (fr fakeRepo) IsAutoApproveUnownedSubfolders(ownerFilePath string) bool {
+	return fr.autoApproveUnownedSubfolders[ownerFilePath]
 }
 func (fr fakeRepo) TopLevelApprovers() sets.String {
 	return nil
@@ -1050,6 +1058,37 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 </details>
 <!-- META={"approvers":[]} -->`,
 		},
+		{
+			name:                "Approved because of AutoApproveUnownedSubfolders:",
+			hasLabel:            true,
+			humanApproved:       true,
+			files:               []string{"d/new-folder/new_file.go"},
+			selfApprove:         false,
+			needsIssue:          false,
+			lgtmActsAsApprove:   false,
+			reviewActsAsApprove: false,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
+
+			expectDelete:  false,
+			expectToggle:  false,
+			expectComment: true,
+			expectedComment: `[APPROVALNOTIFIER] This PR is **APPROVED**
+
+This pull-request has been approved by:
+
+The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo=org%2Frepo).
+
+The pull request process is described [here](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process)
+
+<details >
+Needs approval from an approver in each of these files:
+
+
+Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
+Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
+</details>
+<!-- META={"approvers":[]} -->`,
+		},
 	}
 
 	fr := fakeRepo{
@@ -1064,122 +1103,123 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			"c":   sets.NewString("cblecker", "cjwagner"),
 		},
 		approverOwners: map[string]string{
-			"a/a.go":   "a",
-			"a/aa.go":  "a",
-			"a/b/b.go": "a/b",
-			"c/c.go":   "c",
+			"a/a.go":                   "a",
+			"a/aa.go":                  "a",
+			"a/b/b.go":                 "a/b",
+			"c/c.go":                   "c",
+			"d/new-folder/new_file.go": "d",
+		},
+		autoApproveUnownedSubfolders: map[string]bool{
+			"d": true,
 		},
 	}
 
 	for _, test := range tests {
-		fghc := newFakeGitHubClient(test.hasLabel, test.humanApproved, test.files, test.comments, test.reviews)
-		branch := "master"
-		if test.branch != "" {
-			branch = test.branch
-		}
+		t.Run(test.name, func(t *testing.T) {
+			fghc := newFakeGitHubClient(test.hasLabel, test.humanApproved, test.files, test.comments, test.reviews)
+			branch := "master"
+			if test.branch != "" {
+				branch = test.branch
+			}
 
-		rsa := !test.selfApprove
-		irs := !test.reviewActsAsApprove
-		if err := handle(
-			logrus.WithField("plugin", "approve"),
-			fghc,
-			fr,
-			config.GitHubOptions{
-				LinkURL: test.githubLinkURL,
-			},
-			&plugins.Approve{
-				Repos:               []string{"org/repo"},
-				RequireSelfApproval: &rsa,
-				IssueRequired:       test.needsIssue,
-				LgtmActsAsApprove:   test.lgtmActsAsApprove,
-				IgnoreReviewState:   &irs,
-				CommandHelpLink:     "https://go.k8s.io/bot-commands",
-				PrProcessLink:       "https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process",
-			},
-			&state{
-				org:       "org",
-				repo:      "repo",
-				branch:    branch,
-				number:    prNumber,
-				body:      test.prBody,
-				author:    "cjwagner",
-				assignees: []github.User{{Login: "spxtr"}},
-			},
-		); err != nil {
-			t.Errorf("[%s] Unexpected error handling event: %v.", test.name, err)
-		}
+			rsa := !test.selfApprove
+			irs := !test.reviewActsAsApprove
+			if err := handle(
+				logrus.WithField("plugin", "approve"),
+				fghc,
+				fr,
+				config.GitHubOptions{
+					LinkURL: test.githubLinkURL,
+				},
+				&plugins.Approve{
+					Repos:               []string{"org/repo"},
+					RequireSelfApproval: &rsa,
+					IssueRequired:       test.needsIssue,
+					LgtmActsAsApprove:   test.lgtmActsAsApprove,
+					IgnoreReviewState:   &irs,
+					CommandHelpLink:     "https://go.k8s.io/bot-commands",
+					PrProcessLink:       "https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process",
+				},
+				&state{
+					org:       "org",
+					repo:      "repo",
+					branch:    branch,
+					number:    prNumber,
+					body:      test.prBody,
+					author:    "cjwagner",
+					assignees: []github.User{{Login: "spxtr"}},
+				},
+			); err != nil {
+				t.Errorf("[%s] Unexpected error handling event: %v.", test.name, err)
+			}
 
-		if test.expectDelete {
-			if len(fghc.IssueCommentsDeleted) != 1 {
-				t.Errorf(
-					"[%s] Expected 1 notification to be deleted but %d notifications were deleted.",
-					test.name,
-					len(fghc.IssueCommentsDeleted),
-				)
-			}
-		} else {
-			if len(fghc.IssueCommentsDeleted) != 0 {
-				t.Errorf(
-					"[%s] Expected 0 notifications to be deleted but %d notification was deleted.",
-					test.name,
-					len(fghc.IssueCommentsDeleted),
-				)
-			}
-		}
-		if test.expectComment {
-			if len(fghc.IssueCommentsAdded) != 1 {
-				t.Errorf(
-					"[%s] Expected 1 notification to be added but %d notifications were added.",
-					test.name,
-					len(fghc.IssueCommentsAdded),
-				)
-			} else if expect, got := fmt.Sprintf("org/repo#%v:", prNumber)+test.expectedComment, fghc.IssueCommentsAdded[0]; test.expectedComment != "" && got != expect {
-				t.Errorf(
-					"[%s] Expected the created notification to be:\n%s\n\nbut got:\n%s\n\n",
-					test.name,
-					expect,
-					got,
-				)
-			}
-		} else {
-			if len(fghc.IssueCommentsAdded) != 0 {
-				t.Errorf(
-					"[%s] Expected 0 notifications to be added but %d notification was added.",
-					test.name,
-					len(fghc.IssueCommentsAdded),
-				)
-			}
-		}
-
-		labelAdded := false
-		for _, l := range fghc.IssueLabelsAdded {
-			if l == fmt.Sprintf("org/repo#%v:approved", prNumber) {
-				if labelAdded {
-					t.Errorf("[%s] The approved label was applied to a PR that already had it!", test.name)
+			if test.expectDelete {
+				if len(fghc.IssueCommentsDeleted) != 1 {
+					t.Errorf(
+						"[%s] Expected 1 notification to be deleted but %d notifications were deleted.",
+						test.name,
+						len(fghc.IssueCommentsDeleted),
+					)
 				}
-				labelAdded = true
-			}
-		}
-		if test.hasLabel {
-			labelAdded = false
-		}
-		toggled := labelAdded
-		for _, l := range fghc.IssueLabelsRemoved {
-			if l == fmt.Sprintf("org/repo#%v:approved", prNumber) {
-				if !test.hasLabel {
-					t.Errorf("[%s] The approved label was removed from a PR that doesn't have it!", test.name)
+			} else {
+				if len(fghc.IssueCommentsDeleted) != 0 {
+					t.Errorf(
+						"[%s] Expected 0 notifications to be deleted but %d notification was deleted.",
+						test.name,
+						len(fghc.IssueCommentsDeleted),
+					)
 				}
-				toggled = true
 			}
-		}
-		if test.expectToggle != toggled {
-			t.Errorf(
-				"[%s] Expected 'approved' label toggled: %t, but got %t.",
-				test.name,
-				test.expectToggle,
-				toggled,
-			)
-		}
+			if test.expectComment {
+				if len(fghc.IssueCommentsAdded) != 1 {
+					t.Errorf(
+						"[%s] Expected 1 notification to be added but %d notifications were added.",
+						test.name,
+						len(fghc.IssueCommentsAdded),
+					)
+				} else if expect, got := fmt.Sprintf("org/repo#%v:", prNumber)+test.expectedComment, fghc.IssueCommentsAdded[0]; test.expectedComment != "" && got != expect {
+					t.Errorf("expected notification differs from actual: %s", cmp.Diff(expect, got))
+				}
+			} else {
+				if len(fghc.IssueCommentsAdded) != 0 {
+					t.Errorf(
+						"[%s] Expected 0 notifications to be added but %d notification was added.",
+						test.name,
+						len(fghc.IssueCommentsAdded),
+					)
+				}
+			}
+
+			labelAdded := false
+			for _, l := range fghc.IssueLabelsAdded {
+				if l == fmt.Sprintf("org/repo#%v:approved", prNumber) {
+					if labelAdded {
+						t.Errorf("[%s] The approved label was applied to a PR that already had it!", test.name)
+					}
+					labelAdded = true
+				}
+			}
+			if test.hasLabel {
+				labelAdded = false
+			}
+			toggled := labelAdded
+			for _, l := range fghc.IssueLabelsRemoved {
+				if l == fmt.Sprintf("org/repo#%v:approved", prNumber) {
+					if !test.hasLabel {
+						t.Errorf("[%s] The approved label was removed from a PR that doesn't have it!", test.name)
+					}
+					toggled = true
+				}
+			}
+			if test.expectToggle != toggled {
+				t.Errorf(
+					"[%s] Expected 'approved' label toggled: %t, but got %t.",
+					test.name,
+					test.expectToggle,
+					toggled,
+				)
+			}
+		})
 	}
 }
 

--- a/prow/plugins/approve/approvers/BUILD.bazel
+++ b/prow/plugins/approve/approvers/BUILD.bazel
@@ -23,6 +23,8 @@ go_test(
     deps = [
         "//prow/pkg/layeredsets:go_default_library",
         "//prow/plugins/ownersconfig:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
+        "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
     ],

--- a/prow/plugins/approve/approvers/owners_test.go
+++ b/prow/plugins/approve/approvers/owners_test.go
@@ -35,9 +35,10 @@ const (
 )
 
 type FakeRepo struct {
-	approversMap      map[string]layeredsets.String
-	leafApproversMap  map[string]sets.String
-	noParentOwnersMap map[string]bool
+	approversMap                 map[string]layeredsets.String
+	leafApproversMap             map[string]sets.String
+	noParentOwnersMap            map[string]bool
+	autoApproveUnownedSubfolders map[string]bool
 }
 
 func (f FakeRepo) Filenames() ownersconfig.Filenames {
@@ -65,6 +66,10 @@ func (f FakeRepo) IsNoParentOwners(path string) bool {
 	return f.noParentOwnersMap[path]
 }
 
+func (f FakeRepo) IsAutoApproveUnownedSubfolders(ownerFilePath string) bool {
+	return f.autoApproveUnownedSubfolders[ownerFilePath]
+}
+
 type dir struct {
 	fullPath  string
 	approvers sets.String
@@ -77,16 +82,16 @@ func canonicalize(path string) string {
 	return strings.TrimSuffix(path, "/")
 }
 
-func createFakeRepo(la map[string]sets.String) FakeRepo {
+func createFakeRepo(leafApproversMap map[string]sets.String, modify ...func(*FakeRepo)) FakeRepo {
 	// github doesn't use / at the root
 	a := map[string]layeredsets.String{}
-	for dir, approvers := range la {
-		la[dir] = setToLower(approvers)
+	for dir, approvers := range leafApproversMap {
+		leafApproversMap[dir] = setToLower(approvers)
 		a[dir] = setToLowerMulti(approvers)
 		startingPath := dir
 		for {
 			dir = canonicalize(filepath.Dir(dir))
-			if parentApprovers, ok := la[dir]; ok {
+			if parentApprovers, ok := leafApproversMap[dir]; ok {
 				a[startingPath] = a[startingPath].Union(setToLowerMulti(parentApprovers))
 			}
 			if dir == "" {
@@ -95,7 +100,11 @@ func createFakeRepo(la map[string]sets.String) FakeRepo {
 		}
 	}
 
-	return FakeRepo{approversMap: a, leafApproversMap: la}
+	fr := FakeRepo{approversMap: a, leafApproversMap: leafApproversMap}
+	for _, m := range modify {
+		m(&fr)
+	}
+	return fr
 }
 
 func setToLower(s sets.String) sets.String {

--- a/prow/plugins/blunderbuss/blunderbuss_test.go
+++ b/prow/plugins/blunderbuss/blunderbuss_test.go
@@ -155,6 +155,10 @@ func (foc *fakeOwnersClient) IsNoParentOwners(path string) bool {
 	return false
 }
 
+func (foc *fakeOwnersClient) IsAutoApproveUnownedSubfolders(path string) bool {
+	return false
+}
+
 func (foc *fakeOwnersClient) ParseSimpleConfig(path string) (repoowners.SimpleConfig, error) {
 	dir := filepath.Dir(path)
 	for _, re := range foc.dirBlacklist {

--- a/prow/plugins/lgtm/lgtm_test.go
+++ b/prow/plugins/lgtm/lgtm_test.go
@@ -88,16 +88,17 @@ func (fp *fakePruner) PruneComments(shouldPrune func(github.IssueComment) bool) 
 
 var _ repoowners.RepoOwner = &fakeRepoOwners{}
 
-func (f *fakeRepoOwners) FindApproverOwnersForFile(path string) string  { return "" }
-func (f *fakeRepoOwners) FindReviewersOwnersForFile(path string) string { return "" }
-func (f *fakeRepoOwners) FindLabelsForFile(path string) sets.String     { return nil }
-func (f *fakeRepoOwners) IsNoParentOwners(path string) bool             { return false }
-func (f *fakeRepoOwners) LeafApprovers(path string) sets.String         { return nil }
-func (f *fakeRepoOwners) Approvers(path string) layeredsets.String      { return f.approvers[path] }
-func (f *fakeRepoOwners) LeafReviewers(path string) sets.String         { return nil }
-func (f *fakeRepoOwners) Reviewers(path string) layeredsets.String      { return f.reviewers[path] }
-func (f *fakeRepoOwners) RequiredReviewers(path string) sets.String     { return nil }
-func (f *fakeRepoOwners) TopLevelApprovers() sets.String                { return nil }
+func (f *fakeRepoOwners) FindApproverOwnersForFile(path string) string    { return "" }
+func (f *fakeRepoOwners) FindReviewersOwnersForFile(path string) string   { return "" }
+func (f *fakeRepoOwners) FindLabelsForFile(path string) sets.String       { return nil }
+func (f *fakeRepoOwners) IsNoParentOwners(path string) bool               { return false }
+func (f *fakeRepoOwners) IsAutoApproveUnownedSubfolders(path string) bool { return false }
+func (f *fakeRepoOwners) LeafApprovers(path string) sets.String           { return nil }
+func (f *fakeRepoOwners) Approvers(path string) layeredsets.String        { return f.approvers[path] }
+func (f *fakeRepoOwners) LeafReviewers(path string) sets.String           { return nil }
+func (f *fakeRepoOwners) Reviewers(path string) layeredsets.String        { return f.reviewers[path] }
+func (f *fakeRepoOwners) RequiredReviewers(path string) sets.String       { return nil }
+func (f *fakeRepoOwners) TopLevelApprovers() sets.String                  { return nil }
 
 func (f *fakeRepoOwners) ParseSimpleConfig(path string) (repoowners.SimpleConfig, error) {
 	dir := filepath.Dir(path)

--- a/prow/plugins/override/override_test.go
+++ b/prow/plugins/override/override_test.go
@@ -102,6 +102,10 @@ func (foc *fakeOwnersClient) IsNoParentOwners(path string) bool {
 	return false
 }
 
+func (foc *fakeOwnersClient) IsAutoApproveUnownedSubfolders(path string) bool {
+	return false
+}
+
 func (foc *fakeOwnersClient) ParseSimpleConfig(path string) (repoowners.SimpleConfig, error) {
 	return repoowners.SimpleConfig{}, nil
 }

--- a/prow/plugins/verify-owners/verify-owners_test.go
+++ b/prow/plugins/verify-owners/verify-owners_test.go
@@ -256,6 +256,10 @@ func (foc *fakeOwnersClient) IsNoParentOwners(path string) bool {
 	return false
 }
 
+func (foc *fakeOwnersClient) IsAutoApproveUnownedSubfolders(path string) bool {
+	return false
+}
+
 func (foc *fakeOwnersClient) ParseSimpleConfig(path string) (repoowners.SimpleConfig, error) {
 	dir := filepath.Dir(path)
 	for _, re := range foc.dirIgnorelist {

--- a/prow/repoowners/repoowners.go
+++ b/prow/repoowners/repoowners.go
@@ -46,6 +46,10 @@ const (
 
 type dirOptions struct {
 	NoParentOwners bool `json:"no_parent_owners,omitempty"`
+	// AutoApproveUnownedSubfolders will result in changes to a subpath of a given path
+	// that does not have an OWNERS file being auto-approved. This should be
+	// enabled with caution.
+	AutoApproveUnownedSubfolders bool `json:"auto_approve_unowned_subfolders,omitempty"`
 }
 
 // Config holds roles+usernames and labels for a directory considered as a unit of independent code
@@ -219,6 +223,7 @@ type RepoOwner interface {
 	FindReviewersOwnersForFile(path string) string
 	FindLabelsForFile(path string) sets.String
 	IsNoParentOwners(path string) bool
+	IsAutoApproveUnownedSubfolders(directory string) bool
 	LeafApprovers(path string) sets.String
 	Approvers(path string) layeredsets.String
 	LeafReviewers(path string) sets.String
@@ -773,7 +778,7 @@ func findOwnersForFile(log *logrus.Entry, path string, ownerMap map[string]map[*
 	return ""
 }
 
-// FindApproverOwnersForFile returns the OWNERS file path furthest down the tree for a specified file
+// FindApproverOwnersForFile returns the directory containing the OWNERS file furthest down the tree for a specified file
 // that contains an approvers section
 func (o *RepoOwners) FindApproverOwnersForFile(path string) string {
 	return findOwnersForFile(o.log, path, o.approvers)
@@ -794,6 +799,10 @@ func (o *RepoOwners) FindLabelsForFile(path string) sets.String {
 // IsNoParentOwners checks if an OWNERS file path refers to an OWNERS file with NoParentOwners enabled.
 func (o *RepoOwners) IsNoParentOwners(path string) bool {
 	return o.options[path].NoParentOwners
+}
+
+func (o *RepoOwners) IsAutoApproveUnownedSubfolders(ownersFilePath string) bool {
+	return o.options[ownersFilePath].AutoApproveUnownedSubfolders
 }
 
 // entriesForFile returns a set of users who are assignees to the

--- a/prow/test/BUILD.bazel
+++ b/prow/test/BUILD.bazel
@@ -23,6 +23,8 @@ filegroup(
     srcs = [
         ":package-srcs",
         "//prow/test/data:all-srcs",
+        "//prow/test/integration/fakeghserver:all-srcs",
+        "//prow/test/integration/test:all-srcs",
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],

--- a/prow/test/integration/fakeghserver/BUILD.bazel
+++ b/prow/test/integration/fakeghserver/BUILD.bazel
@@ -29,7 +29,6 @@ go_library(
         "//prow/interrupts:go_default_library",
         "//prow/logrusutil:go_default_library",
         "//prow/pjutil:go_default_library",
-        "@com_github_google_go_github//github:go_default_library",
         "@com_github_gorilla_mux//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
@@ -44,9 +43,7 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [
-        ":package-srcs",
-    ],
+    srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This change adds an allow_folder_creation option to the approvers. When
opted-in, it will not require approval for subfolders in a folder with
this set. It is implemented by purging the files that fall into this
category from the list of approval-needing files in the approve plugin.

Note for reviewers: In two occasions I have changed a set of table-driven tests to use subtests, please disable whitespace on the diff, that drastically reduces the diff size.

/assign @stevekuznetsov @cjwagner 