### PR TITLE
Phaino: accept user provided repo paths from args

### DIFF
--- a/prow/cmd/phaino/BUILD.bazel
+++ b/prow/cmd/phaino/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/interrupts:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_github_spf13_pflag//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_sigs_yaml//:go_default_library",
     ],
@@ -27,6 +28,7 @@ go_test(
     name = "go_default_test",
     srcs = ["local_test.go"],
     embed = [":go_default_library"],
+    deps = ["//prow/apis/prowjobs/v1:go_default_library"],
 )
 
 filegroup(

--- a/prow/cmd/phaino/README.md
+++ b/prow/cmd/phaino/README.md
@@ -29,10 +29,11 @@ volumes that the Prow Job may require.
 
 ### Common options
 
-* `--grace=5m` controls how long to wait for interrupted jobs before terminating.
+* `--grace=5m` controls how long to wait for interrupted jobs before terminating
 * `--print` the command that runs each job without running it
 * `--privileged` jobs are allowed to run instead of rejected
 * `--timeout=10m` controls how long to allow jobs to run before interrupting them
+* `--repo=k8s/test-infra=/go/src/k8s-test-infra` local path where prow job required repos are cloned at, can be passed in repeatedly
 
 See `bazel run //prow/cmd/phaino -- --help` for full option list.
 


### PR DESCRIPTION
Improve phaino so that user can run prow job locally without interactive prompts for confirming repos paths. By the way changed the following:
- path resolve respects org name containing "http(s)://"
- add unit test for pathAlias function
- use pflag instead of flag for map argument