### PR TITLE
Prow job labeled with prow version

### DIFF
--- a/prow/kube/prowjob.go
+++ b/prow/kube/prowjob.go
@@ -41,6 +41,9 @@ const (
 	// job names can be arbitrarily long, this is added as
 	// an annotation instead of a label.
 	ProwJobAnnotation = "prow.k8s.io/job"
+	// ProwVersionLabel is added in resources created by prow and
+	// carries the version of prow that decorated this job.
+	ProwVersionLabel = "prow.k8s.io/version"
 	// OrgLabel is added in resources created by prow and
 	// carries the org associated with the job, eg kubernetes-sigs.
 	OrgLabel = "prow.k8s.io/refs.org"

--- a/prow/kube/prowjob.go
+++ b/prow/kube/prowjob.go
@@ -41,9 +41,9 @@ const (
 	// job names can be arbitrarily long, this is added as
 	// an annotation instead of a label.
 	ProwJobAnnotation = "prow.k8s.io/job"
-	// ProwVersionLabel is added in resources created by prow and
+	// PlankVersionLabel is added in resources created by prow and
 	// carries the version of prow that decorated this job.
-	ProwVersionLabel = "prow.k8s.io/version"
+	PlankVersionLabel = "prow.k8s.io/plank-version"
 	// OrgLabel is added in resources created by prow and
 	// carries the org associated with the job, eg kubernetes-sigs.
 	OrgLabel = "prow.k8s.io/refs.org"

--- a/prow/plank/reconciler.go
+++ b/prow/plank/reconciler.go
@@ -605,7 +605,7 @@ func (r *reconciler) startPod(ctx context.Context, pj *prowv1.ProwJob) (string, 
 	}
 	pod.Namespace = r.config().PodNamespace
 	// Add prow version as a label for better debugging prowjobs.
-	pod.ObjectMeta.Labels[kube.ProwVersionLabel] = version.Version
+	pod.ObjectMeta.Labels[kube.PlankVersionLabel] = version.Version
 
 	client, ok := r.buildClients[pj.ClusterAlias()]
 	if !ok {

--- a/prow/plank/reconciler.go
+++ b/prow/plank/reconciler.go
@@ -604,6 +604,8 @@ func (r *reconciler) startPod(ctx context.Context, pj *prowv1.ProwJob) (string, 
 		return "", "", err
 	}
 	pod.Namespace = r.config().PodNamespace
+	// Add prow version as a label for better debugging prowjobs.
+	pod.ObjectMeta.Labels[kube.ProwVersionLabel] = version.Version
 
 	client, ok := r.buildClients[pj.ClusterAlias()]
 	if !ok {


### PR DESCRIPTION
As proposed in https://github.com/kubernetes/enhancements/pull/2540, k8s prow will be bumped more frequently than once per work day, adding this label to the job so that it could help associate failures with specific prow versions