### PR TITLE
releng: Add verify and test presubmits for sigs.k8s.io/release-utils

### DIFF
--- a/config/jobs/kubernetes-sigs/release-utils/OWNERS
+++ b/config/jobs/kubernetes-sigs/release-utils/OWNERS
@@ -1,0 +1,11 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- release-engineering-approvers
+
+reviewers:
+- release-engineering-reviewers
+
+labels:
+- sig/release
+- area/release-eng

--- a/config/jobs/kubernetes-sigs/release-utils/release-utils-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/release-utils/release-utils-presubmits.yaml
@@ -1,0 +1,38 @@
+presubmits:
+  kubernetes-sigs/release-utils:
+  - name: pull-release-utils-test
+    always_run: true
+    decorate: true
+    path_alias: "sigs.k8s.io/release-utils"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest
+        command:
+        - go
+        args:
+        - run
+        - mage.go
+        - Test
+    annotations:
+      testgrid-dashboards: sig-release-releng-presubmits
+      testgrid-tab-name: release-utils-test
+      testgrid-alert-email: release-managers+alerts@kubernetes.io
+      testgrid-num-columns-recent: '30'
+  - name: pull-release-utils-verify
+    always_run: true
+    decorate: true
+    path_alias: "sigs.k8s.io/release-utils"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest
+        command:
+        - go
+        args:
+        - run
+        - mage.go
+        - Verify
+    annotations:
+      testgrid-dashboards: sig-release-releng-presubmits
+      testgrid-tab-name: release-utils-verify
+      testgrid-alert-email: release-managers+alerts@kubernetes.io
+      testgrid-num-columns-recent: '30'


### PR DESCRIPTION
Required to test https://github.com/kubernetes-sigs/release-utils/pull/5.
Continuation of https://github.com/kubernetes/org/issues/2539.

/assign @BenTheElder @hasheddan @jeremyrickard 
cc: @kubernetes/release-engineering 

Signed-off-by: Stephen Augustus <foo@auggie.dev>