### PR TITLE
releng: set job to be optional during the canary phase

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -84,7 +84,7 @@ presubmits:
       testgrid-alert-email: release-managers+alerts@kubernetes.io
       testgrid-num-columns-recent: '30'
   - name: pull-release-image-kube-cross
-    optional: false
+    optional: true
     decorate: true
     run_if_changed: '^images\/build\/cross\/'
     path_alias: k8s.io/release


### PR DESCRIPTION
the job `pull-release-image-kube-cross` is in development is was set wrong for now as required, setting to be optional for now

/assign @saschagrunert 