### PR TITLE
wg-k8s-infra: add pull-k8s.io-verify job

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/k8sio-presubmit.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/k8sio-presubmit.yaml
@@ -20,17 +20,16 @@ presubmits:
         env:
         - name: GO111MODULE
           value: "on"
-  - name: pull-k8sio-yamllint
+  - name: pull-k8sio-verify
     annotations:
       testgrid-dashboards: wg-k8s-infra-k8sio
-      testgrid-tab-name: pull-k8sio-yamllint
+      testgrid-tab-name: pull-k8sio-verify
     always_run: true
     decorate: true
     spec:
       containers:
-      - image: quay.io/kubermatic/yamllint:0.1
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-master
         command:
-        - yamllint
-        - -c
-        - hack/.yamllint.conf
-        - .
+        - runner.sh
+        args:
+        - ./hack/verify.sh


### PR DESCRIPTION
For https://github.com/kubernetes/k8s.io/pull/1765

/hold
this should not merge until https://github.com/kubernetes/k8s.io/pull/1765 has merged

/assign @spiffxp 