### PR TITLE
Job history: Fix listing

### DIFF
--- a/prow/cmd/deck/job_history.go
+++ b/prow/cmd/deck/job_history.go
@@ -211,6 +211,9 @@ func (bucket blobStorageBucket) listSubDirs(ctx context.Context, prefix string) 
 
 // Lists all keys with given prefix.
 func (bucket blobStorageBucket) listAll(ctx context.Context, prefix string) ([]string, error) {
+	if !strings.HasSuffix(prefix, "/") {
+		prefix = prefix + "/"
+	}
 	it, err := bucket.Opener.Iterator(ctx, fmt.Sprintf("%s://%s/%s", bucket.storageProvider, bucket.name, prefix), "")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Currently when we try to list the buildIDs for a job, we do not add a
trailing slash to the path. This results in the list operation also
matching other dirs with the same prefix, for example when there is a
job `pull-ci-openshift-release-master-ci-operator-config` and a job
`pull-ci-openshift-release-master-ci-operator-config-metadata`, listing
the history for the former will yield results for the latter, but then
subsequently fail to find the job runs for those ids (as they do not
exist) and display all of them as 0s runs.

Fixes https://github.com/kubernetes/test-infra/issues/19721
Supersedes and thereby closes https://github.com/kubernetes/test-infra/pull/20018