### PR TITLE
Add dashboard for CAPI release-0.3 E2E jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-3.yaml
@@ -18,7 +18,7 @@ periodics:
         requests:
           cpu: 7300m
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.3
     testgrid-tab-name: capi-test-release-0-3
     testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
     testgrid-num-failures-to-alert: "2"
@@ -46,7 +46,7 @@ periodics:
           requests:
             cpu: 7300m
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.3
     testgrid-tab-name: capi-e2e-release-0-3
     testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
     testgrid-num-failures-to-alert: "2"
@@ -79,5 +79,5 @@ periodics:
       - key: cluster-lifecycle-github-token
         path: cluster-lifecycle-github-token
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.3
     testgrid-tab-name: capi-verify-book-links-release-0-3

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-0-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-0-3.yaml
@@ -16,7 +16,7 @@ presubmits:
         - runner.sh
         - ./scripts/ci-build.sh
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.3
       testgrid-tab-name: capi-pr-build-release-0-3
   - name: pull-cluster-api-make
     decorate: true
@@ -41,7 +41,7 @@ presubmits:
           requests:
             cpu: 7300m
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.3
       testgrid-tab-name: capi-pr-make-release-0-3
   - name: pull-cluster-api-apidiff-release-0-3
     decorate: true
@@ -60,7 +60,7 @@ presubmits:
         - ./scripts/ci-apidiff.sh
         image: gcr.io/k8s-testimages/kubekins-e2e:v20210223-952586a143-1.18
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.3
       testgrid-tab-name: capi-pr-apidiff-release-0-3
   - name: pull-cluster-api-verify-release-0-3
     decorate: true
@@ -82,7 +82,7 @@ presubmits:
           requests:
             cpu: 7300m
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.3
       testgrid-tab-name: capi-pr-verify-release-0-3
   - name: pull-cluster-api-test-release-0-3
     decorate: true
@@ -103,7 +103,7 @@ presubmits:
           requests:
             cpu: 7300m
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.3
       testgrid-tab-name: capi-pr-test-release-0-3
   - name: pull-cluster-api-e2e-release-0-3
     labels:
@@ -131,7 +131,7 @@ presubmits:
           requests:
             cpu: 7300m
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.3
       testgrid-tab-name: capi-pr-e2e-release-0-3
   - name: pull-cluster-api-e2e-full-release-0-3
     labels:
@@ -157,5 +157,5 @@ presubmits:
           requests:
             cpu: 7300m
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.3
       testgrid-tab-name: capi-pr-e2e-full-release-0-3

--- a/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
+++ b/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
@@ -5,6 +5,7 @@ dashboard_groups:
     - sig-cluster-lifecycle-kubeadm
     - sig-cluster-lifecycle-cluster-addons
     - sig-cluster-lifecycle-cluster-api
+    - sig-cluster-lifecycle-cluster-api-0.3
     - sig-cluster-lifecycle-cluster-api-provider-aws
     - sig-cluster-lifecycle-cluster-api-provider-azure
     - sig-cluster-lifecycle-cluster-api-provider-digitalocean
@@ -26,6 +27,7 @@ dashboards:
 - name: sig-cluster-lifecycle-kubeadm
 - name: sig-cluster-lifecycle-cluster-addons
 - name: sig-cluster-lifecycle-cluster-api
+- name: sig-cluster-lifecycle-cluster-api-0.3
 - name: sig-cluster-lifecycle-cluster-api-provider-aws
 - name: sig-cluster-lifecycle-cluster-api-provider-azure
   dashboard_tab:


### PR DESCRIPTION
Add a new dashboard for Cluster-API project to host its `release-0.3` branch E2E jobs separately from master branch.
Fixes: https://github.com/kubernetes-sigs/cluster-api/issues/4226