### PR TITLE
disable pull-kubernetes-e2e-azure-file-windows-containerd test

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
@@ -443,7 +443,6 @@ presubmits:
       timeout: 2h
     always_run: false
     optional: true
-    run_if_changed: 'azure.*\.go$|.*windows\.go$'
     path_alias: k8s.io/kubernetes
     branches:
     - master


### PR DESCRIPTION
test `pull-kubernetes-e2e-azure-file-windows-containerd` is not stable, disable it now:

https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/99825/pull-kubernetes-e2e-azure-file-windows-containerd/1368758016064622592/build-log.txt
