### PR TITLE
Fix HNC postsubmits

### DIFF
--- a/config/jobs/kubernetes-sigs/wg-multi-tenancy/hnc-e2e.yaml
+++ b/config/jobs/kubernetes-sigs/wg-multi-tenancy/hnc-e2e.yaml
@@ -23,9 +23,7 @@ postsubmits:
     spec:
       containers:
       - image: gcr.io/k8s-staging-multitenancy/hnc-postsubmit-tests:latest
-        # The default command in the image runs the tests, but apparently
-        # decorated containers must have a command anyway.
-        command: ["wrapper.sh", "./run-e2e-tests.sh"]
+        command: ["wrapper.sh", "/start/run-e2e-tests.sh"]
         securityContext:
           privileged: true # Required for docker-in-docker
         resources:
@@ -55,9 +53,7 @@ periodics:
   spec:
     containers:
     - image: gcr.io/k8s-staging-multitenancy/hnc-postsubmit-tests:latest
-      # The default command in the image runs the tests, but apparently
-      # decorated containers must have a command anyway.
-      command: ["wrapper.sh", "./run-e2e-tests.sh"]
+      command: ["wrapper.sh", "/start/run-e2e-tests.sh"]
       securityContext:
         privileged: true # Required for docker-in-docker
       resources:


### PR DESCRIPTION
Our first postsubmits failed, apparently because Prow changes the
workdir for postsubmits but not periodics. This change will work with
https://github.com/kubernetes-sigs/multi-tenancy/pull/1398 (which is not
yet submitted, but whose image has already been pushed) to ensure that
the e2e tests work as both periodic and postsubmits.

Tested: cannot test prow; as soon as the PR mentioned above is merged,
we'll find out if the postsubmits work or not.