### PR TITLE
Fix ci-containerd-build-1-3 and ci-containerd-build-1-2 to work with go 1.16

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -71,6 +71,7 @@ periodics:
       - --upload=gs://kubernetes-jenkins/logs
       - --scenario=execute
       - --
+      - --env=GO111MODULE=off
       - --env=DEPLOY_DIR=containerd/release-1.2
       - /go/src/github.com/containerd/cri/test/containerd/build.sh
   annotations:
@@ -91,6 +92,7 @@ periodics:
       - --upload=gs://kubernetes-jenkins/logs
       - --scenario=execute
       - --
+      - --env=GO111MODULE=off
       - --env=DEPLOY_DIR=containerd/release-1.3
       - /go/src/github.com/containerd/cri/test/containerd/build.sh
   annotations:


### PR DESCRIPTION
See failures in:

https://testgrid.k8s.io/sig-node-containerd#containerd-build-1.2
and https://testgrid.k8s.io/sig-node-containerd#containerd-build-1.3

show issues because go modules are switched on by default now as the
kubekins image is now at 1.16, so let's switch it off

Signed-off-by: Davanum Srinivas <davanum@gmail.com>