### PR TITLE
configurator: prefix gs/ to prow-derived open_test_templates

### DIFF
--- a/config/testgrids/default.yaml
+++ b/config/testgrids/default.yaml
@@ -20,7 +20,7 @@ default_test_group:
 
 default_dashboard_tab:
   open_test_template: # The URL template to visit after clicking on a cell
-    url: https://prow.k8s.io/view/gcs/<gcs_prefix>/<changelist>
+    url: https://prow.k8s.io/view/gs/<gcs_prefix>/<changelist>
   file_bug_template: # The URL template to visit when filing a bug
     url: https://github.com/kubernetes/kubernetes/issues/new
     options:

--- a/testgrid/cmd/configurator/prow.go
+++ b/testgrid/cmd/configurator/prow.go
@@ -201,7 +201,7 @@ func (pac *prowAwareConfigurator) applySingleProwjobAnnotations(c *configpb.Conf
 			var openTestLinkTemplate *configpb.LinkTemplate
 			if jobURLPrefix != "" {
 				openTestLinkTemplate = &configpb.LinkTemplate{
-					Url: strings.TrimRight(jobURLPrefix, "/") + "/<gcs_prefix>/<changelist>",
+					Url: strings.TrimRight(jobURLPrefix, "/") + "/gs/<gcs_prefix>/<changelist>",
 				}
 			}
 

--- a/testgrid/cmd/configurator/prow_test.go
+++ b/testgrid/cmd/configurator/prow_test.go
@@ -651,7 +651,7 @@ func Test_applySingleProwjobAnnotations_OpenTestTemplate(t *testing.T) {
 				"*": "https://config.go.k8s.io/",
 			},
 			expectedOpenTestTemplate: &config.LinkTemplate{
-				Url: "https://config.go.k8s.io/<gcs_prefix>/<changelist>",
+				Url: "https://config.go.k8s.io/gs/<gcs_prefix>/<changelist>",
 			},
 		},
 		{
@@ -660,7 +660,7 @@ func Test_applySingleProwjobAnnotations_OpenTestTemplate(t *testing.T) {
 				"*": "https://config.go.k8s.io/view",
 			},
 			expectedOpenTestTemplate: &config.LinkTemplate{
-				Url: "https://config.go.k8s.io/view/<gcs_prefix>/<changelist>",
+				Url: "https://config.go.k8s.io/view/gs/<gcs_prefix>/<changelist>",
 			},
 		},
 		{
@@ -669,7 +669,7 @@ func Test_applySingleProwjobAnnotations_OpenTestTemplate(t *testing.T) {
 				"*": "https://config.go.k8s.io/gcs",
 			},
 			expectedOpenTestTemplate: &config.LinkTemplate{
-				Url: "https://config.go.k8s.io/<gcs_prefix>/<changelist>",
+				Url: "https://config.go.k8s.io/gs/<gcs_prefix>/<changelist>",
 			},
 		},
 		{
@@ -679,7 +679,7 @@ func Test_applySingleProwjobAnnotations_OpenTestTemplate(t *testing.T) {
 				"test": "https://config.go.k8s.io/",
 			},
 			expectedOpenTestTemplate: &config.LinkTemplate{
-				Url: "https://config.go.k8s.io/<gcs_prefix>/<changelist>",
+				Url: "https://config.go.k8s.io/gs/<gcs_prefix>/<changelist>",
 			},
 		},
 		{
@@ -690,7 +690,7 @@ func Test_applySingleProwjobAnnotations_OpenTestTemplate(t *testing.T) {
 				"test/repo": "https://config.go.k8s.io/",
 			},
 			expectedOpenTestTemplate: &config.LinkTemplate{
-				Url: "https://config.go.k8s.io/<gcs_prefix>/<changelist>",
+				Url: "https://config.go.k8s.io/gs/<gcs_prefix>/<changelist>",
 			},
 		},
 		{
@@ -707,7 +707,7 @@ func Test_applySingleProwjobAnnotations_OpenTestTemplate(t *testing.T) {
 				},
 			},
 			expectedOpenTestTemplate: &config.LinkTemplate{
-				Url: "https://config.go.k8s.io/<gcs_prefix>/<changelist>",
+				Url: "https://config.go.k8s.io/gs/<gcs_prefix>/<changelist>",
 			},
 		},
 	}


### PR DESCRIPTION
Followup to https://github.com/kubernetes/test-infra/pull/20902

https://testgrid.k8s.io/conformance-all#Conformance%20-%20GCE%20-%201.20

click on a cell, get sent to https://prow.k8s.io/view/kubernetes-jenkins/logs/ci-kubernetes-gce-conformance-latest-1-20/1364346208910315520

```
error rendering spyglass page: error when resolving real path kubernetes-jenkins/logs/ci-kubernetes-gce-conformance-latest-1-20/1364346208910315520: 
  error opening file bucket: 
  open blob.Bucket: 
  no driver registered for "kubernetes-jenkins" for URL "kubernetes-jenkins://logs"; 
  available schemes: mem, s3
```

We should be defaulting to `gs://` since that's the only place testgrid updater scrapes from IIRC

Fixes https://github.com/kubernetes/test-infra/issues/20988