### PR TITLE
Migrate some sig-net jobs to podutils

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -110,20 +110,18 @@ presubmits:
 
   kubernetes/dns:
   - name: pull-kubernetes-dns-test
-    branches:
-    - master
     always_run: true
+    decorate: true
+    path_alias: k8s.io/dns
     labels:
       preset-service-account: "true"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/gcloud-in-go:v20200824-5d057db
+        command:
+        - runner.sh
+        - /workspace/scenarios/execute.py
         args:
-        - --repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)
-        - --root=/go/src
-        - --upload=gs://kubernetes-jenkins/pr-logs
-        - --scenario=execute
-        - --
         - "true"
 
 periodics:

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -69,6 +69,13 @@ presubmits:
     always_run: false
     run_if_changed: '^pkg/.*/ipvs/'
     optional: true
+    decorate: true
+    path_alias: k8s.io/kubernetes
+    extra_refs:
+    - org: kubernetes
+      repo: release
+      base_ref: master
+      path_alias: "k8s.io/release"
     skip_report: false
     annotations:
       testgrid-create-test-group: "true"
@@ -81,14 +88,10 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
     spec:
       containers:
-      - args:
-        - --root=/go/src
-        - --repo=k8s.io/kubernetes=$(PULL_REFS)
-        - --repo=k8s.io/release
-        - --upload=gs://kubernetes-jenkins/pr-logs
-        - --timeout=105
-        - --scenario=kubernetes_e2e
-        - --
+      - command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        args:
         - --build=bazel
         - --cluster=
         - --env=KUBE_PROXY_MODE=ipvs


### PR DESCRIPTION
Fixes: #20324 (partially, periodic jobs still need to be migrated)

This PR migrates some Sig Network Prow jobs to use podutils 

In a future, we will also need to migrate to kubetest2, and check the periodic tests (figuring out owners, if this is still something, etc).

/cc @aojea @spiffxp 