### PR TITLE
config: remove master branch references for k/k8s.io

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-infra-tools.yaml
+++ b/config/jobs/image-pushing/k8s-staging-infra-tools.yaml
@@ -8,7 +8,6 @@ postsubmits:
       run_if_changed: "^dns/octodns-docker/"
       branches:
         - ^main$
-        - ^master$
       spec:
         serviceAccountName: gcb-builder
         containers:

--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -11,7 +11,6 @@ presubmits:
     max_concurrency: 10
     branches:
     - ^main$
-    - ^master$
     spec:
       containers:
       - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v2.4.1
@@ -53,7 +52,6 @@ presubmits:
     max_concurrency: 1
     branches:
     - ^main$
-    - ^master$
     spec:
       serviceAccountName: k8s-infra-gcr-promoter-test
       containers:

--- a/config/jobs/kubernetes/wg-k8s-infra/k8sio-presubmit.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/k8sio-presubmit.yaml
@@ -9,7 +9,6 @@ presubmits:
     run_if_changed: "^groups/"
     branches:
     - ^main$
-    - ^master$
     spec:
       containers:
       - image: golang:1.13

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -10,7 +10,6 @@ postsubmits:
     max_concurrency: 1
     branches:
     - ^main$
-    - ^master$
     spec:
       serviceAccountName: k8s-infra-gcr-promoter
       containers:

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
@@ -104,7 +104,6 @@ postsubmits:
     run_if_changed: '^groups/groups.yaml'
     branches:
     - ^main$
-    - ^master$
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: wg-k8s-infra-k8sio
@@ -127,7 +126,6 @@ postsubmits:
     run_if_changed: "^dns/zone-configs/"
     branches:
     - ^main$
-    - ^master$
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: wg-k8s-infra-k8sio
@@ -149,7 +147,6 @@ postsubmits:
     run_if_changed: "^infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/"
     branches:
     - ^main$
-    - ^master$
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: wg-k8s-infra-k8sio
@@ -174,7 +171,6 @@ postsubmits:
     run_if_changed: "^infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/"
     branches:
     - ^main$
-    - ^master$
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: wg-k8s-infra-k8sio

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -339,7 +339,6 @@ milestone_applier:
     master: v1.21
   kubernetes/k8s.io:
     main: v1.21
-    master: v1.21
   kubernetes/kops:
     master: v1.21
     release-1.20: v1.20


### PR DESCRIPTION
Ref: https://github.com/kubernetes/k8s.io/issues/1597
Follow up to https://github.com/kubernetes/test-infra/pull/20675

The repo has been migrated to use the `main` branch as default.

/assign @spiffxp 
cc @mrbobbytables 
