### PR TITLE
Use generic autobump image for autobump job

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -893,13 +893,10 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210223-952586a143-master
+    - image: gcr.io/k8s-testimages/generic_autobump:v20210222-e84a689
       command:
-      - runner.sh
+      - /generic_autobump
       args:
-      - go
-      - run
-      - experiment/autobumper/main.go
       - --config=config/prow/autobump-config.yaml
       volumeMounts:
       - name: github


### PR DESCRIPTION
Replacing the current way that autobumper is run with the way that uses the generic_autobump images. This will allow us to use the generic_autobump image in k8s/t-i as a reference when bumping the autobump jobs in other repos. 