### PR TITLE
Revert "Upgrade prometheus operator to 0.45.0"

### DIFF
--- a/config/prow/cluster/monitoring/prometheus_operator_deployment.yaml
+++ b/config/prow/cluster/monitoring/prometheus_operator_deployment.yaml
@@ -18,11 +18,12 @@ spec:
     spec:
       containers:
       - args:
-        - --log-level=all
         - --kubelet-service=kube-system/kubelet
-        - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.45.0
+        - --logtostderr=true
+        - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
+        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.29.0
         - --namespaces=prow-monitoring
-        image: quay.io/prometheus-operator/prometheus-operator:v0.45.0
+        image: quay.io/coreos/prometheus-operator:v0.29.0
         name: prometheus-operator
         ports:
         - containerPort: 8080

--- a/config/prow/cluster/monitoring/prometheus_operator_rbac.yaml
+++ b/config/prow/cluster/monitoring/prometheus_operator_rbac.yaml
@@ -18,19 +18,20 @@ metadata:
   name: prow-prometheus-operator
 rules:
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - alertmanagers
   - alertmanagers/finalizers
-  - alertmanagerconfigs
   - prometheuses
   - prometheuses/finalizers
-  - thanosrulers
-  - thanosrulers/finalizers
-  - servicemonitors
-  - podmonitors
-  - probes
   - prometheusrules
+  - servicemonitors
   verbs:
   - '*'
 - apiGroups:
@@ -51,17 +52,18 @@ rules:
   resources:
   - pods
   verbs:
-  - list
   - delete
+  - list
 - apiGroups:
   - ""
+  attributeRestrictions: null
   resources:
+  - endpoints
   - services
   - services/finalizers
-  - endpoints
   verbs:
-  - get
   - create
+  - get
   - update
   - delete
 - apiGroups:
@@ -75,14 +77,6 @@ rules:
   - ""
   resources:
   - namespaces
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
   verbs:
   - get
   - list

--- a/config/prow/cluster/monitoring/prow_alertmanager.yaml
+++ b/config/prow/cluster/monitoring/prow_alertmanager.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: prow-monitoring
 spec:
   replicas: 3
-  image: docker.io/prom/alertmanager
+  baseImage: docker.io/prom/alertmanager
   listenLocal: false
   nodeSelector: {}
   securityContext:

--- a/config/prow/cluster/monitoring/prow_prometheus.yaml
+++ b/config/prow/cluster/monitoring/prow_prometheus.yaml
@@ -33,7 +33,7 @@ spec:
     - key: app
       operator: Exists
   version: v2.7.1
-  image: docker.io/prom/prometheus
+  baseImage: docker.io/prom/prometheus
   externalLabels: {}
   listenLocal: false
   nodeSelector: {}


### PR DESCRIPTION
Revert "Prometheus operator: replace deprected flag logtostderr with log-level"

This reverts commit 2c3c8aa5dc35946df30b450465a0b956e42f3809.

Revert "Upgrade prometheus operator to 0.45.0"

This reverts commit 515d7401fb5224c95f14680634108571f027a67a.