### PR TITLE
Revert "Dump nodes better when instance groups are not used (node-e2e)"

### DIFF
--- a/logexporter/cluster/log-dump.sh
+++ b/logexporter/cluster/log-dump.sh
@@ -179,10 +179,6 @@ function detect-node-names() {
         "${group}" --zone "${ZONE}" --project "${PROJECT}" \
         --format='value(instance)'))
     done
-  else
-      NODE_NAMES+=($(gcloud compute instances list \
-        --project "${PROJECT}" \
-        --format='get(name)'))
   fi
   # Add heapster node name to the list too (if it exists).
   if [[ -n "${HEAPSTER_MACHINE_TYPE:-}" ]]; then


### PR DESCRIPTION
This reverts commit 10e52ae47ff79318cf33e97f8ae7934e85b209a8.

Causes more problems :( https://kubernetes.slack.com/archives/C0BP8PW9G/p1615061536229100

Signed-off-by: Davanum Srinivas <davanum@gmail.com>