### PR TITLE
Enable override plugin in kubernetes-sigs/kubebuilder

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -990,6 +990,10 @@ plugins:
     - override
     - release-note
 
+  kubernetes-sigs/kubebuilder:
+    plugins:
+    - override
+
   containerd/cri:
     plugins:
     - assign


### PR DESCRIPTION
According to:

https://github.com/kubernetes/test-infra/blob/b023bd33f7999be8fefe25900a59b44defe3271f/config/prow/plugins.yaml#L643-L645

This is how `override` is enabled for https://github.com/kubernetes-sigs/kubebuilder.

As an example,  https://github.com/kubernetes-sigs/kind is doing the same:

https://github.com/kubernetes/test-infra/blob/b023bd33f7999be8fefe25900a59b44defe3271f/config/prow/plugins.yaml#L912-L914

There doesn't seem to be any order, so I placed it the last of `kubernetes-sigs/*` repos.

/cc @DirectXMan12 