### PR TITLE
bump clonerefs proof of concept in pull-kubernetes-unit-experimental

### DIFF
--- a/config/jobs/kubernetes/sig-testing/make-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/make-test.yaml
@@ -34,7 +34,7 @@ presubmits:
     # try clonerefs with preclone
     decoration_config:
       utility_images:
-        clonerefs: "gcr.io/spiffxp-gke-dev/clonerefs-k8s-preclone:v20210225-6252cf69ff"
+        clonerefs: "gcr.io/spiffxp-gke-dev/clonerefs-k8s-preclone:latest"
     annotations:
       testgrid-dashboards: sig-testing-misc
     decorate: true


### PR DESCRIPTION
/cc @spiffxp @amwat 
https://github.com/kubernetes/test-infra/pull/21031#discussion_r583292424

~there's no imagePullPolicy tweak for podutils so ...~
there's no imagePullPolicy set at all, so using `:latest` will give us automatic always pull