### PR TITLE
readme/architecture: fix readme to reflect diagram architecture update.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 This repository contains tools and configuration files for the testing and
 automation needs of the Kubernetes project.
 
-Our [architecture diagram](docs/architecture.svg) provides a (wildly out of date [#13063])
+Our [architecture diagram](docs/architecture.svg) provides an (updated [#13063])
 overview of how the different tools and services interact.
 
 ## CI Job Management


### PR DESCRIPTION
This corrects the statement that the arch diagram is out of date since
it was updated in https://github.com/kubernetes/test-infra/pull/21096.

Signed-off-by: Victor Palade <victor@cloudflavor.io>

P.S.: Sorry, I guess today I'm the guy that opens a two word change PR. I'll do better next time, promise! 😄 