### PR TITLE
Relax ghproxy alert rules by extending duration of status code starting with 4 or 5

### DIFF
--- a/config/prow/cluster/monitoring/mixins/prometheus/ghproxy_alerts.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/ghproxy_alerts.libsonnet
@@ -7,9 +7,9 @@
         name: 'ghproxy',
         rules: [
           {
-            alert: 'ghproxy-specific-status-code-abnormal',
+            alert: 'ghproxy-specific-status-code-5xx',
             expr: |||
-              sum(rate(github_request_duration_count{status=~"[45]..",status!="404",status!="410"}[30m])) by (status,path) / ignoring(status) group_left sum(rate(github_request_duration_count[5m])) by (path) * 100 > 10
+              sum(rate(github_request_duration_count{status=~"5.."}[5m])) by (status,path) / ignoring(status) group_left sum(rate(github_request_duration_count[5m])) by (path) * 100 > 10
             |||,
             labels: {
               severity: 'warning',
@@ -19,9 +19,33 @@
             },
           },
           {
-            alert: 'ghproxy-global-status-code-abnormal',
+            alert: 'ghproxy-global-status-code-5xx',
             expr: |||
-              sum(rate(github_request_duration_count{status=~"[45]..",status!="404",status!="410"}[30m])) by (status) / ignoring(status) group_left sum(rate(github_request_duration_count[5m])) * 100 > 3
+              sum(rate(github_request_duration_count{status=~"5.."}[5m])) by (status) / ignoring(status) group_left sum(rate(github_request_duration_count[5m])) * 100 > 3
+            |||,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: '{{ $value | humanize }}%% of all API requests through the GitHub proxy are errorring with code {{ $labels.status }}. Check %s.' % [monitoringLink('/d/%s/github-cache?orgId=1&refresh=1m&fullscreen&panelId=8' % [dashboardID], 'the ghproxy dashboard')],
+            },
+          },
+          {
+            alert: 'ghproxy-specific-status-code-4xx',
+            expr: |||
+              sum(rate(github_request_duration_count{status=~"4..",status!="404",status!="410"}[30m])) by (status,path) / ignoring(status) group_left sum(rate(github_request_duration_count[30m])) by (path) * 100 > 10
+            |||,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: '{{ $value | humanize }}%% of all requests for {{ $labels.path }} through the GitHub proxy are erroring with code {{ $labels.status }}. Check %s.' % [monitoringLink('/d/%s/github-cache?orgId=1&refresh=1m&fullscreen&panelId=9' % [dashboardID], 'the ghproxy dashboard')],
+            },
+          },
+          {
+            alert: 'ghproxy-global-status-code-4xx',
+            expr: |||
+              sum(rate(github_request_duration_count{status=~"4..",status!="404",status!="410"}[30m])) by (status) / ignoring(status) group_left sum(rate(github_request_duration_count[30m])) * 100 > 3
             |||,
             labels: {
               severity: 'warning',

--- a/config/prow/cluster/monitoring/mixins/prometheus/ghproxy_alerts.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/ghproxy_alerts.libsonnet
@@ -9,7 +9,7 @@
           {
             alert: 'ghproxy-specific-status-code-abnormal',
             expr: |||
-              sum(rate(github_request_duration_count{status=~"[45]..",status!="404",status!="410"}[5m])) by (status,path) / ignoring(status) group_left sum(rate(github_request_duration_count[5m])) by (path) * 100 > 10
+              sum(rate(github_request_duration_count{status=~"[45]..",status!="404",status!="410"}[30m])) by (status,path) / ignoring(status) group_left sum(rate(github_request_duration_count[5m])) by (path) * 100 > 10
             |||,
             labels: {
               severity: 'warning',
@@ -21,7 +21,7 @@
           {
             alert: 'ghproxy-global-status-code-abnormal',
             expr: |||
-              sum(rate(github_request_duration_count{status=~"[45]..",status!="404",status!="410"}[5m])) by (status) / ignoring(status) group_left sum(rate(github_request_duration_count[5m])) * 100 > 3
+              sum(rate(github_request_duration_count{status=~"[45]..",status!="404",status!="410"}[30m])) by (status) / ignoring(status) group_left sum(rate(github_request_duration_count[5m])) * 100 > 3
             |||,
             labels: {
               severity: 'warning',


### PR DESCRIPTION
Part of: #21138 

Currently prow-alerts channel is pretty much filled with warnings from ghproxy, they might provide some value but it's so spammy that if any other useful alerts were surfaced they would easily be overlooked.

Simply inspecting the warnings, majority of them were 422 and 405 codes. And some of them were actually expected, for example:

Expecting 422 from https://github.com/kubernetes/test-infra/blob/7f3fe6c5ffbd8a665d68e38b6ddbd865e06716a6/prow/github/client.go#L2707
Expecting 405 from https://github.com/kubernetes/test-infra/blob/7f3fe6c5ffbd8a665d68e38b6ddbd865e06716a6/prow/github/client.go#L3472

Extending to 30 minutes and hopefully it would dilute the impact enough to eliminate the noise. If this doesn't work will need to figure out how to correctly set warnings for these two status codes