### PR TITLE
Add config merger lists for k8s

### DIFF
--- a/config/mergelists/BUILD.bazel
+++ b/config/mergelists/BUILD.bazel
@@ -1,0 +1,22 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "mergelists",
+    srcs = glob([
+        "*.yaml",
+    ]),
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/config/mergelists/canary.yaml
+++ b/config/mergelists/canary.yaml
@@ -1,0 +1,4 @@
+target: "gs://k8s-testgrid-canary/config"
+sources:
+- name: ""
+  location: "gs://k8s-testgrid-canary/configs/k8s/config"

--- a/config/mergelists/prod.yaml
+++ b/config/mergelists/prod.yaml
@@ -1,0 +1,4 @@
+target: "gs://k8s-testgrid/config"
+sources:
+- name: ""
+  location: "gs://k8s-testgrid/configs/k8s/config"

--- a/testgrid/config-upload.sh
+++ b/testgrid/config-upload.sh
@@ -19,7 +19,7 @@ set -o pipefail
 
 TESTINFRA_ROOT=$(git rev-parse --show-toplevel)
 
-for output in gs://k8s-testgrid-canary/config gs://k8s-testgrid/config; do
+for output in gs://k8s-testgrid-canary/config gs://k8s-testgrid-canary/configs/k8s/config gs://k8s-testgrid/config gs://k8s-testgrid/configs/k8s/config; do
   dir="$(dirname "${BASH_SOURCE}")"
   (
     set -o xtrace


### PR DESCRIPTION
The [config merger](https://github.com/GoogleCloudPlatform/testgrid/tree/master/cmd/config_merger) utility allows TestGrid configurations to be merged together without a PR request (compare to [Transfigure](https://github.com/kubernetes/test-infra/tree/master/testgrid/cmd/transfigure)) after being initially registered.