### PR TITLE
Fix typo in the scalability 100 nodes CI job

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -144,7 +144,7 @@ periodics:
   - org: kubernetes
     repo: perf-tests
     base_ref: master
-    path_alias: k8s.io/perf-test
+    path_alias: k8s.io/perf-tests
   annotations:
     fork-per-release: "true"
     fork-per-release-cron: 0 */6 * * *, 0 0/12 * * *, 0 4-16/12 * * *, 0 8-20/12 * * *


### PR DESCRIPTION
Apparently, proper execution of `ctrl+c ctrl+v` was too hard for me...

/sig scalability
/assign @mborsz 