### PR TITLE
Deck: surface all initcontainer errors

### DIFF
--- a/prow/spyglass/lenses/metadata/lens.go
+++ b/prow/spyglass/lenses/metadata/lens.go
@@ -235,11 +235,12 @@ func hintFromPodInfo(buf []byte) string {
 	}
 
 	// There are cases where initContainers failed to start
-	var msg string
+	var msgs []string
 	for _, ic := range report.Pod.Status.InitContainerStatuses {
 		if ic.Ready {
 			continue
 		}
+		var msg string
 		// Init container not ready by the time this job failed
 		// The 3 different states should be mutually exclusive, if it happens
 		// that there are more than one, use the most severe one
@@ -250,9 +251,9 @@ func hintFromPodInfo(buf []byte) string {
 		} else if state := ic.State.Running; state != nil { // This shouldn't happen at all, just in case.
 			logrus.WithField("pod", report.Pod.Name).WithField("container", ic.Name).Warning("Init container is running but not ready")
 		}
-		msg = fmt.Sprintf("Init container %s not ready: (%s)", ic.Name, msg)
+		msgs = append(msgs, fmt.Sprintf("Init container %s not ready: (%s)", ic.Name, msg))
 	}
-	return msg
+	return strings.Join(msgs, "\n")
 }
 
 func hintFromProwJob(buf []byte) (string, bool) {

--- a/prow/spyglass/lenses/metadata/lens_test.go
+++ b/prow/spyglass/lenses/metadata/lens_test.go
@@ -372,6 +372,62 @@ func TestHintFromPodInfo(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "multiple init containers failed to start",
+			expected: "Init container entrypoint not ready: (state: waiting, reason: \"PodInitializing\", message: \"\")\nInit container initupload not ready: (state: terminated, reason: \"Error\", message: \"failed fetching oauth2 token\")",
+			info: k8sreporter.PodReport{
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "8ef160fc-46b6-11ea-a907-1a9873703b03",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name:  "test",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-master",
+							},
+						},
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodPending,
+						InitContainerStatuses: []v1.ContainerStatus{
+							{
+								Name:  "entrypoint",
+								Ready: false,
+								State: v1.ContainerState{
+									Waiting: &v1.ContainerStateWaiting{
+										Reason:  "PodInitializing",
+										Message: "",
+									},
+								},
+							},
+							{
+								Name:  "initupload",
+								Ready: false,
+								State: v1.ContainerState{
+									Terminated: &v1.ContainerStateTerminated{
+										Reason:  "Error",
+										Message: "failed fetching oauth2 token",
+									},
+								},
+							},
+						},
+						ContainerStatuses: []v1.ContainerStatus{
+							{
+								Name:  "test",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-master",
+								Ready: false,
+								State: v1.ContainerState{
+									Waiting: &v1.ContainerStateWaiting{
+										Reason: "PodInitializing",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
#20827 enabled deck to report initcontainer error, but it only reported the last failed container instead of all, correcting that in this PR