### PR TITLE
images: stop building 1.17 variant of kubekins-e2e

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -43,9 +43,3 @@ variants:
     K8S_RELEASE: stable-1.18
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.23.2
-  '1.17':
-    CONFIG: '1.17'
-    GO_VERSION: 1.13.15
-    K8S_RELEASE: stable-1.17
-    BAZEL_VERSION: 2.2.0
-    OLD_BAZEL_VERSION: 0.23.2


### PR DESCRIPTION
1.17 is no longer receiving patch releases
- https://github.com/kubernetes/test-infra/pull/20755 dropped the 1.17 jobs
- https://github.com/kubernetes/test-infra/pull/20589 dropped some config info

this drops the 1.17 variant of kubekins-e2e

is there an umbrella issue for these sorts of "turn down infra for old releases" PRs?