### PR TITLE
Switch to go1.16 images for security-profile-operator

### DIFF
--- a/config/jobs/kubernetes-sigs/security-profiles-operator/seccomp-operator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/security-profiles-operator/seccomp-operator-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
       testgrid-create-test-group: 'true'
     spec:
       containers:
-      - image: golang:1.15
+      - image: golang:1.16
         command:
         - hack/pull-security-profiles-operator-build
 
@@ -20,7 +20,7 @@ presubmits:
       testgrid-create-test-group: 'true'
     spec:
       containers:
-      - image: golang:1.15
+      - image: golang:1.16
         command:
         - hack/pull-security-profiles-operator-verify
 
@@ -32,7 +32,7 @@ presubmits:
       testgrid-create-test-group: 'true'
     spec:
       containers:
-      - image: golang:1.15
+      - image: golang:1.16
         command:
         - hack/pull-security-profiles-operator-test-unit
 


### PR DESCRIPTION
We now use the golang 1.16 images for the operator to keep the CI
updated.

cc @pjbgf @hasheddan 