### PR TITLE
Kops - increase memory resources for kubetest2 presubmit

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -130,10 +130,10 @@ presubmits:
           privileged: true
         resources:
           limits:
-            memory: "2Gi"
+            memory: "3Gi"
           requests:
             cpu: "2"
-            memory: "2Gi"
+            memory: "3Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits, kops-kubetest2
       testgrid-tab-name: e2e-kubetest2


### PR DESCRIPTION
2Gi caused the identical timeout behavior that we've seen on the periodic jobs that use 2Gi. Next step is to keep increasing this until the original 6Gi to see how much is needed to avoid the timeouts.

failure: https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/directory/pull-kops-e2e-kubernetes-aws-kubetest2/1363170189926993920

followup to https://github.com/kubernetes/test-infra/pull/20928