### PR TITLE
Cherrypicker: Do not react to unrelated label events

### DIFF
--- a/prow/external-plugins/cherrypicker/server.go
+++ b/prow/external-plugins/cherrypicker/server.go
@@ -321,6 +321,10 @@ func (s *Server) handlePullRequest(l *logrus.Entry, pre github.PullRequestEvent)
 		return nil
 	}
 
+	if !foundCherryPickLabels && pre.Action == github.PullRequestActionLabeled {
+		return nil
+	}
+
 	// Figure out membership.
 	if !s.allowAll {
 		// TODO: Possibly cache this.


### PR DESCRIPTION
If a PR was labeled but doesn't have the cherrypick label, we should just do nothing