### PR TITLE
Use kubekins-e2e images 1.18 variant for capdo

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics.yaml
@@ -13,7 +13,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.18
       command:
         - "runner.sh"
         - "./scripts/ci-janitor.sh"
@@ -41,7 +41,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.18
       command:
         - "runner.sh"
         - "./scripts/ci-conformance.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.18
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -20,7 +20,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.18
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -33,7 +33,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.18
         command:
         - make
         args:
@@ -70,7 +70,7 @@ presubmits:
       preset-do-credential: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.18
         command:
           - "runner.sh"
           - "./scripts/ci-e2e.sh"
@@ -97,7 +97,7 @@ presubmits:
       preset-do-credential: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.18
         command:
           - "runner.sh"
           - "./scripts/ci-conformance.sh"


### PR DESCRIPTION
This PR makes capdo jobs to using kubekins-e2e images 1.18 variant since capdo master branch still using `go 1.13` and depend on capi `release-3`. Before we have any preparation for adopting capi `v1alpha4` api types we could keep to target k8s v1.18 by using kubekins-e2e images 1.18 variant.

This PR also fixes `pull-cluster-api-provider-digitalocean-verify` jobs that were error here https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/pull/240

/cc @cpanato @MorrisLaw @timoreimann