### PR TITLE
Kops - enable ginkgo debugging on kubetest2 jobs

### DIFF
--- a/config/jobs/kubernetes/kops/build_grid.py
+++ b/config/jobs/kubernetes/kops/build_grid.py
@@ -99,6 +99,7 @@ kubetest2_template = """
           --terraform-version={{terraform_version}} \\
           --test=kops \\
           -- \\
+          --ginkgo-args="--debug" \\
           --test-args="-test.timeout={{test_timeout}} -num-nodes=0" \\
           --test-package-marker={{marker}} \\
           --parallel {{test_parallelism}} \\

--- a/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
@@ -37,6 +37,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable.txt \
           --parallel 25 \
@@ -101,6 +102,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable.txt \
           --parallel 25 \
@@ -165,6 +167,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable.txt \
           --parallel 25 \
@@ -229,6 +232,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable.txt \
           --parallel 25 \
@@ -293,6 +297,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable.txt \
           --parallel 25 \
@@ -357,6 +362,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable.txt \
           --parallel 25 \
@@ -421,6 +427,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable.txt \
           --parallel 25 \
@@ -485,6 +492,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable.txt \
           --parallel 25 \
@@ -549,6 +557,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable.txt \
           --parallel 25 \
@@ -613,6 +622,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable.txt \
           --parallel 25 \

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -18757,6 +18757,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -18821,6 +18822,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -18885,6 +18887,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -18949,6 +18952,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -19013,6 +19017,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -19077,6 +19082,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -19141,6 +19147,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -19205,6 +19212,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -19269,6 +19277,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -19333,6 +19342,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -19397,6 +19407,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -19461,6 +19472,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -19525,6 +19537,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -19589,6 +19602,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -19653,6 +19667,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -19717,6 +19732,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -19781,6 +19797,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -19845,6 +19862,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -19909,6 +19927,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -19973,6 +19992,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -20037,6 +20057,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -20101,6 +20122,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -20165,6 +20187,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -20229,6 +20252,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -20293,6 +20317,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -20357,6 +20382,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -20421,6 +20447,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -20485,6 +20512,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -20549,6 +20577,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -20613,6 +20642,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -20677,6 +20707,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -20741,6 +20772,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -20805,6 +20837,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -20869,6 +20902,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -20933,6 +20967,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -20997,6 +21032,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -21061,6 +21097,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -21125,6 +21162,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -21189,6 +21227,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -21253,6 +21292,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -21317,6 +21357,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -21381,6 +21422,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -21445,6 +21487,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -21509,6 +21552,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -21573,6 +21617,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -21637,6 +21682,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -21701,6 +21747,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -21765,6 +21812,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -21829,6 +21877,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -21893,6 +21942,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -21957,6 +22007,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -22021,6 +22072,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -22085,6 +22137,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -22149,6 +22202,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -22213,6 +22267,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -22277,6 +22332,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -22341,6 +22397,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -22405,6 +22462,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -22469,6 +22527,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -22533,6 +22592,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -22597,6 +22657,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -22661,6 +22722,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -22725,6 +22787,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -22789,6 +22852,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -22853,6 +22917,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -22917,6 +22982,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -22981,6 +23047,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -23045,6 +23112,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -23109,6 +23177,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -23173,6 +23242,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -23237,6 +23307,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -23301,6 +23372,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -23365,6 +23437,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -23429,6 +23502,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -23493,6 +23567,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -23557,6 +23632,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -23621,6 +23697,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -23685,6 +23762,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -23749,6 +23827,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -23813,6 +23892,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -23877,6 +23957,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -23941,6 +24022,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -24005,6 +24087,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -24069,6 +24152,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -24133,6 +24217,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -24197,6 +24282,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -24261,6 +24347,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -24325,6 +24412,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -24389,6 +24477,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -24453,6 +24542,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -24517,6 +24607,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -24581,6 +24672,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -24645,6 +24737,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -24709,6 +24802,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -24773,6 +24867,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -24837,6 +24932,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -24901,6 +24997,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -24965,6 +25062,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -25029,6 +25127,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -25093,6 +25192,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -25157,6 +25257,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -25221,6 +25322,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -25285,6 +25387,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -25349,6 +25452,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -25413,6 +25517,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -25477,6 +25582,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -25541,6 +25647,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -25605,6 +25712,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -25669,6 +25777,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -25733,6 +25842,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -25797,6 +25907,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -25861,6 +25972,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -25925,6 +26037,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -25989,6 +26102,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -26053,6 +26167,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -26117,6 +26232,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -26181,6 +26297,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -26245,6 +26362,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -26309,6 +26427,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -26373,6 +26492,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -26437,6 +26557,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -26501,6 +26622,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -26565,6 +26687,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -26629,6 +26752,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -26693,6 +26817,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -26757,6 +26882,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -26821,6 +26947,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -26885,6 +27012,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -26949,6 +27077,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -27013,6 +27142,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -27077,6 +27207,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -27141,6 +27272,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -27205,6 +27337,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -27269,6 +27402,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -27333,6 +27467,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -27397,6 +27532,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -27461,6 +27597,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -27525,6 +27662,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -27589,6 +27727,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -27653,6 +27792,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -27717,6 +27857,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -27781,6 +27922,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -27845,6 +27987,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -27909,6 +28052,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -27973,6 +28117,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -28037,6 +28182,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -28101,6 +28247,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -28165,6 +28312,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -28229,6 +28377,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -28293,6 +28442,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -28357,6 +28507,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -28421,6 +28572,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -28485,6 +28637,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -28549,6 +28702,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -28613,6 +28767,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -28677,6 +28832,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -28741,6 +28897,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -28805,6 +28962,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -28869,6 +29027,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -28933,6 +29092,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -28997,6 +29157,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -29061,6 +29222,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -29125,6 +29287,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -29189,6 +29352,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -29253,6 +29417,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -29317,6 +29482,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -29381,6 +29547,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -29445,6 +29612,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -29509,6 +29677,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -29573,6 +29742,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -29637,6 +29807,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -29701,6 +29872,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -29765,6 +29937,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -29829,6 +30002,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -29893,6 +30067,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -29957,6 +30132,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -30021,6 +30197,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -30085,6 +30262,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -30149,6 +30327,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -30213,6 +30392,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -30277,6 +30457,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -30341,6 +30522,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -30405,6 +30587,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -30469,6 +30652,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -30533,6 +30717,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -30597,6 +30782,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -30661,6 +30847,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -30725,6 +30912,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -30789,6 +30977,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -30853,6 +31042,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -30917,6 +31107,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -30981,6 +31172,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -31045,6 +31237,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -31109,6 +31302,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -31173,6 +31367,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -31237,6 +31432,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -31301,6 +31497,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -31365,6 +31562,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -31429,6 +31627,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -31493,6 +31692,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -31557,6 +31757,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -31621,6 +31822,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -31685,6 +31887,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -31749,6 +31952,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -31813,6 +32017,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -31877,6 +32082,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -31941,6 +32147,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -32005,6 +32212,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -32069,6 +32277,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -32133,6 +32342,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -32197,6 +32407,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -32261,6 +32472,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -32325,6 +32537,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -32389,6 +32602,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -32453,6 +32667,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -32517,6 +32732,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -32581,6 +32797,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -32645,6 +32862,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -32709,6 +32927,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -32773,6 +32992,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -32837,6 +33057,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -32901,6 +33122,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -32965,6 +33187,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -33029,6 +33252,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -33093,6 +33317,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -33157,6 +33382,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -33221,6 +33447,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -33285,6 +33512,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -33349,6 +33577,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -33413,6 +33642,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -33477,6 +33707,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -33541,6 +33772,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -33605,6 +33837,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -33669,6 +33902,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -33733,6 +33967,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -33797,6 +34032,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -33861,6 +34097,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -33925,6 +34162,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -33989,6 +34227,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -34053,6 +34292,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -34117,6 +34357,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -34181,6 +34422,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -34245,6 +34487,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -34309,6 +34552,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -34373,6 +34617,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -34437,6 +34682,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -34501,6 +34747,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -34565,6 +34812,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -34629,6 +34877,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -34693,6 +34942,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -34757,6 +35007,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -34821,6 +35072,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -34885,6 +35137,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -34949,6 +35202,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -35013,6 +35267,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -35077,6 +35332,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -35141,6 +35397,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -35205,6 +35462,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -35269,6 +35527,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -35333,6 +35592,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -35397,6 +35657,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -35461,6 +35722,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -35525,6 +35787,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -35589,6 +35852,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -35653,6 +35917,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -35717,6 +35982,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -35781,6 +36047,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -35845,6 +36112,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -35909,6 +36177,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -35973,6 +36242,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -36037,6 +36307,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -36101,6 +36372,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -36165,6 +36437,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \
@@ -36229,6 +36502,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -36293,6 +36567,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.17.txt \
           --parallel 25 \
@@ -36357,6 +36632,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -36421,6 +36697,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.18.txt \
           --parallel 25 \
@@ -36485,6 +36762,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -36549,6 +36827,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.19.txt \
           --parallel 25 \
@@ -36613,6 +36892,7 @@ periodics:
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -255,6 +255,7 @@ periodics:
           --terraform-version=0.14.6 \
           --test=kops \
           -- \
+          --ginkgo-args="--debug" \
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.20.txt \
           --parallel 25 \


### PR DESCRIPTION
depends on https://github.com/kubernetes/kops/pull/10866