### PR TITLE
Add pull-k8sio-yamllint

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/k8sio-presubmit.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/k8sio-presubmit.yaml
@@ -21,3 +21,16 @@ presubmits:
         env:
         - name: GO111MODULE
           value: "on"
+  - name: pull-k8sio-yamllint
+    annotations:
+      testgrid-dashboards: wg-k8s-infra-k8sio
+      testgrid-tab-name: pull-k8sio-yamllint
+    always_run: true
+    decorate: true
+    spec:
+      containers:
+      - image: quay.io/kubermatic/yamllint:0.1
+        command:
+        - yamllint
+        - -c
+        - hack/.yamllint.conf


### PR DESCRIPTION
Based off of test-infra-yamllint job

/hold
Needs https://github.com/kubernetes/k8s.io/pull/1694 to merge first

I realized we have a lot of yaml in kubernetes/k8s.io, and there is really
not much in the way of presubmit validation.  This is a really bare-bones
start.

Ideas for followup if anyone is interested:
- use a non-quay.io image and call hack/verify-yamllint.sh instead
- move toward a pull-k8sio-verify job that calls hack/verify-* similar to
  kubernetes/kubernetes
- add boilerplate check to that job