### PR TITLE
fix CAPI pull-cluster-api-verify

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -68,8 +68,9 @@ presubmits:
     always_run: true
     labels:
       preset-service-account: "true"
-    skip_branches:
-    - gh-pages
+    branches:
+    # The script this job runs is not in all branches.
+    - ^master$
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-go-canary

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-0-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-0-3.yaml
@@ -18,7 +18,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-build-release-0-3
-  - name: pull-cluster-api-make
+  - name: pull-cluster-api-make-release-0-3
     decorate: true
     path_alias: sigs.k8s.io/cluster-api
     always_run: true


### PR DESCRIPTION
This PR makes pull-cluster-api-verify to run only on the main branch.

Also it add a missing suffix pull-cluster-api-make for the release 0.3 branch

/cc @vincepri 