### PR TITLE
Phaino: also detect repo under GOPATH

### DIFF
--- a/prow/cmd/phaino/local.go
+++ b/prow/cmd/phaino/local.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"go/build"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -86,7 +87,10 @@ func readRepo(ctx context.Context, path string) (string, error) {
 	}
 	def, err := findRepo(wd, path)
 	if err != nil { // If k8s/test-infra is not under GOPATH, find under GOPATH.
-		def, err = findRepo(filepath.Join(os.Getenv("GOPATH"), "src"), path)
+		pkg, err := build.Default.Import(path, build.Default.GOPATH, build.FindOnly|build.IgnoreVendor)
+		if err == nil {
+			def = pkg.Dir
+		}
 	}
 	if err != nil {
 		logrus.WithError(err).WithField("repo", path).Warn("could not find repo")

--- a/prow/cmd/phaino/local.go
+++ b/prow/cmd/phaino/local.go
@@ -85,6 +85,9 @@ func readRepo(ctx context.Context, path string) (string, error) {
 		return "", fmt.Errorf("workingDir: %v", err)
 	}
 	def, err := findRepo(wd, path)
+	if err != nil { // If k8s/test-infra is not under GOPATH, find under GOPATH.
+		def, err = findRepo(filepath.Join(os.Getenv("GOPATH"), "src"), path)
+	}
 	if err != nil {
 		logrus.WithError(err).WithField("repo", path).Warn("could not find repo")
 	}

--- a/prow/cmd/phaino/local.go
+++ b/prow/cmd/phaino/local.go
@@ -87,7 +87,8 @@ func readRepo(ctx context.Context, path string) (string, error) {
 	}
 	def, err := findRepo(wd, path)
 	if err != nil { // If k8s/test-infra is not under GOPATH, find under GOPATH.
-		pkg, err := build.Default.Import(path, build.Default.GOPATH, build.FindOnly|build.IgnoreVendor)
+		pkg, err2 := build.Default.Import(path, build.Default.GOPATH, build.FindOnly|build.IgnoreVendor)
+		err = err2
 		if err == nil {
 			def = pkg.Dir
 		}

--- a/prow/cmd/phaino/local_test.go
+++ b/prow/cmd/phaino/local_test.go
@@ -50,14 +50,32 @@ func TestReadRepo(t *testing.T) {
 			expected: path.Join(dir, "find_from_local", "go/src/k8s.io/test-infra2"),
 		},
 		{
+			name:     "find from local fallback",
+			goal:     "k8s.io/test-infra2",
+			wd:       path.Join(dir, "find_from_local_fallback", "go/src/test-infra2"),
+			expected: path.Join(dir, "find_from_local_fallback", "go/src/test-infra2"),
+		},
+		{
 			name:   "find from explicit gopath",
 			goal:   "k8s.io/test-infra2",
 			gopath: path.Join(dir, "find_from_explicit_gopath"),
 			wd:     path.Join(dir, "find_from_explicit_gopath_random", "random"),
 			dirs: []string{
 				path.Join(dir, "find_from_explicit_gopath", "src", "k8s.io/test-infra2"),
+				path.Join(dir, "find_from_explicit_gopath_random", "src", "test-infra2"),
 			},
 			expected: path.Join(dir, "find_from_explicit_gopath", "src", "k8s.io/test-infra2"),
+		},
+		{
+			name:   "prefer gopath",
+			goal:   "k8s.io/test-infra2",
+			gopath: path.Join(dir, "prefer_gopath"),
+			wd:     path.Join(dir, "prefer_gopath_random", "random"),
+			dirs: []string{
+				path.Join(dir, "prefer_gopath", "src", "k8s.io/test-infra2"),
+				path.Join(dir, "prefer_gopath", "src", "test-infra2"),
+			},
+			expected: path.Join(dir, "prefer_gopath", "src", "k8s.io/test-infra2"),
 		},
 		{
 			name:   "not exist",
@@ -113,7 +131,7 @@ func TestReadRepo(t *testing.T) {
 	}
 }
 
-func TestFindRepo(t *testing.T) {
+func TestFindRepoFromLocal(t *testing.T) {
 	cases := []struct {
 		name     string
 		goal     string
@@ -188,7 +206,7 @@ func TestFindRepo(t *testing.T) {
 			wd := filepath.Join(dir, tc.wd)
 			expected := filepath.Join(dir, tc.expected)
 
-			actual, err := findRepo(wd, tc.goal)
+			actual, err := findRepoFromLocal(wd, tc.goal)
 			switch {
 			case err != nil:
 				if !tc.err {

--- a/prow/cmd/phaino/local_test.go
+++ b/prow/cmd/phaino/local_test.go
@@ -17,11 +17,101 @@ limitations under the License.
 package main
 
 import (
+	"context"
+	"go/build"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 )
+
+func TestReadRepo(t *testing.T) {
+	dir, err := ioutil.TempDir("", "read-repo")
+	if err != nil {
+		t.Fatalf("Cannot create temp dir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	cases := []struct {
+		name      string
+		goal      string
+		wd        string
+		gopath    string
+		dirs      []string
+		userInput string
+		expected  string
+		err       bool
+	}{
+		{
+			name:     "find from local",
+			goal:     "k8s.io/test-infra2",
+			wd:       path.Join(dir, "find_from_local", "go/src/k8s.io/test-infra2"),
+			expected: path.Join(dir, "find_from_local", "go/src/k8s.io/test-infra2"),
+		},
+		{
+			name:   "find from explicit gopath",
+			goal:   "k8s.io/test-infra2",
+			gopath: path.Join(dir, "find_from_explicit_gopath"),
+			wd:     path.Join(dir, "find_from_explicit_gopath_random", "random"),
+			dirs: []string{
+				path.Join(dir, "find_from_explicit_gopath", "src", "k8s.io/test-infra2"),
+			},
+			expected: path.Join(dir, "find_from_explicit_gopath", "src", "k8s.io/test-infra2"),
+		},
+		{
+			name:   "not exist",
+			goal:   "k8s.io/test-infra2",
+			gopath: path.Join(dir, "not_exist", "random1"),
+			wd:     path.Join(dir, "not_exist", "random2"),
+			err:    true,
+		},
+		{
+			name:      "not exist due to user error",
+			goal:      "k8s.io/test-infra2",
+			wd:        path.Join(dir, "not_exist_due_to_user_error", "go/src/k8s.io/test-infra2"),
+			expected:  "/random/other/path",
+			userInput: "/random/other/path",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.dirs = append(tc.dirs, tc.wd)
+			for _, d := range tc.dirs {
+				if err := os.MkdirAll(d, 0755); err != nil {
+					t.Fatalf("Cannot create subdir %q: %v", d, err)
+				}
+			}
+
+			// build.Default was loaded while imported, override it directly.
+			oldGopath := build.Default.GOPATH
+			defer func() {
+				build.Default.GOPATH = oldGopath
+			}()
+			build.Default.GOPATH = tc.gopath
+
+			// Trick the system to think it's running in bazel and wd is tc.wd.
+			oldPwd := os.Getenv("BUILD_WORKING_DIRECTORY")
+			defer os.Setenv("BUILD_WORKING_DIRECTORY", oldPwd)
+			os.Setenv("BUILD_WORKING_DIRECTORY", tc.wd)
+
+			actual, err := readRepo(context.Background(), tc.goal, func(path, def string) (string, error) {
+				return tc.userInput, nil
+			})
+			switch {
+			case err != nil:
+				if !tc.err {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			case tc.err:
+				t.Error("Failed to get an error")
+			case actual != tc.expected:
+				t.Errorf("Actual %q != expected %q", actual, tc.expected)
+			}
+		})
+	}
+}
 
 func TestFindRepo(t *testing.T) {
 	cases := []struct {

--- a/prow/test/integration/fakeghserver/BUILD.bazel
+++ b/prow/test/integration/fakeghserver/BUILD.bazel
@@ -29,7 +29,6 @@ go_library(
         "//prow/interrupts:go_default_library",
         "//prow/logrusutil:go_default_library",
         "//prow/pjutil:go_default_library",
-        "@com_github_google_go_github//github:go_default_library",
         "@com_github_gorilla_mux//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],


### PR DESCRIPTION
When k8s/test-infra was not cloned under GOPATH, running phaino cannot find the source code, make it also checking under GOPATH