### PR TITLE
Move periodic-kubernetes-bazel-build jobs to release-informing

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -410,7 +410,7 @@ periodics:
   - 'perfDashBuildsCount: 500'
 - annotations:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
-    testgrid-dashboards: sig-release-1.18-blocking, google-unit
+    testgrid-dashboards: sig-release-1.18-informing, google-unit
     testgrid-tab-name: bazel-build-1.18
   decorate: true
   extra_refs:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -361,7 +361,7 @@ periodics:
   - 'perfDashBuildsCount: 500'
 - annotations:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
-    testgrid-dashboards: sig-release-1.19-blocking, google-unit
+    testgrid-dashboards: sig-release-1.19-informing, google-unit
     testgrid-tab-name: bazel-build-1.19
   decorate: true
   extra_refs:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
@@ -358,7 +358,7 @@ periodics:
   - 'perfDashBuildsCount: 500'
 - annotations:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
-    testgrid-dashboards: sig-release-1.20-blocking, google-unit
+    testgrid-dashboards: sig-release-1.20-informing, google-unit
     testgrid-tab-name: bazel-build-1.20
   decorate: true
   extra_refs:

--- a/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
@@ -139,7 +139,7 @@ postsubmits:
 
     annotations:
       testgrid-dashboards: sig-release-master-informing
-      testgrid-tab-name: bazel-build-master
+      testgrid-tab-name: post-bazel-build-master
       description: 'OWNER: sig-testing; Builds kubernetes at each bommit using bazel with RBE'
 
 periodics:
@@ -150,7 +150,7 @@ periodics:
     fork-per-release-replacements: "latest-bazel.txt -> latest-bazel-{{.Version}}.txt"
     fork-per-release-periodic-interval: 6h
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
-    testgrid-dashboards: sig-release-master-blocking, google-unit
+    testgrid-dashboards: sig-release-master-informing, google-unit
     testgrid-tab-name: bazel-build-master
     description: run bazel build //... -//vendor/...
   interval: 5m


### PR DESCRIPTION
Part of https://github.com/kubernetes/test-infra/issues/18549

The intent here is to remove these jobs from the list of release-blocking jobs that need to be migrated over.

Given https://github.com/kubernetes/enhancements/issues/2420 I think we should stop considering these as release-blocking, since we already have release-blocking non-bazel build jobs