### PR TITLE
Stop running 5k performance 3 times a day

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -50,7 +50,7 @@ periodics:
           memory: "48Gi"
 
 # This is a sig-release-master-blocking job.
-- cron: '1 5,17,23 * * *' # In UTC
+- cron: '1 17 * * *' # Run daily at 9:01PST (17:01 UTC)
   name: ci-kubernetes-e2e-gce-scale-performance
   tags:
   - "perfDashPrefix: gce-5000Nodes"


### PR DESCRIPTION
It has been added in https://github.com/kubernetes/test-infra/pull/19749 to validate flakiness of 5k tests after speedup.

Looks good so far, so we can reduce number of test runs per day to reduce cost.

/assign @wojtek-t 