### PR TITLE
Re-add additional labels

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -117,6 +117,23 @@ label:
     # This label is used by the API review process
     # https://git.k8s.io/community/sig-architecture/api-review-process.md#mechanics
     - api-review
+    # These labels are used by Kubeflow
+    # TODO(https://github.com/kubernetes/test-infra/issues/8648): Switch
+    # to configuring prefixes and not individual labels once  that's supported.
+    - community/discussion
+    - community/maintenance
+    - community/question
+    - cuj/build-train-deploy
+    - cuj/multi-user
+    - platform/aws
+    - platform/azure
+    - platform/gcp
+    - platform/minikube
+    - platform/other
+    - tide/merge-method-merge
+    - tide/merge-method-rebase
+    - tide/merge-method-squash
+
 
 lgtm:
 - repos:
@@ -954,7 +971,7 @@ plugins:
   kubernetes-sigs/cluster-api-provider-ibmcloud:
     plugins:
     - milestone
-  
+
   kubernetes-sigs/cluster-api-provider-nested:
     plugins:
     - milestone


### PR DESCRIPTION
They got removed in 6edfa06cea600aba8df5342a3b2c3716d8cede8f when cleaning up kubeflow.

Its not entirely clear for me which of these only belonged to kubeflow, so I've re-added all of them. Removing them later should be easy. The tide labels are definitely needed everywhere.

/assign @fejta @chaodaiG