### PR TITLE
Cherrypicker: Improve Logging

### DIFF
--- a/prow/external-plugins/cherrypicker/BUILD.bazel
+++ b/prow/external-plugins/cherrypicker/BUILD.bazel
@@ -18,11 +18,13 @@ go_library(
         "//prow/git/v2:go_default_library",
         "//prow/github:go_default_library",
         "//prow/interrupts:go_default_library",
+        "//prow/logrusutil:go_default_library",
         "//prow/pjutil:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/pluginhelp/externalplugins:go_default_library",
         "//prow/plugins:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/errors:go_default_library",
     ],
 )
 

--- a/prow/external-plugins/cherrypicker/main.go
+++ b/prow/external-plugins/cherrypicker/main.go
@@ -31,6 +31,7 @@ import (
 	prowflagutil "k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/git/v2"
 	"k8s.io/test-infra/prow/interrupts"
+	"k8s.io/test-infra/prow/logrusutil"
 	"k8s.io/test-infra/prow/pjutil"
 	"k8s.io/test-infra/prow/pluginhelp/externalplugins"
 )
@@ -79,6 +80,7 @@ func gatherOptions() options {
 }
 
 func main() {
+	logrusutil.ComponentInit()
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {
 		logrus.Fatalf("Invalid options: %v", err)

--- a/prow/external-plugins/cherrypicker/server.go
+++ b/prow/external-plugins/cherrypicker/server.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/test-infra/prow/config"
 	cherrypicker "k8s.io/test-infra/prow/external-plugins/cherrypicker/lib"
 	"k8s.io/test-infra/prow/git/v2"
@@ -123,12 +124,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleEvent(eventType, eventGUID string, payload []byte) error {
-	l := logrus.WithFields(
-		logrus.Fields{
-			"event-type":     eventType,
-			github.EventGUID: eventGUID,
-		},
-	)
+	l := logrus.WithFields(logrus.Fields{
+		"event-type":     eventType,
+		github.EventGUID: eventGUID,
+	})
 	switch eventType {
 	case "issue_comment":
 		var ic github.IssueCommentEvent
@@ -168,7 +167,7 @@ func (s *Server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent
 	commentAuthor := ic.Comment.User.Login
 
 	// Do not create a new logger, its fields are re-used by the caller in case of errors
-	l = l.WithFields(logrus.Fields{
+	*l = *l.WithFields(logrus.Fields{
 		github.OrgLogField:  org,
 		github.RepoLogField: repo,
 		github.PrLogField:   num,
@@ -200,7 +199,7 @@ func (s *Server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent
 
 	pr, err := s.ghc.GetPullRequest(org, repo, num)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get pull request %s/%s#%d: %w", org, repo, num, err)
 	}
 	baseBranch := pr.Base.Ref
 	title := pr.Title
@@ -233,7 +232,7 @@ func (s *Server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent
 		}
 	}
 
-	l = l.WithFields(logrus.Fields{
+	*l = *l.WithFields(logrus.Fields{
 		"requestor":     ic.Comment.User.Login,
 		"target_branch": targetBranch,
 	})
@@ -260,7 +259,7 @@ func (s *Server) handlePullRequest(l *logrus.Entry, pre github.PullRequestEvent)
 	body := pr.Body
 
 	// Do not create a new logger, its fields are re-used by the caller in case of errors
-	l = l.WithFields(logrus.Fields{
+	*l = *l.WithFields(logrus.Fields{
 		github.OrgLogField:  org,
 		github.RepoLogField: repo,
 		github.PrLogField:   num,
@@ -268,7 +267,7 @@ func (s *Server) handlePullRequest(l *logrus.Entry, pre github.PullRequestEvent)
 
 	comments, err := s.ghc.ListIssueComments(org, repo, num)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to list comments: %w", err)
 	}
 
 	// requestor -> target branch -> issue comment
@@ -294,7 +293,7 @@ func (s *Server) handlePullRequest(l *logrus.Entry, pre github.PullRequestEvent)
 	// now look for our special labels
 	labels, err := s.ghc.GetIssueLabels(org, repo, num)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get issue labels: %w", err)
 	}
 
 	if requestorToComments[pr.User.Login] == nil {
@@ -339,23 +338,25 @@ func (s *Server) handlePullRequest(l *logrus.Entry, pre github.PullRequestEvent)
 	handledBranches := make(map[string]bool)
 	for requestor, branches := range requestorToComments {
 		for targetBranch, ic := range branches {
-			if targetBranch == baseBranch {
-				resp := fmt.Sprintf("base branch (%s) needs to differ from target branch (%s)", baseBranch, targetBranch)
-				l.Info(resp)
-				s.createComment(org, repo, num, ic, resp)
-				continue
-			}
 			if handledBranches[targetBranch] {
 				// Branch already handled. Skip.
 				continue
 			}
+			if targetBranch == baseBranch {
+				resp := fmt.Sprintf("base branch (%s) needs to differ from target branch (%s)", baseBranch, targetBranch)
+				l.Info(resp)
+				s.createComment(l, org, repo, num, ic, resp)
+				continue
+			}
 			handledBranches[targetBranch] = true
-			l.WithFields(logrus.Fields{
+			l := l.WithFields(logrus.Fields{
 				"requestor":     requestor,
 				"target_branch": targetBranch,
-			}).Debug("Cherrypick request.")
+			})
+			l.Debug("Cherrypick request.")
 			err := s.handle(l, requestor, ic, org, repo, targetBranch, title, body, num)
 			if err != nil {
+				l.WithError(err).Error("failed to create cherrypick")
 				return err
 			}
 		}
@@ -368,16 +369,16 @@ var cherryPickBranchFmt = "cherry-pick-%d-to-%s"
 func (s *Server) handle(logger *logrus.Entry, requestor string, comment *github.IssueComment, org, repo, targetBranch, title, body string, num int) error {
 	forkName, err := s.ensureForkExists(org, repo)
 	if err != nil {
+		logger.WithError(err).Warn("failed to ensure fork exists")
 		resp := fmt.Sprintf("cannot fork %s/%s: %v", org, repo, err)
-		logger.Warningf(resp)
-		return s.createComment(org, repo, num, comment, resp)
+		return s.createComment(logger, org, repo, num, comment, resp)
 	}
 
 	// Clone the repo, checkout the target branch.
 	startClone := time.Now()
 	r, err := s.gc.ClientFor(org, forkName)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get git client for %s/%s: %w", org, forkName, err)
 	}
 	defer func() {
 		if err := r.Clean(); err != nil {
@@ -385,27 +386,27 @@ func (s *Server) handle(logger *logrus.Entry, requestor string, comment *github.
 		}
 	}()
 	if err := r.Checkout(targetBranch); err != nil {
+		logger.WithError(err).Warn("failed to checkout target branch")
 		resp := fmt.Sprintf("cannot checkout `%s`: %v", targetBranch, err)
-		logger.Warningf(resp)
-		return s.createComment(org, repo, num, comment, resp)
+		return s.createComment(logger, org, repo, num, comment, resp)
 	}
 	logger.WithField("duration", time.Since(startClone)).Info("Cloned and checked out target branch.")
 
 	// Fetch the patch from GitHub
 	localPath, err := s.getPatch(org, repo, targetBranch, num)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get patch: %w", err)
 	}
 
 	if err := r.Config("user.name", s.botUser.Login); err != nil {
-		return err
+		return fmt.Errorf("failed to configure git user: %w", err)
 	}
 	email := s.email
 	if email == "" {
 		email = s.botUser.Email
 	}
 	if err := r.Config("user.email", email); err != nil {
-		return err
+		return fmt.Errorf("failed to configure git email: %w", err)
 	}
 
 	// New branch for the cherry-pick.
@@ -416,20 +417,20 @@ func (s *Server) handle(logger *logrus.Entry, requestor string, comment *github.
 		// Find the PR and link to it.
 		prs, err := s.ghc.GetPullRequests(org, repo)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to get pullrequests for %s/%s: %w", org, repo, err)
 		}
 		for _, pr := range prs {
 			if pr.Head.Ref == fmt.Sprintf("%s:%s", s.botUser.Login, newBranch) {
+				logger.WithField("preexisting_cherrypick", pr.HTMLURL).Info("PR already has cherrypick")
 				resp := fmt.Sprintf("Looks like #%d has already been cherry picked in %s", num, pr.HTMLURL)
-				logger.Info(resp)
-				return s.createComment(org, repo, num, comment, resp)
+				return s.createComment(logger, org, repo, num, comment, resp)
 			}
 		}
 	}
 
 	// Create the branch for the cherry-pick.
 	if err := r.CheckoutNewBranch(newBranch); err != nil {
-		return err
+		return fmt.Errorf("failed to checkout %s: %w", newBranch, err)
 	}
 
 	// Title for GitHub issue/PR.
@@ -437,16 +438,21 @@ func (s *Server) handle(logger *logrus.Entry, requestor string, comment *github.
 
 	// Apply the patch.
 	if err := r.Am(localPath); err != nil {
+		errs := []error{fmt.Errorf("failed to `git am`: %w", err)}
+		logger.WithError(err).Warn("failed to apply PR on top of target branch")
 		resp := fmt.Sprintf("#%d failed to apply on top of branch %q:\n```\n%v\n```", num, targetBranch, err)
-		logger.Info(resp)
-		err := s.createComment(org, repo, num, comment, resp)
+		if err := s.createComment(logger, org, repo, num, comment, resp); err != nil {
+			errs = append(errs, fmt.Errorf("failed to create comment: %w", err))
+		}
 
 		if s.issueOnConflict {
 			resp = fmt.Sprintf("Manual cherrypick required.\n\n%v", resp)
-			return s.createIssue(org, repo, title, resp, num, comment, nil, []string{requestor})
+			if err := s.createIssue(logger, org, repo, title, resp, num, comment, nil, []string{requestor}); err != nil {
+				errs = append(errs, fmt.Errorf("failed to create issue: %w", err))
+			}
 		}
 
-		return err
+		return utilerrors.NewAggregate(errs)
 	}
 
 	push := r.PushToFork
@@ -455,9 +461,9 @@ func (s *Server) handle(logger *logrus.Entry, requestor string, comment *github.
 	}
 	// Push the new branch in the bot's fork.
 	if err := push(newBranch, true); err != nil {
+		logger.WithError(err).Warn("failed to push chery-picked changes to GitHub")
 		resp := fmt.Sprintf("failed to push cherry-picked changes in GitHub: %v", err)
-		logger.Info(resp)
-		return s.createComment(org, repo, num, comment, resp)
+		return utilerrors.NewAggregate([]error{err, s.createComment(logger, org, repo, num, comment, resp)})
 	}
 
 	// Open a PR in GitHub.
@@ -470,23 +476,24 @@ func (s *Server) handle(logger *logrus.Entry, requestor string, comment *github.
 	head := fmt.Sprintf("%s:%s", s.botUser.Login, newBranch)
 	createdNum, err := s.ghc.CreatePullRequest(org, repo, title, cherryPickBody, head, targetBranch, true)
 	if err != nil {
+		logger.WithError(err).Warn("failed to create new pull request")
 		resp := fmt.Sprintf("new pull request could not be created: %v", err)
-		logger.Info(resp)
-		return s.createComment(org, repo, num, comment, resp)
+		return utilerrors.NewAggregate([]error{err, s.createComment(logger, org, repo, num, comment, resp)})
 	}
+	*logger = *logger.WithField("new_pull_request_number", createdNum)
 	resp := fmt.Sprintf("new pull request created: #%d", createdNum)
-	logger.Info(resp)
-	if err := s.createComment(org, repo, num, comment, resp); err != nil {
-		return err
+	logger.Info("new pull request created")
+	if err := s.createComment(logger, org, repo, num, comment, resp); err != nil {
+		return fmt.Errorf("failed to create comment: %w", err)
 	}
 	for _, label := range s.labels {
 		if err := s.ghc.AddLabel(org, repo, createdNum, label); err != nil {
-			return err
+			return fmt.Errorf("failed to add label %s: %w", label, err)
 		}
 	}
 	if !s.prowAssignments {
 		if err := s.ghc.AssignIssue(org, repo, createdNum, []string{requestor}); err != nil {
-			logger.Warningf("Cannot assign to new PR: %v", err)
+			logger.WithError(err).Warn("failed to assign to new PR")
 			// Ignore returning errors on failure to assign as this is most likely
 			// due to users not being members of the org so that they can't be assigned
 			// in PRs.
@@ -496,21 +503,28 @@ func (s *Server) handle(logger *logrus.Entry, requestor string, comment *github.
 	return nil
 }
 
-func (s *Server) createComment(org, repo string, num int, comment *github.IssueComment, resp string) error {
-	if comment != nil {
-		return s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(*comment, resp))
+func (s *Server) createComment(l *logrus.Entry, org, repo string, num int, comment *github.IssueComment, resp string) error {
+	if err := func() error {
+		if comment != nil {
+			return s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(*comment, resp))
+		}
+		return s.ghc.CreateComment(org, repo, num, fmt.Sprintf("In response to a cherrypick label: %s", resp))
+	}(); err != nil {
+		l.WithError(err).Warn("failed to create comment")
+		return err
 	}
-	return s.ghc.CreateComment(org, repo, num, fmt.Sprintf("In response to a cherrypick label: %s", resp))
+	logrus.Debug("Created comment")
+	return nil
 }
 
 // createIssue creates an issue on GitHub.
-func (s *Server) createIssue(org, repo, title, body string, num int, comment *github.IssueComment, labels, assignees []string) error {
+func (s *Server) createIssue(l *logrus.Entry, org, repo, title, body string, num int, comment *github.IssueComment, labels, assignees []string) error {
 	issueNum, err := s.ghc.CreateIssue(org, repo, title, body, 0, labels, assignees)
 	if err != nil {
-		return s.createComment(org, repo, num, comment, fmt.Sprintf("new issue could not be created for failed cherrypick: %v", err))
+		return s.createComment(l, org, repo, num, comment, fmt.Sprintf("new issue could not be created for failed cherrypick: %v", err))
 	}
 
-	return s.createComment(org, repo, num, comment, fmt.Sprintf("new issue created for failed cherrypick: #%d", issueNum))
+	return s.createComment(l, org, repo, num, comment, fmt.Sprintf("new issue created for failed cherrypick: #%d", issueNum))
 }
 
 // ensureForkExists ensures a fork of org/repo exists for the bot.

--- a/prow/external-plugins/cherrypicker/server_test.go
+++ b/prow/external-plugins/cherrypicker/server_test.go
@@ -217,10 +217,12 @@ index 1ea52dc..5bd70a9 100644
 var body = "This PR updates the magic number.\n\n```release-note\nUpdate the magic number from 42 to 49\n```"
 
 func TestCherryPickIC(t *testing.T) {
+	t.Parallel()
 	testCherryPickIC(localgit.New, t)
 }
 
 func TestCherryPickICV2(t *testing.T) {
+	t.Parallel()
 	testCherryPickIC(localgit.NewV2, t)
 }
 
@@ -315,10 +317,12 @@ func testCherryPickIC(clients localgit.Clients, t *testing.T) {
 }
 
 func TestCherryPickPR(t *testing.T) {
+	t.Parallel()
 	testCherryPickPR(localgit.New, t)
 }
 
 func TestCherryPickPRV2(t *testing.T) {
+	t.Parallel()
 	testCherryPickPR(localgit.NewV2, t)
 }
 
@@ -486,10 +490,12 @@ func testCherryPickPR(clients localgit.Clients, t *testing.T) {
 }
 
 func TestCherryPickPRWithLabels(t *testing.T) {
+	t.Parallel()
 	testCherryPickPRWithLabels(localgit.New, t)
 }
 
 func TestCherryPickPRWithLabelsV2(t *testing.T) {
+	t.Parallel()
 	testCherryPickPRWithLabels(localgit.NewV2, t)
 }
 
@@ -669,6 +675,7 @@ func testCherryPickPRWithLabels(clients localgit.Clients, t *testing.T) {
 }
 
 func TestCherryPickCreateIssue(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		org       string
 		repo      string
@@ -710,7 +717,7 @@ func TestCherryPickCreateIssue(t *testing.T) {
 			ghc: ghc,
 		}
 
-		if err := s.createIssue(tc.org, tc.repo, tc.title, tc.body, tc.prNum, nil, tc.labels, tc.assignees); err != nil {
+		if err := s.createIssue(logrus.WithField("test", t.Name()), tc.org, tc.repo, tc.title, tc.body, tc.prNum, nil, tc.labels, tc.assignees); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 


### PR DESCRIPTION
* Initialize log so it gets standard component field and json formatting
* Actually propagate logger back up by adding fields to the value of the
  logger rather than assigning a new pointer to the pointer var which
  does not do anything wrt backpropagating
* Use fields instead of printf-style logging
* Add some error wrapping
* Aggregate errors rather than swallowing them when getting follow-up
  errors
* Parallelize tests, because they are uber slow _and_ executed serially