### PR TITLE
Skip K8s 1.20 tests for external-snapshotter@release-2.1 branch

### DIFF
--- a/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
+++ b/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
@@ -183,7 +183,7 @@ presubmits:
     optional: true
     decorate: true
     skip_report: false
-    skip_branches: ["^(k8s_1.12.0-beta.1|release-0.4|release-1.0)$"]
+    skip_branches: ["^(k8s_1.12.0-beta.1|release-0.4|release-1.0|release-2.1)$"]
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -275,7 +275,7 @@ presubmits:
     optional: true
     decorate: true
     skip_report: false
-    skip_branches: ["^(k8s_1.12.0-beta.1|release-0.4|release-1.0)$"]
+    skip_branches: ["^(k8s_1.12.0-beta.1|release-0.4|release-1.0|release-2.1)$"]
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"


### PR DESCRIPTION
As discussed in https://github.com/kubernetes-csi/external-snapshotter/pull/471, the K8s 1.20 e2e tests are not appropriate for `release-2.1` branch of `kubernetes-csi/external-snapshotter` - the tests are assuming apiversion v1 but the only available apiversion in kubernetes-csi/external-snapshotter@release-2.1 is v1beta1. 