### PR TITLE
Github flagutil: Fix being able to use multiple throttler settings

### DIFF
--- a/prow/flagutil/BUILD.bazel
+++ b/prow/flagutil/BUILD.bazel
@@ -69,6 +69,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/flagutil:go_default_library",
+        "//prow/config/secret:go_default_library",
         "//prow/github:go_default_library",
     ],
 )


### PR DESCRIPTION
Currently, the flagutil caches the client and always returns the same
one on multiple invocations. This causes Tide that wants to construct
two GH clients with different throttler settings to apply the last
setting for both its clients. This means that by default, Tide gets the
the status clients settings (400 tokens) for everything it does, rather
than 800 tokens for the sync and 400 tokens for the status client.

Interestingly, the status controllers ratelimiting seems to only apply
to the v3 client, which indicates a bug in the throttler wrapping of
the v4 client after unwrap/wrap. Directly setting the throttler on the
sync client does cause V4 calls to get throttled.