### PR TITLE
cluster-api-provider-digitalocean: Update OWNERS

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/OWNERS
@@ -4,9 +4,7 @@ reviewers:
 - cpanato
 - MorrisLaw
 - prksu
-- xmudrii
 approvers:
 - cpanato
 - MorrisLaw
 - prksu
-- xmudrii

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/OWNERS
@@ -4,7 +4,9 @@ reviewers:
 - cpanato
 - MorrisLaw
 - prksu
+- timoreimann
 approvers:
 - cpanato
 - MorrisLaw
 - prksu
+- timoreimann


### PR DESCRIPTION
As per https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/pull/234:

* Remove Marko Mudrinić (@xmudrii) from OWNERS
* Add Timo Reimann (@timoreimann) to OWNERS

/assign @cpanato @MorrisLaw @prksu @timoreimann 
