### PR TITLE
kubernetes-verify: Use kubekins-e2e `master` variant for blocking jobs

### DIFF
--- a/config/jobs/kubernetes/sig-testing/dependencies.yaml
+++ b/config/jobs/kubernetes/sig-testing/dependencies.yaml
@@ -21,10 +21,7 @@ presubmits:
       - name: main
         command:
         - runner.sh
-        # TODO(releng): Use the 'master' variant once kubernetes/kubernetes has
-        #               been updated to go1.16
-        #               ref: https://github.com/kubernetes/kubernetes/pull/98572
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-c18942a-go-canary
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-c18942a-master
         args:
         - make
         - verify

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -17,10 +17,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      # TODO(releng): Use the 'master' variant once kubernetes/kubernetes has
-      #               been updated to go1.16
-      #               ref: https://github.com/kubernetes/kubernetes/pull/98572
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-c18942a-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-c18942a-master
         imagePullPolicy: Always
         command:
         - runner.sh


### PR DESCRIPTION
Part of https://github.com/kubernetes/release/issues/1834.

Now that kubernetes/kubernetes has been updated to go1.16, we can return
to using the `master` variants of the kubekins-e2e image.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @dims @spiffxp 
cc: @kubernetes/release-engineering 