### PR TITLE
Deprecate google-hosted kubernetes-build jobs

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -30,7 +30,7 @@ presubmits:
 
 periodics:
 - interval: 1h
-  name: ci-kubernetes-build
+  name: ci-kubernetes-build-deprecated
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
@@ -63,11 +63,11 @@ periodics:
   annotations:
     fork-per-release: "true"
     fork-per-release-replacements: "k8s-master -> k8s-beta"
-    testgrid-dashboards: sig-release-master-blocking
-    testgrid-tab-name: build-master
+    testgrid-dashboards: sig-release-master-informing
+    testgrid-tab-name: build-master-deprecated
     testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
 
-- name: ci-kubernetes-build-canary
+- name: ci-kubernetes-build
   interval: 1h
   cluster: k8s-infra-prow-build
   decorate: true
@@ -106,8 +106,8 @@ periodics:
   annotations:
     fork-per-release: "true"
     fork-per-release-replacements: "k8s-master -> k8s-beta"
-    testgrid-dashboards: sig-release-releng-blocking, sig-release-master-informing, sig-testing-canaries
-    testgrid-tab-name: build-master-canary
+    testgrid-dashboards: sig-release-master-blocking, sig-release-releng-blocking
+    testgrid-tab-name: build-master
     testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
 
 - interval: 5m

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -197,8 +197,8 @@ periodics:
           memory: 6Gi
 - annotations:
     testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
-    testgrid-dashboards: sig-release-releng-blocking, sig-release-1.18-informing, sig-testing-canaries
-    testgrid-tab-name: build-1.18-canary
+    testgrid-dashboards: sig-release-1.18-blocking, sig-release-releng-blocking
+    testgrid-tab-name: build-1.18
   cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
@@ -209,7 +209,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-build-1-18-canary
+  name: ci-kubernetes-build-1-18
   rerun_auth_config:
     github_team_ids:
     - 2241179
@@ -237,13 +237,13 @@ periodics:
         privileged: true
 - annotations:
     testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
-    testgrid-dashboards: sig-release-1.18-blocking
-    testgrid-tab-name: build-1.18
+    testgrid-dashboards: sig-release-1.18-informing
+    testgrid-tab-name: build-1.18-deprecated
   interval: 1h
   labels:
     preset-dind-enabled: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-build-1-18
+  name: ci-kubernetes-build-1-18-deprecated
   rerun_auth_config:
     github_team_ids:
     - 2241179

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -155,8 +155,8 @@ periodics:
           memory: 6Gi
 - annotations:
     testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
-    testgrid-dashboards: sig-release-releng-blocking, sig-release-1.19-informing, sig-testing-canaries
-    testgrid-tab-name: build-1.19-canary
+    testgrid-dashboards: sig-release-1.19-blocking, sig-release-releng-blocking
+    testgrid-tab-name: build-1.19
   cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
@@ -167,7 +167,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-build-1-19-canary
+  name: ci-kubernetes-build-1-19
   rerun_auth_config:
     github_team_ids:
     - 2241179
@@ -195,13 +195,13 @@ periodics:
         privileged: true
 - annotations:
     testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
-    testgrid-dashboards: sig-release-1.19-blocking
-    testgrid-tab-name: build-1.19
+    testgrid-dashboards: sig-release-1.19-informing
+    testgrid-tab-name: build-1.19-deprecated
   interval: 1h
   labels:
     preset-dind-enabled: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-build-1-19
+  name: ci-kubernetes-build-1-19-deprecated
   rerun_auth_config:
     github_team_ids:
     - 2241179

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
@@ -154,8 +154,8 @@ periodics:
           memory: 6Gi
 - annotations:
     testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
-    testgrid-dashboards: sig-release-releng-blocking, sig-release-1.20-informing, sig-testing-canaries
-    testgrid-tab-name: build-1.20-canary
+    testgrid-dashboards: sig-release-1.20-blocking, sig-release-releng-blocking
+    testgrid-tab-name: build-1.20
   cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
@@ -166,7 +166,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-build-1-20-canary
+  name: ci-kubernetes-build-1-20
   rerun_auth_config:
     github_team_ids:
     - 2241179
@@ -194,13 +194,13 @@ periodics:
         privileged: true
 - annotations:
     testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
-    testgrid-dashboards: sig-release-1.20-blocking
-    testgrid-tab-name: build-1.20
+    testgrid-dashboards: sig-release-1.20-informing
+    testgrid-tab-name: build-1.20-deprecated
   interval: 1h
   labels:
     preset-dind-enabled: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-build-1-20
+  name: ci-kubernetes-build-1-20-deprecated
   rerun_auth_config:
     github_team_ids:
     - 2241179


### PR DESCRIPTION
Part of https://github.com/kubernetes/test-infra/issues/18549 (more specifically part of https://github.com/kubernetes/test-infra/issues/19483)

Now that all release-blocking jobs use artifacts stored in community-owned `gs://k8s-release-dev` (ref: https://github.com/kubernetes/test-infra/pull/20885), it's time to call the jobs that produce those artifacts release-blocking, and demote the jobs that write to `gs://kubernetes-release-dev` as release-informing.

Deprecate jobs that write to `gs://kuebrnetes-release-dev` by:
- appending deprecated to their job name and testgrid tab name
- moving from release-blocking to release-informing

Promote jobs that write to `gs://k8s-release-dev` by:
- removing canary from their job name and testgrid tab name
- moving from release-informing to release-blocking
- removing from sig-testing-canaries

/hold
This is a "breaking" change that will split job history across the rename boundary since tools like testgrid and kettle don't understand the concept of job renames.

Would like consensus from SIG Release subprojects