### PR TITLE
Standardize on review = lgtm (+ approve) for SIG Testing repos

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -132,9 +132,10 @@ label:
 lgtm:
 - repos:
   - bazelbuild
-  - kubernetes/repo-infra
   - kubernetes-sigs/boskos
   - kubernetes-sigs/kind
+  - kubernetes/k8s.io
+  - kubernetes/repo-infra
   - kubernetes/test-infra
   review_acts_as_lgtm: true
 - repos:

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -85,7 +85,10 @@ approve:
 - repos:
   - bazelbuild
   - kubernetes-sigs/boskos
+  - kubernetes-sigs/e2e-framework
+  - kubernetes-sigs/k8s-gsm-tools
   - kubernetes-sigs/kind
+  - kubernetes-sigs/kubetest2
   - kubernetes-sigs/slack-infra
   - kubernetes/community
   - kubernetes/k8s.io
@@ -133,7 +136,10 @@ lgtm:
 - repos:
   - bazelbuild
   - kubernetes-sigs/boskos
+  - kubernetes-sigs/e2e-framework
+  - kubernetes-sigs/k8s-gsm-tools
   - kubernetes-sigs/kind
+  - kubernetes-sigs/kubetest2
   - kubernetes/k8s.io
   - kubernetes/repo-infra
   - kubernetes/test-infra


### PR DESCRIPTION
The workflow present today for kubernetes/test-infra a few other repos owned by SIG Testing is:
- click "Review Pull Request" click the "Approve" radio button
- if you are an org member, this will act as /lgtm
- if you are an approver, this will also act as /approve

I propose we standardize on this workflow for all SIG Testing subprojects

In addition, I propose we use this for kubernetes/k8s.io (which already allows reviews to act as /approve)