### PR TITLE
add e2e test jobs for sigs.k8s.io/cluster-api-provider-openstack

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
@@ -2,36 +2,127 @@ presubmits:
   kubernetes-sigs/cluster-api-provider-openstack:
   - name: pull-cluster-api-provider-openstack-build
     always_run: true
+    optional: false
     decorate: true
-    path_alias: sigs.k8s.io/cluster-api-provider-openstack
+    path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
     labels:
-      preset-service-account: "true"
       preset-dind-enabled: "true"
     spec:
       containers:
-      - command:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210226-c001921-master
+        command:
         - "./scripts/ci-build.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210226-c001921-master
         resources:
           requests:
             memory: "6Gi"
+            cpu: "2"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
       testgrid-tab-name: pr-build
   - name: pull-cluster-api-provider-openstack-test
     always_run: true
+    optional: false
     decorate: true
-    path_alias: sigs.k8s.io/cluster-api-provider-openstack
-    labels:
-      preset-service-account: "true"
+    path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210226-c001921-master
         command:
         - "./scripts/ci-test.sh"
+        resources:
+          requests:
+            memory: "6Gi"
+            cpu: "2"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
       testgrid-tab-name: pr-test
+  - name: pull-cluster-api-provider-openstack-e2e-test
+    labels:
+      preset-service-account: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
+    # TODO(sbueringer): always_run: true, optional: false after test has been merged on CAPO master
+    always_run: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 3h
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: image-builder
+        base_ref: master
+        path_alias: "sigs.k8s.io/image-builder"
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210226-c001921-master
+          env:
+            - name: "BOSKOS_HOST"
+              value: "boskos.test-pods.svc.cluster.local"
+          command:
+            - "runner.sh"
+            - "./scripts/ci-e2e.sh"
+          # we need privileged mode in order to do docker in docker
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              # these are both a bit below peak usage during build
+              # this is mostly for building kubernetes
+              memory: "9000Mi"
+              # during the tests more like 3-20m is used
+              cpu: 2000m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
+      testgrid-tab-name: pr-e2e-test
+  # conformance test against kubernetes master branch with `kind` + cluster-api-provider-openstack
+  - name: pull-cluster-api-provider-openstack-make-conformance
+    labels:
+      preset-service-account: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
+    always_run: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 3h
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: image-builder
+        base_ref: master
+        path_alias: "sigs.k8s.io/image-builder"
+      - org: kubernetes
+        repo: kubernetes
+        base_ref: master
+        path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210226-c001921-master
+          env:
+            - name: "BOSKOS_HOST"
+              value: "boskos.test-pods.svc.cluster.local"
+          command:
+            - "runner.sh"
+            - "./scripts/ci-conformance.sh"
+            - "--use-ci-artifacts"
+          # we need privileged mode in order to do docker in docker
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              # these are both a bit below peak usage during build
+              # this is mostly for building kubernetes
+              memory: "9000Mi"
+              # during the tests more like 3-20m is used
+              cpu: 2000m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
+      testgrid-tab-name: pr-conformance


### PR DESCRIPTION
Adds new cluster-api-provider-openstack jobs to get finally rid of our OpenLab tests.

The tests itself will be added in a separate PR in the cluster-api-provider-openstack repo


Notes:
* only cosmetic changes to the existing jobs (I diffed it against other providers and cleaned it up a bit)
* we have two new jobs which are both optional for PR merge and won't be triggered per default:
  * pull-cluster-api-provider-openstack-e2e-test: will execute our new e2e tests
  * pull-cluster-api-provider-openstack-make-conformance: analog to our existing OpenLab conformance test, installs a cluster and executes conformance tests

xref: https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/577