### PR TITLE
Kops - quote image flag value because it may contain spaces

### DIFF
--- a/config/jobs/kubernetes/kops/build_grid.py
+++ b/config/jobs/kubernetes/kops/build_grid.py
@@ -92,7 +92,7 @@ kubetest2_template = """
           -v 2 \\
           --up --down \\
           --cloud-provider=aws \\
-          --create-args="--image={{kops_image}} --networking={{networking}} --container-runtime={{container_runtime}}" \\
+          --create-args="--image='{{kops_image}}' --networking={{networking}} --container-runtime={{container_runtime}}" \\
           --env=KOPS_FEATURE_FLAGS={{kops_feature_flags}} \\
           --kops-version-marker={{kops_deploy_url}} \\
           --kubernetes-version={{k8s_deploy_url}} \\

--- a/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
@@ -31,7 +31,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
@@ -94,7 +94,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
@@ -157,7 +157,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
@@ -220,7 +220,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
@@ -283,7 +283,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=125523088429/CentOS 7.9.2009 x86_64 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='125523088429/CentOS 7.9.2009 x86_64' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
@@ -346,7 +346,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=125523088429/CentOS 8.3.2011 x86_64 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='125523088429/CentOS 8.3.2011 x86_64' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
@@ -409,7 +409,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
@@ -472,7 +472,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
@@ -535,7 +535,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
@@ -598,7 +598,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=calico --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -18751,7 +18751,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -18814,7 +18814,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -18877,7 +18877,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -18940,7 +18940,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -19003,7 +19003,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -19066,7 +19066,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -19129,7 +19129,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -19192,7 +19192,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -19255,7 +19255,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -19318,7 +19318,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -19381,7 +19381,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -19444,7 +19444,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -19507,7 +19507,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -19570,7 +19570,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -19633,7 +19633,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -19696,7 +19696,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -19759,7 +19759,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -19822,7 +19822,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -19885,7 +19885,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -19948,7 +19948,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -20011,7 +20011,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -20074,7 +20074,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -20137,7 +20137,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -20200,7 +20200,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -20263,7 +20263,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -20326,7 +20326,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -20389,7 +20389,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -20452,7 +20452,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -20515,7 +20515,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -20578,7 +20578,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -20641,7 +20641,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -20704,7 +20704,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -20767,7 +20767,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -20830,7 +20830,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -20893,7 +20893,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -20956,7 +20956,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -21019,7 +21019,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -21082,7 +21082,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -21145,7 +21145,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -21208,7 +21208,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -21271,7 +21271,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -21334,7 +21334,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -21397,7 +21397,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -21460,7 +21460,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -21523,7 +21523,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -21586,7 +21586,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -21649,7 +21649,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -21712,7 +21712,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -21775,7 +21775,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -21838,7 +21838,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -21901,7 +21901,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -21964,7 +21964,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -22027,7 +22027,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -22090,7 +22090,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -22153,7 +22153,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -22216,7 +22216,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=kubenet --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=kubenet --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -22279,7 +22279,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -22342,7 +22342,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -22405,7 +22405,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -22468,7 +22468,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -22531,7 +22531,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -22594,7 +22594,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -22657,7 +22657,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -22720,7 +22720,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -22783,7 +22783,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -22846,7 +22846,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -22909,7 +22909,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -22972,7 +22972,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -23035,7 +23035,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -23098,7 +23098,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -23161,7 +23161,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -23224,7 +23224,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -23287,7 +23287,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -23350,7 +23350,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -23413,7 +23413,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -23476,7 +23476,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -23539,7 +23539,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -23602,7 +23602,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=calico --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -23665,7 +23665,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=calico --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -23728,7 +23728,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=calico --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -23791,7 +23791,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=calico --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -23854,7 +23854,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=calico --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -23917,7 +23917,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=calico --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -23980,7 +23980,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=calico --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -24043,7 +24043,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -24106,7 +24106,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -24169,7 +24169,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -24232,7 +24232,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -24295,7 +24295,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -24358,7 +24358,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -24421,7 +24421,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -24484,7 +24484,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -24547,7 +24547,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -24610,7 +24610,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -24673,7 +24673,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -24736,7 +24736,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -24799,7 +24799,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -24862,7 +24862,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -24925,7 +24925,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -24988,7 +24988,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -25051,7 +25051,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -25114,7 +25114,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -25177,7 +25177,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -25240,7 +25240,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -25303,7 +25303,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -25366,7 +25366,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -25429,7 +25429,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -25492,7 +25492,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -25555,7 +25555,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -25618,7 +25618,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -25681,7 +25681,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -25744,7 +25744,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=calico --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=calico --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -25807,7 +25807,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -25870,7 +25870,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -25933,7 +25933,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -25996,7 +25996,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -26059,7 +26059,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -26122,7 +26122,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -26185,7 +26185,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -26248,7 +26248,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -26311,7 +26311,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -26374,7 +26374,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -26437,7 +26437,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -26500,7 +26500,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -26563,7 +26563,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -26626,7 +26626,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -26689,7 +26689,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -26752,7 +26752,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -26815,7 +26815,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -26878,7 +26878,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -26941,7 +26941,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -27004,7 +27004,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -27067,7 +27067,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -27130,7 +27130,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -27193,7 +27193,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -27256,7 +27256,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -27319,7 +27319,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -27382,7 +27382,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -27445,7 +27445,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -27508,7 +27508,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -27571,7 +27571,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -27634,7 +27634,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -27697,7 +27697,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -27760,7 +27760,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -27823,7 +27823,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -27886,7 +27886,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -27949,7 +27949,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -28012,7 +28012,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -28075,7 +28075,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -28138,7 +28138,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -28201,7 +28201,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -28264,7 +28264,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -28327,7 +28327,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -28390,7 +28390,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -28453,7 +28453,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -28516,7 +28516,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -28579,7 +28579,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -28642,7 +28642,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -28705,7 +28705,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -28768,7 +28768,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -28831,7 +28831,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -28894,7 +28894,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -28957,7 +28957,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -29020,7 +29020,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -29083,7 +29083,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -29146,7 +29146,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -29209,7 +29209,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -29272,7 +29272,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=cilium --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=cilium --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -29335,7 +29335,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -29398,7 +29398,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -29461,7 +29461,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -29524,7 +29524,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -29587,7 +29587,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -29650,7 +29650,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -29713,7 +29713,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -29776,7 +29776,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -29839,7 +29839,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -29902,7 +29902,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -29965,7 +29965,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -30028,7 +30028,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -30091,7 +30091,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -30154,7 +30154,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -30217,7 +30217,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -30280,7 +30280,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -30343,7 +30343,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -30406,7 +30406,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -30469,7 +30469,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -30532,7 +30532,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -30595,7 +30595,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -30658,7 +30658,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -30721,7 +30721,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -30784,7 +30784,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -30847,7 +30847,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -30910,7 +30910,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -30973,7 +30973,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -31036,7 +31036,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -31099,7 +31099,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -31162,7 +31162,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -31225,7 +31225,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -31288,7 +31288,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -31351,7 +31351,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -31414,7 +31414,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -31477,7 +31477,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -31540,7 +31540,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -31603,7 +31603,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -31666,7 +31666,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -31729,7 +31729,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -31792,7 +31792,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -31855,7 +31855,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -31918,7 +31918,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -31981,7 +31981,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -32044,7 +32044,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -32107,7 +32107,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -32170,7 +32170,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -32233,7 +32233,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -32296,7 +32296,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -32359,7 +32359,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -32422,7 +32422,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -32485,7 +32485,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -32548,7 +32548,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -32611,7 +32611,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -32674,7 +32674,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -32737,7 +32737,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -32800,7 +32800,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=flannel --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=flannel --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -32863,7 +32863,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -32926,7 +32926,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -32989,7 +32989,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -33052,7 +33052,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -33115,7 +33115,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -33178,7 +33178,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -33241,7 +33241,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='137112412989/amzn2-ami-hvm-2.0.20201126.0-x86_64-gp2' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -33304,7 +33304,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -33367,7 +33367,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -33430,7 +33430,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -33493,7 +33493,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -33556,7 +33556,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -33619,7 +33619,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -33682,7 +33682,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2020-10-31-2842' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -33745,7 +33745,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -33808,7 +33808,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -33871,7 +33871,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -33934,7 +33934,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -33997,7 +33997,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -34060,7 +34060,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -34123,7 +34123,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=136693071363/debian-10-amd64-20201207-477 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='136693071363/debian-10-amd64-20201207-477' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -34186,7 +34186,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -34249,7 +34249,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -34312,7 +34312,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -34375,7 +34375,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -34438,7 +34438,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -34501,7 +34501,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -34564,7 +34564,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=075585003325/Flatcar-stable-2605.11.0-hvm --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='075585003325/Flatcar-stable-2605.11.0-hvm' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -34627,7 +34627,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -34690,7 +34690,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -34753,7 +34753,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -34816,7 +34816,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -34879,7 +34879,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -34942,7 +34942,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -35005,7 +35005,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -35068,7 +35068,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -35131,7 +35131,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -35194,7 +35194,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -35257,7 +35257,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -35320,7 +35320,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -35383,7 +35383,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -35446,7 +35446,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='309956199498/RHEL-8.3.0_HVM-20201031-x86_64-0-Hourly2-GP2' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -35509,7 +35509,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -35572,7 +35572,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -35635,7 +35635,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -35698,7 +35698,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -35761,7 +35761,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -35824,7 +35824,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -35887,7 +35887,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201201' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
@@ -35950,7 +35950,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -36013,7 +36013,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
@@ -36076,7 +36076,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -36139,7 +36139,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
@@ -36202,7 +36202,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -36265,7 +36265,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
@@ -36328,7 +36328,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1 --networking=kopeio --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=kopeio --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \


### PR DESCRIPTION
the centos image name contains spaces so we need to quote this value.

fixes: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/e2e-kops-aws-distro-imagecentos8/1358857681191833600


This likely wont fix this entirely because we still split on spaces before while passing the args to the kops command, but we will address that in the kops repo:

https://github.com/kubernetes/kops/blob/b78d66464a8e876e8d17a3d532b7bd4402b50e5f/tests/e2e/kubetest2-kops/deployer/up.go#L94-L96

