### PR TITLE
Gerrit label processing: include job name and id in debug logs

### DIFF
--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -92,11 +92,14 @@ func PodUtilsContainerNames() sets.String {
 // User-provided extraLabels and extraAnnotations values will take precedence over auto-provided values.
 func LabelsAndAnnotationsForSpec(spec prowapi.ProwJobSpec, extraLabels, extraAnnotations map[string]string) (map[string]string, map[string]string) {
 	jobNameForLabel := spec.Job
+	log := logrus.WithFields(logrus.Fields{
+		"job": spec.Job,
+		"id":  extraLabels[kube.ProwBuildIDLabel],
+	})
 	if len(jobNameForLabel) > validation.LabelValueMaxLength {
 		// TODO(fejta): consider truncating middle rather than end.
 		jobNameForLabel = strings.TrimRight(spec.Job[:validation.LabelValueMaxLength], ".-")
-		logrus.WithFields(logrus.Fields{
-			"job":       spec.Job,
+		log.WithFields(logrus.Fields{
 			"key":       kube.ProwJobAnnotation,
 			"value":     spec.Job,
 			"truncated": jobNameForLabel,
@@ -128,7 +131,7 @@ func LabelsAndAnnotationsForSpec(spec prowapi.ProwJobSpec, extraLabels, extraAnn
 				labels[key] = base
 				continue
 			}
-			logrus.WithFields(logrus.Fields{
+			log.WithFields(logrus.Fields{
 				"key":    key,
 				"value":  value,
 				"errors": errs,


### PR DESCRIPTION
We are seeing very strange behavior of gerrit label processing, that the value for label 'prow.k8s.io/gerrit-patchset' is a whitespace. The only place this value being set is https://github.com/kubernetes/test-infra/blob/cdbc8651410c316098479c03fbf54d22fe6db8b8/prow/gerrit/adapter/adapter.go#L306, and 'strconv.Itoa' technically should never return a whitespace. The current log doesn't tell which prowjob it is from and made it hard to debug, add these fields in debug message to help debug