### PR TITLE
optionally strict parse prow config

### DIFF
--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -59,7 +59,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	conf, err := cfg.Load(*configPath, *jobConfigPath)
+	conf, err := cfg.LoadStrict(*configPath, *jobConfigPath)
 	if err != nil {
 		fmt.Printf("Could not load config: %v", err)
 		os.Exit(1)

--- a/prow/cmd/checkconfig/BUILD.bazel
+++ b/prow/cmd/checkconfig/BUILD.bazel
@@ -86,7 +86,6 @@ go_test(
         "@io_k8s_apimachinery//pkg/util/diff:go_default_library",
         "@io_k8s_apimachinery//pkg/util/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
-        "@io_k8s_sigs_yaml//:go_default_library",
         "@io_k8s_utils//pointer:go_default_library",
     ],
 )

--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -330,20 +330,7 @@ func validate(o options) error {
 		}
 	}
 	if o.warningEnabled(unknownFieldsWarning) {
-		cfgBytes, err := ioutil.ReadFile(o.configPath)
-		if err != nil {
-			return fmt.Errorf("error reading Prow config for validation: %w", err)
-		}
-		if err := validateUnknownFields(&config.Config{}, cfgBytes, o.configPath); err != nil {
-			errs = append(errs, err)
-		}
-	}
-	if pcfg != nil && o.warningEnabled(unknownFieldsWarning) {
-		pcfgBytes, err := ioutil.ReadFile(o.pluginConfig)
-		if err != nil {
-			return fmt.Errorf("error reading Prow plugin config for validation: %w", err)
-		}
-		if err := validateUnknownFields(&plugins.Configuration{}, pcfgBytes, o.pluginConfig); err != nil {
+		if _, err := config.LoadStrict(o.configPath, o.jobConfigPath); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -461,14 +448,6 @@ func validateURLs(c config.ProwConfig) error {
 	}
 
 	return utilerrors.NewAggregate(validationErrs)
-}
-
-func validateUnknownFields(cfg interface{}, cfgBytes []byte, filePath string) error {
-	err := yaml.Unmarshal(cfgBytes, &cfg, yaml.DisallowUnknownFields)
-	if err != nil {
-		return fmt.Errorf("unknown fields or bad config in %s: %v", filePath, err)
-	}
-	return nil
 }
 
 func validateJobRequirements(c config.JobConfig) error {

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -961,13 +961,23 @@ func (cfg *SlackReporter) DefaultAndValidate() error {
 
 // Load loads and parses the config at path.
 func Load(prowConfig, jobConfig string, additionals ...func(*Config) error) (c *Config, err error) {
+	return loadWithYamlOpts(nil, prowConfig, jobConfig, additionals...)
+}
+
+// LoadStrict loads and parses the config at path.
+// Unlike Load it unmarshalls yaml with strict parsing.
+func LoadStrict(prowConfig, jobConfig string, additionals ...func(*Config) error) (c *Config, err error) {
+	return loadWithYamlOpts([]yaml.JSONOpt{yaml.DisallowUnknownFields}, prowConfig, jobConfig, additionals...)
+}
+
+func loadWithYamlOpts(yamlOpts []yaml.JSONOpt, prowConfig, jobConfig string, additionals ...func(*Config) error) (c *Config, err error) {
 	// we never want config loading to take down the prow components
 	defer func() {
 		if r := recover(); r != nil {
 			c, err = nil, fmt.Errorf("panic loading config: %v\n%s", r, string(debug.Stack()))
 		}
 	}()
-	c, err = loadConfig(prowConfig, jobConfig)
+	c, err = loadConfig(prowConfig, jobConfig, yamlOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -990,7 +1000,7 @@ func Load(prowConfig, jobConfig string, additionals ...func(*Config) error) (c *
 }
 
 // ReadJobConfig reads the JobConfig yaml, but does not expand or validate it.
-func ReadJobConfig(jobConfig string) (JobConfig, error) {
+func ReadJobConfig(jobConfig string, yamlOpts ...yaml.JSONOpt) (JobConfig, error) {
 	stat, err := os.Stat(jobConfig)
 	if err != nil {
 		return JobConfig{}, err
@@ -999,7 +1009,7 @@ func ReadJobConfig(jobConfig string) (JobConfig, error) {
 	if !stat.IsDir() {
 		// still support a single file
 		var jc JobConfig
-		if err := yamlToConfig(jobConfig, &jc); err != nil {
+		if err := yamlToConfig(jobConfig, &jc, yamlOpts...); err != nil {
 			return JobConfig{}, err
 		}
 		return jc, nil
@@ -1041,7 +1051,7 @@ func ReadJobConfig(jobConfig string) (JobConfig, error) {
 		uniqueBasenames.Insert(base)
 
 		var subConfig JobConfig
-		if err := yamlToConfig(path, &subConfig); err != nil {
+		if err := yamlToConfig(path, &subConfig, yamlOpts...); err != nil {
 			return err
 		}
 		jc, err = mergeJobConfigs(jc, subConfig)
@@ -1056,7 +1066,7 @@ func ReadJobConfig(jobConfig string) (JobConfig, error) {
 }
 
 // loadConfig loads one or multiple config files and returns a config object.
-func loadConfig(prowConfig, jobConfig string) (*Config, error) {
+func loadConfig(prowConfig, jobConfig string, yamlOpts ...yaml.JSONOpt) (*Config, error) {
 	stat, err := os.Stat(prowConfig)
 	if err != nil {
 		return nil, err
@@ -1067,7 +1077,7 @@ func loadConfig(prowConfig, jobConfig string) (*Config, error) {
 	}
 
 	var nc Config
-	if err := yamlToConfig(prowConfig, &nc); err != nil {
+	if err := yamlToConfig(prowConfig, &nc, yamlOpts...); err != nil {
 		return nil, err
 	}
 	if err := parseProwConfig(&nc); err != nil {
@@ -1106,7 +1116,7 @@ func loadConfig(prowConfig, jobConfig string) (*Config, error) {
 		return &nc, nil
 	}
 
-	jc, err := ReadJobConfig(jobConfig)
+	jc, err := ReadJobConfig(jobConfig, yamlOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1118,12 +1128,12 @@ func loadConfig(prowConfig, jobConfig string) (*Config, error) {
 }
 
 // yamlToConfig converts a yaml file into a Config object
-func yamlToConfig(path string, nc interface{}) error {
+func yamlToConfig(path string, nc interface{}, opts ...yaml.JSONOpt) error {
 	b, err := ReadFileMaybeGZIP(path)
 	if err != nil {
 		return fmt.Errorf("error reading %s: %v", path, err)
 	}
-	if err := yaml.Unmarshal(b, nc); err != nil {
+	if err := yaml.Unmarshal(b, nc, opts...); err != nil {
 		return fmt.Errorf("error unmarshaling %s: %v", path, err)
 	}
 	var jc *JobConfig


### PR DESCRIPTION
... initially enable it for `config/test/jobs` and as a more powerful `--warning=unknown-fields` in `prow/cmd/checkconfig`.

alternative to https://github.com/kubernetes/test-infra/pull/21073