### PR TITLE
Fix: Add PULL_BASE_REF to periodic cluster-api-push-images-nightly job

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
@@ -214,6 +214,11 @@ periodics:
           - --env-passthrough=PULL_BASE_REF
           - --gcb-config=cloudbuild-nightly.yaml
           - .
+        env:
+        # We need to emulate a pull job for the cloud build to work the same
+        # way as it usually does.
+        - name: PULL_BASE_REF
+          value: master
   annotations:
     # this is the name of some testgrid dashboard to report to.
     testgrid-dashboards: sig-cluster-lifecycle-image-pushes


### PR DESCRIPTION
Periodic jobs do not seem to pass `PULL_BASE_REF` variable similar to postsubmits, hence adding it as env.

As an example: 
`PULL_BASE_REF` exists in a postsubmit job:
https://storage.googleapis.com/kubernetes-jenkins/logs/post-cluster-api-push-images/1357888745109458944/podinfo.json

It is missing in a periodic job:
https://storage.googleapis.com/kubernetes-jenkins/logs/cluster-api-push-images-nightly/1358324712068878336/podinfo.json

cc @CecileRobertMichon @vincepri 