### PR TITLE
Update kubekins go-canary variant to 1.16 and add go-canary verify presubmits

### DIFF
--- a/config/jobs/kubernetes/sig-testing/dependencies.yaml
+++ b/config/jobs/kubernetes/sig-testing/dependencies.yaml
@@ -60,7 +60,9 @@ presubmits:
       - name: main
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210226-c001921-go-canary
+        # TODO(releng): Remove if we are able to support verify tests using the releng-ci image
+        #image: gcr.io/k8s-testimages/kubekins-e2e:v20210226-c001921-go-canary
+        image: k8s.gcr.io/releng/releng-ci:v0.4.0
         args:
         - make
         - verify

--- a/config/jobs/kubernetes/sig-testing/dependencies.yaml
+++ b/config/jobs/kubernetes/sig-testing/dependencies.yaml
@@ -39,12 +39,19 @@ presubmits:
           requests:
             cpu: 2
             memory: 1.2Gi
-  - name: pull-kubernetes-dependencies-canary
+  - name: pull-kubernetes-dependencies-go-canary
+    cluster: k8s-infra-prow-build
     path_alias: "k8s.io/kubernetes"
     decorate: true
     skip_branches:
     - release-\d+.\d+ # per-release job
+    annotations:
+      fork-per-release: "true"
+      testgrid-num-failures-to-alert: '10'
+      testgrid-alert-stale-results-hours: '24'
+      testgrid-create-test-group: 'true'
     always_run: false
+    skip_report: true
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -53,7 +60,7 @@ presubmits:
       - name: main
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210226-c001921-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210226-c001921-go-canary
         args:
         - make
         - verify
@@ -71,5 +78,3 @@ presubmits:
           requests:
             cpu: 2
             memory: 1.2Gi
-    annotations:
-      testgrid-create-test-group: 'true'

--- a/config/jobs/kubernetes/sig-testing/dependencies.yaml
+++ b/config/jobs/kubernetes/sig-testing/dependencies.yaml
@@ -50,6 +50,7 @@ presubmits:
       testgrid-num-failures-to-alert: '10'
       testgrid-alert-stale-results-hours: '24'
       testgrid-create-test-group: 'true'
+      testgrid-dashboards: sig-release-releng-informing, sig-testing-canaries
     always_run: false
     skip_report: true
     labels:

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -47,6 +47,54 @@ presubmits:
           requests:
             cpu: 7
             memory: 12Gi
+  - name: pull-kubernetes-verify-go-canary
+    cluster: k8s-infra-prow-build
+    always_run: false
+    skip_report: true
+    decorate: true
+    skip_branches:
+    - release-\d+.\d+ # per-release job
+    annotations:
+      fork-per-release: "true"
+      testgrid-num-failures-to-alert: '10'
+      testgrid-alert-stale-results-hours: '24'
+      testgrid-create-test-group: 'true'
+    path_alias: k8s.io/kubernetes
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210226-c001921-go-canary
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - ./hack/jenkins/verify-dockerized.sh
+        env:
+        - name: EXCLUDE_TYPECHECK
+          value: "y"
+        # this is now covered by the optional pull-kubernetes-files-remake that runs when Makefile.generated_files / make-rules changes
+        - name: EXCLUDE_FILES_REMAKE
+          value: "y"
+        - name: EXCLUDE_GODEP
+          value: "y"
+        - name: KUBE_VERIFY_GIT_BRANCH
+          value: master
+        - name: REPO_DIR
+          value: /workspace/k8s.io/kubernetes
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          # Consider reducing memory limits after govet memory usage issue is
+          # addressed in https://github.com/kubernetes/kubernetes/issues/93822
+          limits:
+            cpu: 7
+            memory: 12Gi
+          requests:
+            cpu: 7
+            memory: 12Gi
 periodics:
 - interval: 1h
   cluster: k8s-infra-prow-build

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -65,7 +65,9 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210226-c001921-go-canary
+      # TODO(releng): Remove if we are able to support verify tests using the releng-ci image
+      #- image: gcr.io/k8s-testimages/kubekins-e2e:v20210226-c001921-go-canary
+      - image: k8s.gcr.io/releng/releng-ci:v0.4.0
         imagePullPolicy: Always
         command:
         - runner.sh

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -59,6 +59,7 @@ presubmits:
       testgrid-num-failures-to-alert: '10'
       testgrid-alert-stale-results-hours: '24'
       testgrid-create-test-group: 'true'
+      testgrid-dashboards: sig-release-releng-informing, sig-testing-canaries
     path_alias: k8s.io/kubernetes
     labels:
       preset-service-account: "true"

--- a/config/testgrids/kubernetes/presubmits/config.yaml
+++ b/config/testgrids/kubernetes/presubmits/config.yaml
@@ -127,9 +127,6 @@ dashboards:
   - name: pull-kubernetes-e2e-kops-aws
     test_group_name: pull-kubernetes-e2e-kops-aws
     base_options: width=10
-  - name: pull-canaries
-    test_group_name: pull-kubernetes-dependencies-canary
-    base_options: width=10
   - name: pull-kubernetes-e2e-gce-iscsi
     test_group_name: pull-kubernetes-e2e-gce-iscsi
     base_options: width=10

--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -8,7 +8,7 @@ variants:
     UPGRADE_DOCKER: 'true'
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.15.8
+    GO_VERSION: 1.16
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
Required for k/k go1.16 update (https://github.com/kubernetes/kubernetes/pull/98572, https://github.com/kubernetes/release/issues/1834)

- kubekins-e2e: Update go-canary variant to go1.16
- kubernetes-verify: Create/update Golang canaries for verify presubmits
- kubernetes-verify: Use k8s.gcr.io/releng/releng-ci:v0.4.0 as image

  k8s.gcr.io/releng/releng-ci:v0.4.0 is built on go1.16, so we should be
  able to use it to preflight the go-canary presubmit jobs ahead of a
  go1.16 go-canary variant being available for kubekins-e2e.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @hasheddan @BenTheElder @spiffxp @dims 
cc: @kubernetes/release-engineering @liggitt 