### PR TITLE
Dump nodes better when instance groups are not used (node-e2e)

### DIFF
--- a/logexporter/cluster/log-dump.sh
+++ b/logexporter/cluster/log-dump.sh
@@ -179,6 +179,10 @@ function detect-node-names() {
         "${group}" --zone "${ZONE}" --project "${PROJECT}" \
         --format='value(instance)'))
     done
+  else
+      NODE_NAMES+=($(gcloud compute instances list \
+        --project "${PROJECT}" \
+        --format='get(name)'))
   fi
   # Add heapster node name to the list too (if it exists).
   if [[ -n "${HEAPSTER_MACHINE_TYPE:-}" ]]; then


### PR DESCRIPTION
In node e2e tests, we don't end up capturing any logs directly from
nodes so it is very difficult to diagnose issues. This happends because
the node e2e harness does not create/use instance groups, so in this
case we just do a simple query to list instances and use that.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>