### PR TITLE
Prow component autobumper: also include prow images in prow jobs

### DIFF
--- a/config/prow/autobump-config/prow-component-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-component-autobump-config.yaml
@@ -13,7 +13,6 @@ includedConfigPaths:
   - "."
 excludedConfigPaths:
   - "config/prow-staging"
-  - "config/jobs"
 targetVersion: "latest"
 prefixes:
   - name: "Prow"


### PR DESCRIPTION
They will be restricted to only bump gcr.io/k8s-prow/ and gcr.io/k8s-staging-boskos/

Part of https://github.com/kubernetes/test-infra/issues/21137