### PR TITLE
Updating OWNERS files for sig-windows job configs

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/OWNERS
+++ b/config/jobs/kubernetes-sigs/sig-windows/OWNERS
@@ -1,22 +1,26 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- PatrickLang
 - adelina-t
 - andyzhangx
-- benmoss
 - chewong
 - claudiubelu
+- ddebroy
 - feiskyer
+- jayunit100
 - jsturtevant
 - marosset
 approvers:
-- PatrickLang
 - adelina-t
 - andyzhangx
 - benmoss
 - chewong
 - claudiubelu
+- ddebroy
 - feiskyer
+- jayunit100
 - jsturtevant
 - marosset
+
+labels:
+- sig/windows

--- a/config/jobs/kubernetes/sig-windows/OWNERS
+++ b/config/jobs/kubernetes/sig-windows/OWNERS
@@ -1,16 +1,18 @@
 reviewers:
-- benmoss
+- chewong
 - ddebroy
+- jayunit100
 - jeremyje
-- michmike
-- PatrickLang
+- jsturtevant
+- marosset
 - pjh
 approvers:
-- benmoss
+- chewong
 - ddebroy
+- jayunit100
 - jeremyje
-- michmike
-- PatrickLang
+- jsturtevant
+- marosset
 - pjh
 
 labels:


### PR DESCRIPTION
Updating owners files for sig-windows job configs.
- Removing old leads
- Adding new leads
- Adding chewong to kubernetes/sig-windows/OWNERS