### PR TITLE
Kops - fix kube-router job's networking flag

### DIFF
--- a/config/jobs/kubernetes/kops/build_grid.py
+++ b/config/jobs/kubernetes/kops/build_grid.py
@@ -636,8 +636,10 @@ def generate_network_plugins():
     results = []
     skip_base = r'\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler'# pylint: disable=line-too-long
     for plugin in plugins:
-        networking_arg = plugin.replace('-', '') # amazon vpc cni uses --networking=amazonvpc
+        networking_arg = plugin
         skip_regex = skip_base
+        if plugin == 'amazon-vpc':
+            networking_arg = 'amazonvpc'
         if plugin == 'cilium':
             skip_regex += r'|should.set.TCP.CLOSE_WAIT'
         else:
@@ -646,6 +648,7 @@ def generate_network_plugins():
             skip_regex += r'|Services.*rejected.*endpoints'
         if plugin == 'kuberouter':
             skip_regex += r'|load-balancer|hairpin|affinity\stimeout|service\.kubernetes\.io|CLOSE_WAIT' # pylint: disable=line-too-long
+            networking_arg = 'kube-router'
         results.append(
             build_test(
                 container_runtime='containerd',

--- a/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
@@ -392,7 +392,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-kopeio
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "stable", "kops_channel": "stable", "kops_version": null, "networking": "kuberouter"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "stable", "kops_channel": "stable", "kops_version": null, "networking": "kube-router"}
 - name: e2e-kops-aws-cni-kuberouter
   interval: '8h'
   labels:
@@ -421,7 +421,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=kuberouter --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1' --networking=kube-router --container-runtime=containerd" \
           --env=KOPS_FEATURE_FLAGS= \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
@@ -452,7 +452,7 @@ periodics:
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: stable
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: kuberouter
+    test.kops.k8s.io/networking: kube-router
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-kuberouter


### PR DESCRIPTION
The hyphenation in our job names is not consistent with our flag names, this fixes that.
Long term it would be good to have both match but changing the job name will lose the history in testgrid.

Fixes https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/e2e-kops-aws-cni-kuberouter/1363772797209284608