### PR TITLE
Kubernetes v1.21 Code Freeze

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -512,6 +512,30 @@ tide:
     - needs-rebase
   - repos:
     - kubernetes/kubernetes
+    excludedBranches:
+    - master
+    labels:
+    - lgtm
+    - approved
+    - "cncf-cla: yes"
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/blocked-paths
+    - do-not-merge/cherry-pick-not-approved
+    - do-not-merge/contains-merge-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-commit-message
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/needs-kind
+    - do-not-merge/needs-sig
+    - do-not-merge/release-note-label-needed
+    - do-not-merge/work-in-progress
+    - needs-rebase
+  - repos:
+    - kubernetes/kubernetes
+    milestone: v1.21
+    includedBranches:
+    - master
     labels:
     - lgtm
     - approved


### PR DESCRIPTION
This PR adds the 1.21 milestone requirement to `kubernetes/kubernetes:master` to enact code freeze.

/hold
To be merged only after Tuesday, March 9th, 2021 PST EOD.

/sig release
/area release-eng

cc: @kubernetes/release-team-leads @kubernetes/release-engineering

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>