### PR TITLE
Tide: Limit duration of searches to 5 mins

### DIFF
--- a/prow/config/branch_protection.go
+++ b/prow/config/branch_protection.go
@@ -362,10 +362,11 @@ func (c *Config) unprotectedBranches(presubmits map[string][]Presubmit) []string
 //     because any branches not explicitly specified in the configuration will be unprotected.
 func (c *Config) BranchProtectionWarnings(logger *logrus.Entry, presubmits map[string][]Presubmit) {
 	if warnings := c.reposWithDisabledPolicy(); len(warnings) > 0 {
-		logger.Warnf("The following repos define a policy, but have protect: false: %s", strings.Join(warnings, ","))
+
+		logger.WithField("repos", strings.Join(warnings, ",")).Warn("The following repos define a policy, but have protect: false")
 	}
 	if warnings := c.unprotectedBranches(presubmits); len(warnings) > 0 {
-		logger.Warnf("The following repos define a policy or require context(s), but have one or more branches with protect: false: %s", strings.Join(warnings, ","))
+		logger.WithField("repos", strings.Join(warnings, ",")).Warn("The following repos define a policy or require context(s), but have one or more branches with protect: false")
 	}
 }
 

--- a/prow/tide/blockers/blockers.go
+++ b/prow/tide/blockers/blockers.go
@@ -71,8 +71,10 @@ func (b Blockers) GetApplicable(org, repo, branch string) []Blocker {
 
 // FindAll finds issues with label in the specified orgs/repos that should block tide.
 func FindAll(ghc githubClient, log *logrus.Entry, label, orgRepoTokens string) (Blockers, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
 	issues, err := search(
-		context.Background(),
+		ctx,
 		ghc,
 		log,
 		blockerQuery(label, orgRepoTokens),

--- a/prow/tide/search.go
+++ b/prow/tide/search.go
@@ -58,7 +58,8 @@ func search(query querier, log *logrus.Entry, q string, start, end time.Time, or
 	var totalCost, remaining int
 	var ret []PullRequest
 	var sq searchQuery
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
 	for {
 		log.Debug("Sending query")
 		if err := query(ctx, &sq, vars, org); err != nil {


### PR DESCRIPTION
We see occurences were status udpate time takes more than 3.8k seconds
(about 63 minutes). Not entirely sure why this happens, but normal sync
durations for everything is < 60 seconds: https://monitoring.prow.k8s.io/d/d69a91f76d8110d3e72885ee5ce8038e/tide-dashboard?panelId=7&fullscreen&orgId=1
    
FGprof shows that its spending the time querying github. Now sure how
that can take so long, but we should under no cirumstances block the
entire controller for longer durations.

/assign @stevekuznetsov @chaodaiG 

Graph for the durations today in Openshift:
<img width="1627" alt="tide-wtf" src="https://user-images.githubusercontent.com/6496100/107100586-d93f3480-67e2-11eb-8127-31f7e9c5d17e.png">
