### PR TITLE
Remove kubeflow/kubeflow tests

### DIFF
--- a/config/jobs/kubeflow/kubeflow-periodics.yaml
+++ b/config/jobs/kubeflow/kubeflow-periodics.yaml
@@ -1,31 +1,5 @@
 periodics:
 #******************************************************************************
-# kubeflow/kubeflow
-#******************************************************************************
-- name: kubeflow-periodic-master
-  cluster: kubeflow
-  interval: 4h
-  labels:
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: gcr.io/kubeflow-ci/test-worker:latest
-      imagePullPolicy: Always
-      env:
-      - name: REPO_OWNER
-        value: kubeflow
-      - name: REPO_NAME
-        value: kubeflow
-      - name: BRANCH_NAME
-        value: master
-  annotations:
-    testgrid-dashboards: sig-big-data
-    description: Periodic testing of Kubeflow on the latest master branch.
-    # TODO: use a public email group
-    testgrid-alert-email: kubeflow-engineering@google.com
-    testgrid-num-failures-to-alert: "3"
-
-#******************************************************************************
 # kubeflow/gcp-blueprints
 #******************************************************************************
 # Periodic tests currently aren't deploying infrastructure; they are

--- a/config/jobs/kubeflow/kubeflow-postsubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-postsubmits.yaml
@@ -12,22 +12,6 @@ postsubmits:
     annotations:
       testgrid-dashboards: sig-big-data
       description: Postsubmit tests for kubeflow/gcp-blueprints.
-  kubeflow/kubeflow:
-  - name: kubeflow-postsubmit
-    cluster: kubeflow
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Postsubmit tests for Kubeflow.
-      # TODO: use a public email group
-      testgrid-alert-email: kubeflow-engineering@google.com
-      testgrid-num-failures-to-alert: "3"
   kubeflow/testing:
   - name: kubeflow-testing-postsubmit
     cluster: kubeflow

--- a/config/jobs/kubeflow/kubeflow-presubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-presubmits.yaml
@@ -13,20 +13,6 @@ presubmits:
       testgrid-dashboards: sig-big-data
       description: Presubmit tests for Kubeflow GCP gcp-blueprints.
       testgrid-num-columns-recent: '30'
-  kubeflow/kubeflow:
-  - name: kubeflow-presubmit
-    cluster: kubeflow
-    always_run: true         # Run for every PR, or only when requested.
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Presubmit tests for Kubeflow.
-      testgrid-num-columns-recent: '30'
   kubeflow/testing:
   - name: kubeflow-testing-presubmit
     cluster: kubeflow

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -690,9 +690,6 @@ plugins:
   kubeflow/gcp-blueprints:
   - trigger
 
-  kubeflow/kubeflow:
-  - trigger
-
   kubeflow/testing:
   - trigger
 

--- a/config/testgrids/kubeflow/kubeflow.yaml
+++ b/config/testgrids/kubeflow/kubeflow.yaml
@@ -1,7 +1,5 @@
 # Temporary kubeflow overrides until we fix prow to calculate correct paths.
 test_groups:
-- name: kubeflow-postsubmit
-  gcs_prefix: kubernetes-jenkins/logs/kubeflow_kubeflow/kubeflow-postsubmit
 - name: kubeflow-gcp-blueprints-postsubmit
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_gcp-blueprints/kubeflow-gcp-blueprints-postsubmit
 - name: kubeflow-testing-postsubmit


### PR DESCRIPTION
Since kubeflow/kubeflow is not using upstream prow, and succeded in migration.

Disable kubeflow/kubeflow triggers and preSubmit + postSubmit + periodic tests.

This PR is made upon the agreement of https://github.com/kubeflow/kubeflow/issues/5482#issuecomment-782573046

/cc @Bobgy @kimwnasptd