### PR TITLE
pod-utils: be more intelligent with grace period

### DIFF
--- a/prow/pod-utils/decorate/podspec_test.go
+++ b/prow/pod-utils/decorate/podspec_test.go
@@ -1020,7 +1020,7 @@ func TestProwJobToPod_setsTerminationGracePeriodSeconds(t *testing.T) {
 					},
 				},
 			},
-			expectedTerminationGracePeriodSeconds: 10,
+			expectedTerminationGracePeriodSeconds: 12,
 		},
 		{
 			name: "Existing GracePeriodSeconds is not overwritten",

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_1.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_1.yaml
@@ -134,7 +134,7 @@ spec:
     - mountPath: /tools
       name: tools
   restartPolicy: Never
-  terminationGracePeriodSeconds: 10
+  terminationGracePeriodSeconds: 12
   volumes:
   - emptyDir: {}
     name: logs

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_2.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_2.yaml
@@ -134,7 +134,7 @@ spec:
     - mountPath: /tools
       name: tools
   restartPolicy: Never
-  terminationGracePeriodSeconds: 10
+  terminationGracePeriodSeconds: 12
   volumes:
   - emptyDir: {}
     name: logs

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_3.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_3.yaml
@@ -135,7 +135,7 @@ spec:
     - mountPath: /tools
       name: tools
   restartPolicy: Never
-  terminationGracePeriodSeconds: 10
+  terminationGracePeriodSeconds: 12
   volumes:
   - emptyDir: {}
     name: logs

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_4.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_4.yaml
@@ -135,7 +135,7 @@ spec:
     - mountPath: /tools
       name: tools
   restartPolicy: Never
-  terminationGracePeriodSeconds: 10
+  terminationGracePeriodSeconds: 12
   volumes:
   - emptyDir: {}
     name: logs

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_5.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_5.yaml
@@ -91,7 +91,7 @@ spec:
     - mountPath: /tools
       name: tools
   restartPolicy: Never
-  terminationGracePeriodSeconds: 10
+  terminationGracePeriodSeconds: 12
   volumes:
   - emptyDir: {}
     name: logs

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_6.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_6.yaml
@@ -108,7 +108,7 @@ spec:
     - mountPath: /tools
       name: tools
   restartPolicy: Never
-  terminationGracePeriodSeconds: 10
+  terminationGracePeriodSeconds: 12
   volumes:
   - emptyDir: {}
     name: logs

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_7.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_7.yaml
@@ -191,7 +191,7 @@ spec:
     - mountPath: /tools
       name: tools
   restartPolicy: Never
-  terminationGracePeriodSeconds: 10
+  terminationGracePeriodSeconds: 12
   volumes:
   - emptyDir: {}
     name: logs

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_8.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_8.yaml
@@ -131,7 +131,7 @@ spec:
       name: tools
   restartPolicy: Never
   serviceAccountName: default-SA
-  terminationGracePeriodSeconds: 10
+  terminationGracePeriodSeconds: 12
   volumes:
   - emptyDir: {}
     name: logs


### PR DESCRIPTION
When a user sets a grace period, today they have to consider they're
setting one for the gracful termination of their process *and* the
upload that follows it. This is error-prone and causes artifact losses.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @alvaroaleman 