### PR TITLE
Use go-canary image for Go 1.16

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
@@ -15,7 +15,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.19
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-go-canary
         command:
         - "runner.sh"
         - "./scripts/ci-conformance.sh"
@@ -47,7 +47,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.19
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-go-canary
         command:
         - "runner.sh"
         - "./scripts/ci-conformance.sh"
@@ -83,7 +83,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.19
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-go-canary
       command:
       - "runner.sh"
       - "./scripts/ci-e2e.sh"
@@ -114,7 +114,7 @@ periodics:
       path_alias: k8s.io/test-infra
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.19
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-go-canary
       command:
       - runner.sh
       - bash
@@ -151,7 +151,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.19
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-go-canary
       command:
       - "runner.sh"
       - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-postsubmits.yaml
@@ -14,7 +14,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.19
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-go-canary
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.19
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-go-canary
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -27,7 +27,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.19
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-go-canary
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -51,7 +51,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.19
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-go-canary
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -85,7 +85,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.19
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-go-canary
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -120,7 +120,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.19
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-go-canary
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -156,7 +156,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.19
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-go-canary
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -182,7 +182,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.19
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-go-canary
         command:
         - "runner.sh"
         - "make"
@@ -208,7 +208,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.19
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-go-canary
         command:
         - "runner.sh"
         - "./scripts/ci-conformance.sh"
@@ -240,7 +240,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.19
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-go-canary
           command:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"
@@ -271,7 +271,7 @@ presubmits:
       - command:
         - runner.sh
         - ./scripts/ci-apidiff.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-go-canary
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-apidiff-main
@@ -290,7 +290,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.19
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-go-canary
         command:
         - runner.sh
         - bash


### PR DESCRIPTION
Update test images used by cluster-api-provider-azure to use go 1.16