### PR TITLE
move sig testing Kubernetes presubmits to quick

### DIFF
--- a/config/jobs/kubernetes/sig-testing/local-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/local-e2e.yaml
@@ -24,7 +24,7 @@ presubmits:
         - "--timeout=140"
         - --scenario=kubernetes_e2e
         - --
-        - --build=bazel
+        - --build=quick
         - --deployment=local
         - --ginkgo-parallel=1
         - --provider=local

--- a/experiment/kind-conformance-image-e2e.sh
+++ b/experiment/kind-conformance-image-e2e.sh
@@ -47,21 +47,12 @@ install_kind() {
 
 # build kubernetes / node image, e2e binaries
 build() {
-    # possibly enable bazel build caching before building kubernetes
-    BAZEL_REMOTE_CACHE_ENABLED=${BAZEL_REMOTE_CACHE_ENABLED:-false}
-    if [[ "${BAZEL_REMOTE_CACHE_ENABLED}" == "true" ]]; then
-        # run the script in the kubekins image, do not fail if it fails
-        /usr/local/bin/create_bazel_cache_rcs.sh || true
-    fi
-
     # build the node image w/ kubernetes
-    kind build node-image --type=bazel --kube-root="${PWD}"
+    kind build node-image --kube-root="${PWD}"
 
-    # try to make sure the kubectl we built is in PATH
+    # ensure kubectl is in path
     local maybe_kubectl
-    maybe_kubectl="$(bazel aquery 'mnemonic("GoLink", //cmd/kubectl)' \
-      | grep '^  Outputs: \[.*\]$' \
-      | sed 's/^  Outputs: \[\(.*\)\]$/\1/')"
+    maybe_kubectl="$(find "${PWD}/_output" -name "kubectl" -type f)"
     if [[ -n "${maybe_kubectl}" ]]; then
         PATH="$(dirname "${maybe_kubectl}"):${PATH}"
         export PATH


### PR DESCRIPTION
build
/cc @spiffxp @dims 
local-up-cluster and conformance image jobs. simplifies the conformance-image script.
broken out of https://github.com/kubernetes/test-infra/pull/21039