### PR TITLE
Split prow bump

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -906,7 +906,7 @@ periodics:
       command:
       - /generic_autobump
       args:
-      - --config=config/prow/autobump-config.yaml
+      - --config=config/prow/autobump-config/prow-component-autobump-config.yaml
       volumeMounts:
       - name: github
         mountPath: /etc/github-token
@@ -924,7 +924,40 @@ periodics:
   annotations:
     testgrid-dashboards: sig-testing-prow
     testgrid-tab-name: autobump-prow
-    description: runs prow/autobump.sh to create/update a PR that bumps prow to the latest RC
+    description: runs experiment/autobumper to create/update a PR that bumps prow to the latest RC
+- cron: "06 15-23 * * 1-5"  # Run at 7:06-15:06 PST (15:05 UTC) Mon-Fri
+  name: ci-test-infra-autobump-prowjobs
+  cluster: test-infra-trusted
+  decorate: true
+  extra_refs:
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/generic_autobump:v20210303-204466f
+      command:
+      - /generic_autobump
+      args:
+      - --config=config/prow/autobump-config/prow-job-autobump-config.yaml
+      volumeMounts:
+      - name: github
+        mountPath: /etc/github-token
+        readOnly: true
+      - name: ssh
+        mountPath: /root/.ssh
+    volumes:
+    - name: github
+      secret:
+        secretName: oauth-token
+    - name: ssh
+      secret:
+        secretName: k8s-ci-robot-ssh-keys
+        defaultMode: 0400
+  annotations:
+    testgrid-dashboards: sig-testing-prow
+    testgrid-tab-name: autobump-prowjobs
+    description: runs experiment/autobumper to create/update a PR that bumps prowjobs to the latest RC
 - cron: "30 * * * *"  # Run at half past the hour, every hour, every day
   name: ci-test-infra-update-slack-oncall
   cluster: test-infra-trusted

--- a/config/prow/autobump-config/prow-component-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-component-autobump-config.yaml
@@ -13,13 +13,7 @@ includedConfigPaths:
   - "."
 excludedConfigPaths:
   - "config/prow-staging"
-extraFiles:
-  - "config/jobs/image-pushing/k8s-staging-e2e-test-images.sh"
-  - "config/jobs/image-pushing/k8s-staging-sig-storage.sh"
-  - "config/jobs/kubernetes/kops/build_grid.py"
-  - "config/jobs/kubernetes/kops/build_pipeline.py"
-  - "releng/generate_tests.py"
-  - "images/kubekins-e2e/Dockerfile"
+  - "config/jobs"
 targetVersion: "latest"
 prefixes:
   - name: "Prow"
@@ -36,8 +30,3 @@ prefixes:
     repo: "https://github.com/kubernetes-sigs/boskos"
     summarise: false
     consistentImages: true
-  - name: "K8s-Test-Images"
-    prefix: "gcr.io/k8s-testimages/"
-    repo: "https://github.com/kubernetes/test-infra"
-    summarise: false
-    consistentImages: false

--- a/config/prow/autobump-config/prow-job-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-job-autobump-config.yaml
@@ -1,0 +1,28 @@
+---
+gitHubLogin: "k8s-ci-robot"
+gitHubToken: "/etc/github-token/oauth"
+gitName: "Kubernetes Prow Robot"
+gitEmail: "k8s.ci.robot@gmail.com"
+onCallAddress: "https://storage.googleapis.com/kubernetes-jenkins/oncall.json"
+skipPullRequest: false
+gitHubOrg: "kubernetes"
+gitHubRepo: "test-infra"
+remoteName: "test-infra"
+headBranchName: "prowjobs-autobump"
+upstreamURLBase: "https://raw.githubusercontent.com/kubernetes/test-infra/master"
+includedConfigPaths:
+  - "config/jobs"
+extraFiles:
+  - "config/jobs/image-pushing/k8s-staging-e2e-test-images.sh"
+  - "config/jobs/image-pushing/k8s-staging-sig-storage.sh"
+  - "config/jobs/kubernetes/kops/build_grid.py"
+  - "config/jobs/kubernetes/kops/build_pipeline.py"
+  - "releng/generate_tests.py"
+  - "images/kubekins-e2e/Dockerfile"
+targetVersion: "latest"
+prefixes:
+  - name: "K8s-Test-Images"
+    prefix: "gcr.io/k8s-testimages/"
+    repo: "https://github.com/kubernetes/test-infra"
+    summarise: false
+    consistentImages: false


### PR DESCRIPTION
Fixed https://github.com/kubernetes/test-infra/issues/21137

Note that this change still results in both PRs assigned to testinfra oncalls. And #21142 was created to address this problem