### PR TITLE
[tide] Ensure that tide github context is success before attempting to merge.

### DIFF
--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -4086,3 +4086,61 @@ func TestQueryShardsByOrgWhenAppsAuthIsEnabledOnly(t *testing.T) {
 		})
 	}
 }
+
+func TestSetTideStatusSuccess(t *testing.T) {
+	testcases := []struct {
+		name string
+
+		hasContext bool
+		state      githubql.StatusState
+	}{
+		{
+			name: "existing success status tide context",
+
+			hasContext: true,
+			state:      githubql.StatusStateSuccess,
+		},
+		{
+			name: "existing failed status tide context",
+
+			hasContext: true,
+			state:      githubql.StatusStateFailure,
+		},
+		{
+			name: "existing pending status tide context",
+
+			hasContext: true,
+			state:      githubql.StatusStatePending,
+		},
+		{
+			name: "no tide context",
+
+			hasContext: false,
+		},
+	}
+	for _, tc := range testcases {
+		var pr PullRequest
+		pr.Commits.Nodes = []struct{ Commit Commit }{{}}
+		if tc.hasContext {
+			pr.Commits.Nodes[0].Commit.Status.Contexts = []Context{
+				{
+					Context: githubql.String(statusContext),
+					State:   tc.state,
+				},
+			}
+		}
+		log := logrus.WithField("component", "tide")
+		_, err := log.String()
+		if err != nil {
+			t.Fatalf("Failed to get log output before testing: %v", err)
+		}
+		ghc := &fgc{}
+		err = setTideStatusSuccess(pr, ghc, &config.Config{}, log)
+		if err != nil {
+			t.Fatalf("For case %s: error setting tide context success: %v", tc.name, err)
+		}
+		if !ghc.setStatus {
+			t.Errorf("For case %s: should set but didn't", tc.name)
+		}
+	}
+}


### PR DESCRIPTION
This ensure the statusContext "tide" is set to success before attempting to merge.

It allows users to rely on the "tide" context branch protection without having to set all the other as required contexts.

Another behavior I believe this fixes is where a presubmit job gets triggered for a PR that is about to be merged.

This is a very needed improvement if you're also using this other setting still not merge in PROW #20679 . Restarting builds for the PRs that didn't get merged in time and get picked again for a batch.