### PR TITLE
tide: add Message and MessageBody feilds to Commit

### DIFF
--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -1731,6 +1731,8 @@ type Commit struct {
 		Contexts []Context
 	}
 	OID               githubql.String `graphql:"oid"`
+	Message           githubql.String
+	MessageBody       githubql.String
 	StatusCheckRollup StatusCheckRollup
 }
 


### PR DESCRIPTION
We would like to be able to add only the sign off message to the commit body when tide squash merges, but it seems that tide does not currently support that feature. So I would like to add these two fields and use the message body of the first commit in the template.

These fields are defined in commit, for more information see: https://docs.github.com/en/graphql/reference/objects#commit