### PR TITLE
Install kind on kubekins-e2e image in test-infra variant

### DIFF
--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -90,6 +90,12 @@ RUN [ "${UPGRADE_DOCKER_ARG}" = "true" ] && \
     rm -rf /var/lib/apt/lists/* && \
     sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker || true
 
+# install kind if a version is provided
+ARG KIND_VERSION
+RUN [ -n "${KIND_VERSION:-}" ] && \
+    wget -q -O /usr/local/bin/kind https://kind.sigs.k8s.io/dl/v${KIND_VERSION}/kind-linux-amd64 && \
+    chmod +x /usr/local/bin/kind
+
 # configure dockerd to use mirror.gcr.io
 # per instructions at https://cloud.google.com/container-registry/docs/pulling-cached-images
 ARG DOCKER_REGISTRY_MIRROR_URL=https://mirror.gcr.io

--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -18,6 +18,7 @@ variants:
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 3.1.0
+    KIND_VERSION: 0.10.0
   master:
     CONFIG: master
     GO_VERSION: 1.15.8


### PR DESCRIPTION
Prow integration test requires kind installation, install it in kubekins-e2e image so that the test doesn't need to download kind every time