### PR TITLE
Update GCE containerd windows test job to 1.20 (instead of 1.18)

### DIFF
--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -366,7 +366,7 @@ periodics:
     testgrid-tab-name: gce-windows-2019-containerd-master
     description: Runs tests on a Kubernetes cluster with Windows containerd nodes on GCE
 
-- name: ci-kubernetes-e2e-windows-containerd-gce-1-18
+- name: ci-kubernetes-e2e-windows-containerd-gce-1-20
   decorate: true
   decoration_config:
     timeout: 4h0m0s
@@ -387,7 +387,7 @@ periodics:
     - args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/latest-1.18
+      - --extract=ci/latest-1.20
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=8
       - --provider=gce
@@ -408,12 +408,12 @@ periodics:
         value: win2019
       - name: PREPULL_YAML
         value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210207-08ffabe-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210207-08ffabe-1.20
       name: ""
       resources: {}
   annotations:
     testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-containerd, sig-node-containerd
-    testgrid-tab-name: gce-windows-2019-containerd-1.18
+    testgrid-tab-name: gce-windows-2019-containerd-1.20
 
 - name: ci-kubernetes-e2e-windows-node-throughput
   interval: 6h


### PR DESCRIPTION
The change updates the existing 1.18 test job to 1.20. It's required for having a continuous validation over 1.20 with ltsc2019 in addition to the master test job.