### PR TITLE
Prow integration test: make it as required

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -100,7 +100,7 @@ presubmits:
   - name: pull-test-infra-integration
     branches:
     - master
-    always_run: false # TODO(fejta): merge into bazel test //...
+    always_run: true # TODO(fejta): merge into bazel test //...
     decorate: true
     labels:
       preset-service-account: "true"


### PR DESCRIPTION
Now that https://github.com/kubernetes/test-infra/pull/20708 is merged, re-enabling integration test as gating