### PR TITLE
Adds VM public/private key pair

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -32,14 +32,28 @@ presets:
       secretKeyRef:
         name: clusterapi-provider-vsphere-ci-prow
         key: target-vm-ssh-pub
+  - name: VM_SSH_PUB_KEY
+    valueFrom:
+      secretKeyRef:
+        name: clusterapi-provider-vsphere-ci-prow
+        key: vm-ssh-pub-key
   volumeMounts:
   - name: jumphost-key
     mountPath: /root/ssh/.jumphost
+  - name: private-key
+    mountPath: /root/ssh/.private-key
   - name: bootstrapper-key
     mountPath: /root/ssh/.bootstrapper
   - name: vpn-conf
     mountPath: /root/.openvpn
   volumes:
+  - name: private-key
+    secret:
+      secretName: clusterapi-provider-vsphere-ci-prow
+      defaultMode: 256
+      items:
+      - key: vm-ssh-key
+        path: private-key
   - name: jumphost-key
     secret:
       secretName: clusterapi-provider-vsphere-ci-prow


### PR DESCRIPTION
This patch adds a public/private key pair to the prow job for `cluster-api-provider-vsphere`. This will be used to ssh into the provided machines to enable log collection.