### PR TITLE
Revert "Prometheus operator: update to 0.45"

### DIFF
--- a/config/prow/cluster/monitoring/BUILD.bazel
+++ b/config/prow/cluster/monitoring/BUILD.bazel
@@ -27,10 +27,31 @@ release(
 load("@io_bazel_rules_k8s//k8s:object.bzl", "k8s_object")
 
 k8s_object(
-    name = "prometheus_crd_bundle",
+    name = "alertmanager_crd",
     cluster = "{STABLE_PROW_CLUSTER}",
     kind = None,
-    template = "@com_github_prometheus_operator//:bundle.yaml",
+    template = "@com_github_operator_framework_community_operators//:upstream-community-operators/prometheus/alertmanager.crd.yaml",
+)
+
+k8s_object(
+    name = "prometheus_crd",
+    cluster = "{STABLE_PROW_CLUSTER}",
+    kind = None,
+    template = "@com_github_operator_framework_community_operators//:upstream-community-operators/prometheus/prometheus.crd.yaml",
+)
+
+k8s_object(
+    name = "prometheusrule_crd",
+    cluster = "{STABLE_PROW_CLUSTER}",
+    kind = None,
+    template = "@com_github_operator_framework_community_operators//:upstream-community-operators/prometheus/prometheusrule.crd.yaml",
+)
+
+k8s_object(
+    name = "servicemonitor_crd",
+    cluster = "{STABLE_PROW_CLUSTER}",
+    kind = None,
+    template = "@com_github_operator_framework_community_operators//:upstream-community-operators/prometheus/servicemonitor.crd.yaml",
 )
 
 k8s_object(
@@ -45,7 +66,10 @@ load("@io_bazel_rules_k8s//k8s:objects.bzl", "k8s_objects")
 k8s_objects(
     name = "prow_monitoring_objects",
     objects = [
-        ":prometheus_crd_bundle",
+        ":alertmanager_crd",
+        ":prometheus_crd",
+        ":prometheusrule_crd",
+        ":servicemonitor_crd",
         "//config/prow/cluster/monitoring/mixins/prometheus_out:prow_prometheusrule",
         "//config/prow/cluster/monitoring/mixins/dashboards_out:grafana-dashboard-boskos",
         "//config/prow/cluster/monitoring/mixins/dashboards_out:grafana-dashboard-boskos-http",

--- a/config/prow/cluster/monitoring/prometheus_operator_deployment.yaml
+++ b/config/prow/cluster/monitoring/prometheus_operator_deployment.yaml
@@ -18,11 +18,12 @@ spec:
     spec:
       containers:
       - args:
-        - --log-level=all
         - --kubelet-service=kube-system/kubelet
-        - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.45.0
+        - --logtostderr=true
+        - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
+        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.29.0
         - --namespaces=prow-monitoring
-        image: quay.io/prometheus-operator/prometheus-operator:v0.45.0
+        image: quay.io/coreos/prometheus-operator:v0.29.0
         name: prometheus-operator
         ports:
         - containerPort: 8080

--- a/config/prow/cluster/monitoring/prometheus_operator_rbac.yaml
+++ b/config/prow/cluster/monitoring/prometheus_operator_rbac.yaml
@@ -28,15 +28,10 @@ rules:
   resources:
   - alertmanagers
   - alertmanagers/finalizers
-  - alertmanagerconfigs
   - prometheuses
   - prometheuses/finalizers
-  - thanosrulers
-  - thanosrulers/finalizers
-  - servicemonitors
-  - podmonitors
-  - probes
   - prometheusrules
+  - servicemonitors
   verbs:
   - '*'
 - apiGroups:
@@ -57,17 +52,18 @@ rules:
   resources:
   - pods
   verbs:
-  - list
   - delete
+  - list
 - apiGroups:
   - ""
+  attributeRestrictions: null
   resources:
+  - endpoints
   - services
   - services/finalizers
-  - endpoints
   verbs:
-  - get
   - create
+  - get
   - update
   - delete
 - apiGroups:
@@ -81,14 +77,6 @@ rules:
   - ""
   resources:
   - namespaces
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
   verbs:
   - get
   - list

--- a/config/prow/cluster/monitoring/prow_alertmanager.yaml
+++ b/config/prow/cluster/monitoring/prow_alertmanager.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: prow-monitoring
 spec:
   replicas: 3
-  image: docker.io/prom/alertmanager
+  baseImage: docker.io/prom/alertmanager
   listenLocal: false
   nodeSelector: {}
   securityContext:

--- a/config/prow/cluster/monitoring/prow_prometheus.yaml
+++ b/config/prow/cluster/monitoring/prow_prometheus.yaml
@@ -33,7 +33,7 @@ spec:
     - key: app
       operator: Exists
   version: v2.7.1
-  image: docker.io/prom/prometheus
+  baseImage: docker.io/prom/prometheus
   externalLabels: {}
   listenLocal: false
   nodeSelector: {}

--- a/load.bzl
+++ b/load.bzl
@@ -66,15 +66,18 @@ def repositories():
     )
 
     new_git_repository(
-        name = "com_github_prometheus_operator",
+        name = "com_github_operator_framework_community_operators",
         build_file_content = """
 exports_files([
-    "bundle.yaml",
+    "upstream-community-operators/prometheus/alertmanager.crd.yaml",
+    "upstream-community-operators/prometheus/prometheus.crd.yaml",
+    "upstream-community-operators/prometheus/prometheusrule.crd.yaml",
+    "upstream-community-operators/prometheus/servicemonitor.crd.yaml",
 ])
 """,
-        commit = "5555f492df250168657b72bb8cb60bec071de71f",  # Latest of release-0.45 branch
-        remote = "https://github.com/prometheus-operator/prometheus-operator.git",
-        shallow_since = "1610438400 +0200",
+        commit = "efda5dc98fd580ab5f1115a50a28825ae4fe6562",
+        remote = "https://github.com/operator-framework/community-operators.git",
+        shallow_since = "1568320223 +0200",
     )
 
     http_archive(


### PR DESCRIPTION
This reverts commit e76291346469b61914973f277b5b5436d7c5e0b6.

Revert "Revert "Revert "Prometheus operator: replace deprected flag logtostderr with log-level"""

This reverts commit f30a9d8ab8c4dd003a50ec29ac8771599a90536f.

The changes failed postsubmit job with partial successful deployment, also failed prometheus, reverting