### PR TITLE
update job for new main branch convention

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-apisnoop.yaml
+++ b/config/jobs/image-pushing/k8s-staging-apisnoop.yaml
@@ -9,7 +9,7 @@ postsubmits:
         description: Builds the auditlogger image for APISnoop deployments
       decorate: true
       branches:
-        - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -31,7 +31,7 @@ postsubmits:
         description: Builds the snoopdb image for APISnoop deployments
       decorate: true
       branches:
-        - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:


### PR DESCRIPTION
The apisnoop repo has updated naming conventions so that master is now main.  This PR updates our image pushing job accordingly.