### PR TITLE
kubernetes-integration: Add go-canary integration job

### DIFF
--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -33,6 +33,40 @@ presubmits:
           requests:
             cpu: 6
             memory: 15Gi
+  - name: pull-kubernetes-integration-go-canary
+    cluster: k8s-infra-prow-build
+    always_run: false
+    skip_report: true
+    decorate: true
+    skip_branches:
+    - release-\d+.\d+ # per-release job
+    annotations:
+      fork-per-release: "true"
+      testgrid-num-failures-to-alert: '10'
+      testgrid-alert-stale-results-hours: '24'
+      testgrid-create-test-group: 'true'
+      testgrid-dashboards: sig-release-releng-informing, sig-testing-canaries
+    path_alias: k8s.io/kubernetes
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-c18942a-go-canary
+        command:
+        - runner.sh
+        args:
+        - ./hack/jenkins/test-dockerized.sh
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 6
+            memory: 15Gi
+          requests:
+            cpu: 6
+            memory: 15Gi
 periodics:
 - interval: 1h
   cluster: k8s-infra-prow-build


### PR DESCRIPTION
From @liggitt in https://github.com/kubernetes/kubernetes/pull/98572#issuecomment-788566314:
> do we have a canary integration job that uses go1.16?

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @spiffxp @BenTheElder @dims 
cc: @kubernetes/release-engineering 