### PR TITLE
Set CL2_PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT to 15m

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -236,7 +236,7 @@ presets:
     preset-e2e-scalability-containerd: "true"
   env:
   - name: CL2_PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT
-    value: "10m"
+    value: "15m"
   - name: KUBE_CONTAINER_RUNTIME
     value: "containerd"
 


### PR DESCRIPTION
To avoid overriding default value (15m: https://github.com/kubernetes/perf-tests/pull/1704). We cannot delete this env as in old perf-test branches it's needed to increase timeout (5m is a default there).

/assign @mm4tt 