### PR TITLE
Use the image-repo-list-2004 for GCE Kubernetes Windows 2004 and 20H2 E2E tests.

### DIFF
--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -154,6 +154,7 @@ periodics:
     preset-service-account: "true"
     preset-common-gce-windows: "true"
     preset-e2e-gce-windows: "true"
+    preset-windows-repo-list-2004: "true"
   spec:
     containers:
     - command:
@@ -199,6 +200,7 @@ periodics:
     preset-service-account: "true"
     preset-common-gce-windows: "true"
     preset-e2e-gce-windows: "true"
+    preset-windows-repo-list-2004: "true"
   spec:
     containers:
     - command:


### PR DESCRIPTION
This change will address the network failures in https://testgrid.k8s.io/sig-release-master-informing#gce-windows-2004-master.

What's happening here is:
```
Feb  9 09:25:19.431: INFO: At 2021-02-09 09:10:54 +0000 UTC - event for dns-test-49433686-a5d4-4dff-a502-c3ae62a30f2b: {kubelet e2e-117c4d6c7f-c48e0-windows-node-group-137d} Pulling: Pulling image "k8sprow.azurecr.io/kubernetes-e2e-test-images/jessie-dnsutils:1.4"
Feb  9 09:25:19.431: INFO: At 2021-02-09 09:10:56 +0000 UTC - event for dns-test-49433686-a5d4-4dff-a502-c3ae62a30f2b: {kubelet e2e-117c4d6c7f-c48e0-windows-node-group-137d} Failed: Error: ErrImagePull
Feb  9 09:25:19.431: INFO: At 2021-02-09 09:11:33 +0000 UTC - event for dns-test-49433686-a5d4-4dff-a502-c3ae62a30f2b: {kubelet e2e-117c4d6c7f-c48e0-windows-node-group-137d} BackOff: Back-off pulling image "k8sprow.azurecr.io/kubernetes-e2e-test-images/jessie-dnsutils:1.4"
Feb  9 09:25:19.431: INFO: At 2021-02-09 09:13:07 +0000 UTC - event for dns-test-49433686-a5d4-4dff-a502-c3ae62a30f2b: {kubelet e2e-117c4d6c7f-c48e0-windows-node-group-137d} BackOff: Back-off restarting failed container
```

These images are actually sourced from the `promoterE2eRegistry` spec which defaults to [`k8s.gcr.io/e2e-test-images`](https://github.com/kubernetes/kubernetes/blob/master/test/utils/image/manifest.go#L78). The 1.4 image is located there.