### PR TITLE
Link to prowjob config in testgrid descriptions

### DIFF
--- a/testgrid/config-upload.sh
+++ b/testgrid/config-upload.sh
@@ -29,6 +29,8 @@ for output in gs://k8s-testgrid-canary/config gs://k8s-testgrid/config; do
       --prow-config="${TESTINFRA_ROOT}/config/prow/config.yaml" \
       --prow-job-config="${TESTINFRA_ROOT}/config/jobs/" \
       --output="${output}" \
+      --prowjob-url-prefix="https://git.k8s.io/test-infra/config/jobs/" \
+      --update-description \
       --oneshot \
       --world-readable \
       "$@"


### PR DESCRIPTION
Since k8s community is using testgrid as one-stop-shop, make
it easy to get to the job config for reading / PR'ing

If --prow-job-url-prefix specified, add link to prowjob config
to auto-defaulted testgrid tab description.

If --update-description enabled, prepend the auto-defaulted
testgrid tab description to the description picked up from
annotated prowjobs.

Since it is unlikely testgrid supports links in tab descriptions
at present, use a copy-pastable url.

Added test cases