### PR TITLE
kubernetes-sigs/nfd-operator: update golang-based test images to v1.15

### DIFF
--- a/config/jobs/kubernetes-sigs/node-feature-discovery-operator/node-feature-discovery-operator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery-operator/node-feature-discovery-operator-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       description: "Verify source code of node-feature-discovery-operator: check formatting, lint etc."
     spec:
       containers:
-      - image: golang:1.14
+      - image: golang:1.15
         command:
         - scripts/test-infra/verify.sh
   - name: pull-node-feature-discovery-operator-build-image


### PR DESCRIPTION
Sync with node-feature-discovery-operator repo.

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>