### PR TITLE
e2e-framework: add initial job

### DIFF
--- a/config/jobs/kubernetes-sigs/e2e-framework/OWNERS
+++ b/config/jobs/kubernetes-sigs/e2e-framework/OWNERS
@@ -1,0 +1,15 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - andrewsykim
+  - alejandrox1
+  - BenTheElder
+  - spiffxp
+reviewers:
+  - andrewsykim
+  - alejandrox1
+  - BenTheElder
+  - spiffxp
+
+labels:
+- sig/testing

--- a/config/jobs/kubernetes-sigs/e2e-framework/e2e-framework-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/e2e-framework/e2e-framework-presubmits.yaml
@@ -1,0 +1,17 @@
+presubmits:
+  kubernetes-sigs/e2e-framework:
+  - name: pull-e2e-framework-verify
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/e2e-framework
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest
+        command:
+        - make
+        - verify
+    annotations:
+      testgrid-dashboards: sig-testing-e2e-framework
+      testgrid-tab-name: pull-e2e-framework-verify
+      testgrid-num-columns-recent: '30'
+      testgrid-create-test-group: 'true'

--- a/config/testgrids/kubernetes/sig-testing/sig-testing.yaml
+++ b/config/testgrids/kubernetes/sig-testing/sig-testing.yaml
@@ -12,6 +12,7 @@ dashboard_groups:
   dashboard_names:
   - sig-testing-misc
   - sig-testing-canaries
+  - sig-testing-e2e-framework
   - sig-testing-fejtabot
   - sig-testing-kind
   - sig-testing-maintenance
@@ -28,6 +29,7 @@ dashboards:
   - name: ci-kubernetes-coverage-unit
     test_group_name: ci-kubernetes-coverage-unit
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
+- name: sig-testing-e2e-framework
 - name: sig-testing-fejtabot
 - name: sig-testing-kind
 - name: sig-testing-maintenance


### PR DESCRIPTION
Add initial job for the [E2E-framework repo](https://github.com/kubernetes-sigs/e2e-framework)

- Adding the same owners that are set in the E2E-framework repo

ref: https://github.com/kubernetes-sigs/e2e-framework/pull/2

/assign @vladimirvivien  