### PR TITLE
[KEP-1933]: Graduation to GA

### DIFF
--- a/config/jobs/kubernetes/sig-instrumentation/verify-govet-levee.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/verify-govet-levee.yaml
@@ -6,7 +6,7 @@ presubmits:
     decorate: true
     skip_branches:
       - release-\d+.\d+ # per-release job
-    optional: true
+    optional: false
     skip_report: false
     path_alias: k8s.io/kubernetes
     annotations:

--- a/config/testgrids/kubernetes/presubmits/config.yaml
+++ b/config/testgrids/kubernetes/presubmits/config.yaml
@@ -77,6 +77,9 @@ dashboards:
   - name: pull-kubernetes-e2e-gce-ubuntu-containerd
     test_group_name: pull-kubernetes-e2e-gce-ubuntu-containerd
     base_options: width=10
+  - name: pull-kubernetes-verify-govet-levee
+    test_group_name: pull-kubernetes-verify-govet-levee
+    base_options: width=10
 - name: presubmits-kubernetes-nonblocking
   dashboard_tab:
   - name: pull-kubernetes-e2e-gce-network-proxy-grpc
@@ -147,9 +150,6 @@ dashboards:
     base_options: width=10
   - name: pull-kubernetes-files-remake
     test_group_name: pull-kubernetes-files-remake
-    base_options: width=10
-  - name: pull-kubernetes-verify-govet-levee
-    test_group_name: pull-kubernetes-verify-govet-levee
     base_options: width=10
 - name: presubmits-kubernetes-scalability
   dashboard_tab:


### PR DESCRIPTION
This PR changes the job configuration for [KEP-1933](https://github.com/kubernetes/enhancements/issues/1933)'s `verify-govet-levee` presubmit to make it blocking, which represents graduation to GA.

The job has been running in Prow without issues for a few months now (started in December 2020). Therefore we consider the graduation criteria to have been met. `Beta --> GA` graduation criteria are described in the KEP as follows:
* Test is validated as running soundly at scale.
* No false positives, test failures, or other concerning issues are raised for 1-2 weeks.

(Link to the original KEP proposal [here](https://github.com/kubernetes/enhancements/pull/1936).)

Past runs may be seen in the Prow dashboard [here](https://prow.k8s.io/?job=pull-kubernetes-verify-govet-levee). The few failures that we've observed seem to be due to errors that are unrelated to the analysis itself (e.g. merge conflicts, code that doesn't build, etc.)

Since the analysis was originally introduced, we have made improvements to the tool resulting in a new version. We have a PR open for incrementing the version in `kubernetes/kubernetes` here:
https://github.com/kubernetes/kubernetes/pull/96999

Although it is not technically a graduation criteria, we care about the developer experience and we want to make sure that developers are able to diagnose and resolve issues found by the tool. We are adding documentation to `kubernetes/community` in a PR here: 
https://github.com/kubernetes/community/pull/5349#pullrequestreview-588612788

We will include a link to this documentation in the error message produced by the analysis once the documentation has been merged.

---

FYI: we are currently transferring ownership of the KEP (see https://github.com/kubernetes/enhancements/pull/2303), as well as the analyzer's configuration (https://github.com/kubernetes/kubernetes/pull/97168), to SIG-Security.