### PR TITLE
Remove inactive members from OWNERS - Jan 2021

### DIFF
--- a/config/jobs/GoogleCloudPlatform/k8s-multicluster-ingress/OWNERS
+++ b/config/jobs/GoogleCloudPlatform/k8s-multicluster-ingress/OWNERS
@@ -1,6 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- nikhiljindal
+- G-Harmon
 approvers:
-- nikhiljindal
+- G-Harmon

--- a/config/jobs/kubernetes-client/haskell/OWNERS
+++ b/config/jobs/kubernetes-client/haskell/OWNERS
@@ -2,7 +2,8 @@
 
 approvers:
 - brendandburns
-- mbohlool
 reviewers:
 - brendandburns
+
+emeritus_approvers:
 - mbohlool

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/OWNERS
@@ -5,16 +5,17 @@ reviewers:
 - detiber
 - justinsb
 - krousey
-- maisem
 - vincepri
 approvers:
 - cpanato
 - detiber
 - justinsb
 - krousey
-- maisem
 - vincepri
 
 labels:
 - sig/cluster-lifecycle
 - area/provider/gcp
+
+emeritus_approvers:
+- maisem

--- a/config/jobs/kubernetes/cloud-provider-vsphere/OWNERS
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/OWNERS
@@ -4,7 +4,6 @@ reviewers:
 - baludontu
 - divyenpatel
 - imkin
-- kerneltime
 - frapposelli
 - dougm
 - figo
@@ -14,7 +13,6 @@ approvers:
 - baludontu
 - divyenpatel
 - imkin
-- kerneltime
 - frapposelli
 - dougm
 - figo
@@ -22,6 +20,7 @@ approvers:
 - yastij
 emeritus_approvers:
 - abrarshivani
+- kerneltime
 labels:
 - sig/cloud-provider
 - area/provider/vmware

--- a/config/jobs/kubernetes/cluster-registry/OWNERS
+++ b/config/jobs/kubernetes/cluster-registry/OWNERS
@@ -2,13 +2,13 @@
 
 reviewers:
 - font
-- madhusudancs
-- perotinus
 - pmorie
 approvers:
 - font
-- madhusudancs
-- perotinus
 - pmorie
 labels:
 - sig/multicluster
+
+emeritus_approvers:
+- madhusudancs
+- perotinus

--- a/config/jobs/kubernetes/sig-network/OWNERS
+++ b/config/jobs/kubernetes/sig-network/OWNERS
@@ -4,15 +4,16 @@ reviewers:
 - aojea
 - bowei
 - cadmuxe
-- jingax10
 - mrhohn
 - rramkumar1
 approvers:
 - aojea
 - bowei
 - cadmuxe
-- jingax10
 - mrhohn
 - rramkumar1
 labels:
 - sig/network
+
+emeritus_approvers:
+- jingax10

--- a/config/testgrids/kubernetes/clients/OWNERS
+++ b/config/testgrids/kubernetes/clients/OWNERS
@@ -2,7 +2,8 @@
 
 approvers:
 - brendandburns
-- mbohlool
 reviewers:
 - brendandburns
+
+emeritus_approvers:
 - mbohlool

--- a/docs/OWNERS
+++ b/docs/OWNERS
@@ -2,10 +2,10 @@
 
 reviewers:
 - cblecker
-- mithrav
 - spiffxp
 approvers:
 - cblecker
-- mithrav
 - spiffxp
 
+emeritus_approvers:
+- mithrav


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/2456

As a part of cleaning up inactive members (those with no activity within
the past 18 months), this commit removes the following people from
various OWNERS files:

   - @jingax10
   - @kerneltime
   - @madhusudancs
   - @maisem
   - @mbohlool
   - @mithrav
   - @nikhiljindal
   - @perotinus 

The second commit replaces @nikhiljindal with @G-Harmon for  `GoogleCloudPlatform/k8s-multicluster-ingress` jobs because @G-Harmon is the only approver of the repo who is also a Kubernetes GitHub org member.

/kind cleanup
/assign @spiffxp 
cc @mrbobbytables 