### PR TITLE
kubebuilder-presubmits: pin k8s-testimages/kubekins-e2e to 1.19

### DIFF
--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
     - ^feature/plugins-.+$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.19
         command:
         # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
         - runner.sh
@@ -89,7 +89,7 @@ presubmits:
     - ^feature/plugins-.+$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.19
         command:
         # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
         - runner.sh
@@ -119,7 +119,7 @@ presubmits:
     - ^feature/plugins-.+$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.19
         command:
         # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
         - runner.sh
@@ -149,7 +149,7 @@ presubmits:
     - ^feature/plugins-.+$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.19
         command:
         # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
         - runner.sh
@@ -179,7 +179,7 @@ presubmits:
     - ^feature/plugins-.+$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.19
         command:
         # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
         - runner.sh


### PR DESCRIPTION
This is a follow-up from #21173. Apparently go1.15 is the sweet spot because these jobs build kubebuilder and scaffold projects that use either go1.13 or go1.15. Binary builds should be decoupled from tests, but for now this reversion works.

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>