### PR TITLE
Switch containerd cri e2e to the right project

### DIFF
--- a/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
@@ -60,7 +60,7 @@ presubmits:
           &&
           /workspace/scenarios/kubernetes_e2e.py
           --deployment=node
-          --gcp-project=cri-c8d-pr-node-e2e
+          --gcp-project=cri-containerd-node-e2e
           --gcp-zone=us-central1-f
           '--node-test-args=--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
           --node-tests=true


### PR DESCRIPTION
sig-node/containerd.yaml is using `cri-containerd-node-e2e` lets switch
away from the `cri-c8d-pr-node-e2e` which seems to be broken

See https://github.com/containerd/containerd/pull/5095#issuecomment-786908342

Signed-off-by: Davanum Srinivas <davanum@gmail.com>