### PR TITLE
Skipping SCTPConnectivity tests on e2e-cos-alpha-features tab

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -501,7 +501,7 @@ periodics:
       - --gcp-zone=us-west1-b
       - --provider=gce
       - --runtime-config=api/all=true
-      - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandPersistentVolumes|VolumeSubpathEnvExpansion|RunAsGroup|NodeLease)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
+      - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandPersistentVolumes|VolumeSubpathEnvExpansion|RunAsGroup|NodeLease)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:(Volumes|SCTPConnectivity) --minStartupPods=8
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-master
   annotations:


### PR DESCRIPTION
There's a clean up of SCTP tests in progress (the cleanup tracking issue is: kubernetes/kubernetes#96717)

The [e2e-cos-alpha-features](https://testgrid.k8s.io/sig-node-containerd#e2e-cos-alpha-features) tab has only SCTP ones flaking, this PR skip these tests (they are under work and marked as disruptive).

It hits the same case as https://github.com/kubernetes/test-infra/pull/20558.