### PR TITLE
Add links lens to render new master-and-node-logs.txt file

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -81,6 +81,10 @@ deck:
         name: podinfo
       required_files:
         - ^podinfo\.json$
+    - lens:
+        name: links
+      required_files:
+        - artifacts/.*\.link\.txt
   tide_update_period: 1s
   hidden_repos:
   - kubernetes-security


### PR DESCRIPTION
Enable the great work of @mborsz done in https://github.com/kubernetes/test-infra/pull/20869 and https://github.com/kubernetes/test-infra/pull/20897 for `k8s-prow` cluster.

/assign @mborsz
/assign @cjwagner