### PR TITLE
Use master repo list for GCE Windows 20H2 tests.

### DIFF
--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -154,7 +154,7 @@ periodics:
     preset-service-account: "true"
     preset-common-gce-windows: "true"
     preset-e2e-gce-windows: "true"
-    preset-windows-repo-list-2004: "true"
+    preset-windows-repo-list-master: "true"
   spec:
     containers:
     - command:


### PR DESCRIPTION
This change brings GCE Windows in alignment with Azure test infra for running Windows 20H2 tests.

/sig windows
/priority important-soon