### PR TITLE
Change log-dump.sh to write GCS path to master-and-node-logs.link.txt

### DIFF
--- a/logexporter/cluster/log-dump.sh
+++ b/logexporter/cluster/log-dump.sh
@@ -867,7 +867,7 @@ function main() {
   if [[ "${DUMP_TO_GCS_ONLY:-}" == "true" ]]; then
     report_dir="${KUBE_TEMP}/logs"
     mkdir -p "${report_dir}"
-    echo "${gcs_artifacts_dir}" > "${local_report_dir}/master-and-node-logs.txt"
+    echo "${gcs_artifacts_dir}" > "${local_report_dir}/master-and-node-logs.link.txt"
     echo "Dumping logs temporarily to '${report_dir}'. Will upload to '${gcs_artifacts_dir}' later."
   else
     report_dir="${local_report_dir}"


### PR DESCRIPTION
In https://github.com/kubernetes/test-infra/pull/20897 I make all *.link.txt files to be automatically added to the deck.
To avoid special handling of 'master-and-node-logs', let's change the suffix to 'link.txt'.

/assign @wojtek-t