### PR TITLE
kubernetes-sigs/blob-csi-driver: add new job for e2e test using blobfuse proxy

### DIFF
--- a/config/jobs/kubernetes-sigs/blob-csi-driver/blob-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/blob-csi-driver/blob-csi-driver-config.yaml
@@ -190,3 +190,55 @@ presubmits:
       testgrid-tab-name: pr-blob-csi-driver-e2e-vmss
       description: "Run E2E tests on a VMSS-based cluster for Azure Blob Storage CSI driver."
       testgrid-num-columns-recent: '30'
+  - name: pull-blob-csi-driver-e2e-proxy
+    decorate: true
+    always_run: true
+    path_alias: sigs.k8s.io/blob-csi-driver
+    branches:
+    - master
+    labels:
+      preset-service-account: "true"
+      preset-azure-cred: "true"
+      preset-dind-enabled: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210217-8c72491-master
+        command:
+        - runner.sh
+        - kubetest
+        args:
+        # Generic e2e test args
+        - --test
+        - --up
+        - --down
+        - --dump=$(ARTIFACTS)
+        # Azure-specific test args
+        - --provider=skeleton
+        - --deployment=aksengine
+        - --aksengine-admin-username=azureuser
+        - --aksengine-creds=$(AZURE_CREDENTIALS)
+        - --aksengine-orchestratorRelease=1.16
+        - --aksengine-location=eastus2
+        - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
+        - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/blob-csi-driver/master/test/manifest/linux.json
+        - --aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz
+        - --test-blob-csi-driver
+        # Specific test args
+        - --ginkgo-parallel=1
+        - --timeout=420m
+        securityContext:
+          privileged: true
+        env:
+          - name: ENABLE_BLOBFUSE_PROXY
+            value: "true"
+    annotations:
+      testgrid-dashboards: provider-azure-blobfuse-csi-driver, provider-azure-presubmit
+      testgrid-tab-name: pull-blob-csi-driver-e2e-proxy
+      description: "Run E2E tests for Azure Blob Storage CSI driver based on blobfuse-proxy"
+      testgrid-num-columns-recent: '30'


### PR DESCRIPTION
https://github.com/kubernetes-sigs/blob-csi-driver/pull/349  In this PR, I have added support for blob-csi-driver NodeStage calls to be able to mount via a proxy that is running either or node or by using a daemonset.

This new jobs will test if NodeStage calls through blobfuse-proxy are working as expected.

In the above PR, blob-csi-driver will looks for an env: `ENABLE_BLOBFUSE_PROXY` if that is available, then it will install blobfuse-proxy as a daemonset.