### PR TITLE
Fix cherrypicker when the fork is not named the same as the repo

### DIFF
--- a/prow/external-plugins/cherrypicker/server.go
+++ b/prow/external-plugins/cherrypicker/server.go
@@ -556,7 +556,8 @@ func (s *Server) ensureForkExists(org, repo string) (string, error) {
 	fork := s.botUser.Login + "/" + repo
 
 	// fork repo if it doesn't exsit
-	if _, err := s.ghc.EnsureFork(s.botUser.Login, org, repo); err != nil {
+	repo, err := s.ghc.EnsureFork(s.botUser.Login, org, repo)
+	if err != nil {
 		return repo, err
 	}
 


### PR DESCRIPTION
If the fork name was not the same as the repo name, we were not returning the right value for ensureForkExists