### PR TITLE
prow/plugins: allow label-based automatic posting of comments

### DIFF
--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -632,6 +632,10 @@ type RequireMatchingLabel struct {
 	// Re is the compiled version of Regexp. It should not be specified in config.
 	Re *regexp.Regexp `json:"-"`
 
+	// MatchingComment is the comment to post when an issue or PR contains
+	// labels matching the Regexp.
+	MatchingComment string `json:"matching_comment,omitempty"`
+
 	// MissingLabel is the label to apply if an issue does not have any label
 	// matching the Regexp.
 	MissingLabel string `json:"missing_label,omitempty"`

--- a/prow/plugins/plugin-config-documented.yaml
+++ b/prow/plugins/plugin-config-documented.yaml
@@ -505,6 +505,10 @@ require_matching_label:
     # Defaults to '5s'.
     grace_period: ' '
 
+    # MatchingComment is the comment to post when an issue or PR contains
+    # labels matching the Regexp.
+    matching_comment: ' '
+
     # MissingComment is the comment to post when we add the MissingLabel to an
     # issue. This is typically used to explain why MissingLabel was added and
     # how to move forward.

--- a/prow/plugins/require-matching-label/require-matching-label_test.go
+++ b/prow/plugins/require-matching-label/require-matching-label_test.go
@@ -99,6 +99,15 @@ func TestHandle(t *testing.T) {
 			MissingLabel:   "needs-cat",
 			MissingComment: "Meow?",
 		},
+		// comment on kind/feature label over k/k repo (issues)
+		{
+			Org:             "k8s",
+			Repo:            "k8s",
+			Issues:          true,
+			Re:              regexp.MustCompile(`^kind/feature$`),
+			MatchingComment: "create KEPs!",
+			MissingLabel:    "needs-kind",
+		},
 	}
 
 	tcs := []struct {
@@ -238,6 +247,34 @@ func TestHandle(t *testing.T) {
 			initialLabels:   []string{labels.LGTM, "needs-sig", "wg/foo"},
 			expectedAdded:   sets.NewString("needs-cat"),
 			expectedRemoved: sets.NewString("needs-sig"),
+			expectComment:   true,
+		},
+		{
+			name: "comment on kind/feature label on issue",
+			event: &event{
+				org:  "k8s",
+				repo: "k8s",
+			},
+			initialLabels: []string{"kind/feature", "kind/bug", "sig/foo"},
+			expectComment: true,
+		},
+		{
+			name: "don't comment on kind/feature labels on PRs",
+			event: &event{
+				org:    "k8s",
+				repo:   "k8s",
+				branch: "main",
+			},
+			initialLabels: []string{"kind/feature", "sig/foo"},
+		},
+		{
+			name: "remove needs-kind label and add comment on issue",
+			event: &event{
+				org:  "k8s",
+				repo: "k8s",
+			},
+			initialLabels:   []string{"sig/foo", "needs-kind", "kind/feature"},
+			expectedRemoved: sets.NewString("needs-kind"),
 			expectComment:   true,
 		},
 	}


### PR DESCRIPTION
This commit allows automatically posting a comment based on the presence
of certain labels (labels matching a particular regexp).

Some examples where this feature can be useful:

1. If an issue contains the `kind/feature` label, the bot can add a
comment pointing to the KEPs process (https://github.com/kubernetes/kubernetes/pull/98867).

2. If an issue contains the `kind/support` label, the bot can add a
comment pointing to the support resources. The bot can also automatically
close the issue with a `/close` comment (https://github.com/kubernetes/community/issues/5435#issuecomment-774974714).

This feature is being added to the `require-matching-label` plugin.
While this feature isn't inherently related to requiring a particular
label, porting this feature to a new/different plugin requires
duplication of code.

/kind feature
/sig contributor-experience
/cc @mrbobbytables @cblecker 
/assign @cblecker 