### PR TITLE
phaino supports using local gcloud credentials and kubeconfig

### DIFF
--- a/prow/cmd/phaino/BUILD.bazel
+++ b/prow/cmd/phaino/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_spf13_pflag//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
         "@io_k8s_sigs_yaml//:go_default_library",
     ],
 )
@@ -28,7 +29,11 @@ go_test(
     name = "go_default_test",
     srcs = ["local_test.go"],
     embed = [":go_default_library"],
-    deps = ["//prow/apis/prowjobs/v1:go_default_library"],
+    deps = [
+        "//prow/apis/prowjobs/v1:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+    ],
 )
 
 filegroup(

--- a/prow/cmd/phaino/README.md
+++ b/prow/cmd/phaino/README.md
@@ -33,10 +33,15 @@ volumes that the Prow Job may require.
 * `--print` the command that runs each job without running it
 * `--privileged` jobs are allowed to run instead of rejected
 * `--timeout=10m` controls how long to allow jobs to run before interrupting them
-* `--repo=k8s/test-infra=/go/src/k8s-test-infra` local path where prow job required repos are cloned at, can be passed in repeatedly
+* `--gopath=/go` provides the GOPATH that is used in the container
+* `--skip-volume-mounts=volume1,volume2` includes the unwanted volume mounts that are defined in the job spec
+* `--extra-volume-mounts=/go/src/k8s.io/test-infra=/Users/xyz/k8s-test-infra` includes the extra volume mounts needed for the container. Key is the mount path and value is the local path
+* `--skip-envs=env1,env2` includes the unwanted env vars that are defined in the job spec
+* `--extra-envs=env1=val1,env2=val2` includes the extra env vars needed for the container
+* `--use-local-gcloud-credentials` controls whether to use the same gcloud credentials as local or not
+* `--use-local-kubeconfig` controls whether to use the same kubeconfig as local or not
 
 See `bazel run //prow/cmd/phaino -- --help` for full option list.
-
 
 ### Usage examples
 #### URL example

--- a/prow/cmd/phaino/main.go
+++ b/prow/cmd/phaino/main.go
@@ -30,8 +30,9 @@ import (
 	flag "github.com/spf13/pflag"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/test-infra/prow/interrupts"
 	"sigs.k8s.io/yaml"
+
+	"k8s.io/test-infra/prow/interrupts"
 
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 )
@@ -43,7 +44,15 @@ type options struct {
 	timeout      time.Duration
 	totalTimeout time.Duration
 	grace        time.Duration
-	repoPath     map[string]string
+	gopath       string
+
+	skippedVolumesMounts []string
+	extraVolumesMounts   map[string]string
+	skippedEnvVars       []string
+	extraEnvVars         map[string]string
+
+	useLocalGcloudCredentials bool
+	useLocalKubeconfig        bool
 
 	jobs []string
 }
@@ -57,7 +66,19 @@ func gatherOptions() options {
 	fs.DurationVar(&o.timeout, "timeout", time.Hour, "Maximum duration for each job (0 for unlimited)")
 	fs.DurationVar(&o.totalTimeout, "total-timeout", 0, "Maximum duration for all jobs (0 for unlimited)")
 	fs.DurationVar(&o.grace, "grace", 10*time.Second, "Terminate timed out jobs after this grace period (1s minimum)")
-	fs.StringToStringVar(&o.repoPath, "repo", map[string]string{}, "Local path of repos, can be passed in repeatedly")
+	fs.StringVar(&o.gopath, "gopath", defaultGOPATH, "The GOPATH that is used in the container. "+
+		"Default is /go, need to be changed if the repository depends on GOPATH and it's is set to a different value in the container.")
+
+	fs.StringSliceVar(&o.skippedVolumesMounts, "skip-volume-mounts", []string{}, "Volume mount names that are not needed")
+	fs.StringToStringVar(&o.extraVolumesMounts, "extra-volume-mounts", map[string]string{}, "Extra volume mounts")
+	fs.StringSliceVar(&o.skippedEnvVars, "skip-envs", []string{}, "Env names that are not needed to be set")
+	fs.StringToStringVar(&o.extraEnvVars, "extra-envs", map[string]string{}, "Extra envs to be set")
+
+	fs.BoolVar(&o.useLocalGcloudCredentials, "use-local-gcloud-credentials", false, "Use the same gcloud credentials as local, which can be set "+
+		"either by setting env var GOOGLE_CLOUD_APPLICATION_CREDENTIALS or from ~/.config/gcloud")
+	fs.BoolVar(&o.useLocalKubeconfig, "use-local-kubeconfig", false, "Use the same kubeconfig as local, which can be set "+
+		"either by setting env var KUBECONFIG or from ~/.kube/config")
+
 	fs.Parse(os.Args[1:])
 	o.jobs = fs.Args()
 	return o
@@ -65,8 +86,6 @@ func gatherOptions() options {
 
 func validate(pj prowapi.ProwJob) error {
 	switch {
-	case pj.Kind != "ProwJob":
-		return fmt.Errorf("bad kind: %q", pj.Kind)
 	case pj.Spec.PodSpec == nil && pj.Spec.Agent != prowapi.KubernetesAgent:
 		return fmt.Errorf("unsupported agent: %q. Only %q with a pod_spec is supported at present", pj.Spec.Agent, prowapi.KubernetesAgent)
 	case pj.Spec.PodSpec == nil:
@@ -97,7 +116,6 @@ func readFile(path string) (*prowapi.ProwJob, error) {
 	}
 	defer f.Close()
 	return readPJ(f)
-
 }
 
 func readHTTP(url string) (*prowapi.ProwJob, error) {
@@ -188,7 +206,7 @@ func processJobs(ctx context.Context, opt options, pjs <-chan prowapi.ProwJob, e
 			start := time.Now()
 			log := logrus.WithField("job", jobName(pj))
 			// Start job execution.
-			err := convertJob(ctx, log, pj, opt.repoPath, opt.priv, opt.printCmd, opt.timeout, opt.grace)
+			err := opt.convertJob(ctx, log, pj)
 			log = log.WithField("duration", time.Since(start))
 			if err != nil {
 				log.WithError(err).Error("FAIL")


### PR DESCRIPTION
1. Add `--use-local-gcloud-credentials` and `--use-local-kubeconfig` to simplify the steps to use local credentials
2. Add `--skip-volume-mounts`,`--extra-volume-mounts`, `--skip-envs`, `--extra-envs`  to allow more customizations on how to run the Prow job
3. Loose the restriction for `checkPrivilege` by removing the user confirmation and print a warning message instead
4. A few other small improvements

/cc @chaodaiG 