### PR TITLE
bump kind presubmit jobs resources

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -39,10 +39,10 @@ presubmits:
           privileged: true
         resources:
           limits:
-            cpu: 4
+            cpu: 7
             memory: 9000Mi
           requests:
-            cpu: 4
+            cpu: 7
             memory: 9000Mi
     annotations:
       testgrid-num-failures-to-alert: '10'


### PR DESCRIPTION
Since these jobs are flaking, mainly because pods times out waiting to be running, one guess is that this is due to resources constraint.

With no evidence, maybe try something and observe how it affects is a good approach

xref: https://github.com/kubernetes/test-infra/pull/18825#issuecomment-673632240