### PR TITLE
sig-windows: update pause-win image to the new one k8s.gcr.io/pause:3.4.1

### DIFF
--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -447,7 +447,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210207-08ffabe-master
       env:
       - name: CL2_CONTAINER_IMAGE
-        value: "gcr.io/gke-release/pause-win:1.2.1"
+        value: "k8s.gcr.io/pause:3.4.1"
       - name: CL2_WMI_EXPORTER_URL
         value: "https://github.com/martinlindhe/wmi_exporter/releases/download/v0.11.0/wmi_exporter-0.11.0-amd64.exe"
       - name: CL2_WMI_EXPORTER_ENABLED_COLLECTORS


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

As part of the efforts described in this Issue: https://github.com/kubernetes/k8s.io/issues/1525 we are trying to move away from `gcp project gke-release`

Also the pause image was release with windows support as we can see in the merged or in k/k https://github.com/kubernetes/kubernetes/pull/98205

/assign @spiffxp @jeremyje
