### PR TITLE
Enable using built binaries on the kubetest2 gce conformance job.

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
@@ -92,4 +92,5 @@ periodics:
           --down \;
           --test=ginkgo \;
           -- \;
-          --focus-regex='\[Conformance\]'
+          --focus-regex='\[Conformance\]';
+          --use-built-binaries


### PR DESCRIPTION
follow up to : https://github.com/kubernetes-sigs/kubetest2/pull/95

xref: https://github.com/kubernetes/enhancements/issues/2464

/cc @BenTheElder @spiffxp 