### PR TITLE
periodic job to catch unit test flakes

### DIFF
--- a/config/jobs/kubernetes/sig-testing/make-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/make-test.yaml
@@ -120,3 +120,24 @@ periodics:
               time tar -xzf cache.tar.gz -C _output/local/go
               # Run tests as usual
               time make test KUBE_TIMEOUT=--timeout=600s
+  - interval: 6h
+    name: ci-kubernetes-generate-make-test-count10
+    annotations:
+      testgrid-dashboards: sig-testing-canaries
+    decorate: true
+    extra_refs:
+      - org: kubernetes
+        repo: kubernetes
+        base_ref: master
+        path_alias: k8s.io/kubernetes
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-master
+          command:
+            - runner.sh
+            - bash
+            - -c
+          args:
+            - 'make test KUBE_RACE=-race KUBE_TIMEOUT=--timeout=300s GOFLAGS=-count=10'


### PR DESCRIPTION
We can run the unit tests 10 times in a row to catch flakes, this is impossible to do in a presubmit, but doing it periodically we can correlate presubmit flakes with this job results and identify flakes sooner