### PR TITLE
releng: Add a label for security-related issues/PRs

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -340,6 +340,7 @@ larger set of contributors to apply/remove them.
 | ---- | ----------- | -------- | --- |
 | <a id="area/artifacts" href="#area/artifacts">`area/artifacts`</a> | Issues or PRs related to the hosting of release artifacts for subprojects| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="area/release-eng" href="#area/release-eng">`area/release-eng`</a> | Issues or PRs related to the Release Engineering subproject <br><br> This was previously `area/release-infra`, | label | |
+| <a id="area/release-eng/security" href="#area/release-eng/security">`area/release-eng/security`</a> | Issues or PRs related to release engineering security| label | |
 
 ## Labels that apply to kubernetes/sig-release, for both issues and PRs
 
@@ -348,6 +349,7 @@ larger set of contributors to apply/remove them.
 | <a id="area/artifacts" href="#area/artifacts">`area/artifacts`</a> | Issues or PRs related to the hosting of release artifacts for subprojects| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="area/enhancements" href="#area/enhancements">`area/enhancements`</a> | Issues or PRs related to the Enhancements subproject| label | |
 | <a id="area/release-eng" href="#area/release-eng">`area/release-eng`</a> | Issues or PRs related to the Release Engineering subproject <br><br> This was previously `area/release-infra`, | label | |
+| <a id="area/release-eng/security" href="#area/release-eng/security">`area/release-eng/security`</a> | Issues or PRs related to release engineering security| label | |
 | <a id="area/release-team" href="#area/release-team">`area/release-team`</a> | Issues or PRs related to the release-team subproject| label | |
 
 ## Labels that apply to kubernetes/test-infra, for both issues and PRs

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -1051,6 +1051,11 @@ repos:
           - name: area/release-infra
         target: both
         addedBy: label
+      - color: 0052cc
+        description: Issues or PRs related to release engineering security
+        name: area/release-eng/security
+        target: both
+        addedBy: label
   kubernetes/sig-release:
     labels:
       - color: 0052cc
@@ -1069,6 +1074,11 @@ repos:
         name: area/release-eng
         previously:
           - name: area/release-infra
+        target: both
+        addedBy: label
+      - color: 0052cc
+        description: Issues or PRs related to release engineering security
+        name: area/release-eng/security
         target: both
         addedBy: label
       - color: 0052cc


### PR DESCRIPTION
...because we often "do a security" and don't have a label to represent that.
ref: https://github.com/kubernetes/release/pull/1903#issuecomment-776430786

Signed-off-by: Stephen Augustus <foo@auggie.dev>

cc: @kubernetes/release-engineering @kubernetes/sig-release-leads 
/area release-eng
