### PR TITLE
jobs: enforce kubernetes CI policy for blocking jobs

### DIFF
--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -1036,17 +1036,14 @@ func TestKubernetesMergeBlockingJobMustRunOnK8sInfraProwBuild(t *testing.T) {
 	}
 }
 
-// TODO: may need to rewrite to handle nodepools or handle jobs that can't be
-// migrated over for a while
-// TODO: s/Should/Must and s/Logf/Errorf when all jobs pass
-func TestKubernetesReleaseBlockingJobsShouldRunOnK8sInfraProwBuild(t *testing.T) {
+func TestKubernetesReleaseBlockingJobsMustRunOnK8sInfraProwBuild(t *testing.T) {
 	for _, job := range allStaticJobs() {
 		// Only consider Pods that are release-blocking
 		if job.Spec == nil || !isKubernetesReleaseBlocking(job) {
 			continue
 		}
 		if job.Cluster != "k8s-infra-prow-build" {
-			t.Logf("%v: should run on cluster: k8s-infra-prow-build, found: %v", job.Name, job.Cluster)
+			t.Errorf("%v: must run on cluster: k8s-infra-prow-build, found: %v", job.Name, job.Cluster)
 		}
 	}
 }


### PR DESCRIPTION
- First commit enables "release-blocking must run on k8s-infra"
- Next commit refactors into "CI Policy" tests instead of individual tests for each policy

I think this is the last thing to do for https://github.com/kubernetes/test-infra/issues/18549 but am going to avoid auto-closing with this PR