### PR TITLE
Update CAPZ owners

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/OWNERS
@@ -2,7 +2,6 @@
 
 approvers:
 - andyzhangx
-- awesomenix
 - brendandburns
 - CecileRobertMichon
 - feiskyer


### PR DESCRIPTION
Update OWNERS file to match recent update in https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/master/OWNERS_ALIASES 

Note: justaugustus is an approver for cloud-provider-azure so only removed awesomix here.