### PR TITLE
Kops - try lowering presubmit resources to match failing periodic job

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -129,8 +129,11 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            memory: "2Gi"
           requests:
-            memory: "6Gi"
+            cpu: "2"
+            memory: "2Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits, kops-kubetest2
       testgrid-tab-name: e2e-kubetest2


### PR DESCRIPTION
Trying to see whether the job's resources has an impact on whether ginkgo times out or not.

matching the resources here:
https://github.com/kubernetes/test-infra/blob/9326ed7bd00dbf4b4edb1112dfabdf720808ebf1/config/jobs/kubernetes/kops/build_grid.py#L114-L119