### PR TITLE
Fix blockade regexp compilation.

### DIFF
--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -1166,15 +1166,15 @@ func compileRegexpsAndDurations(pc *Configuration) error {
 	}
 	pc.CherryPickUnapproved.BranchRe = branchRe
 
-	for _, blockade := range pc.Blockades {
-		if blockade.BranchRegexp == nil {
+	for i := range pc.Blockades {
+		if pc.Blockades[i].BranchRegexp == nil {
 			continue
 		}
-		branchRe, err := regexp.Compile(*blockade.BranchRegexp)
+		branchRe, err := regexp.Compile(*pc.Blockades[i].BranchRegexp)
 		if err != nil {
-			return fmt.Errorf("failed to compile blockade branchregexp: %q, error: %v", *blockade.BranchRegexp, err)
+			return fmt.Errorf("failed to compile blockade branchregexp: %q, error: %v", *pc.Blockades[i].BranchRegexp, err)
 		}
-		blockade.BranchRe = branchRe
+		pc.Blockades[i].BranchRe = branchRe
 	}
 
 	commentRe, err := regexp.Compile(pc.Heart.CommentRegexp)


### PR DESCRIPTION
We were compiling the branch regexp, but incorrectly storing the result in a struct scoped to the for loop rather than updating the actual configuration.
/assign @BenTheElder @spiffxp 
fixes https://github.com/kubernetes/test-infra/issues/21090