### PR TITLE
CAPI: Add operator branch to main jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -9,6 +9,7 @@ presubmits:
     branches:
     # The script this job runs is not in all branches.
     - ^master$
+    - ^operator-0.4$
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-go-canary
@@ -28,6 +29,7 @@ presubmits:
     branches:
     # The script this job runs is not in all branches.
     - ^master$
+    - ^operator-0.4$
     spec:
       containers:
       - command:
@@ -53,6 +55,7 @@ presubmits:
     branches:
     # The script this job runs is not in all branches.
     - ^master$
+    - ^operator-0.4$
     spec:
       containers:
       - command:
@@ -71,6 +74,7 @@ presubmits:
     branches:
     # The script this job runs is not in all branches.
     - ^master$
+    - ^operator-0.4$
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-go-canary
@@ -93,6 +97,7 @@ presubmits:
     branches:
     # The script this job runs is not in all branches.
     - ^master$
+    - ^operator-0.4$
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-go-canary

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -80,8 +80,7 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-go-canary
         command:
         - "runner.sh"
-        - "make"
-        - "verify"
+        - ./scripts/ci-verify.sh
         resources:
           requests:
             cpu: 7300m


### PR DESCRIPTION
There was created a separate branch for developing new operator. This branch will later be merged in main but now it needs the same CI jobs.

Fixes: https://github.com/kubernetes-sigs/cluster-api/issues/4269