### PR TITLE
Add DO SSH Keys for e2e job

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presets-do.yaml
+++ b/config/jobs/kubernetes/kops/kops-presets-do.yaml
@@ -13,3 +13,17 @@ presets:
       secretKeyRef:
         name: spaces-digitalocean-s3
         key: secret-key
+- labels:
+    preset-do-ssh: "true"
+  env:
+  - name: DO_SSH_PUBLIC_KEY_FILE
+    value: /etc/do-ssh/public-ssh-key
+  volumes:
+  - name: do-ssh
+    secret:
+      defaultMode: 0400
+      secretName: kops-e2e-do-ssh-key
+  volumeMounts:
+  - name: do-ssh
+    mountPath: /etc/do-ssh
+    readOnly: true

--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -145,7 +145,7 @@ presubmits:
       preset-service-account: "true"
       preset-do-credential: "true"
       preset-do-spaces-credential: "true"
-      preset-aws-ssh: "true"
+      preset-do-ssh: "true"
       preset-bazel-scratch-dir: "true"
       preset-bazel-remote-cache-enabled: "true"
       preset-dind-enabled: "true"


### PR DESCRIPTION
@rifelpet - We got the secret added for ssh keys for DO, this should help fixing the SSH errors when creating the droplet.
Once this gets merged, I'll continue to test from KOPS side for any further issues.

Please let me know in case you have any questions, Thanks !

FYI - @timoreimann 