### PR TITLE
GracefulNodeShutdown skip ubuntu

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -373,7 +373,7 @@ periodics:
           - --deployment=node
           - --gcp-project-type=node-e2e-project
           - --gcp-zone=us-west1-b
-          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial.yaml
+          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial-graceful-node-shutdown.yaml
           - --node-test-args=--feature-gates=GracefulNodeShutdown=true --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
           - --node-tests=true
           - --provider=gce

--- a/jobs/e2e_node/image-config-serial-graceful-node-shutdown.yaml
+++ b/jobs/e2e_node/image-config-serial-graceful-node-shutdown.yaml
@@ -1,0 +1,12 @@
+# To copy an image between projects:
+# `gcloud compute --project <to-project> disks create <image name> --image=https://www.googleapis.com/compute/v1/projects/<from-project>/global/images/<image-name>`
+# `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
+images:
+  cos-stable1:
+    image_family: cos-85-lts
+    project: cos-cloud
+    metadata: "user-data<test/e2e_node/jenkins/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"
+  cos-stable2:
+    image_family: cos-81-lts
+    project: cos-cloud
+    metadata: "user-data<test/e2e_node/jenkins/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"


### PR DESCRIPTION
xref kubernetes/kubernetes#99766

Skip testing GracefulNodeShutdown on ubuntu, because it does not have gdbus installed by default.
