### PR TITLE
prow/deck: fix pr status (GHE)

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -4109,6 +4109,7 @@ func (c *client) ListCheckRuns(org, repo, ref string) (*CheckRunList, error) {
 
 	var checkRunList CheckRunList
 	_, err := c.request(&request{
+		accept:    "application/vnd.github.antiope-preview+json",
 		method:    http.MethodGet,
 		path:      fmt.Sprintf("/repos/%s/%s/commits/%s/check-runs", org, repo, ref),
 		org:       org,


### PR DESCRIPTION
Previously the check header was only send for GraphQL calls. The pr
status page also needs calls to the regular check endpoint. Thus, we
also have to send the header in this case.

xref: https://github.com/kubernetes/test-infra/pull/19806