### PR TITLE
Bump k8s Versions For Descheduler E2E Tests

### DIFF
--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
@@ -73,7 +73,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBERNETES_VERSION
-          value: "v1.20.0"
+          value: "v1.20.2"
         - name: KIND_E2E
           value: "true"
         args:
@@ -103,7 +103,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBERNETES_VERSION
-          value: "v1.19.1"
+          value: "v1.19.7"
         - name: KIND_E2E
           value: "true"
         args:
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBERNETES_VERSION
-          value: "v1.18.8"
+          value: "v1.18.15"
         - name: KIND_E2E
           value: "true"
         args:


### PR DESCRIPTION
The most up to date kindest/node tags are currently 1.20.2, 1.19.7 and
1.18.15. These image tags correspond to the kind v0.10.0 release.