### PR TITLE
Add kops job for testing on DO cloud provider

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -173,7 +173,7 @@ presubmits:
             memory: "3Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits, kops-kubetest2
-      testgrid-tab-name: e2e-kubetest2
+      testgrid-tab-name: e2e-do-kubetest2
   - name: pull-kops-e2e-k8s-containerd
     branches:
     - master

--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -137,6 +137,43 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits, kops-kubetest2
       testgrid-tab-name: e2e-kubetest2
+  - name: pull-kops-e2e-kubernetes-do-kubetest2
+    branches:
+    - master
+    always_run: false
+    labels:
+      preset-service-account: "true"
+      preset-do-credential: "true"
+      preset-do-spaces-credential: "true"
+      preset-aws-ssh: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+    decorate: true
+    decoration_config:
+      timeout: 90m
+    path_alias: k8s.io/kops
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - make
+        - test-e2e-do-simple-1-20
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            memory: "3Gi"
+          requests:
+            cpu: "2"
+            memory: "3Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits, kops-kubetest2
+      testgrid-tab-name: e2e-kubetest2
   - name: pull-kops-e2e-k8s-containerd
     branches:
     - master


### PR DESCRIPTION
Adding a job to test end to end tests with DO cloud.
@rifelpet - Next, I'll add test-e2e-do-simple-1-20 script in KOPS [here](https://github.com/kubernetes/kops/blob/master/tests/e2e/e2e.mk#L26)

Also using preset-aws-ssh for now, once things work, I'll add a new preset for do-ssh as well.

Please let me know in case you have any questions.

FYI - @timoreimann 