### PR TITLE
Revert "Block conformance changes on release branches in k/k"

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -161,12 +161,6 @@ blockades:
   - ^pkg/util/[^/]+\.go$
   explanation: "Utility code must be added to a subpackage like pkg/util/flag, not pkg/util directly. See: #49923"
 - repos:
-  - kubernetes/kubernetes
-  blockregexps:
-  - ^test/conformance/testdata/conformance.yaml$
-  branchregexp: "^release-*"
-  explanation: "`test/conformance/testdata/conformance.yaml` cannot be updated on release branches."
-- repos:
   - kubernetes/community
   blockregexps:
   - ^events/2016


### PR DESCRIPTION
This reverts commit 1f152d6a89bc1ec4bb5dd4e9cdb0d6e664fe7ab6.

Reverts PR https://github.com/kubernetes/test-infra/pull/21082

We're hitting nil pointer exceptions in hook now, blocking presubmits from trigger in kubernetes/kubernetes (ref: https://github.com/kubernetes/test-infra/issues/21090)

Faster to roll this config change back than update prow