### PR TITLE
Needs rebase: Include PR metadata in log when handling

### DIFF
--- a/prow/external-plugins/needs-rebase/BUILD.bazel
+++ b/prow/external-plugins/needs-rebase/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//prow/github:go_default_library",
         "//prow/interrupts:go_default_library",
         "//prow/labels:go_default_library",
+        "//prow/logrusutil:go_default_library",
         "//prow/pjutil:go_default_library",
         "//prow/pluginhelp/externalplugins:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/external-plugins/needs-rebase/main.go
+++ b/prow/external-plugins/needs-rebase/main.go
@@ -35,6 +35,7 @@ import (
 	prowflagutil "k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/labels"
+	"k8s.io/test-infra/prow/logrusutil"
 
 	"k8s.io/test-infra/prow/pluginhelp/externalplugins"
 	"k8s.io/test-infra/prow/plugins"
@@ -80,12 +81,12 @@ func gatherOptions() options {
 }
 
 func main() {
+	logrusutil.ComponentInit()
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {
 		logrus.Fatalf("Invalid options: %v", err)
 	}
 
-	logrus.SetFormatter(&logrus.JSONFormatter{})
 	// TODO: Use global option from the prow config.
 	logrus.SetLevel(logrus.InfoLevel)
 	log := logrus.StandardLogger().WithField("plugin", labels.NeedsRebase)

--- a/prow/external-plugins/needs-rebase/plugin/plugin.go
+++ b/prow/external-plugins/needs-rebase/plugin/plugin.go
@@ -103,6 +103,12 @@ func handle(log *logrus.Entry, ghc githubClient, pr *github.PullRequest) error {
 	repo := pr.Base.Repo.Name
 	number := pr.Number
 	sha := pr.Head.SHA
+	*log = *log.WithFields(logrus.Fields{
+		github.OrgLogField:  org,
+		github.RepoLogField: repo,
+		github.PrLogField:   number,
+		"head-sha":          sha,
+	})
 
 	mergeable, err := ghc.IsMergeable(org, repo, number, sha)
 	if err != nil {


### PR DESCRIPTION
After the plugin doesn't appear to be working properly in https://github.com/kubernetes/test-infra/pull/20797 I noticed that its error log is pretty useless, it currently emits something like:
```
error: "pull request head changed while checking mergeability (10ef7a42a600712635a09f833b5b0c433f75c36a -> c2d078d0d6cd3cdf516f9894ecc754f3db618896)"
event-type: "issue_comment"
level: "info"
msg: "Error handling event."
plugin: "needs-rebase"
event-GUID: "b1a78d80-6acd-11eb-8e57-c94ff737657a"
```

Which is hard to correlate to a PR. Very ironic after I just said that our logging is fine. It appears the external plugins didn't get much love there.

/assign @matthyx 