### PR TITLE
[Digital Ocean] Fix environment variable that KOPS expects for Spaces

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presets-do.yaml
+++ b/config/jobs/kubernetes/kops/kops-presets-do.yaml
@@ -3,12 +3,12 @@ presets:
 - labels:
     preset-do-spaces-credential: "true"
   env:
-  - name: DO_S3_ACCESS_KEY_ID
+  - name: S3_ACCESS_KEY_ID
     valueFrom:
       secretKeyRef:
         name: spaces-digitalocean-s3
         key: access-key
-  - name: DO_S3_SECRET_ACCESS_KEY
+  - name: S3_SECRET_ACCESS_KEY
     valueFrom:
       secretKeyRef:
         name: spaces-digitalocean-s3


### PR DESCRIPTION
Minor fix to use the proper environment variable for KOPS DO Spaces.
Once this gets merged, I'll do the "actual" tests by adding DO specific tests to build_grid.py.
