### PR TITLE
Adding a period to messages replied to by the label plugin

### DIFF
--- a/prow/plugins/label/label.go
+++ b/prow/plugins/label/label.go
@@ -225,7 +225,7 @@ func handle(gc githubClient, log *logrus.Entry, additionalLabels []string, e *gi
 
 	if len(noSuchLabelsInRepo) > 0 {
 		log.Infof("Labels missing in repo: %v", noSuchLabelsInRepo)
-		msg := fmt.Sprintf("The label(s) `%s` cannot be applied, because the repository doesn't have them", strings.Join(noSuchLabelsInRepo, ", "))
+		msg := fmt.Sprintf("The label(s) `%s` cannot be applied, because the repository doesn't have them.", strings.Join(noSuchLabelsInRepo, ", "))
 		return gc.CreateComment(org, repo, e.Number, plugins.FormatResponseRaw(bodyWithoutComments, e.HTMLURL, e.User.Login, msg))
 	}
 

--- a/prow/plugins/label/label_test.go
+++ b/prow/plugins/label/label_test.go
@@ -193,7 +193,7 @@ func TestLabel(t *testing.T) {
 			expectedRemovedLabels: []string{},
 			commenter:             orgMember,
 			expectedBotComment:    true,
-			expectedCommentText:   "The label(s) `priority/critical` cannot be applied, because the repository doesn't have them",
+			expectedCommentText:   "The label(s) `priority/critical` cannot be applied, because the repository doesn't have them.",
 			action:                github.GenericCommentActionCreated,
 		},
 		{
@@ -225,7 +225,7 @@ func TestLabel(t *testing.T) {
 			expectedRemovedLabels: []string{},
 			commenter:             orgMember,
 			expectedBotComment:    true,
-			expectedCommentText:   "The label(s) `area/lgtm` cannot be applied, because the repository doesn't have them",
+			expectedCommentText:   "The label(s) `area/lgtm` cannot be applied, because the repository doesn't have them.",
 			action:                github.GenericCommentActionCreated,
 		},
 		{
@@ -277,7 +277,7 @@ func TestLabel(t *testing.T) {
 			expectedRemovedLabels: []string{},
 			commenter:             orgMember,
 			expectedBotComment:    true,
-			expectedCommentText:   "The label(s) `area/urgent` cannot be applied, because the repository doesn't have them",
+			expectedCommentText:   "The label(s) `area/urgent` cannot be applied, because the repository doesn't have them.",
 			action:                github.GenericCommentActionCreated,
 		},
 		{
@@ -289,7 +289,7 @@ func TestLabel(t *testing.T) {
 			expectedRemovedLabels: []string{},
 			commenter:             orgMember,
 			expectedBotComment:    true,
-			expectedCommentText:   "The label(s) `priority/infra` cannot be applied, because the repository doesn't have them",
+			expectedCommentText:   "The label(s) `priority/infra` cannot be applied, because the repository doesn't have them.",
 			action:                github.GenericCommentActionCreated,
 		},
 		{
@@ -301,7 +301,7 @@ func TestLabel(t *testing.T) {
 			expectedRemovedLabels: []string{},
 			commenter:             orgMember,
 			expectedBotComment:    true,
-			expectedCommentText:   "The label(s) `area/lgtm` cannot be applied, because the repository doesn't have them",
+			expectedCommentText:   "The label(s) `area/lgtm` cannot be applied, because the repository doesn't have them.",
 			action:                github.GenericCommentActionCreated,
 		},
 		{
@@ -313,7 +313,7 @@ func TestLabel(t *testing.T) {
 			expectedRemovedLabels: []string{},
 			commenter:             orgMember,
 			expectedBotComment:    true,
-			expectedCommentText:   "The label(s) `committee/calamity` cannot be applied, because the repository doesn't have them",
+			expectedCommentText:   "The label(s) `committee/calamity` cannot be applied, because the repository doesn't have them.",
 			action:                github.GenericCommentActionCreated,
 		},
 		{


### PR DESCRIPTION
All the other replies from the robot have periods. But this reply is missing the period.

See: https://github.com/kubernetes/test-infra/issues/21057#issuecomment-786932682