### PR TITLE
jobs: tell pull-k8sio-yamllint what files to lint

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/k8sio-presubmit.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/k8sio-presubmit.yaml
@@ -34,3 +34,4 @@ presubmits:
         - yamllint
         - -c
         - hack/.yamllint.conf
+        - .


### PR DESCRIPTION
Followup to https://github.com/kubernetes/test-infra/pull/20956, which has now blocked all PRs to that repo whoops

This is what I get for not just straight up calling the `hack/verify-yamllint.sh` script... but it relies on bash, which is not in this job's container

/assign @nikhita