### PR TITLE
Prow dashboard: use job name instead of ip address for filtering bosk…

### DIFF
--- a/config/prow/cluster/monitoring/additional-scrape-configs_secret.yaml
+++ b/config/prow/cluster/monitoring/additional-scrape-configs_secret.yaml
@@ -12,6 +12,10 @@ stringData:
       static_configs:
         - targets:
             - "104.197.27.114:9090"  # external ip boskos-metrics in k8s-prow-builds cluster
+    - job_name: k8s-infra-prow-builds-boskos
+      metrics_path: /metrics
+      static_configs:
+        - targets:
             - "35.225.208.117:9090"  # external ip boskos-metrics in k8s-infra-prow-build cluster
     - job_name: greenhouse-metrics
       metrics_path: /prometheus

--- a/config/prow/cluster/monitoring/mixins/grafana_dashboards/boskos.jsonnet
+++ b/config/prow/cluster/monitoring/mixins/grafana_dashboards/boskos.jsonnet
@@ -25,7 +25,7 @@ dashboard.new(
         aliasColors={'busy': '#ff0000', 'cleaning': '#00eeff', 'dirty': '#ff8000', 'free': '#00ff00', 'leased': '#ee00ff', 'other': '#aaaaff', 'toBeDeleted': '#fafa00', 'tombstone': '#cccccc'}
     )
     .addTarget(prometheus.target(
-        std.format('sum(boskos_resources{type="%s",instance="%s"}) by (state)', [resource.type, resource.instance]),
+        std.format('sum(boskos_resources{type="%s",job="%s"}) by (state)', [resource.type, resource.job]),
         legendFormat='{{state}}',
     ))
     {gridPos: {

--- a/config/prow/cluster/monitoring/mixins/grafana_dashboards/boskos.jsonnet
+++ b/config/prow/cluster/monitoring/mixins/grafana_dashboards/boskos.jsonnet
@@ -25,7 +25,7 @@ dashboard.new(
         aliasColors={'busy': '#ff0000', 'cleaning': '#00eeff', 'dirty': '#ff8000', 'free': '#00ff00', 'leased': '#ee00ff', 'other': '#aaaaff', 'toBeDeleted': '#fafa00', 'tombstone': '#cccccc'}
     )
     .addTarget(prometheus.target(
-        std.format('sum(boskos_resources{type="%s",job="%s"}) by (state)', [resource.type, resource.job]),
+        std.format('sum(boskos_resources{type="%s",job="%s"} or boskos_resources{type="%s",instance="%s"}) by (state)', [resource.type, resource.job, resource.type, resource.instance]),
         legendFormat='{{state}}',
     ))
     {gridPos: {

--- a/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
@@ -63,7 +63,7 @@ local config = {
 
   // Boskos endpoints to be monitored
   boskosResourcetypes: [
-    {job: "k8s-prow-builds-boskos", type: "aws-account", friendly: "AWS account"},
+    {instance: "104.197.27.114:9090", job: "k8s-prow-builds-boskos", type: "aws-account", friendly: "AWS account"},
     {job: "k8s-prow-builds-boskos", type: "gce-project", friendly: "GCE project"},
     {job: "k8s-infra-prow-builds-boskos", type: "gce-project", friendly: "GCE project (k8s-infra)"},
     {job: "k8s-prow-builds-boskos", type: "gke-project", friendly: "GKE project"},

--- a/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
@@ -63,17 +63,18 @@ local config = {
 
   // Boskos endpoints to be monitored
   boskosResourcetypes: [
+    # TODO(chaodaiG after 05/18/2021): drop instance. https://github.com/kubernetes/test-infra/pull/20888
     {instance: "104.197.27.114:9090", job: "k8s-prow-builds-boskos", type: "aws-account", friendly: "AWS account"},
-    {job: "k8s-prow-builds-boskos", type: "gce-project", friendly: "GCE project"},
-    {job: "k8s-infra-prow-builds-boskos", type: "gce-project", friendly: "GCE project (k8s-infra)"},
-    {job: "k8s-prow-builds-boskos", type: "gke-project", friendly: "GKE project"},
-    {job: "k8s-prow-builds-boskos", type: "gpu-project", friendly: "GPU project"},
-    {job: "k8s-infra-prow-builds-boskos", type: "gpu-project", friendly: "GPU project (k8s-infra)"},
-    {job: "k8s-prow-builds-boskos", type: "ingress-project", friendly: "Ingress project"},
-    {job: "k8s-prow-builds-boskos", type: "node-e2e-project", friendly: "Node e2e project"},
-    {job: "k8s-prow-builds-boskos", type: "scalability-project", friendly: "Scalability project"},
-    {job: "k8s-infra-prow-builds-boskos", type: "scalability-project", friendly: "Scalability project (k8s-infra)"},
-    {job: "k8s-prow-builds-boskos", type: "scalability-presubmit-project", friendly: "Scalability presubmit project"}
+    {instance: "104.197.27.114:9090", job: "k8s-prow-builds-boskos", type: "gce-project", friendly: "GCE project"},
+    {instance: "35.225.208.117:9090", job: "k8s-infra-prow-builds-boskos", type: "gce-project", friendly: "GCE project (k8s-infra)"},
+    {instance: "104.197.27.114:9090", job: "k8s-prow-builds-boskos", type: "gke-project", friendly: "GKE project"},
+    {instance: "104.197.27.114:9090", job: "k8s-prow-builds-boskos", type: "gpu-project", friendly: "GPU project"},
+    {instance: "35.225.208.117:9090", job: "k8s-infra-prow-builds-boskos", type: "gpu-project", friendly: "GPU project (k8s-infra)"},
+    {instance: "104.197.27.114:9090", job: "k8s-prow-builds-boskos", type: "ingress-project", friendly: "Ingress project"},
+    {instance: "104.197.27.114:9090", job: "k8s-prow-builds-boskos", type: "node-e2e-project", friendly: "Node e2e project"},
+    {instance: "104.197.27.114:9090", job: "k8s-prow-builds-boskos", type: "scalability-project", friendly: "Scalability project"},
+    {instance: "35.225.208.117:9090", job: "k8s-infra-prow-builds-boskos", type: "scalability-project", friendly: "Scalability project (k8s-infra)"},
+    {instance: "104.197.27.114:9090", job: "k8s-prow-builds-boskos", type: "scalability-presubmit-project", friendly: "Scalability presubmit project"}
   ],
 
   // How long we go during work hours without seeing a webhook before alerting.

--- a/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
@@ -63,17 +63,17 @@ local config = {
 
   // Boskos endpoints to be monitored
   boskosResourcetypes: [
-    {instance: "104.197.27.114:9090", type: "aws-account", friendly: "AWS account"},
-    {instance: "104.197.27.114:9090", type: "gce-project", friendly: "GCE project"},
-    {instance: "35.225.208.117:9090", type: "gce-project", friendly: "GCE project (k8s-infra)"},
-    {instance: "104.197.27.114:9090", type: "gke-project", friendly: "GKE project"},
-    {instance: "104.197.27.114:9090", type: "gpu-project", friendly: "GPU project"},
-    {instance: "35.225.208.117:9090", type: "gpu-project", friendly: "GPU project (k8s-infra)"},
-    {instance: "104.197.27.114:9090", type: "ingress-project", friendly: "Ingress project"},
-    {instance: "104.197.27.114:9090", type: "node-e2e-project", friendly: "Node e2e project"},
-    {instance: "104.197.27.114:9090", type: "scalability-project", friendly: "Scalability project"},
-    {instance: "35.225.208.117:9090", type: "scalability-project", friendly: "Scalability project (k8s-infra)"},
-    {instance: "104.197.27.114:9090", type: "scalability-presubmit-project", friendly: "Scalability presubmit project"}
+    {job: "k8s-prow-builds-boskos", type: "aws-account", friendly: "AWS account"},
+    {job: "k8s-prow-builds-boskos", type: "gce-project", friendly: "GCE project"},
+    {job: "k8s-infra-prow-builds-boskos", type: "gce-project", friendly: "GCE project (k8s-infra)"},
+    {job: "k8s-prow-builds-boskos", type: "gke-project", friendly: "GKE project"},
+    {job: "k8s-prow-builds-boskos", type: "gpu-project", friendly: "GPU project"},
+    {job: "k8s-infra-prow-builds-boskos", type: "gpu-project", friendly: "GPU project (k8s-infra)"},
+    {job: "k8s-prow-builds-boskos", type: "ingress-project", friendly: "Ingress project"},
+    {job: "k8s-prow-builds-boskos", type: "node-e2e-project", friendly: "Node e2e project"},
+    {job: "k8s-prow-builds-boskos", type: "scalability-project", friendly: "Scalability project"},
+    {job: "k8s-infra-prow-builds-boskos", type: "scalability-project", friendly: "Scalability project (k8s-infra)"},
+    {job: "k8s-prow-builds-boskos", type: "scalability-presubmit-project", friendly: "Scalability presubmit project"}
   ],
 
   // How long we go during work hours without seeing a webhook before alerting.


### PR DESCRIPTION
…os instances

There are prow instance(s) running boskos, the metrics it emits are from the pod running boskos, the instance name (ip address) changes when the boskos pod is recreated, which makes it impossible to use it as diffentiator. Use job name as differentiator is more reliable and less easy breaking when external boskos ip changes.

Note: this is a breaking change, boskos dashboard will only display values from k8s-infra-prow-builds-boskos after this PR