### PR TITLE
fix NPE in blockade

### DIFF
--- a/prow/plugins/blockade/blockade.go
+++ b/prow/plugins/blockade/blockade.go
@@ -218,7 +218,7 @@ func compileApplicableBlockades(org, repo, branch string, log *logrus.Entry, blo
 			continue
 		}
 		// if branchregexp is specified, only consider blockades that apply to this branch
-		if raw.BranchRegexp != nil && !raw.BranchRe.MatchString(branch) {
+		if raw.BranchRe != nil && !raw.BranchRe.MatchString(branch) {
 			continue
 		}
 

--- a/prow/plugins/blockade/blockade_test.go
+++ b/prow/plugins/blockade/blockade_test.go
@@ -81,6 +81,12 @@ var (
 		BlockRegexps: []string{`test/conformance/testdata/.*`},
 		Explanation:  "6",
 	}
+	blockBadBranchRe = plugins.Blockade{
+		Repos:        []string{"org/repo"},
+		BranchRegexp: &releaseBranchRegexp,
+		BlockRegexps: []string{`test/conformance/testdata/.*`},
+		Explanation:  "6",
+	}
 )
 
 // TestCalculateBlocks validates that changes are blocked or allowed correctly.
@@ -92,6 +98,12 @@ func TestCalculateBlocks(t *testing.T) {
 		config          []plugins.Blockade
 		expectedSummary summary
 	}{
+		{
+			name:            "nil BranchRe",
+			config:          []plugins.Blockade{blockBadBranchRe},
+			changes:         []github.PullRequestChange{},
+			expectedSummary: summary{},
+		},
 		{
 			name:    "blocked by 1/1 blockade (no exceptions), extra file",
 			config:  []plugins.Blockade{blockDocs},


### PR DESCRIPTION
I think this is sufficient anyhow, see: https://github.com/kubernetes/test-infra/issues/21090#issuecomment-788253621

We probably should be doing this even if it's not the whole fix, we should check the actual value we want to gate for nil instead of it's source of truth / a proxy value.