### PR TITLE
test(kubeflow): remove empty or not maintained tests

### DIFF
--- a/config/jobs/kubeflow/kubeflow-periodics.yaml
+++ b/config/jobs/kubeflow/kubeflow-periodics.yaml
@@ -75,25 +75,3 @@ periodics:
     # TODO: use a public email group
     testgrid-alert-email: kubeflow-engineering@google.com
     testgrid-num-failures-to-alert: "3"
-#******************************************************************************
-# kubeflow/examples
-#******************************************************************************
-- name: kubeflow-examples-periodic
-  cluster: kubeflow
-  interval: 1h
-  labels:
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: gcr.io/kubeflow-ci/test-worker:latest
-      imagePullPolicy: Always
-      env:
-      - name: REPO_OWNER
-        value: kubeflow
-      - name: REPO_NAME
-        value: examples
-      - name: BRANCH_NAME
-        value: master
-  annotations:
-    testgrid-dashboards: sig-big-data
-    description: Periodic testing of Kubeflow examples

--- a/config/jobs/kubeflow/kubeflow-postsubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-postsubmits.yaml
@@ -1,30 +1,4 @@
 postsubmits:
-  kubeflow/examples:
-  - name: kubeflow-examples-postsubmit
-    cluster: kubeflow
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Postsubmit kubeflow/examples.
-  kubeflow/internal-acls:
-  - name: kubeflow-internal-acls-postsubmit
-    cluster: kubeflow
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Postsubmit tests for kubeflow/internal-acls.
   kubeflow/gcp-blueprints:
   - name: kubeflow-gcp-blueprints-postsubmit
     cluster: kubeflow
@@ -54,20 +28,6 @@ postsubmits:
       # TODO: use a public email group
       testgrid-alert-email: kubeflow-engineering@google.com
       testgrid-num-failures-to-alert: "3"
-
-  kubeflow/website:
-  - name: kubeflow-website-postsubmit
-    cluster: kubeflow
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Postsubmit kubeflow/website.
   kubeflow/testing:
   - name: kubeflow-testing-postsubmit
     cluster: kubeflow

--- a/config/jobs/kubeflow/kubeflow-presubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-presubmits.yaml
@@ -1,18 +1,4 @@
 presubmits:
-  kubeflow/examples:
-  - name: kubeflow-examples-presubmit
-    cluster: kubeflow
-    always_run: true         # Run for every PR, or only when requested.
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Presubmits for kubeflow/examples.
-      testgrid-num-columns-recent: '30'
   kubeflow/gcp-blueprints:
   - name: kubeflow-gcp-blueprints-presubmit
     cluster: kubeflow
@@ -27,20 +13,6 @@ presubmits:
       testgrid-dashboards: sig-big-data
       description: Presubmit tests for Kubeflow GCP gcp-blueprints.
       testgrid-num-columns-recent: '30'
-  kubeflow/internal-acls:
-  - name: kubeflow-internal-acls-presubmit
-    cluster: kubeflow
-    always_run: true         # Run for every PR, or only when requested.
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Presubmit tests for Kubeflow/internal-acls.
-      testgrid-num-columns-recent: '30'
   kubeflow/kubeflow:
   - name: kubeflow-presubmit
     cluster: kubeflow
@@ -54,33 +26,6 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-big-data
       description: Presubmit tests for Kubeflow.
-      testgrid-num-columns-recent: '30'
-  kubeflow/website:
-  - name: kubeflow-website-presubmit
-    cluster: kubeflow
-    always_run: true         # Run for every PR, or only when requested.
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Presubmits for kubeflow/website.
-      testgrid-num-columns-recent: '30'
-  - name: kubeflow-website-link-check
-    cluster: kubeflow
-    optional: true
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: praqma/linkchecker:v9.3.1-154-g22449abb-10
-        imagePullPolicy: Always
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Presubmits for kubeflow/website to check for broken links.
       testgrid-num-columns-recent: '30'
   kubeflow/testing:
   - name: kubeflow-testing-presubmit

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -676,73 +676,13 @@ plugins:
   - verify-owners   # Validates OWNERS file changes in PRs.
   - wip   # Applies a label to PRs with wip in the title to block merge
 
-  kubeflow/arena:
-  - trigger
-
-  kubeflow/batch-predict:
-  - trigger
-
-  kubeflow/caffe2-operator:
-  - trigger
-
-  kubeflow/chainer-operator:
-  - trigger
-
-  kubeflow/common:
-  - trigger
-
-  kubeflow/community-infra:
-  - trigger
-
-  kubeflow/examples:
-  - trigger
-
-  kubeflow/experimental-seldon:
-  - trigger
-
-  kubeflow/fairing:
-  - trigger
-
   kubeflow/gcp-blueprints:
-  - trigger
-
-  kubeflow/internal-acls:
-  - trigger
-
-  kubeflow/kfp-tekton:
-  - trigger
-
-  kubeflow/kfp-tekton-backend:
-  - trigger
-
-  kubeflow/kubebench:
   - trigger
 
   kubeflow/kubeflow:
   - trigger
 
-  kubeflow/metadata:
-  - trigger
-
-  kubeflow/mpi-operator:
-  - trigger
-
-  kubeflow/mxnet-operator:
-  - trigger
-
-  kubeflow/reporting:
-  - trigger
-
   kubeflow/testing:
-  - trigger
-
-  kubeflow/tf-operator:
-  - trigger
-
-  kubeflow/website:
-  - trigger
-
-  kubeflow/xgboost-operator:
   - trigger
 
   kubernetes:

--- a/config/testgrids/kubeflow/kubeflow.yaml
+++ b/config/testgrids/kubeflow/kubeflow.yaml
@@ -2,11 +2,7 @@
 test_groups:
 - name: kubeflow-postsubmit
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_kubeflow/kubeflow-postsubmit
-- name: kubeflow-examples-postsubmit
-  gcs_prefix: kubernetes-jenkins/logs/kubeflow_examples/kubeflow-examples-postsubmit
 - name: kubeflow-gcp-blueprints-postsubmit
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_gcp-blueprints/kubeflow-gcp-blueprints-postsubmit
 - name: kubeflow-testing-postsubmit
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_testing/kubeflow-testing-postsubmit
-- name: kubeflow-website-postsubmit
-  gcs_prefix: kubernetes-jenkins/logs/kubeflow_website/kubeflow-website-postsubmit


### PR DESCRIPTION
Part of https://github.com/kubernetes/test-infra/issues/14343

Changes:
* clean up empty/not maintained tests
* remove trigger plugin for repos without tests

After this PR, `kubeflow/kubeflow`, `kubeflow/testing`, `kubeflow/kubeflow` are the last three repos using k8s/test-infra.

I didn't disable status reconciler, because it's OK to let it retire the contexts.

/assign @chaodaiG 