### PR TITLE
prow/deck: add filtering by cluster

### DIFF
--- a/prow/cmd/deck/runlocal
+++ b/prow/cmd/deck/runlocal
@@ -16,15 +16,23 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "${DIR}"
 cd localdata
-HOST="https://prow.k8s.io"
-if [[ "${1}" == "openshift" ]]; then
+HOST=${1:-"https://prow.k8s.io"}
+if [[ "${HOST}" == "openshift" ]]; then
 	HOST="https://deck-ci.svc.ci.openshift.org"
 fi
 
+echo "fetching localdata from ${HOST}"
 curl "${HOST}/prowjobs.js" > prowjobs.json
 curl "${HOST}/tide.js?var=tideData" > tide.js
 curl "${HOST}/tide-history.js?var=tideHistory" > tide-history.js
 curl "${HOST}/plugin-help.js?var=allHelp" > plugin-help.js
 curl "${HOST}/pr-data.js" > pr-data.js
 
-bazel run //prow/cmd/deck:deck -- --pregenerated-data=${DIR}/localdata --static-files-location=./prow/cmd/deck/static --template-files-location=./prow/cmd/deck/template --spyglass-files-location=./prow/spyglass/lenses --config-path "${DIR}/../../../config/prow/config.yaml" --spyglass --gcs-no-auth
+bazel run //prow/cmd/deck:deck -- \
+  --pregenerated-data=${DIR}/localdata \
+  --static-files-location=./prow/cmd/deck/static \
+  --template-files-location=./prow/cmd/deck/template \
+  --spyglass-files-location=./prow/spyglass/lenses \
+  --config-path "${DIR}/../../../config/prow/config.yaml" \
+  --spyglass \
+  --gcs-no-auth

--- a/prow/cmd/deck/static/prow/prow.ts
+++ b/prow/cmd/deck/static/prow/prow.ts
@@ -31,12 +31,14 @@ interface RepoOptions {
     pulls: {[key: string]: boolean};
     batches: {[key: string]: boolean};
     states: {[key: string]: boolean};
+    clusters: {[key: string]: boolean};
 }
 
 function optionsForRepo(repository: string): RepoOptions {
     const opts: RepoOptions = {
         authors: {},
         batches: {},
+        clusters: {},
         jobs: {},
         pulls: {},
         repos: {},
@@ -47,6 +49,7 @@ function optionsForRepo(repository: string): RepoOptions {
     for (const build of allBuilds.items) {
         const {
             spec: {
+                cluster = "",
                 type = "",
                 job = "",
                 refs: {
@@ -59,6 +62,7 @@ function optionsForRepo(repository: string): RepoOptions {
         } = build;
 
         opts.types[type] = true;
+        opts.clusters[cluster] = true;
         const repoKey = `${org}/${repo}`;
         if (repoKey) {
             opts.repos[repoKey] = true;
@@ -102,6 +106,8 @@ function redrawOptions(fz: FuzzySearch, opts: RepoOptions) {
     }
     const ss = Object.keys(opts.states).sort();
     addOptions(ss, "state");
+    const cs = Object.keys(opts.clusters).sort();
+    addOptions(cs, "cluster");
 }
 
 function adjustScroll(el: Element): void {
@@ -479,6 +485,7 @@ function redraw(fz: FuzzySearch, pushState: boolean = true): void {
     const authorSel = getSelection("author");
     const jobSel = getSelectionFuzzySearch("job", "job-input");
     const stateSel = getSelection("state");
+    const clusterSel = getSelection("cluster");
 
     if (pushState && window.history && window.history.pushState !== undefined) {
         if (args.length > 0) {
@@ -506,6 +513,7 @@ function redraw(fz: FuzzySearch, pushState: boolean = true): void {
                 name: prowJobName = "",
             },
             spec: {
+                cluster = "",
                 type = "",
                 job = "",
                 agent = "",
@@ -532,6 +540,9 @@ function redraw(fz: FuzzySearch, pushState: boolean = true): void {
             continue;
         }
         if (!equalSelected(stateSel, state)) {
+            continue;
+        }
+        if (!equalSelected(clusterSel, cluster)) {
             continue;
         }
         if (!jobSel.test(job)) {

--- a/prow/cmd/deck/template/index.html
+++ b/prow/cmd/deck/template/index.html
@@ -30,6 +30,7 @@
           </div>
         </li>
         <li><select id="state"><option>all states</option></select></li>
+        <li><select id="cluster"><option>all clusters</option></select></li>
         <li id="job-count"></li>
       </ul>
     </div>


### PR DESCRIPTION
Fixes https://github.com/kubernetes/test-infra/issues/20922

With this I can visit https://prow.k8s.io/?cluster=k8s-infra-prow-build to see everything running on that cluster