### PR TITLE
Add clarity to pr-creator base/head error message

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -1922,7 +1922,7 @@ func (c *client) CreatePullRequest(org, repo, title, body, head, base string, ca
 		exitCodes:   []int{201},
 	}, &resp)
 	if err != nil {
-		return 0, fmt.Errorf("failed to create pull request against %s/%s#%s from %s: %v", org, repo, head, base, err)
+		return 0, fmt.Errorf("failed to create pull request against %s/%s#%s from head %s: %v", org, repo, base, head, err)
 	}
 	return resp.Num, nil
 }


### PR DESCRIPTION
I've been trying to debug my usage of *pr-creator* and was having trouble understanding this error message:

```
FATA[0001] Failed to ensure PR exists.                   error=
"create error: failed to create pull request against ORG/REPO#HEAD from BASE: unexpected end of JSON input"
```

I checked the docs https://docs.github.com/en/rest/reference/pulls#create-a-pull-request

- HEAD : The name of the branch where your changes are implemented. For cross-repository pull requests in the same network, namespace head with a user like this: username:branch. |
- BASE : The name of the branch you want the changes pulled into. This should be an existing branch on the current repository. You cannot submit a pull request to one repository that requests a merge to a base of another repository.

This PR updates the error message to provide more clarity and match the documentation more closely.

```
hh@Hippies-Air test-infra % git push --set-upstream ii pr-creator-base
Enumerating objects: 9, done.
Counting objects: 100% (9/9), done.
Delta compression using up to 8 threads
Compressing objects: 100% (5/5), done.
Writing objects: 100% (5/5), 483 bytes | 483.00 KiB/s, done.
Total 5 (delta 4), reused 0 (delta 0)
remote: Resolving deltas: 100% (4/4), completed with 4 local objects.
remote:
remote: Create a pull request for 'pr-creator-base' on GitHub by visiting:
remote:      https://github.com/ii/test-infra/pull/new/pr-creator-base
remote:
To github.com:ii/test-infra
 * [new branch]            pr-creator-base -> pr-creator-base
Branch 'pr-creator-base' set up to track remote branch 'pr-creator-base' from 'ii'.
```

```
hh@Hippies-Air test-infra % go build -o pr-creator ./robots/pr-creator && \
  ./pr-creator --org=kubernetes --repo=test-infra --branch=master \
                     --source=pr-creator-base --local --github-token-path=`pwd`/github-token \
                     --head-branch=pr-creator-base --title=TITLE --body=BODY
```

```
INFO[0000] Looking for a PR to reuse...
INFO[0000] User()                                        client=github
INFO[0001] FindIssues(is:open is:pr archived:false repo:kubernetes/test-infra author:hh head:pr-creator-base)  client=github
INFO[0001] No reusable issues found
INFO[0001] CreatePullRequest(kubernetes, test-infra, TITLE)  client=github
FATA[0001] Failed to ensure PR exists.                   error=
"create error: failed to create pull request against kubernetes/test-infra#master from head pr-creator-base: unexpected end of JSON input"
```

While I feel more certain I'm getting my arguments right with the updated error message, it's still unclear what is causing the unexpected error.