### PR TITLE
[wip] autobumper: support base branches other than master

### DIFF
--- a/config/prow/autobump-config.yaml
+++ b/config/prow/autobump-config.yaml
@@ -7,6 +7,7 @@ onCallAddress: "https://storage.googleapis.com/kubernetes-jenkins/oncall.json"
 skipPullRequest: false
 gitHubOrg: "kubernetes"
 gitHubRepo: "test-infra"
+baseBranchName: "master"
 remoteName: "test-infra"
 upstreamURLBase: "https://raw.githubusercontent.com/kubernetes/test-infra/master"
 includedConfigPaths:


### PR DESCRIPTION
default to `main`, updated autobump-config.yaml for test-infra to use `master`

needed this to use autobumper to open https://github.com/kubernetes/k8s.io/pull/1740