### PR TITLE
secrets: censor more efficiently

### DIFF
--- a/experiment/autobumper/bumper/bumper_test.go
+++ b/experiment/autobumper/bumper/bumper_test.go
@@ -305,13 +305,13 @@ func TestCallWithWriter(t *testing.T) {
 			description: "secret in stdout are censored",
 			command:     "echo",
 			args:        []string{"-n", "abc: 123"},
-			expectedOut: "CENSORED: 123",
+			expectedOut: "***: 123",
 		},
 		{
 			description: "secret in stderr are censored",
 			command:     "ls",
 			args:        []string{"/tmp/file-not-exist/abc/xyz/file-not-exist"},
-			expectedErr: "/tmp/file-not-exist/CENSORED/CENSORED/file-not-exist",
+			expectedErr: "/tmp/file-not-exist/***/***/file-not-exist",
 		},
 		{
 			description: "no secret in stderr are working well",

--- a/go.mod
+++ b/go.mod
@@ -74,6 +74,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/tektoncd/pipeline v0.13.1-0.20200625065359-44f22a067b75
 	go.uber.org/zap v1.15.0
+	go4.org v0.0.0-20201209231011-d4a079459e60
 	gocloud.dev v0.19.0
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b

--- a/go.sum
+++ b/go.sum
@@ -1104,6 +1104,7 @@ github.com/rogpeppe/go-internal v1.5.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rubiojr/go-vhd v0.0.0-20160810183302-0bfd3b39853c/go.mod h1:DM5xW0nvfNNm2uytzsvhI3OnX8uzaRAg8UX/CnDqbto=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd/go.mod h1:hPqNNc0+uJM6H+SuU8sEs5K5IQeKccPqeSjfgcKGgPk=
 github.com/ryancurrah/gomodguard v1.0.4/go.mod h1:9T/Cfuxs5StfsocWr4WzDL36HqnX0fVb9d5fSEaLhoE=
 github.com/ryancurrah/gomodguard v1.1.0/go.mod h1:4O8tr7hBODaGE6VIhfJDHcwzh5GUccKSJBU0UMXJFVM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
@@ -1307,6 +1308,8 @@ go.uber.org/zap v1.13.0/go.mod h1:zwrFLgMcdUuIBviXEYEH1YKNaOBnKXsx2IPda5bBwHM=
 go.uber.org/zap v1.14.1/go.mod h1:Mb2vm2krFEG5DV0W9qcHBYFtp/Wku1cvYaqPsS/WYfc=
 go.uber.org/zap v1.15.0 h1:ZZCA22JRF2gQE5FoNmhmrf7jeJJ2uhqDUNRYKm8dvmM=
 go.uber.org/zap v1.15.0/go.mod h1:Mb2vm2krFEG5DV0W9qcHBYFtp/Wku1cvYaqPsS/WYfc=
+go4.org v0.0.0-20201209231011-d4a079459e60 h1:iqAGo78tVOJXELHQFRjR6TMwItrvXH4hrGJ32I/NFF8=
+go4.org v0.0.0-20201209231011-d4a079459e60/go.mod h1:CIiUVy99QCPfoE13bO4EZaz5GZMZXMSBGhxRdsvzbkg=
 gocloud.dev v0.19.0 h1:EDRyaRAnMGSq/QBto486gWFxMLczAfIYUmusV7XLNBM=
 gocloud.dev v0.19.0/go.mod h1:SmKwiR8YwIMMJvQBKLsC3fHNyMwXLw3PMDO+VVteJMI=
 golang.org/x/crypto v0.0.0-20171113213409-9f005a07e0d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -169,6 +169,7 @@ filegroup(
         "//prow/prstatus:all-srcs",
         "//prow/pubsub/subscriber:all-srcs",
         "//prow/repoowners:all-srcs",
+        "//prow/secretutil:all-srcs",
         "//prow/sidecar:all-srcs",
         "//prow/simplifypath:all-srcs",
         "//prow/slack:all-srcs",

--- a/prow/config/secret/agent_test.go
+++ b/prow/config/secret/agent_test.go
@@ -61,22 +61,22 @@ func TestCensoringFormatter(t *testing.T) {
 		{
 			description: "all occurrences of a single secret in a message are censored",
 			entry:       &logrus.Entry{Message: "A SECRET is a SECRET if it is secret"},
-			expected:    "level=panic msg=\"A CENSORED is a CENSORED if it is secret\"\n",
+			expected:    "level=panic msg=\"A ****** is a ****** if it is secret\"\n",
 		},
 		{
 			description: "occurrences of a multiple secrets in a message are censored",
 			entry:       &logrus.Entry{Message: "A SECRET is a MYSTERY"},
-			expected:    "level=panic msg=\"A CENSORED is a CENSORED\"\n",
+			expected:    "level=panic msg=\"A ****** is a *******\"\n",
 		},
 		{
 			description: "occurrences of multiple secrets in a field",
 			entry:       &logrus.Entry{Message: "message", Data: logrus.Fields{"key": "A SECRET is a MYSTERY"}},
-			expected:    "level=panic msg=message key=\"A CENSORED is a CENSORED\"\n",
+			expected:    "level=panic msg=message key=\"A ****** is a *******\"\n",
 		},
 		{
 			description: "occurrences of a secret in a non-string field",
 			entry:       &logrus.Entry{Message: "message", Data: logrus.Fields{"key": fmt.Errorf("A SECRET is a MYSTERY")}},
-			expected:    "level=panic msg=message key=\"A CENSORED is a CENSORED\"\n",
+			expected:    "level=panic msg=message key=\"A ****** is a *******\"\n",
 		},
 	}
 

--- a/prow/logrusutil/BUILD.bazel
+++ b/prow/logrusutil/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/logrusutil",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/secretutil:go_default_library",
         "//prow/version:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",

--- a/prow/logrusutil/logrusutil.go
+++ b/prow/logrusutil/logrusutil.go
@@ -18,14 +18,13 @@ limitations under the License.
 package logrusutil
 
 import (
-	"bytes"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"k8s.io/test-infra/prow/secretutil"
 	"k8s.io/test-infra/prow/version"
 )
 
@@ -87,8 +86,8 @@ func (f *DefaultFieldsFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 // CensoringFormatter represents a logrus formatter that
 // can be used to censor sensitive information
 type CensoringFormatter struct {
-	delegate   logrus.Formatter
-	getSecrets func() sets.String
+	delegate logrus.Formatter
+	censorer secretutil.Censorer
 }
 
 func (f CensoringFormatter) Format(entry *logrus.Entry) ([]byte, error) {
@@ -96,39 +95,24 @@ func (f CensoringFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	if err != nil {
 		return raw, err
 	}
-	return f.censor(raw), nil
-}
-
-const censored = "CENSORED"
-
-var (
-	censoredBytes = []byte(censored)
-	standardLog   = logrus.NewEntry(logrus.New())
-)
-
-// Censor replaces sensitive parts of the content with a placeholder.
-func (f CensoringFormatter) censor(content []byte) []byte {
-	for _, secret := range f.getSecrets().List() {
-		trimmedSecret := strings.TrimSpace(secret)
-		if trimmedSecret != secret {
-			standardLog.Warning("Secret is not trimmed")
-			secret = trimmedSecret
-		}
-		if secret == "" {
-			standardLog.Warning("Secret is an empty string, ignoring")
-			continue
-		}
-		content = bytes.ReplaceAll(content, []byte(secret), censoredBytes)
-	}
-	return content
+	f.censorer.Censor(&raw)
+	return raw, nil
 }
 
 // NewCensoringFormatter generates a `CensoringFormatter` with
 // a formatter as delegate and a set of strings to censor
 func NewCensoringFormatter(f logrus.Formatter, getSecrets func() sets.String) CensoringFormatter {
+	censorer := secretutil.NewCensorer()
+	censorer.Refresh(getSecrets().List()...)
+	return NewFormatterWithCensor(f, censorer)
+}
+
+// NewFormatterWithCensor generates a `CensoringFormatter` with
+// a formatter as delegate and censorer to use
+func NewFormatterWithCensor(f logrus.Formatter, censorer secretutil.Censorer) CensoringFormatter {
 	return CensoringFormatter{
-		getSecrets: getSecrets,
-		delegate:   f,
+		censorer: censorer,
+		delegate: f,
 	}
 }
 

--- a/prow/logrusutil/logrusutil_test.go
+++ b/prow/logrusutil/logrusutil_test.go
@@ -35,22 +35,22 @@ func TestCensoringFormatter(t *testing.T) {
 		{
 			description: "all occurrences of a single secret in a message are censored",
 			entry:       &logrus.Entry{Message: "A SECRET is a SECRET if it is secret"},
-			expected:    "level=panic msg=\"A CENSORED is a CENSORED if it is secret\"\n",
+			expected:    "level=panic msg=\"A ****** is a ****** if it is secret\"\n",
 		},
 		{
 			description: "occurrences of a multiple secrets in a message are censored",
 			entry:       &logrus.Entry{Message: "A SECRET is a MYSTERY"},
-			expected:    "level=panic msg=\"A CENSORED is a CENSORED\"\n",
+			expected:    "level=panic msg=\"A ****** is a *******\"\n",
 		},
 		{
 			description: "occurrences of multiple secrets in a field",
 			entry:       &logrus.Entry{Message: "message", Data: logrus.Fields{"key": "A SECRET is a MYSTERY"}},
-			expected:    "level=panic msg=message key=\"A CENSORED is a CENSORED\"\n",
+			expected:    "level=panic msg=message key=\"A ****** is a *******\"\n",
 		},
 		{
 			description: "occurrences of a secret in a non-string field",
 			entry:       &logrus.Entry{Message: "message", Data: logrus.Fields{"key": fmt.Errorf("A SECRET is a MYSTERY")}},
-			expected:    "level=panic msg=message key=\"A CENSORED is a CENSORED\"\n",
+			expected:    "level=panic msg=message key=\"A ****** is a *******\"\n",
 		},
 	}
 
@@ -77,7 +77,7 @@ func TestCensoringFormatter(t *testing.T) {
 
 func TestCensoringFormatterWithCornerCases(t *testing.T) {
 	entry := &logrus.Entry{Message: "message", Data: logrus.Fields{"key": fmt.Errorf("A SECRET is a secret")}}
-	expectedEntry := "level=panic msg=message key=\"A CENSORED is a secret\"\n"
+	expectedEntry := "level=panic msg=message key=\"A ****** is a secret\"\n"
 
 	testCases := []struct {
 		description string

--- a/prow/secretutil/BUILD.bazel
+++ b/prow/secretutil/BUILD.bazel
@@ -1,21 +1,14 @@
-package(default_visibility = ["//visibility:public"])
-
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
     srcs = [
-        "agent.go",
-        "secret.go",
+        "censor.go",
+        "doc.go",
     ],
-    importpath = "k8s.io/test-infra/prow/config/secret",
+    importpath = "k8s.io/test-infra/prow/secretutil",
     visibility = ["//visibility:public"],
-    deps = [
-        "//prow/logrusutil:go_default_library",
-        "//prow/secretutil:go_default_library",
-        "@com_github_sirupsen_logrus//:go_default_library",
-        "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
-    ],
+    deps = ["@org_go4//bytereplacer:go_default_library"],
 )
 
 filegroup(
@@ -34,10 +27,9 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["agent_test.go"],
+    srcs = ["censor_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//prow/logrusutil:go_default_library",
-        "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
     ],
 )

--- a/prow/secretutil/censor.go
+++ b/prow/secretutil/censor.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package secretutil implements utilities to operate on secret data.
+package secretutil
+
+import (
+	"encoding/base64"
+	"strings"
+	"sync"
+
+	"go4.org/bytereplacer"
+)
+
+// Censorer knows how to replace sensitive data from input.
+type Censorer interface {
+	// Censor will remove sensitive data previously registered with the Censorer
+	// from the input. This is thread-safe, will mutate the input and will never
+	// change the overall size of the input.
+	Censor(input *[]byte)
+}
+
+func NewCensorer() *ReloadingCensorer {
+	return &ReloadingCensorer{
+		RWMutex:  &sync.RWMutex{},
+		Replacer: bytereplacer.New(),
+	}
+}
+
+type ReloadingCensorer struct {
+	*sync.RWMutex
+	*bytereplacer.Replacer
+}
+
+var _ Censorer = &ReloadingCensorer{}
+
+// Censor will remove sensitive data previously registered with the Censorer
+// from the input. This is thread-safe, will mutate the input and will never
+// change the overall size of the input.
+// Censoring will attempt to be intelligent about how content is removed from
+// the input - when the ReloadingCensorer is given secrets to censor, we:
+//  - handle the case where whitespace is needed to be trimmed
+//  - censor not only the plaintext representation of the secret but also
+//    the base64-encoded representation of it, as it's common for k8s
+//    Secrets to contain information in this way
+func (c *ReloadingCensorer) Censor(input *[]byte) {
+	c.RLock()
+	// we know our replacer will never have to allocate, as our replacements
+	// are the same size as what they're replacing, so we can throw away
+	// the return value from Replace()
+	c.Replacer.Replace(*input)
+	c.RUnlock()
+}
+
+// RefreshBytes refreshes the set of secrets that we censor.
+func (c *ReloadingCensorer) RefreshBytes(secrets ...[]byte) {
+	var asStrings []string
+	for _, secret := range secrets {
+		asStrings = append(asStrings, string(secret))
+	}
+	c.Refresh(asStrings...)
+}
+
+// Refresh refreshes the set of secrets that we censor.
+func (c *ReloadingCensorer) Refresh(secrets ...string) {
+	var replacements []string
+	addReplacement := func(s string) {
+		replacements = append(replacements, s, strings.Repeat(`*`, len(s)))
+	}
+	for _, secret := range secrets {
+		if trimmed := strings.TrimSpace(secret); trimmed != secret {
+			secret = trimmed
+		}
+		if secret == "" {
+			continue
+		}
+		addReplacement(secret)
+		encoded := base64.StdEncoding.EncodeToString([]byte(secret))
+		addReplacement(encoded)
+	}
+	c.Lock()
+	c.Replacer = bytereplacer.New(replacements...)
+	c.Unlock()
+}
+
+// AdaptCensorer returns a func that censors without touching the input, to
+// be used in places where the previous behavior is required while migrations
+// occur.
+func AdaptCensorer(censorer Censorer) func(input []byte) []byte {
+	return func(input []byte) []byte {
+		output := make([]byte, len(input))
+		copy(output, input)
+		censorer.Censor(&output)
+		return output
+	}
+}

--- a/prow/secretutil/censor_test.go
+++ b/prow/secretutil/censor_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secretutil
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestReloadingCensorer(t *testing.T) {
+	text := func() []byte {
+		return []byte("secret SECRET c2VjcmV0 sEcReT")
+	}
+	var testCases = []struct {
+		name     string
+		mutation func(c *ReloadingCensorer)
+		expected []byte
+	}{
+		{
+			name:     "no registered secrets",
+			mutation: func(c *ReloadingCensorer) {},
+			expected: text(),
+		},
+		{
+			name: "registered strings",
+			mutation: func(c *ReloadingCensorer) {
+				c.Refresh("secret")
+			},
+			expected: []byte("****** SECRET ******** sEcReT"),
+		},
+		{
+			name: "registered strings with padding",
+			mutation: func(c *ReloadingCensorer) {
+				c.Refresh("		secret      ")
+			},
+			expected: []byte("****** SECRET ******** sEcReT"),
+		},
+		{
+			name: "registered strings only padding",
+			mutation: func(c *ReloadingCensorer) {
+				c.Refresh("		      ")
+			},
+			expected: text(),
+		},
+		{
+			name: "registered multiple strings",
+			mutation: func(c *ReloadingCensorer) {
+				c.Refresh("secret", "SECRET", "sEcReT")
+			},
+			expected: []byte("****** ****** ******** ******"),
+		},
+		{
+			name: "registered bytes",
+			mutation: func(c *ReloadingCensorer) {
+				c.RefreshBytes([]byte("secret"))
+			},
+			expected: []byte("****** SECRET ******** sEcReT"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			censorer := NewCensorer()
+			testCase.mutation(censorer)
+			input := text()
+			censorer.Censor(&input)
+			if len(input) != len(text()) {
+				t.Errorf("%s: length of input changed from %d to %d", testCase.name, len(text()), len(input))
+			}
+			if diff := cmp.Diff(testCase.expected, input); diff != "" {
+				t.Errorf("%s: got incorrect text after censor: %v", testCase.name, diff)
+			}
+		})
+	}
+}

--- a/prow/secretutil/doc.go
+++ b/prow/secretutil/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package secretutil contains utilities for operating with secret data.
+package secretutil

--- a/repos.bzl
+++ b/repos.bzl
@@ -3782,6 +3782,14 @@ def go_repositories():
         sum = "h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=",
         version = "v2.0.1",
     )
+    go_repository(
+        name = "com_github_rwcarlsen_goexif",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable",
+        importpath = "github.com/rwcarlsen/goexif",
+        sum = "h1:CmH9+J6ZSsIjUK3dcGsnCnO41eRBOnY12zwkn5qVwgc=",
+        version = "v0.0.0-20190401172101-9e8deecbddbd",
+    )
 
     go_repository(
         name = "com_github_ryancurrah_gomodguard",
@@ -5224,6 +5232,15 @@ def go_repositories():
         sum = "h1:FNCRpXiquG1aoyqcIWVFmpTSKVcx2bQD38uZZeGtdlw=",
         version = "v0.0.0-20180421153158-65cc252bf669",
     )
+    go_repository(
+        name = "org_go4",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable",
+        importpath = "go4.org",
+        sum = "h1:iqAGo78tVOJXELHQFRjR6TMwItrvXH4hrGJ32I/NFF8=",
+        version = "v0.0.0-20201209231011-d4a079459e60",
+    )
+
     go_repository(
         name = "org_golang_google_api",
         build_file_generation = "on",


### PR DESCRIPTION
The `bytes.ReplaceAll()` call will copy the input, so the previous
implementation of the secret agent's censoring would take up O(MN)
memory where M is the size of the input and N is the number of secrets
that are loaded. There's no need for that. The `bytereplacer` utility
will operate in-place (unless it needs to reallocate for a longer
replacement) and is faster, as well. I've kept the old `Censor()`
function around and it will continue not to mutate input. The content of
the censored text is changing, though, from the literal `"CENSORED"`
string to repeated `"*"` characters as long as the input.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @alvaroaleman @cjwagner 