### PR TITLE
Add kube-state-metrics service in prow cluster config directory

### DIFF
--- a/config/prow/cluster/kube-state-metrics_deployment.yaml
+++ b/config/prow/cluster/kube-state-metrics_deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.0.0-beta
+  name: kube-state-metrics
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kube-state-metrics
+        app.kubernetes.io/version: 2.0.0-beta
+    spec:
+      containers:
+      - image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0-beta
+        args:
+        - --metric-allowlist="kube_pod_container_status_restarts_total"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        name: kube-state-metrics
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 8081
+          name: telemetry
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8081
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        securityContext:
+          runAsUser: 65534
+      # nodeSelector:
+      #   kubernetes.io/os: linux
+      serviceAccountName: kube-state-metrics

--- a/config/prow/cluster/kube-state-metrics_rbac.yaml
+++ b/config/prow/cluster/kube-state-metrics_rbac.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.0.0-beta
+  name: kube-state-metrics
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.0.0-beta
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.0.0-beta
+  name: kube-state-metrics
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch

--- a/config/prow/cluster/kube-state-metrics_service.yaml
+++ b/config/prow/cluster/kube-state-metrics_service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.0.0-beta
+  name: kube-state-metrics
+  namespace: kube-system
+spec:
+  clusterIP: None
+  ports:
+  - name: http-metrics
+    port: 8080
+    targetPort: http-metrics
+  - name: telemetry
+    port: 8081
+    targetPort: telemetry
+  selector:
+    app.kubernetes.io/name: kube-state-metrics


### PR DESCRIPTION
Inspired by https://github.com/kubernetes/test-infra/issues/21090#issuecomment-790651066, adding kube-state-metrics so that we can capture prow pods crashlooping metrics, which will allow us set prometheus alert for issues like https://github.com/kubernetes/test-infra/issues/21090

Note: merging of this PR will not result it deployed in prow yet, will do it in a separate PR