### PR TITLE
kubernetes-verify: Update go-canary jobs to use go1.16 images

### DIFF
--- a/config/jobs/kubernetes/sig-testing/dependencies.yaml
+++ b/config/jobs/kubernetes/sig-testing/dependencies.yaml
@@ -61,9 +61,7 @@ presubmits:
       - name: main
         command:
         - runner.sh
-        # TODO(releng): Remove if we are able to support verify tests using the releng-ci image
-        #image: gcr.io/k8s-testimages/kubekins-e2e:v20210226-c001921-go-canary
-        image: k8s.gcr.io/releng/releng-ci:v0.4.0
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-c18942a-go-canary
         args:
         - make
         - verify

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -66,9 +66,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      # TODO(releng): Remove if we are able to support verify tests using the releng-ci image
-      #- image: gcr.io/k8s-testimages/kubekins-e2e:v20210226-c001921-go-canary
-      - image: k8s.gcr.io/releng/releng-ci:v0.4.0
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-c18942a-go-canary
         imagePullPolicy: Always
         command:
         - runner.sh


### PR DESCRIPTION
Follow-up to https://github.com/kubernetes/test-infra/pull/21107.
The releng-ci image does not have some of the runner.sh bootstrap logic, so we switch back to the kubekins go1.16 `go-canary` variant being built in https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-test-infra-push-kubekins-e2e/1366592695471968256.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @spiffxp @dims @BenTheElder 
cc: @kubernetes/release-engineering 
/hold until the [image build postsubmit for kubekins-e2e](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-test-infra-push-kubekins-e2e/1366592695471968256) completes