### PR TITLE
Drop containerd 1.2 related CI jobs

### DIFF
--- a/config/jobs/containerd/cri/containerd-cri-presubmit-jobs.yaml
+++ b/config/jobs/containerd/cri/containerd-cri-presubmit-jobs.yaml
@@ -65,25 +65,6 @@ presubmits:
   - name: pull-cri-containerd-verify
     always_run: true
     branches:
-    - release/1.0
-    - release/1.2
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      # Use go 1.10 for old branches, because gofmt result changed in go 1.11.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190812-5a136da-1.12
-        args:
-        - "--repo=github.com/containerd/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - --scenario=execute
-        - --
-        - ./test/verify.sh
-
-  - name: pull-cri-containerd-verify
-    always_run: true
-    branches:
     - master
     - release/1.3
     labels:

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -58,27 +58,6 @@ periodics:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-build
     description: "builds development in progress branch of upstream containerd"
-- name: ci-containerd-build-1-2
-  interval: 30m
-  labels:
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-master
-      args:
-      - --repo=github.com/containerd/containerd=release/1.2
-      - --repo=github.com/containerd/cri=release/1.2
-      - --root=/go/src
-      - --upload=gs://kubernetes-jenkins/logs
-      - --scenario=execute
-      - --
-      - --env=GO111MODULE=off
-      - --env=DEPLOY_DIR=containerd/release-1.2
-      - /go/src/github.com/containerd/cri/test/containerd/build.sh
-  annotations:
-    testgrid-dashboards: sig-node-containerd
-    testgrid-tab-name: containerd-build-1.2
-    description: "builds release/1.2 branch of upstream containerd as it is distributed with docker"
 - name: ci-containerd-build-1-3
   interval: 30m
   labels:
@@ -130,36 +109,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd, sig-node-cos
     testgrid-tab-name: containerd-e2e-cos
-- interval: 1h
-  name: ci-containerd-e2e-cos-gce-1-2
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-    preset-e2e-containerd: "true"
-    preset-e2e-containerd-image-load: "true"
-  spec:
-    containers:
-    - args:
-      - --repo=github.com/containerd/cri=release/1.2
-      - --timeout=70
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.2/env
-      - --env=KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.2/env
-      - --env=ENABLE_POD_SECURITY_POLICY=true
-      - --extract=ci/latest-1.15
-      - --gcp-node-image=gci
-      - --gcp-nodes=4
-      - --gcp-zone=us-west1-b
-      - --ginkgo-parallel=30
-      - --provider=gce
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
-      - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.15
-  annotations:
-    testgrid-dashboards: sig-node-containerd, sig-node-cos
-    testgrid-tab-name: containerd-e2e-cos-1.2
 - interval: 1h
   name: ci-containerd-e2e-cos-gce-1-3
   labels:
@@ -312,36 +261,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd, sig-node-cri
     testgrid-tab-name: containerd-node-features
-- name: ci-containerd-node-e2e-features-1-2
-  interval: 1h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.15
-      args:
-      - --root=/go/src
-      - --repo=k8s.io/kubernetes=release-1.15
-      - --repo=github.com/containerd/cri=release/1.2
-      - --timeout=90
-      - --scenario=kubernetes_e2e
-      - --
-      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.2/image-config.yaml
-      - --deployment=node
-      - --gcp-project=cri-containerd-node-e2e
-      - --gcp-zone=us-central1-b
-      - '--node-test-args=--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
-      - --node-tests=true
-      - --provider=gce
-      - --test_args=--nodes=8 --focus="\[NodeFeature:.+\]" --skip="\[Flaky\]|\[Serial\]"
-      - --timeout=65m
-      env:
-      - name: GOPATH
-        value: /go
-  annotations:
-    testgrid-dashboards: sig-node-containerd
-    testgrid-tab-name: containerd-node-e2e-features-1.2
 - name: ci-containerd-node-e2e-features-1-3
   interval: 1h
   labels:

--- a/config/testgrids/config.yaml
+++ b/config/testgrids/config.yaml
@@ -41,13 +41,6 @@ test_groups:
     - target_config: Tests name
     - target_config: Context
     name_format: '%s [%s]'
-- name: ci-containerd-node-e2e-features-1-2
-  gcs_prefix: kubernetes-jenkins/logs/ci-containerd-node-e2e-features-1-2
-  test_name_config:
-    name_elements:
-    - target_config: Tests name
-    - target_config: Context
-    name_format: '%s [%s]'
 - name: ci-cos-containerd-node-e2e
   gcs_prefix: kubernetes-jenkins/logs/ci-cos-containerd-node-e2e
   test_name_config:

--- a/jobs/e2e_node/containerd/containerd-release-1.2/env
+++ b/jobs/e2e_node/containerd/containerd-release-1.2/env
@@ -1,4 +1,0 @@
-CONTAINERD_TEST: 'true'
-CONTAINERD_LOG_LEVEL: 'debug'
-CONTAINERD_DEPLOY_PATH: 'cri-containerd-staging/containerd/release-1.2'
-CONTAINERD_PKG_PREFIX: 'containerd-cni'

--- a/jobs/e2e_node/containerd/containerd-release-1.2/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-release-1.2/image-config.yaml
@@ -1,9 +1,0 @@
-images:
-  ubuntu:
-    image: ubuntu-gke-1804-1-16-v20200330
-    project: ubuntu-os-gke-cloud
-    metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.2/env"
-  cos-stable:
-    image_family: cos-81-lts
-    project: cos-cloud
-    metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.2/env,gci-update-strategy=update_disabled"


### PR DESCRIPTION
Containerd 1.2.x was EOL'ed on Oct 15, 2020:
https://github.com/containerd/containerd/blob/master/RELEASES.md

Signed-off-by: Davanum Srinivas <davanum@gmail.com>