### PR TITLE
user apiserver /healthz instead of cs check

### DIFF
--- a/kubetest/conformance/BUILD.bazel
+++ b/kubetest/conformance/BUILD.bazel
@@ -8,8 +8,6 @@ go_library(
     deps = [
         "//kubetest/e2e:go_default_library",
         "//kubetest/process:go_default_library",
-        "@io_k8s_api//core/v1:go_default_library",
-        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_client_go//kubernetes:go_default_library",
         "@io_k8s_client_go//tools/clientcmd:go_default_library",
     ],


### PR DESCRIPTION
As componentstatus as deprecated in 1.19+, https://github.com/kubernetes/kubernetes/pull/93570 conformance test should not use it at all.

