### PR TITLE
[pull-containerd-node-e2e] Temporarily drop the ubuntu-gke-1804

### DIFF
--- a/jobs/e2e_node/containerd/cri-master/image-config-pr.yaml
+++ b/jobs/e2e_node/containerd/cri-master/image-config-pr.yaml
@@ -1,8 +1,4 @@
 images:
-  ubuntu:
-    image: ubuntu-gke-1804-1-16-v20200330
-    project: ubuntu-os-gke-cloud
-    metadata: "user-data</home/prow/go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cri-master/env"
   cos-stable:
     image_family: cos-81-lts
     project: cos-cloud


### PR DESCRIPTION
Let's see if we get reliable signal with just the cos-85

(yes, we'll put this back in a follow up!)

Signed-off-by: Davanum Srinivas <davanum@gmail.com>