### PR TITLE
Trying to fix pull-containerd-node-e2e

### DIFF
--- a/jobs/e2e_node/containerd/containerd-master/image-config-pr.yaml
+++ b/jobs/e2e_node/containerd/containerd-master/image-config-pr.yaml
@@ -4,6 +4,6 @@ images:
     project: ubuntu-os-gke-cloud
     metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-master/env"
   cos-stable:
-    image_family: cos-81-lts
+    image_family: cos-85-lts
     project: cos-cloud
     metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-master/env,gci-update-strategy=update_disabled"


### PR DESCRIPTION
Updating image from cos-81 to cos-85
getting error `unable to create gce instance with running docker daemon for image cos-81-12871-1245-15` and we are using cos-85 everywhere else.

Related to #21055