### PR TITLE
Separate containerd master CI and presubmit configurations

### DIFF
--- a/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
@@ -70,4 +70,4 @@ presubmits:
           --provider=gce
           '--test_args=--nodes=8 --focus="\[NodeConformance\]|\[NodeFeature:.+\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"'
           --timeout=65m
-          "--node-args=--image-config-file=${GOPATH}/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-master/image-config-pr.yaml -node-env=PULL_REFS=$(PULL_REFS)"
+          "--node-args=--image-config-file=${GOPATH}/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-master-presubmit/image-config-presubmit.yaml -node-env=PULL_REFS=$(PULL_REFS)"

--- a/jobs/e2e_node/containerd/containerd-master-presubmit/env
+++ b/jobs/e2e_node/containerd/containerd-master-presubmit/env
@@ -1,6 +1,6 @@
 CONTAINERD_TEST: 'true'
 CONTAINERD_LOG_LEVEL: 'debug'
-CONTAINERD_DEPLOY_PATH: 'cri-containerd-staging/containerd/master'
+CONTAINERD_DEPLOY_PATH: 'cri-containerd-staging'
 CONTAINERD_PKG_PREFIX: 'containerd-cni'
 
 CONTAINERD_EXTRA_RUNTIME_HANDLER: 'test-handler'

--- a/jobs/e2e_node/containerd/containerd-master-presubmit/image-config-presubmit.yaml
+++ b/jobs/e2e_node/containerd/containerd-master-presubmit/image-config-presubmit.yaml
@@ -1,0 +1,5 @@
+images:
+  cos-stable:
+    image_family: cos-85-lts
+    project: cos-cloud
+    metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-master-presubmit/env,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/containerd/containerd-master/image-config-pr.yaml
+++ b/jobs/e2e_node/containerd/containerd-master/image-config-pr.yaml
@@ -1,5 +1,0 @@
-images:
-  cos-stable:
-    image_family: cos-85-lts
-    project: cos-cloud
-    metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-master/env,gci-update-strategy=update_disabled"


### PR DESCRIPTION
Ensure that the presubmit jobs in containerd do not get messed up!

Signed-off-by: Davanum Srinivas <davanum@gmail.com>