### PR TITLE
Block conformance changes on release branches in k/k

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -161,6 +161,12 @@ blockades:
   - ^pkg/util/[^/]+\.go$
   explanation: "Utility code must be added to a subpackage like pkg/util/flag, not pkg/util directly. See: #49923"
 - repos:
+  - kubernetes/kubernetes
+  blockregexps:
+  - ^test/conformance/testdata/conformance.yaml$
+  branchregexp: "^release-*"
+  explanation: "`test/conformance/testdata/conformance.yaml` cannot be updated on release branches."
+- repos:
   - kubernetes/community
   blockregexps:
   - ^events/2016


### PR DESCRIPTION
Ref: slack discussion - https://kubernetes.slack.com/archives/C78F00H99/p1614202310015700?thread_ts=1613501041.053200&cid=C78F00H99

Follow up to https://github.com/kubernetes/test-infra/pull/21021

cc @hh @dims @justaugustus 
folks on original thread

cc @alejandrox1 @hasheddan @saschagrunert @jeremyrickard 
other sig-release leads