### PR TITLE
ProwJob endpoint: Strip managed fields

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -1388,6 +1388,7 @@ func handleProwJob(prowJobClient prowv1.ProwJobInterface, log *logrus.Entry) htt
 			}
 			return
 		}
+		pj.ManagedFields = nil
 		handleSerialize(w, "prowjob", pj, l)
 	}
 }


### PR DESCRIPTION
I doubt anyone looking at their prowjob ever wanted to see this, they
make it required to scroll a lot and provide no value in this context.