### PR TITLE
Cherrypicker: Allow pushing to a differently-named fork

### DIFF
--- a/prow/external-plugins/cherrypicker/server_test.go
+++ b/prow/external-plugins/cherrypicker/server_test.go
@@ -305,7 +305,7 @@ func testCherryPickIC(clients localgit.Clients, t *testing.T) {
 	s := &Server{
 		botUser:        botUser,
 		gc:             c,
-		push:           func(newBranch string, force bool) error { return nil },
+		push:           func(forkName, newBranch string, force bool) error { return nil },
 		ghc:            ghc,
 		tokenGenerator: getSecret,
 		log:            logrus.StandardLogger().WithField("client", "cherrypicker"),
@@ -452,7 +452,7 @@ func testCherryPickPR(clients localgit.Clients, t *testing.T) {
 	s := &Server{
 		botUser:        botUser,
 		gc:             c,
-		push:           func(newBranch string, force bool) error { return nil },
+		push:           func(forkName, newBranch string, force bool) error { return nil },
 		ghc:            ghc,
 		tokenGenerator: getSecret,
 		log:            logrus.StandardLogger().WithField("client", "cherrypicker"),
@@ -644,7 +644,7 @@ func testCherryPickPRWithLabels(clients localgit.Clients, t *testing.T) {
 					s := &Server{
 						botUser:        botUser,
 						gc:             c,
-						push:           func(newBranch string, force bool) error { return nil },
+						push:           func(forkName, newBranch string, force bool) error { return nil },
 						ghc:            ghc,
 						tokenGenerator: getSecret,
 						log:            logrus.StandardLogger().WithField("client", "cherrypicker"),

--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -408,11 +408,15 @@ func (r *Repo) Am(path string) error {
 // Push pushes over https to the provided owner/repo#branch using a password
 // for basic auth.
 func (r *Repo) Push(branch string, force bool) error {
+	return r.PushToNamedFork(r.user, branch, force)
+}
+
+func (r *Repo) PushToNamedFork(forkName, branch string, force bool) error {
 	if r.user == "" || r.pass == "" {
 		return errors.New("cannot push without credentials - configure your git client")
 	}
 	r.logger.Infof("Pushing to '%s/%s (branch: %s)'.", r.user, r.repo, branch)
-	remote := fmt.Sprintf("https://%s:%s@%s/%s/%s", r.user, r.pass, r.host, r.user, r.repo)
+	remote := fmt.Sprintf("https://%s:%s@%s/%s/%s", r.user, r.pass, r.host, r.user, forkName)
 	var co *exec.Cmd
 	if !force {
 		co = r.gitCommand("push", remote, branch)
@@ -425,6 +429,7 @@ func (r *Repo) Push(branch string, force bool) error {
 		return fmt.Errorf("pushing failed, output: %q, error: %v", string(out), err)
 	}
 	return nil
+
 }
 
 // CheckoutPullRequest does exactly that.

--- a/prow/git/v2/adapter.go
+++ b/prow/git/v2/adapter.go
@@ -78,6 +78,10 @@ func (a *repoClientAdapter) PushToFork(branch string, force bool) error {
 	return a.Repo.Push(branch, force)
 }
 
+func (a *repoClientAdapter) PushToNamedFork(forkName, branch string, force bool) error {
+	return a.Repo.PushToNamedFork(forkName, branch, force)
+}
+
 func (a *repoClientAdapter) PushToCentral(branch string, force bool) error {
 	return errors.New("no PushToCentral implementation exists in the v1 repo client")
 }

--- a/prow/git/v2/publisher.go
+++ b/prow/git/v2/publisher.go
@@ -17,6 +17,7 @@ limitations under the License.
 package git
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/sirupsen/logrus"
@@ -28,6 +29,8 @@ type Publisher interface {
 	Commit(title, body string) error
 	// PushToFork pushes the local state to the fork remote
 	PushToFork(branch string, force bool) error
+	// PushToNamedFork is used for when the fork has a different name than the original repp
+	PushToNamedFork(forkName, branch string, force bool) error
 	// PushToCentral pushes the local state to the central remote
 	PushToCentral(branch string, force bool) error
 }
@@ -64,6 +67,10 @@ func (p *publisher) Commit(title, body string) error {
 		}
 	}
 	return nil
+}
+
+func (p *publisher) PushToNamedFork(forkName, branch string, force bool) error {
+	return errors.New("pushToNamedFork is not implemented in the v2 client")
 }
 
 // PublishPush pushes the local state to the publish remote


### PR DESCRIPTION
Currently, if the fork is named differently we use that forks name together with the base organization to pull, which is wrong. This changes it to use the original name for pulling and the forks name for pushing.