### PR TITLE
Fix the testgrid url for Kyma dashboards 

### DIFF
--- a/config/testgrids/kyma/gen-config.yaml
+++ b/config/testgrids/kyma/gen-config.yaml
@@ -17,6 +17,8 @@ dashboards:
     name: kyma-aks-nightly
     open_bug_template:
       url: https://github.com/kyma-project/test-infra/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: kyma-aks-nightly
   - code_search_url_template:
       url: https://github.com/kyma-project/test-infra/compare/<start-custom-0>...<end-custom-0>
@@ -24,6 +26,8 @@ dashboards:
     name: kyma-gke-nightly
     open_bug_template:
       url: https://github.com/kyma-project/test-infra/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: kyma-gke-nightly
   - code_search_url_template:
       url: https://github.com/kyma-project/test-infra/compare/<start-custom-0>...<end-custom-0>
@@ -31,6 +35,8 @@ dashboards:
     name: kyma-gke-weekly
     open_bug_template:
       url: https://github.com/kyma-project/test-infra/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: kyma-gke-weekly
   - code_search_url_template:
       url: https://github.com/kyma-project/test-infra/compare/<start-custom-0>...<end-custom-0>
@@ -38,6 +44,8 @@ dashboards:
     name: kyma-integration-evaluation-gardener-azure
     open_bug_template:
       url: https://github.com/kyma-project/test-infra/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: kyma-integration-evaluation-gardener-azure
   - code_search_url_template:
       url: https://github.com/kyma-project/test-infra/compare/<start-custom-0>...<end-custom-0>
@@ -45,6 +53,8 @@ dashboards:
     name: kyma-integration-evaluation-gardener-azure-big
     open_bug_template:
       url: https://github.com/kyma-project/test-infra/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: kyma-integration-evaluation-gardener-azure-big
   - code_search_url_template:
       url: https://github.com/kyma-project/test-infra/compare/<start-custom-0>...<end-custom-0>
@@ -52,6 +62,8 @@ dashboards:
     name: kyma-integration-gardener-aws
     open_bug_template:
       url: https://github.com/kyma-project/test-infra/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: kyma-integration-gardener-aws
   - code_search_url_template:
       url: https://github.com/kyma-project/test-infra/compare/<start-custom-0>...<end-custom-0>
@@ -59,6 +71,8 @@ dashboards:
     name: kyma-integration-gardener-azure
     open_bug_template:
       url: https://github.com/kyma-project/test-infra/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: kyma-integration-gardener-azure
   - code_search_url_template:
       url: https://github.com/kyma-project/test-infra/compare/<start-custom-0>...<end-custom-0>
@@ -66,6 +80,8 @@ dashboards:
     name: kyma-integration-gardener-gcp
     open_bug_template:
       url: https://github.com/kyma-project/test-infra/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: kyma-integration-gardener-gcp
   - code_search_url_template:
       url: https://github.com/kyma-project/test-infra/compare/<start-custom-0>...<end-custom-0>
@@ -73,6 +89,8 @@ dashboards:
     name: kyma-integration-k3s
     open_bug_template:
       url: https://github.com/kyma-project/test-infra/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: kyma-integration-k3s
   - code_search_url_template:
       url: https://github.com/kyma-project/test-infra/compare/<start-custom-0>...<end-custom-0>
@@ -80,6 +98,8 @@ dashboards:
     name: kyma-integration-production-gardener-azure
     open_bug_template:
       url: https://github.com/kyma-project/test-infra/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: kyma-integration-production-gardener-azure
   - code_search_url_template:
       url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
@@ -87,6 +107,8 @@ dashboards:
     name: post-master-kyma-gke-integration
     open_bug_template:
       url: https://github.com/kyma-project/kyma/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: post-master-kyma-gke-integration
   - code_search_url_template:
       url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
@@ -94,6 +116,8 @@ dashboards:
     name: post-master-kyma-gke-upgrade
     open_bug_template:
       url: https://github.com/kyma-project/kyma/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: post-master-kyma-gke-upgrade
   - code_search_url_template:
       url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
@@ -101,6 +125,8 @@ dashboards:
     name: post-master-kyma-integration
     open_bug_template:
       url: https://github.com/kyma-project/kyma/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: post-master-kyma-integration
   - code_search_url_template:
       url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
@@ -108,6 +134,8 @@ dashboards:
     name: post-master-kyma-integration-k3s
     open_bug_template:
       url: https://github.com/kyma-project/kyma/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: post-master-kyma-integration-k3s
   name: kyma_integration
 - dashboard_tab:
@@ -117,6 +145,8 @@ dashboards:
     name: post-master-control-plane-gke-integration
     open_bug_template:
       url: https://github.com/kyma-project/control-plane/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: post-master-control-plane-gke-integration
   - code_search_url_template:
       url: https://github.com/kyma-project/control-plane/compare/<start-custom-0>...<end-custom-0>
@@ -124,6 +154,8 @@ dashboards:
     name: post-master-control-plane-gke-provisioner-integration
     open_bug_template:
       url: https://github.com/kyma-project/control-plane/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: post-master-control-plane-gke-provisioner-integration
   - code_search_url_template:
       url: https://github.com/kyma-project/control-plane/compare/<start-custom-0>...<end-custom-0>
@@ -131,6 +163,8 @@ dashboards:
     name: post-master-control-plane-integration
     open_bug_template:
       url: https://github.com/kyma-project/control-plane/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: post-master-control-plane-integration
   name: kyma_control-plane
 - dashboard_tab:
@@ -140,6 +174,8 @@ dashboards:
     name: post-master-test-infra-image-syncer-run
     open_bug_template:
       url: https://github.com/kyma-project/test-infra/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: post-master-test-infra-image-syncer-run
   name: kyma_experimental
 - dashboard_tab:
@@ -149,6 +185,8 @@ dashboards:
     name: post-rel121-kyma-gke-integration
     open_bug_template:
       url: https://github.com/kyma-project/kyma/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: post-rel121-kyma-gke-integration
   - code_search_url_template:
       url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
@@ -156,6 +194,8 @@ dashboards:
     name: post-rel121-kyma-gke-release-upgrade
     open_bug_template:
       url: https://github.com/kyma-project/kyma/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: post-rel121-kyma-gke-release-upgrade
   - code_search_url_template:
       url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
@@ -163,6 +203,8 @@ dashboards:
     name: post-rel121-kyma-gke-upgrade
     open_bug_template:
       url: https://github.com/kyma-project/kyma/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: post-rel121-kyma-gke-upgrade
   - code_search_url_template:
       url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
@@ -170,6 +212,8 @@ dashboards:
     name: post-rel121-kyma-integration
     open_bug_template:
       url: https://github.com/kyma-project/kyma/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: post-rel121-kyma-integration
   - code_search_url_template:
       url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
@@ -177,6 +221,8 @@ dashboards:
     name: post-rel121-kyma-release-candidate
     open_bug_template:
       url: https://github.com/kyma-project/kyma/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: post-rel121-kyma-release-candidate
   name: kyma_release-1.21
 - dashboard_tab:
@@ -186,6 +232,8 @@ dashboards:
     name: post-rel120-kyma-gke-integration
     open_bug_template:
       url: https://github.com/kyma-project/kyma/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: post-rel120-kyma-gke-integration
   - code_search_url_template:
       url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
@@ -193,6 +241,8 @@ dashboards:
     name: post-rel120-kyma-gke-release-upgrade
     open_bug_template:
       url: https://github.com/kyma-project/kyma/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: post-rel120-kyma-gke-release-upgrade
   - code_search_url_template:
       url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
@@ -200,6 +250,8 @@ dashboards:
     name: post-rel120-kyma-gke-upgrade
     open_bug_template:
       url: https://github.com/kyma-project/kyma/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: post-rel120-kyma-gke-upgrade
   - code_search_url_template:
       url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
@@ -207,6 +259,8 @@ dashboards:
     name: post-rel120-kyma-integration
     open_bug_template:
       url: https://github.com/kyma-project/kyma/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: post-rel120-kyma-integration
   - code_search_url_template:
       url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
@@ -214,6 +268,8 @@ dashboards:
     name: post-rel120-kyma-release-candidate
     open_bug_template:
       url: https://github.com/kyma-project/kyma/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: post-rel120-kyma-release-candidate
   name: kyma_release-1.20
 - dashboard_tab:
@@ -223,6 +279,8 @@ dashboards:
     name: post-rel119-kyma-gke-integration
     open_bug_template:
       url: https://github.com/kyma-project/kyma/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: post-rel119-kyma-gke-integration
   - code_search_url_template:
       url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
@@ -230,6 +288,8 @@ dashboards:
     name: post-rel119-kyma-gke-release-upgrade
     open_bug_template:
       url: https://github.com/kyma-project/kyma/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: post-rel119-kyma-gke-release-upgrade
   - code_search_url_template:
       url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
@@ -237,6 +297,8 @@ dashboards:
     name: post-rel119-kyma-gke-upgrade
     open_bug_template:
       url: https://github.com/kyma-project/kyma/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: post-rel119-kyma-gke-upgrade
   - code_search_url_template:
       url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
@@ -244,6 +306,8 @@ dashboards:
     name: post-rel119-kyma-integration
     open_bug_template:
       url: https://github.com/kyma-project/kyma/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: post-rel119-kyma-integration
   - code_search_url_template:
       url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
@@ -251,6 +315,8 @@ dashboards:
     name: post-rel119-kyma-release-candidate
     open_bug_template:
       url: https://github.com/kyma-project/kyma/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: post-rel119-kyma-release-candidate
   name: kyma_release-1.19
 - dashboard_tab:
@@ -260,6 +326,8 @@ dashboards:
     name: post-rel118-kyma-gke-integration
     open_bug_template:
       url: https://github.com/kyma-project/kyma/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: post-rel118-kyma-gke-integration
   - code_search_url_template:
       url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
@@ -267,6 +335,8 @@ dashboards:
     name: post-rel118-kyma-gke-release-upgrade
     open_bug_template:
       url: https://github.com/kyma-project/kyma/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: post-rel118-kyma-gke-release-upgrade
   - code_search_url_template:
       url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
@@ -274,6 +344,8 @@ dashboards:
     name: post-rel118-kyma-gke-upgrade
     open_bug_template:
       url: https://github.com/kyma-project/kyma/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: post-rel118-kyma-gke-upgrade
   - code_search_url_template:
       url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
@@ -281,6 +353,8 @@ dashboards:
     name: post-rel118-kyma-integration
     open_bug_template:
       url: https://github.com/kyma-project/kyma/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: post-rel118-kyma-integration
   - code_search_url_template:
       url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
@@ -288,6 +362,8 @@ dashboards:
     name: post-rel118-kyma-release-candidate
     open_bug_template:
       url: https://github.com/kyma-project/kyma/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: post-rel118-kyma-release-candidate
   name: kyma_release-1.18
 - dashboard_tab:
@@ -297,6 +373,8 @@ dashboards:
     name: post-master-compass-gke-integration
     open_bug_template:
       url: https://github.com/kyma-incubator/compass/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: post-master-compass-gke-integration
   - code_search_url_template:
       url: https://github.com/kyma-incubator/compass/compare/<start-custom-0>...<end-custom-0>
@@ -304,6 +382,8 @@ dashboards:
     name: post-master-compass-integration
     open_bug_template:
       url: https://github.com/kyma-incubator/compass/issues/
+    open_test_template:
+      url: https://status.build.kyma-project.io/view/gcs/<gcs_prefix>/<changelist>
     test_group_name: post-master-compass-integration
   name: kyma-incubator_compass
 test_groups:


### PR DESCRIPTION
We're testing to fix our dashboard. Unless this is connected to the issue with failing podinfo.json hopefully this will work.