### PR TITLE
cherrypick: add log when create comment failed

### DIFF
--- a/prow/external-plugins/cherrypicker/server.go
+++ b/prow/external-plugins/cherrypicker/server.go
@@ -358,7 +358,9 @@ func (s *Server) handlePullRequest(l *logrus.Entry, pre github.PullRequestEvent)
 			if targetBranch == baseBranch {
 				resp := fmt.Sprintf("base branch (%s) needs to differ from target branch (%s)", baseBranch, targetBranch)
 				l.Info(resp)
-				s.createComment(l, org, repo, num, ic, resp)
+				if err := s.createComment(l, org, repo, num, ic, resp); err != nil {
+					l.WithError(err).WithField("response", resp).Error("Failed to create comment.")
+				}
 				continue
 			}
 			handledBranches[targetBranch] = true

--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -429,7 +429,6 @@ func (r *Repo) PushToNamedFork(forkName, branch string, force bool) error {
 		return fmt.Errorf("pushing failed, output: %q, error: %v", string(out), err)
 	}
 	return nil
-
 }
 
 // CheckoutPullRequest does exactly that.


### PR DESCRIPTION
Add log when create comment failed and remove useless new line(https://github.com/kubernetes/test-infra/pull/20920#discussion_r579624559).