### PR TITLE
Document docker/containerd versions & update ubuntu image for containerd-master

### DIFF
--- a/jobs/e2e_node/containerd/containerd-master/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-master/image-config.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image: ubuntu-gke-1804-1-16-v20200330
+    image: ubuntu-gke-1804-1-17-v20200729 # docker 19.03.2 / containerd 1.2.10
     project: ubuntu-os-gke-cloud
     metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-master/env"
   cos-stable:

--- a/jobs/e2e_node/containerd/containerd-release-1.3/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-release-1.3/image-config.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image: ubuntu-gke-1804-1-16-v20200330
+    image: ubuntu-gke-1804-1-16-v20200330 # docker 17.03
     project: ubuntu-os-gke-cloud
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.3/env"
   cos-stable:

--- a/jobs/e2e_node/containerd/cri-master/benchmark-config.yaml
+++ b/jobs/e2e_node/containerd/cri-master/benchmark-config.yaml
@@ -161,21 +161,21 @@ images:
 
 # ubuntu gke image pre-configured to run kubernetes
   ubuntu-gke-1804-resource1:
-    Image: ubuntu-gke-1804-1-17-v20200729
+    image: ubuntu-gke-1804-1-17-v20200729 # docker 19.03.2 / containerd 1.2.10
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env"
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   ubuntu-gke-1804-resource2:
-    image: ubuntu-gke-1804-1-17-v20200729
+    image: ubuntu-gke-1804-1-17-v20200729 # docker 19.03.2 / containerd 1.2.10
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env"
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   ubuntu-gke-1804-resource3:
-    image: ubuntu-gke-1804-1-17-v20200729
+    image: ubuntu-gke-1804-1-17-v20200729 # docker 19.03.2 / containerd 1.2.10
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env"

--- a/jobs/e2e_node/containerd/cri-master/image-config-pr.yaml
+++ b/jobs/e2e_node/containerd/cri-master/image-config-pr.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image: ubuntu-gke-1804-1-16-v20200330
+    image: ubuntu-gke-1804-1-16-v20200330 # docker 17.03
     project: ubuntu-os-gke-cloud
     metadata: "user-data</home/prow/go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cri-master/env"
   cos-stable:

--- a/jobs/e2e_node/containerd/cri-master/image-config.yaml
+++ b/jobs/e2e_node/containerd/cri-master/image-config.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image: ubuntu-gke-1804-1-16-v20200330
+    image: ubuntu-gke-1804-1-16-v20200330 # docker 17.03
     project: ubuntu-os-gke-cloud
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env"
   cos-stable:

--- a/jobs/e2e_node/image-config.yaml
+++ b/jobs/e2e_node/image-config.yaml
@@ -3,7 +3,7 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu:
-    image: ubuntu-gke-1804-1-16-v20200330
+    image: ubuntu-gke-1804-1-16-v20200330 # docker 17.03
     project: ubuntu-os-gke-cloud
   cos-stable1:
     image_family: cos-85-lts


### PR DESCRIPTION
Use the same newer ubuntu image (in containerd-master) that is being used in benchmark CI jobs already.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>