### PR TITLE
kubernetes: require pull-kubernetes-unit

### DIFF
--- a/config/jobs/kubernetes/sig-testing/make-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/make-test.yaml
@@ -2,14 +2,14 @@ presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-unit
     annotations:
-      testgrid-dashboards: sig-testing-misc
+      testgrid-dashboards: presubmits-kubernetes-blocking
     decorate: true
     cluster: k8s-infra-prow-build
     skip_branches:
     - release-\d+.\d+ # per-release job
     labels:
       preset-service-account: "true"
-    optional: true
+    optional: false
     always_run: true
     path_alias: k8s.io/kubernetes
     spec:


### PR DESCRIPTION
This job is relatively stable, there are some test case flakes but that's expected and being worked on.
The job itself does not have any flakes that are not flaky tests.
It has a nearly identical pass rate to `pull-kubernetes-bazel-test`, with relatively comparable run times.

Part of https://github.com/kubernetes/enhancements/issues/2420

/cc @dims @spiffxp @liggitt 