### PR TITLE
kubernetes-csi: test distributed provisioning/CSIStorageCapacity

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-host-path/manual-job-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/manual-job-config.yaml
@@ -1,0 +1,102 @@
+# Derived from csi-driver-host-path-config.yaml, modified and maintained manually.
+
+presubmits:
+  kubernetes-csi/csi-driver-host-path:
+  - name: pull-kubernetes-csi-csi-driver-host-path-distributed-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
+      testgrid-tab-name: distributed-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo csi-driver-host-path for distributed deployment on Kubernetes master, with CSIStorageCapacity
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_DEPLOYMENT
+          value: "kubernetes-distributed"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.5.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v3.0.3"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel serial-alpha parallel-alpha"
+        - name: CSI_PROW_SANITY_POD
+          value: csi-hostpath-socat-0
+        - name: CSI_PROW_SANITY_CONTAINER
+          value: socat
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+  - name: pull-kubernetes-csi-csi-driver-host-distributed-on-kubernetes-1-19
+    # Explicitly needs to be started with /test.
+    # Will only work on branches with https://github.com/kubernetes-csi/csi-driver-host-path/pull/248 merged.
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: []
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
+      testgrid-tab-name: distributed-on-kubernetes-1-19
+      description: Kubernetes-CSI pull job in repo csi-driver-host-path for distributed deployment on Kubernetes 1.19, with CSIStorageCapacity
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.19.0"
+        - name: CSI_PROW_DEPLOYMENT
+          value: "kubernetes-distributed"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.5.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v3.0.3"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel serial-alpha parallel-alpha"
+        - name: CSI_PROW_SANITY_POD
+          value: csi-hostpath-socat-0
+        - name: CSI_PROW_SANITY_CONTAINER
+          value: socat
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 2000m
+
+# TODO once https://github.com/kubernetes-csi/csi-driver-host-path/pull/248 is merged:
+# enable periodic testing


### PR DESCRIPTION
These new jobs use a deployment of the hostpath driver with
distributed provisioning and (on alpha clusters) CSIStorageCapacity.

/assign @msau42 