### PR TITLE
Fix custom-metrics-apiserver presubmits failures

### DIFF
--- a/config/jobs/kubernetes-sigs/custom-metrics-apiserver/custom-metrics-apiserver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/custom-metrics-apiserver/custom-metrics-apiserver-presubmits.yaml
@@ -8,7 +8,9 @@ presubmits:
       containers:
       - image: golang:1.15
         command:
-        - make verify && git diff --exit-code
+        - make
+        args:
+        - verify
     annotations:
       testgrid-dashboards: sig-instrumentation-custom-metrics-apiserver
       testgrid-tab-name: pr-verify
@@ -20,7 +22,9 @@ presubmits:
       containers:
       - image: golang:1.15
         command:
-        - make build-test-adapter
+        - make
+        args:
+        - build-test-adapter
     annotations:
       testgrid-dashboards: sig-instrumentation-custom-metrics-apiserver
       testgrid-tab-name: pr-build-test-adapter
@@ -32,7 +36,9 @@ presubmits:
       containers:
       - image: golang:1.15
         command:
-        - make test
+        - make
+        args:
+        - test
     annotations:
       testgrid-dashboards: sig-instrumentation-custom-metrics-apiserver
       testgrid-tab-name: pr-test


### PR DESCRIPTION
Split commands and args as having both together results in CI failures
when the command is being evaluated.

https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_custom-metrics-apiserver/81/pull-custom-metrics-apiserver-build-test-adapter/1361645502378020864

/assign @s-urbaniak 