### PR TITLE
cluster-capacity|descheduler: bump golang version to 1.15.8

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.15.5
+      - image: golang:1.15.8
         command:
         - make
         args:
@@ -18,7 +18,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.15.5
+      - image: golang:1.15.8
         command:
         - make
         args:
@@ -29,7 +29,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.15.5
+      - image: golang:1.15.8
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
@@ -13,7 +13,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.15.5
+      - image: golang:1.15.8
         command:
         - make
         args:
@@ -30,7 +30,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.15.5
+      - image: golang:1.15.8
         command:
         - make
         args:
@@ -47,7 +47,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.15.5
+      - image: golang:1.15.8
         command:
         - make
         args:


### PR DESCRIPTION
Kubernetes master head built with go1.15.8 now: https://github.com/kubernetes/kubernetes/pull/98834