### PR TITLE
blockade: allow configuring blockades per branch

### DIFF
--- a/prow/plugins/blockade/blockade_test.go
+++ b/prow/plugins/blockade/blockade_test.go
@@ -19,6 +19,7 @@ package blockade
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"sort"
 	"strings"
 	"testing"
@@ -34,12 +35,17 @@ import (
 
 var (
 	// Sample changes:
-	docFile    = github.PullRequestChange{Filename: "docs/documentation.md", BlobURL: "<URL1>"}
-	docOwners  = github.PullRequestChange{Filename: "docs/OWNERS", BlobURL: "<URL2>"}
-	docOwners2 = github.PullRequestChange{Filename: "docs/2/OWNERS", BlobURL: "<URL3>"}
-	srcGo      = github.PullRequestChange{Filename: "src/code.go", BlobURL: "<URL4>"}
-	srcSh      = github.PullRequestChange{Filename: "src/shell.sh", BlobURL: "<URL5>"}
-	docSh      = github.PullRequestChange{Filename: "docs/shell.sh", BlobURL: "<URL6>"}
+	docFile         = github.PullRequestChange{Filename: "docs/documentation.md", BlobURL: "<URL1>"}
+	docOwners       = github.PullRequestChange{Filename: "docs/OWNERS", BlobURL: "<URL2>"}
+	docOwners2      = github.PullRequestChange{Filename: "docs/2/OWNERS", BlobURL: "<URL3>"}
+	srcGo           = github.PullRequestChange{Filename: "src/code.go", BlobURL: "<URL4>"}
+	srcSh           = github.PullRequestChange{Filename: "src/shell.sh", BlobURL: "<URL5>"}
+	docSh           = github.PullRequestChange{Filename: "docs/shell.sh", BlobURL: "<URL6>"}
+	conformanceYaml = github.PullRequestChange{Filename: "test/conformance/testdata/conformance.yaml", BlobURL: "<URL6>"}
+
+	// branches
+	releaseBranchRegexp = "^release-*"
+	releaseBranchRe     = regexp.MustCompile(releaseBranchRegexp)
 
 	// Sample blockades:
 	blockDocs = plugins.Blockade{
@@ -68,12 +74,20 @@ var (
 		BlockRegexps: []string{`.*`},
 		Explanation:  "5",
 	}
+	blockConformanceOnReleaseBranch = plugins.Blockade{
+		Repos:        []string{"org/repo"},
+		BranchRegexp: &releaseBranchRegexp,
+		BranchRe:     releaseBranchRe,
+		BlockRegexps: []string{`test/conformance/testdata/.*`},
+		Explanation:  "6",
+	}
 )
 
 // TestCalculateBlocks validates that changes are blocked or allowed correctly.
 func TestCalculateBlocks(t *testing.T) {
 	tcs := []struct {
 		name            string
+		branch          string
 		changes         []github.PullRequestChange
 		config          []plugins.Blockade
 		expectedSummary summary
@@ -147,10 +161,36 @@ func TestCalculateBlocks(t *testing.T) {
 			changes:         []github.PullRequestChange{docOwners, srcGo},
 			expectedSummary: summary{},
 		},
+		{
+			name:    "blocked by 1/1 blockade on release branch w/ single file",
+			branch:  "release-1.20",
+			config:  []plugins.Blockade{blockConformanceOnReleaseBranch},
+			changes: []github.PullRequestChange{conformanceYaml},
+			expectedSummary: summary{
+				"6": []github.PullRequestChange{conformanceYaml},
+			},
+		},
+		{
+			name:            "don't block conformance on main branch",
+			branch:          "main",
+			config:          []plugins.Blockade{blockConformanceOnReleaseBranch},
+			changes:         []github.PullRequestChange{conformanceYaml},
+			expectedSummary: summary{},
+		},
+		{
+			name:    "blocked by 2/2 blockades on release branch (no exceptions), extra file",
+			branch:  "release-1.20",
+			config:  []plugins.Blockade{blockConformanceOnReleaseBranch, blockDocsExceptOwners},
+			changes: []github.PullRequestChange{conformanceYaml, docFile, srcGo},
+			expectedSummary: summary{
+				"2": []github.PullRequestChange{docFile},
+				"6": []github.PullRequestChange{conformanceYaml},
+			},
+		},
 	}
 
 	for _, tc := range tcs {
-		blockades := compileApplicableBlockades("org", "repo", logrus.WithField("plugin", PluginName), tc.config)
+		blockades := compileApplicableBlockades("org", "repo", tc.branch, logrus.WithField("plugin", PluginName), tc.config)
 		sum := calculateBlocks(tc.changes, blockades)
 		if !reflect.DeepEqual(sum, tc.expectedSummary) {
 			t.Errorf("[%s] Expected summary: %#v, actual summary: %#v.", tc.name, tc.expectedSummary, sum)
@@ -372,6 +412,7 @@ func TestHelpProvider(t *testing.T) {
 				Blockades: []plugins.Blockade{
 					{
 						Repos:            []string{"org2/repo"},
+						BranchRegexp:     &releaseBranchRegexp,
 						BlockRegexps:     []string{"no", "nope"},
 						ExceptionRegexps: []string{"except", "exceptional"},
 						Explanation:      "Because I have decided so.",

--- a/prow/plugins/plugin-config-documented.yaml
+++ b/prow/plugins/plugin-config-documented.yaml
@@ -26,6 +26,11 @@ blockades:
     blockregexps:
       - ""
 
+    # BranchRegexp is the regular expression for branches that the the blockade applies to.
+    # If BranchRegexp is not specified, the blockade applies to all branches by default.
+    # Compiles into BranchRe during config load.
+    branchregexp: ""
+
     # ExceptionRegexps are regular expressions matching the file paths that are exceptions to the BlockRegexps.
     exceptionregexps:
       - ""


### PR DESCRIPTION
Ref: slack discussion - https://kubernetes.slack.com/archives/C78F00H99/p1614202310015700?thread_ts=1613501041.053200&cid=C78F00H99

This commit adds a new field to the blockade config to specify the
branch regexp for which the blockade should apply to.

If no branch regexp is specified, it considers all branches (current
behaviour).

This is needed in cases where we want to block changes to certain files
(e.g. test/conformance/testdata/) on release branches.

cc @hh @dims @justaugustus 
folks on original thread

cc @alejandrox1 @hasheddan @saschagrunert @jeremyrickard 
other sig-release leads