### PR TITLE
Prow dashboard: rename boskos job name to avoid wrong matching

### DIFF
--- a/config/prow/cluster/monitoring/additional-scrape-configs_secret.yaml
+++ b/config/prow/cluster/monitoring/additional-scrape-configs_secret.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: prow-monitoring
 stringData:
   prometheus-additional.yaml: |
-    - job_name: k8s-prow-builds-boskos
+    - job_name: k8s-prow-builds-new-boskos
       metrics_path: /metrics
       static_configs:
         - targets:

--- a/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
@@ -64,17 +64,17 @@ local config = {
   // Boskos endpoints to be monitored
   boskosResourcetypes: [
     # TODO(chaodaiG after 05/18/2021): drop instance. https://github.com/kubernetes/test-infra/pull/20888
-    {instance: "104.197.27.114:9090", job: "k8s-prow-builds-boskos", type: "aws-account", friendly: "AWS account"},
-    {instance: "104.197.27.114:9090", job: "k8s-prow-builds-boskos", type: "gce-project", friendly: "GCE project"},
+    {instance: "104.197.27.114:9090", job: "k8s-prow-builds-new-boskos", type: "aws-account", friendly: "AWS account"},
+    {instance: "104.197.27.114:9090", job: "k8s-prow-builds-new-boskos", type: "gce-project", friendly: "GCE project"},
     {instance: "35.225.208.117:9090", job: "k8s-infra-prow-builds-boskos", type: "gce-project", friendly: "GCE project (k8s-infra)"},
-    {instance: "104.197.27.114:9090", job: "k8s-prow-builds-boskos", type: "gke-project", friendly: "GKE project"},
-    {instance: "104.197.27.114:9090", job: "k8s-prow-builds-boskos", type: "gpu-project", friendly: "GPU project"},
+    {instance: "104.197.27.114:9090", job: "k8s-prow-builds-new-boskos", type: "gke-project", friendly: "GKE project"},
+    {instance: "104.197.27.114:9090", job: "k8s-prow-builds-new-boskos", type: "gpu-project", friendly: "GPU project"},
     {instance: "35.225.208.117:9090", job: "k8s-infra-prow-builds-boskos", type: "gpu-project", friendly: "GPU project (k8s-infra)"},
-    {instance: "104.197.27.114:9090", job: "k8s-prow-builds-boskos", type: "ingress-project", friendly: "Ingress project"},
-    {instance: "104.197.27.114:9090", job: "k8s-prow-builds-boskos", type: "node-e2e-project", friendly: "Node e2e project"},
-    {instance: "104.197.27.114:9090", job: "k8s-prow-builds-boskos", type: "scalability-project", friendly: "Scalability project"},
+    {instance: "104.197.27.114:9090", job: "k8s-prow-builds-new-boskos", type: "ingress-project", friendly: "Ingress project"},
+    {instance: "104.197.27.114:9090", job: "k8s-prow-builds-new-boskos", type: "node-e2e-project", friendly: "Node e2e project"},
+    {instance: "104.197.27.114:9090", job: "k8s-prow-builds-new-boskos", type: "scalability-project", friendly: "Scalability project"},
     {instance: "35.225.208.117:9090", job: "k8s-infra-prow-builds-boskos", type: "scalability-project", friendly: "Scalability project (k8s-infra)"},
-    {instance: "104.197.27.114:9090", job: "k8s-prow-builds-boskos", type: "scalability-presubmit-project", friendly: "Scalability presubmit project"}
+    {instance: "104.197.27.114:9090", job: "k8s-prow-builds-new-boskos", type: "scalability-presubmit-project", friendly: "Scalability presubmit project"}
   ],
 
   // How long we go during work hours without seeing a webhook before alerting.


### PR DESCRIPTION
Before https://github.com/kubernetes/test-infra/pull/20888, both k8s-prow-builds-boskos and k8s-infra-prow-builds-boskos use job name of k8s-prow-builds-boskos, so when #20888 changes the matching to , this condition  matches  from both clusters. Renaming it so that the history data is also accurate