### PR TITLE
Expand Gerrit Labels exposed

### DIFF
--- a/prow/gerrit/README.md
+++ b/prow/gerrit/README.md
@@ -47,6 +47,18 @@ If you need extra features, feel free to introduce new gerrit API functions to t
 The adapter package implements a controller that is periodically polling gerrit, and triggering
 presubmit and postsubmit jobs based on your prow config.
 
+#### Gerrit Labels
+
+Prow adds the following [Labels] to Gerrit Presubmits that can be accessed in the container by leveraging the [Downward Api].
+- "prow.k8s.io/gerrit-revision": SHA of current patchset from a gerrit change
+- "prow.k8s.io/gerrit-patchset": Numeric ID of the current patchset
+- "prow.k8s.io/gerrit-report-label": Gerrit label prow will cast vote on, fallback to CodeReview label if unset
+```yaml
+    - name: PATHCSET_NUMBER
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.labels['prow.k8s.io/gerrit-patchset']
+```
 
 ## Caveat
 
@@ -58,3 +70,5 @@ If you need them, please send us a PR to support them :-)
 [Prow]: /prow/README.md
 [grandmatriarch]: /prow/cmd/grandmatriarch
 [crier]: /prow/crier
+[Labels]: /prow/gerrit/client/client.go
+[Downward Api]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -302,6 +302,7 @@ func (c *Controller) processChange(logger logrus.FieldLogger, instance string, c
 			labels[k] = v
 		}
 		labels[client.GerritRevision] = change.CurrentRevision
+		labels[client.GerritPatchset] = string(change.Revisions[change.CurrentRevision].Number)
 
 		if _, ok := labels[client.GerritReportLabel]; !ok {
 			labels[client.GerritReportLabel] = client.CodeReview

--- a/prow/gerrit/client/client.go
+++ b/prow/gerrit/client/client.go
@@ -40,6 +40,8 @@ const (
 	GerritInstance = "prow.k8s.io/gerrit-instance"
 	// GerritRevision is the SHA of current patchset from a gerrit change
 	GerritRevision = "prow.k8s.io/gerrit-revision"
+	// GerritPatchset is the numeric ID of the current patchset
+	GerritPatchset = "prow.k8s.io/gerrit-patchset"
 	// GerritReportLabel is the gerrit label prow will cast vote on, fallback to CodeReview label if unset
 	GerritReportLabel = "prow.k8s.io/gerrit-report-label"
 


### PR DESCRIPTION
I have a need to expose RevisionInfo._number
and ChangeInfo._number to a running pod.

https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#revision-info
I will try to use the downward api to inject these labels into the ENV.

/area prow
/sig testing
/cc @amwat @cjwagner 