### PR TITLE
Add credentials to access e2eprivate in GCE Windows tests (2004 and 20H2).

### DIFF
--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -157,6 +157,7 @@ periodics:
     preset-common-gce-windows: "true"
     preset-e2e-gce-windows: "true"
     preset-windows-repo-list-master: "true"
+    preset-windows-private-registry-cred: "true"
   spec:
     containers:
     - command:
@@ -175,6 +176,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:.+\] --minStartupPods=8
       - --test-cmd-args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:.+\] --minStartupPods=8
       - --test-cmd-args=--node-os-distro=windows
+      - --test-cmd-args=--docker-config-file=$(DOCKER_CONFIG_FILE)
       - --timeout=180m
       env:
       - name: WINDOWS_NODE_OS_DISTRIBUTION
@@ -203,6 +205,7 @@ periodics:
     preset-common-gce-windows: "true"
     preset-e2e-gce-windows: "true"
     preset-windows-repo-list-2004: "true"
+    preset-windows-private-registry-cred: "true"
   spec:
     containers:
     - command:
@@ -221,6 +224,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:.+\] --minStartupPods=8
       - --test-cmd-args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:.+\] --minStartupPods=8
       - --test-cmd-args=--node-os-distro=windows
+      - --test-cmd-args=--docker-config-file=$(DOCKER_CONFIG_FILE)
       - --timeout=180m
       env:
       - name: WINDOWS_NODE_OS_DISTRIBUTION


### PR DESCRIPTION
This changes adds the credentials to access the e2eprivate repository for the GCE Windows tests.
This will add the creds specifically for [gce-windows-2004-master](https://testgrid.k8s.io/sig-release-master-informing#gce-windows-2004-master) and [gce-windows-20h2-master](https://testgrid.k8s.io/sig-release-master-informing#gce-windows-20h2-master).

This will fix the `Kubernetes e2e suite.[sig-node] Container Runtime blackbox test when running a container with a new image should be able to pull from private registry with secret [NodeConformance]` test.