### PR TITLE
Flip Kubernetes jobs to quick build

### DIFF
--- a/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
+++ b/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
@@ -89,8 +89,7 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
       preset-pull-kubernetes-e2e: "true"
       preset-pull-kubernetes-e2e-gce: "true"
     spec:
@@ -103,7 +102,7 @@ presubmits:
         - --timeout=105
         - --scenario=kubernetes_e2e
         - --
-        - --build=bazel
+        - --build=quick
         - --cluster=
         - --extract=local
         - --env=PREPARE_KONNECTIVITY_SERVICE=true
@@ -125,6 +124,8 @@ presubmits:
           limits:
             cpu: 2
             memory: 6Gi
+        securityContext:
+          privileged: true
     annotations:
       testgrid-dashboards: sig-api-machinery-network-proxy
   - name: pull-kubernetes-e2e-gce-network-proxy-grpc
@@ -135,8 +136,7 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
       preset-pull-kubernetes-e2e: "true"
       preset-pull-kubernetes-e2e-gce: "true"
     spec:
@@ -149,7 +149,7 @@ presubmits:
         - --timeout=105
         - --scenario=kubernetes_e2e
         - --
-        - --build=bazel
+        - --build=quick
         - --cluster=
         - --extract=local
         - --env=PREPARE_KONNECTIVITY_SERVICE=true
@@ -171,5 +171,7 @@ presubmits:
           limits:
             cpu: 4
             memory: 14Gi
+        securityContext:
+          privileged: true
     annotations:
       testgrid-dashboards: sig-api-machinery-network-proxy

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
       preset-pull-kubernetes-e2e: "true"
       preset-service-account: "true"
       preset-k8s-ssh: "true"
-      preset-bazel-scratch-dir: "true"
+      preset-dind-enabled: "true"
     spec:
       containers:
       - args:
@@ -24,7 +24,7 @@ presubmits:
         - --timeout=450
         - --scenario=kubernetes_e2e
         - --
-        - --build=bazel
+        - --build=quick
         - --cluster=
         # Override GCE default for cluster size autoscaling purposes.
         - --env=ENABLE_CUSTOM_METRICS=true
@@ -45,3 +45,5 @@ presubmits:
         - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\]|\[Feature:InitialResources\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
         - --timeout=400m
         image: gcr.io/k8s-testimages/kubekins-e2e:v20210226-c001921-master
+        securityContext:
+          privileged: true

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -259,8 +259,8 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --cluster=kubemark-100-scheduler-highqps
-      - --build=bazel
-      - --extract=bazel
+      - --build=quick
+      - --extract=local
       - --gcp-master-size=e2-standard-2
       - --gcp-node-image=gci
       - --gcp-node-size=e2-standard-4

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -12,7 +12,7 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
-      preset-bazel-scratch-dir: "true"
+      preset-dind-enabled: "true"
       preset-e2e-scalability-common: "true"
       preset-e2e-scalability-presubmits: "true"
     annotations:
@@ -28,7 +28,7 @@ presubmits:
         - --timeout=120
         - --scenario=kubernetes_e2e
         - --
-        - --build=bazel
+        - --build=quick
         - --cluster=
         - --extract=local
         - --flush-mem-after-build=true
@@ -61,6 +61,8 @@ presubmits:
           requests:
             cpu: 6
             memory: "14Gi"
+        securityContext:
+          privileged: true
 
   - name: pull-kubernetes-e2e-gce-big-performance
     always_run: false
@@ -70,7 +72,7 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
-      preset-bazel-scratch-dir: "true"
+      preset-dind-enabled: "true"
       preset-e2e-scalability-common: "true"
       preset-e2e-scalability-presubmits: "true"
     spec:
@@ -84,7 +86,7 @@ presubmits:
         - --timeout=270
         - --scenario=kubernetes_e2e
         - --
-        - --build=bazel
+        - --build=quick
         - --cluster=
         - --env=HEAPSTER_MACHINE_TYPE=e2-standard-4
         - --extract=local
@@ -115,6 +117,8 @@ presubmits:
           requests:
             cpu: 6
             memory: "16Gi"
+        securityContext:
+          privileged: true
 
   # This is an equivalent of the ci-kubernetes-e2e-gce-scale-correctness test
   # at 100 node scale. It's an optional presubmit to simplify testing changes
@@ -126,6 +130,7 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
+      preset-dind-enabled: "true"
       preset-e2e-scalability-common: "true"
     annotations:
       testgrid-dashboards: presubmits-kubernetes-scalability
@@ -140,7 +145,7 @@ presubmits:
         - --timeout=270
         - --scenario=kubernetes_e2e
         - --
-        - --build=bazel
+        - --build=quick
         - --cluster=gce-cluster
         - --env=CONCURRENT_SERVICE_SYNCS=5
         - --env=HEAPSTER_MACHINE_TYPE=e2-standard-2
@@ -166,6 +171,8 @@ presubmits:
           requests:
             cpu: 6
             memory: "16Gi"
+        securityContext:
+          privileged: true
 
   - name: pull-kubernetes-e2e-gce-large-performance
     always_run: false
@@ -175,7 +182,7 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
-      preset-bazel-scratch-dir: "true"
+      preset-dind-enabled: "true"
       preset-e2e-scalability-common: "true"
       preset-e2e-scalability-presubmits: "true"
     spec:
@@ -189,7 +196,7 @@ presubmits:
         - --timeout=570
         - --scenario=kubernetes_e2e
         - --
-        - --build=bazel
+        - --build=quick
         - --cluster=
         - --env=HEAPSTER_MACHINE_TYPE=e2-standard-8
         - --extract=local
@@ -221,6 +228,8 @@ presubmits:
           requests:
             cpu: 6
             memory: "16Gi"
+        securityContext:
+          privileged: true
 
   - name: pull-kubernetes-kubemark-e2e-gce-big
     cluster: k8s-infra-prow-build
@@ -233,7 +242,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
-      preset-bazel-scratch-dir: "true"
       preset-dind-enabled: "true"
       preset-e2e-kubemark-common: "true"
       preset-e2e-scalability-presubmits: "true"
@@ -254,7 +262,7 @@ presubmits:
         - "--timeout=120"
         - --scenario=kubernetes_e2e
         - --
-        - --build=bazel
+        - --build=quick
         - --cluster=
         - --extract=local
         - --flush-mem-after-build=true
@@ -297,7 +305,7 @@ presubmits:
             cpu: 6
             memory: 16Gi
         securityContext:
-          privileged: true # TODO(fejta): https://github.com/kubernetes/kubernetes/issues/76484
+          privileged: true
 
   - name: pull-kubernetes-kubemark-e2e-gce-scale
     always_run: false
@@ -307,7 +315,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
-      preset-bazel-scratch-dir: "true"
       preset-dind-enabled: "true"
       preset-e2e-kubemark-common: "true"
       preset-e2e-kubemark-gce-scale: "true"
@@ -326,7 +333,7 @@ presubmits:
         - "--timeout=1220"
         - --scenario=kubernetes_e2e
         - --
-        - --build=bazel
+        - --build=quick
         - --cluster=
         - --extract=local
         - --flush-mem-after-build=true
@@ -363,7 +370,7 @@ presubmits:
             cpu: 6
             memory: "16Gi"
         securityContext:
-          privileged: true # TODO(fejta): https://github.com/kubernetes/kubernetes/issues/76484
+          privileged: true
 
   kubernetes/perf-tests:
   - name: pull-perf-tests-benchmark-kube-dns
@@ -413,7 +420,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
-      preset-bazel-scratch-dir: "true"
       preset-e2e-scalability-common: "true"
       preset-e2e-scalability-presubmits: "true"
     run_if_changed: ^clusterloader2/.*$
@@ -470,7 +476,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
-      preset-bazel-scratch-dir: "true"
       preset-dind-enabled: "true"
       preset-e2e-kubemark-common: "true"
       preset-e2e-scalability-presubmits: "true"


### PR DESCRIPTION
This PR looks indimidating, but it's not quite so:

- A lot of these jobs don't even run, they're manually invoked
- Only jobs targeting github.com/kubernetes/kubernetes on the master branch are updated
- The mechanical approach to update job config follows simple rules:
  - remove `preset-bazel.*` labels
  - ensure a `preset-dind-enabled: "true"` label
  - ensure securityContext for running dind
  - s/--build=bazel/--build=quick/ for kubetest jobs
  - drop `BUILD_TYPE` env from kind jobs (which default to quick otherwise)
- Each commit targets a specific subset for easier review

The remainder of the diff is cleaning up the conformance image test script, ~and dropping some unused 1.13 EKS jobs and kubernetes rbe jobs.~ (moved out the latter).


We've already been testing jobs using the quick build, as expected it's fine.