### PR TITLE
kubernetes-verify: Use go-canary kubekins-e2e variants for go1.16 update

### DIFF
--- a/config/jobs/kubernetes/sig-testing/dependencies.yaml
+++ b/config/jobs/kubernetes/sig-testing/dependencies.yaml
@@ -21,7 +21,10 @@ presubmits:
       - name: main
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210226-c001921-master
+        # TODO(releng): Use the 'master' variant once kubernetes/kubernetes has
+        #               been updated to go1.16
+        #               ref: https://github.com/kubernetes/kubernetes/pull/98572
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-c18942a-go-canary
         args:
         - make
         - verify

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -17,7 +17,10 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210226-c001921-master
+      # TODO(releng): Use the 'master' variant once kubernetes/kubernetes has
+      #               been updated to go1.16
+      #               ref: https://github.com/kubernetes/kubernetes/pull/98572
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-c18942a-go-canary
         imagePullPolicy: Always
         command:
         - runner.sh

--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -14,7 +14,7 @@ variants:
     OLD_BAZEL_VERSION: 2.2.0
   test-infra:
     CONFIG: test-infra
-    GO_VERSION: 1.15.7
+    GO_VERSION: 1.15.8
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 3.1.0
@@ -27,13 +27,13 @@ variants:
     OLD_BAZEL_VERSION: 2.2.0
   '1.20':
     CONFIG: '1.20'
-    GO_VERSION: 1.15.5
+    GO_VERSION: 1.15.8
     K8S_RELEASE: stable-1.20
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.19':
     CONFIG: '1.19'
-    GO_VERSION: 1.15.5
+    GO_VERSION: 1.15.8
     K8S_RELEASE: stable-1.19
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.23.2

--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.15.8
+    GO_VERSION: 1.16
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
@@ -21,7 +21,7 @@ variants:
     KIND_VERSION: 0.10.0
   master:
     CONFIG: master
-    GO_VERSION: 1.15.8
+    GO_VERSION: 1.16
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
Follow-up to https://github.com/kubernetes/test-infra/pull/21108.

- kubernetes-verify: Use go-canary kubekins-e2e variants for go1.16 update
- kubekins-e2e: Build `master` and `experimental` variants with go1.16
- kubekins-e2e: Build go1.15 variants using go1.15.8

`pull-kubernetes-dependencies-go-canary` (go1.16 job) now passes on https://github.com/kubernetes/kubernetes/pull/98572: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/98572/pull-kubernetes-dependencies-go-canary/1366599409453764608

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @spiffxp @dims @BenTheElder 
cc: @kubernetes/release-engineering 
/hold until [`pull-kubernetes-verify-go-canary`](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/98572/pull-kubernetes-verify-go-canary/1366599409504096256) passes as well