### PR TITLE
Always run migration ebs csi test

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -89,7 +89,7 @@ presubmits:
       description: aws ebs csi driver e2e test on mutiple AZs
       testgrid-num-columns-recent: '30'
   - name: pull-aws-ebs-csi-driver-migration-test-latest
-    always_run: false
+    always_run: true
     decorate: true
     skip_branches:
     - gh-pages


### PR DESCRIPTION
Since it seems to be passing consistently with inline bug fix , make it required.

https://testgrid.k8s.io/provider-aws-ebs-csi-driver#migration-test-latest