### PR TITLE
Deck: also capture 'ErrImagePull' as reason for prow job failures

### DIFF
--- a/prow/spyglass/lenses/metadata/lens.go
+++ b/prow/spyglass/lenses/metadata/lens.go
@@ -188,8 +188,8 @@ func hintFromPodInfo(buf []byte) string {
 	}
 	// Check if we have any images that didn't pull
 	for _, s := range append(report.Pod.Status.InitContainerStatuses, report.Pod.Status.ContainerStatuses...) {
-		if s.State.Waiting != nil && s.State.Waiting.Reason == "ImagePullBackOff" {
-			return fmt.Sprintf("The %s container could not start because it could not pull %q. Check your images.", s.Name, s.Image)
+		if s.State.Waiting != nil && (s.State.Waiting.Reason == "ImagePullBackOff" || s.State.Waiting.Reason == "ErrImagePull") {
+			return fmt.Sprintf("The %s container could not start because it could not pull %q. Check your images. Full message: %q", s.Name, s.Image, s.State.Waiting.Message)
 		}
 	}
 	// Check if we're trying to mount a volume

--- a/prow/spyglass/lenses/metadata/lens_test.go
+++ b/prow/spyglass/lenses/metadata/lens_test.go
@@ -145,7 +145,7 @@ func TestHintFromPodInfo(t *testing.T) {
 		},
 		{
 			name:     "stuck images are reported by name",
-			expected: `The test container could not start because it could not pull "gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-master". Check your images.`,
+			expected: `The test container could not start because it could not pull "gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-master". Check your images. Full message: "rpc error: code = Unknown desc"`,
 			info: k8sreporter.PodReport{
 				Pod: &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -168,7 +168,43 @@ func TestHintFromPodInfo(t *testing.T) {
 								Ready: false,
 								State: v1.ContainerState{
 									Waiting: &v1.ContainerStateWaiting{
-										Reason: "ImagePullBackOff",
+										Reason:  "ImagePullBackOff",
+										Message: "rpc error: code = Unknown desc",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "stuck images are reported by name - errimagepull",
+			expected: `The test container could not start because it could not pull "gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-master". Check your images. Full message: "rpc error: code = Unknown desc"`,
+			info: k8sreporter.PodReport{
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "8ef160fc-46b6-11ea-a907-1a9873703b03",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name:  "test",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-master",
+							},
+						},
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodPending,
+						ContainerStatuses: []v1.ContainerStatus{
+							{
+								Name:  "test",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-master",
+								Ready: false,
+								State: v1.ContainerState{
+									Waiting: &v1.ContainerStateWaiting{
+										Reason:  "ErrImagePull",
+										Message: "rpc error: code = Unknown desc",
 									},
 								},
 							},


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/test-infra/issues/20840