### PR TITLE
Report cloud-provider-inspur conformance to testgrid

### DIFF
--- a/config/testgrids/conformance/conformance-all.yaml
+++ b/config/testgrids/conformance/conformance-all.yaml
@@ -7,6 +7,7 @@ dashboard_groups:
     - conformance-kind
     - conformance-cloud-provider-openstack
     - conformance-cloud-provider-huaweicloud
+    - conformance-cloud-provider-inspur
     - conformance-cloud-provider-vsphere
     - conformance-vsphere
     - conformance-hack-local-up-cluster
@@ -132,6 +133,12 @@ dashboards:
     - name: Huawei Cloud Provider, v1.17
       description: Runs conformance tests using kubetest against kubernetes v1.17 with cloud-provider-huaweicloud
       test_group_name: cloud-provider-huaweicloud-e2e-conformance-release-v1.17
+
+- name: conformance-cloud-provider-inspur
+  dashboard_tab:
+    - name: Inspur Cloud Provider, v1.18
+      description: Runs conformance tests using kubetest against kubernetes v1.18 with cloud-provider-inspur
+      test_group_name: cloud-provider-inspur-e2e-conformance-release-v1.18
 
 - name: conformance-cloud-provider-vsphere
 - name: conformance-vsphere
@@ -347,6 +354,9 @@ test_groups:
 - name: cloud-provider-huaweicloud-e2e-conformance-release-v1.17
   gcs_prefix: k8s-conform-huaweicloud/cloud-provider-huaweicloud/e2e-conformance-release-v1.17
 
+# cloud-provider-inspur e2e conformance Test Groups
+- name: cloud-provider-inspur-e2e-conformance-release-v1.18
+  gcs_prefix: k8s-conform-inspur/cloud-provider-inspur/e2e-conformance-release-v1.18
 
 # CEL Conformance Tests
 - name: cel-go-conformance-tests


### PR DESCRIPTION
This PR adds a dashboard for cloud-provider-inspur conformance tests as per [contributing-test-results](https://github.com/kubernetes/test-infra/blob/a69211dc8ee70cd56b4b25fa1eb78de406783dea/docs/contributing-test-results.md#contributing-test-results).

- The GCS bucket  [k8s-conform-inspur](http://storage.googleapis.com/k8s-conform-inspur) is [world-readable](https://cloud.google.com/storage/docs/access-control/making-data-public).
- The conformance test logs have been uploaded to GCS bucket via [upload_e2e.py](https://github.com/kubernetes/test-infra/blob/596fe77f2a00f3cb1c50f2c4b7341d40491525e5/testgrid/conformance/upload_e2e.py)