### PR TITLE
github client: log all args of GetBranches function

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -2232,7 +2232,7 @@ func (c *client) GetSingleCommit(org, repo, SHA string) (RepositoryCommit, error
 //
 // See https://developer.github.com/v3/repos/branches/#list-branches
 func (c *client) GetBranches(org, repo string, onlyProtected bool) ([]Branch, error) {
-	durationLogger := c.log("GetBranches", org, repo)
+	durationLogger := c.log("GetBranches", org, repo, onlyProtected)
 	defer durationLogger()
 
 	var branches []Branch


### PR DESCRIPTION
For each repo, we call `GetBranches` twice with `onlyProtected` as `true` and `false`.
Let us show it in the log as well.

https://github.com/kubernetes/test-infra/blob/e491db3d7af27adb187f14900ebc53c0dceb31c9/prow/cmd/branchprotector/protect.go#L289-L290

/cc @petr-muller 