### PR TITLE
Add author_association field to pull request

### DIFF
--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -273,8 +273,9 @@ type PullRequest struct {
 	// will include a non-null value for the mergeable attribute.
 	Mergable *bool `json:"mergeable,omitempty"`
 	// If the PR doesn't have any milestone, `milestone` is null and is unmarshaled to nil.
-	Milestone *Milestone `json:"milestone,omitempty"`
-	Commits   int        `json:"commits"`
+	Milestone         *Milestone `json:"milestone,omitempty"`
+	Commits           int        `json:"commits"`
+	AuthorAssociation string     `json:"author_association,omitempty"`
 }
 
 // PullRequestBranch contains information about a particular branch in a PR.


### PR DESCRIPTION
We have recently been working on an external plugin and we want to get the field to see if the author is a first time contributor. So I added that field.

This field exists on the Pull Request, see: https://docs.github.com/en/rest/reference/pulls#get-a-pull-request

Also see the definition of go-github: https://github.com/google/go-github/blob/b06cfbb1abc090e2ff47cac2f0d2d1750f847293/github/pulls.go#L62