### PR TITLE
prow: Add ignore-space-change flag to git am

### DIFF
--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -384,7 +384,7 @@ func (r *Repo) MergeAndCheckout(baseSHA string, mergeStrategy prowgithub.PullReq
 // an error if the patch cannot be applied.
 func (r *Repo) Am(path string) error {
 	r.logger.Infof("Applying %s.", path)
-	co := r.gitCommand("am", "--3way", path)
+	co := r.gitCommand("am", "--3way", "--ignore-space-change", path)
 	b, err := co.CombinedOutput()
 	if err == nil {
 		return nil


### PR DESCRIPTION
This commit adds the ignore-space-change flag to git am calls in the git
client. This is being done as certain patches are not able to applied.
This is unexpected behavior as the commits the patches have been created
from are able to be cherry-picked. This behavior may be caused by
carriage returns being present in the contents of the patch.

Signed-off-by: Sebastian Soto <ssoto@redhat.com>