### PR TITLE
kubekins-e2e dockerfile: fix bash weirdness by using if instead of &&

### DIFF
--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -92,9 +92,10 @@ RUN [ "${UPGRADE_DOCKER_ARG}" = "true" ] && \
 
 # install kind if a version is provided
 ARG KIND_VERSION
-RUN [ -n "${KIND_VERSION:-}" ] && \
+RUN if [ -n "${KIND_VERSION}" ]; then \
     wget -q -O /usr/local/bin/kind https://kind.sigs.k8s.io/dl/v${KIND_VERSION}/kind-linux-amd64 && \
-    chmod +x /usr/local/bin/kind
+    chmod +x /usr/local/bin/kind; \
+    fi
 
 # configure dockerd to use mirror.gcr.io
 # per instructions at https://cloud.google.com/container-registry/docs/pulling-cached-images


### PR DESCRIPTION
`&&` style condition makes the docker build exit 1 when the variable evaluated is an empty string, this was verified locally with docker build. The fix is using explicit `if` statement. See where it failed https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-test-infra-push-kubekins-e2e/1364342488625582080