### PR TITLE
Adjust prow components absent alert threshold from 5 to 10 minutes

### DIFF
--- a/config/prow/cluster/monitoring/mixins/prometheus/ci_absent_alerts.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/ci_absent_alerts.libsonnet
@@ -10,13 +10,13 @@
             expr: |||
               absent(up{job="%s"} == 1)
             ||| % name,
-            'for': '5m',
+            'for': '10m',
             labels: {
               severity: 'critical',
               slo: name,
             },
             annotations: {
-              message: '@test-infra-oncall The service %s has been down for 5 minutes.' % name,
+              message: '@test-infra-oncall The service %s has been down for 10 minutes.' % name,
             },
           }
           for name in [


### PR DESCRIPTION
For clusters with no HA enabled, a single master upgrade could make cluster api server irresponsive for more than 5 minutes and trigger this alert. See example https://kubernetes.slack.com/archives/C7J9RP96G/p1610644866000100. Based on my previous observations, adjusting to 10 minutes should greatly reduce this noise