### PR TITLE
Kind job updates: update test target, add more branches

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-postsubmits.yaml
@@ -1,7 +1,7 @@
 # sigs.k8s.io/kind postsubmits
 postsubmits:
   kubernetes-sigs/kind:
-  - name: ci-kind-unit
+  - name: ci-kind-test
     decorate: true
     path_alias: sigs.k8s.io/kind
     always_run: true
@@ -13,7 +13,7 @@ postsubmits:
         command:
         - runner.sh
         - make
-        - unit
+        - test
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -242,6 +242,100 @@ presubmits:
             # during the tests more like 3-20m is used
             cpu: 2000m
   # mimic pull-kubernetes-e2e-kind, but using kind built in this PR
+  - always_run: true
+    branches:
+    - release-1.20
+    decorate: true
+    decoration_config:
+      grace_period: 15m0s
+      timeout: 1h0m0s
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: release-1.20
+      path_alias: k8s.io/kubernetes
+    labels:
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    name: pull-kind-e2e-kubernetes-1-20
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - wrapper.sh
+        - bash
+        - -c
+        - cd ./../../k8s.io/kubernetes && ./../../sigs.k8s.io/kind/hack/ci/e2e.sh
+        env:
+        - name: FOCUS
+          value: .
+        - name: SKIP
+          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|NFS|nfs|inline.execution.and.attach|should.be.rejected.when.no.endpoints.exist
+        - name: PARALLEL
+          value: "true"
+        - name: BUILD_TYPE
+          value: bazel
+        image: gcr.io/k8s-testimages/krte:v20210204-b06ec78-1.20
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 9000Mi
+          requests:
+            cpu: "4"
+            memory: 9000Mi
+        securityContext:
+          privileged: true
+  # mimic pull-kubernetes-e2e-kind, but using kind built in this PR
+  - always_run: true
+    branches:
+    - release-1.19
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: release-1.189
+      path_alias: k8s.io/kubernetes
+    decorate: true
+    decoration_config:
+      grace_period: 15m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    name: pull-kind-e2e-kubernetes-1-19
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - wrapper.sh
+        - bash
+        - -c
+        - cd ./../../k8s.io/kubernetes && ./../../sigs.k8s.io/kind/hack/ci/e2e.sh
+        env:
+        - name: FOCUS
+          value: .
+        - name: SKIP
+          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|Conntrack|udp|UDP|NFS|nfs|inline.execution.and.attach|should.be.rejected.when.no.endpoints.exist
+        - name: PARALLEL
+          value: "true"
+        - name: BUILD_TYPE
+          value: bazel
+        image: gcr.io/k8s-testimages/krte:v20210204-3eaec9a-1.19
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 9000Mi
+          requests:
+            cpu: "4"
+            memory: 9000Mi
+        securityContext:
+          privileged: true
+  # mimic pull-kubernetes-e2e-kind, but using kind built in this PR
   - name: pull-kind-e2e-kubernetes-1-18
     always_run: true
     labels:

--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
-  - name: pull-kind-unit
+  - name: pull-kind-test
     decorate: true
     path_alias: sigs.k8s.io/kind
     always_run: true
@@ -28,7 +28,7 @@ presubmits:
         command:
         - wrapper.sh
         - make
-        - unit
+        - test
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/kind/kind.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind.yaml
@@ -1,5 +1,5 @@
 periodics:
-- name: ci-kind-unit
+- name: ci-kind-test
   interval: 6h
   decorate: true
   extra_refs:
@@ -16,7 +16,7 @@ periodics:
       command:
       - wrapper.sh
       - make
-      - unit
+      - test
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true


### PR DESCRIPTION
1.19/1.20 have been an oversight.
unit => test happened when we made a distinction for integration tests.
these are overdue.