### PR TITLE
drop spurious always_run from multitenancy image pushing job

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-multitenancy.yaml
+++ b/config/jobs/image-pushing/k8s-staging-multitenancy.yaml
@@ -5,7 +5,6 @@ postsubmits:
       annotations:
         testgrid-dashboards: wg-multi-tenancy-externalip
       decorate: true
-      always_run: true
       branches:
         - ^master$
       spec:


### PR DESCRIPTION
Fixes issue surfaced in https://github.com/kubernetes/test-infra/pull/21073

This field does not exist in postsubmits, which are implicitly `always_run: true` unless instead `run_if_changed`.