### PR TITLE
Add canary jobs for periodic-kubernetes-bazel-build variants

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -453,6 +453,50 @@ periodics:
           cpu: "4"
           memory: 12Gi
 - annotations:
+    testgrid-dashboards: sig-release-1.18-blocking, sig-testing-canaries
+    testgrid-tab-name: bazel-build-1.18-canary
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.18
+    org: kubernetes
+    repo: kubernetes
+  - base_ref: master
+    org: kubernetes
+    repo: test-infra
+  interval: 6h
+  labels:
+    preset-bazel-scratch-dir: "true"
+    preset-service-account: "true"
+  name: periodic-kubernetes-bazel-build-1-18-canary
+  cluster: k8s-infra-prow-build
+  rerun_auth_config:
+    github_team_ids:
+    - 2241179
+  spec:
+    containers:
+    - args:
+      - -c
+      - |
+        set -o errexit
+        gcloud auth activate-service-account --key-file=/etc/service-account/service-account.json
+        ../test-infra/scenarios/kubernetes_bazel.py \
+            --config=unit \
+            "--build=//... -//vendor/..." \
+            --release=//build/release-tars \
+            --gcs=gs://k8s-release-dev/ci-periodic \
+            --version-suffix=-bazel
+      command:
+      - bash
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210217-8c72491-1.18
+      name: ""
+      resources:
+        limits:
+          cpu: "4"
+          memory: 12Gi
+        requests:
+          cpu: "4"
+          memory: 12Gi
+- annotations:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
     testgrid-dashboards: sig-release-1.18-blocking, google-unit
     testgrid-tab-name: bazel-test-1.18

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -404,6 +404,50 @@ periodics:
           cpu: "4"
           memory: 12Gi
 - annotations:
+    testgrid-dashboards: sig-release-1.19-blocking, sig-testing-canaries
+    testgrid-tab-name: bazel-build-1.19-canary
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.19
+    org: kubernetes
+    repo: kubernetes
+  - base_ref: master
+    org: kubernetes
+    repo: test-infra
+  interval: 6h
+  labels:
+    preset-bazel-scratch-dir: "true"
+    preset-service-account: "true"
+  name: periodic-kubernetes-bazel-build-1-19-canary
+  cluster: k8s-infra-prow-build
+  rerun_auth_config:
+    github_team_ids:
+    - 2241179
+  spec:
+    containers:
+    - args:
+      - -c
+      - |
+        set -o errexit
+        gcloud auth activate-service-account --key-file=/etc/service-account/service-account.json
+        ../test-infra/scenarios/kubernetes_bazel.py \
+            --config=unit \
+            "--build=//... -//vendor/..." \
+            --release=//build/release-tars \
+            --gcs=gs://k8s-release-dev/ci-periodic \
+            --version-suffix=-bazel
+      command:
+      - bash
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210217-8c72491-1.19
+      name: ""
+      resources:
+        limits:
+          cpu: "4"
+          memory: 12Gi
+        requests:
+          cpu: "4"
+          memory: 12Gi
+- annotations:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
     testgrid-dashboards: sig-release-1.19-blocking, google-unit
     testgrid-tab-name: bazel-test-1.19

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
@@ -401,6 +401,50 @@ periodics:
           cpu: "4"
           memory: 12Gi
 - annotations:
+    testgrid-dashboards: sig-release-1.20-blocking, sig-testing-canaries
+    testgrid-tab-name: bazel-build-1.20-canary
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.20
+    org: kubernetes
+    repo: kubernetes
+  - base_ref: master
+    org: kubernetes
+    repo: test-infra
+  interval: 6h
+  labels:
+    preset-bazel-scratch-dir: "true"
+    preset-service-account: "true"
+  name: periodic-kubernetes-bazel-build-1-20-canary
+  cluster: k8s-infra-prow-build
+  rerun_auth_config:
+    github_team_ids:
+    - 2241179
+  spec:
+    containers:
+    - args:
+      - -c
+      - |
+        set -o errexit
+        gcloud auth activate-service-account --key-file=/etc/service-account/service-account.json
+        ../test-infra/scenarios/kubernetes_bazel.py \
+            --config=unit \
+            "--build=//... -//vendor/..." \
+            --release=//build/release-tars \
+            --gcs=gs://k8s-release-dev/ci-periodic \
+            --version-suffix=-bazel
+      command:
+      - bash
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210217-8c72491-1.20
+      name: ""
+      resources:
+        limits:
+          cpu: "4"
+          memory: 12Gi
+        requests:
+          cpu: "4"
+          memory: 12Gi
+- annotations:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
     testgrid-dashboards: sig-release-1.20-blocking, google-unit
     testgrid-tab-name: bazel-test-1.20


### PR DESCRIPTION
Ensure periodic-kubernetes-bazel-build can run k8s-infra-prow-build
cluster and push artifacts on k8s-release-dev bucket.

Related to : https://github.com/kubernetes/test-infra/issues/19483

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>