### PR TITLE
Fix up ci-containerd-e2e-cos-gce* CI jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -110,13 +110,13 @@ periodics:
   spec:
     containers:
     - args:
-      - --repo=github.com/containerd/cri=master
+      - --repo=github.com/containerd/containerd=master
       - --timeout=70
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
-      - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-master/env
-      - --env=KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-master/env
+      - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-master/env
+      - --env=KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/containerd/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-master/env
       - --env=ENABLE_POD_SECURITY_POLICY=true
       - --extract=ci/latest
       - --gcp-node-image=gci
@@ -148,7 +148,7 @@ periodics:
       - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.3/env
       - --env=KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.3/env
       - --env=ENABLE_POD_SECURITY_POLICY=true
-      - --extract=ci/latest-1.16
+      - --extract=ci/latest-1.20
       - --gcp-node-image=gci
       - --gcp-nodes=4
       - --gcp-zone=us-west1-b
@@ -160,6 +160,36 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd, sig-node-cos
     testgrid-tab-name: containerd-e2e-cos-1.3
+- interval: 1h
+  name: ci-containerd-e2e-cos-gce-1-4
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-e2e-containerd: "true"
+    preset-e2e-containerd-image-load: "true"
+  spec:
+    containers:
+      - args:
+          - --repo=github.com/containerd/cri=release/1.4
+          - --timeout=70
+          - --scenario=kubernetes_e2e
+          - --
+          - --check-leaked-resources
+          - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.4/env
+          - --env=KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.4/env
+          - --env=ENABLE_POD_SECURITY_POLICY=true
+          - --extract=ci/latest-1.20
+          - --gcp-node-image=gci
+          - --gcp-nodes=4
+          - --gcp-zone=us-west1-b
+          - --ginkgo-parallel=30
+          - --provider=gce
+          - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
+          - --timeout=50m
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201031-122dc79-1.16
+  annotations:
+    testgrid-dashboards: sig-node-containerd, sig-node-cos
+    testgrid-tab-name: containerd-e2e-cos-1.4
 
 - interval: 1h
   name: ci-containerd-e2e-ubuntu-gce

--- a/jobs/e2e_node/containerd/containerd-release-1.4/env
+++ b/jobs/e2e_node/containerd/containerd-release-1.4/env
@@ -1,0 +1,8 @@
+CONTAINERD_TEST: 'true'
+CONTAINERD_LOG_LEVEL: 'debug'
+CONTAINERD_DEPLOY_PATH: 'cri-containerd-staging/containerd/release-1.4'
+CONTAINERD_PKG_PREFIX: 'containerd-cni'
+
+CONTAINERD_EXTRA_RUNTIME_HANDLER: 'test-handler'
+CONTAINERD_EXTRA_RUNTIME_OPTIONS: |
+  BinaryName = "/home/containerd/usr/local/sbin/runc"

--- a/jobs/e2e_node/containerd/containerd-release-1.4/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-release-1.4/image-config.yaml
@@ -1,0 +1,9 @@
+images:
+  ubuntu:
+    image: ubuntu-gke-1804-1-17-v20200729 # docker 19.03.2 / containerd 1.2.10
+    project: ubuntu-os-gke-cloud
+    metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.4/env"
+  cos-stable:
+    image_family: cos-85-lts
+    project: cos-cloud
+    metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.4/env,gci-update-strategy=update_disabled"


### PR DESCRIPTION
- ci-containerd-e2e-cos-gce should run against containerd master which
  is now basically containerd 1.5
- ci-containerd-e2e-cos-gce-1-3 should use k8s 1.20 (not 1.16)
- add a new ci-containerd-e2e-cos-gce-1-4 to cover containerd 1.4

Signed-off-by: Davanum Srinivas <davanum@gmail.com>