### PR TITLE
[sig-node-containerd] use newer ubuntu images

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -157,8 +157,8 @@ periodics:
       - --gcp-node-image=ubuntu
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=30
-      - --image-family=ubuntu-gke-1804-1-17-v20200729 # docker 19.03.2 / containerd 1.2.10
-      - --image-project=ubuntu-os-gke-cloud
+      - --image-family=ubuntu-2004-lts
+      - --image-project=ubuntu-os-cloud
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
@@ -638,8 +638,8 @@ periodics:
       - --gcp-node-image=ubuntu
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=30
-      - --image-family=ubuntu-gke-1804-1-17-v20200729 # docker 19.03.2 / containerd 1.2.10
-      - --image-project=ubuntu-os-gke-cloud
+      - --image-family=ubuntu-2004-lts
+      - --image-project=ubuntu-os-cloud
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m


### PR DESCRIPTION
I had wrongly used a specific image name instead of a image family.
while fixing that, realized that we should just update to latest ubuntu
images used else where as well
https://cs.k8s.io/?q=ubuntu-2004-lts&i=nope&files=&excludeFiles=&repos=

tested this using:
```
gcloud compute images describe-from-family ubuntu-2004-lts --project ubuntu-os-cloud
```

Signed-off-by: Davanum Srinivas <davanum@gmail.com>