### PR TITLE
Revert "Revert "Prometheus operator: update to 0.45"

### DIFF
--- a/config/prow/cluster/monitoring/BUILD.bazel
+++ b/config/prow/cluster/monitoring/BUILD.bazel
@@ -27,31 +27,59 @@ release(
 load("@io_bazel_rules_k8s//k8s:object.bzl", "k8s_object")
 
 k8s_object(
-    name = "alertmanager_crd",
+    name = "prometheus_crd_alertmanagerconfigs",
     cluster = "{STABLE_PROW_CLUSTER}",
     kind = None,
-    template = "@com_github_operator_framework_community_operators//:upstream-community-operators/prometheus/alertmanager.crd.yaml",
+    template = "@com_github_prometheus_operator//:example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml",
 )
 
 k8s_object(
-    name = "prometheus_crd",
+    name = "prometheus_crd_alertmanagers",
     cluster = "{STABLE_PROW_CLUSTER}",
     kind = None,
-    template = "@com_github_operator_framework_community_operators//:upstream-community-operators/prometheus/prometheus.crd.yaml",
+    template = "@com_github_prometheus_operator//:example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml",
 )
 
 k8s_object(
-    name = "prometheusrule_crd",
+    name = "prometheus_crd_podmonitors",
     cluster = "{STABLE_PROW_CLUSTER}",
     kind = None,
-    template = "@com_github_operator_framework_community_operators//:upstream-community-operators/prometheus/prometheusrule.crd.yaml",
+    template = "@com_github_prometheus_operator//:example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml",
 )
 
 k8s_object(
-    name = "servicemonitor_crd",
+    name = "prometheus_crd_probes",
     cluster = "{STABLE_PROW_CLUSTER}",
     kind = None,
-    template = "@com_github_operator_framework_community_operators//:upstream-community-operators/prometheus/servicemonitor.crd.yaml",
+    template = "@com_github_prometheus_operator//:example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml",
+)
+
+k8s_object(
+    name = "prometheus_crd_prometheuses",
+    cluster = "{STABLE_PROW_CLUSTER}",
+    kind = None,
+    template = "@com_github_prometheus_operator//:example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml",
+)
+
+k8s_object(
+    name = "prometheus_crd_prometheusrules",
+    cluster = "{STABLE_PROW_CLUSTER}",
+    kind = None,
+    template = "@com_github_prometheus_operator//:example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml",
+)
+
+k8s_object(
+    name = "prometheus_crd_servicemonitors",
+    cluster = "{STABLE_PROW_CLUSTER}",
+    kind = None,
+    template = "@com_github_prometheus_operator//:example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml",
+)
+
+k8s_object(
+    name = "prometheus_crd_bundle",
+    cluster = "{STABLE_PROW_CLUSTER}",
+    kind = None,
+    template = "@com_github_prometheus_operator//:example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml",
 )
 
 k8s_object(
@@ -66,10 +94,13 @@ load("@io_bazel_rules_k8s//k8s:objects.bzl", "k8s_objects")
 k8s_objects(
     name = "prow_monitoring_objects",
     objects = [
-        ":alertmanager_crd",
-        ":prometheus_crd",
-        ":prometheusrule_crd",
-        ":servicemonitor_crd",
+        "prometheus_crd_alertmanagerconfigs",
+        "prometheus_crd_alertmanagers",
+        "prometheus_crd_podmonitors",
+        "prometheus_crd_probes",
+        "prometheus_crd_prometheuses",
+        "prometheus_crd_prometheusrules",
+        "prometheus_crd_servicemonitors",
         "//config/prow/cluster/monitoring/mixins/prometheus_out:prow_prometheusrule",
         "//config/prow/cluster/monitoring/mixins/dashboards_out:grafana-dashboard-boskos",
         "//config/prow/cluster/monitoring/mixins/dashboards_out:grafana-dashboard-boskos-http",

--- a/config/prow/cluster/monitoring/prometheus_operator_deployment.yaml
+++ b/config/prow/cluster/monitoring/prometheus_operator_deployment.yaml
@@ -18,12 +18,11 @@ spec:
     spec:
       containers:
       - args:
+        - --log-level=all
         - --kubelet-service=kube-system/kubelet
-        - --logtostderr=true
-        - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
-        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.29.0
+        - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.45.0
         - --namespaces=prow-monitoring
-        image: quay.io/coreos/prometheus-operator:v0.29.0
+        image: quay.io/prometheus-operator/prometheus-operator:v0.45.0
         name: prometheus-operator
         ports:
         - containerPort: 8080

--- a/config/prow/cluster/monitoring/prometheus_operator_rbac.yaml
+++ b/config/prow/cluster/monitoring/prometheus_operator_rbac.yaml
@@ -18,20 +18,19 @@ metadata:
   name: prow-prometheus-operator
 rules:
 - apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - '*'
-- apiGroups:
   - monitoring.coreos.com
   resources:
   - alertmanagers
   - alertmanagers/finalizers
+  - alertmanagerconfigs
   - prometheuses
   - prometheuses/finalizers
-  - prometheusrules
+  - thanosrulers
+  - thanosrulers/finalizers
   - servicemonitors
+  - podmonitors
+  - probes
+  - prometheusrules
   verbs:
   - '*'
 - apiGroups:
@@ -52,18 +51,17 @@ rules:
   resources:
   - pods
   verbs:
-  - delete
   - list
+  - delete
 - apiGroups:
   - ""
-  attributeRestrictions: null
   resources:
-  - endpoints
   - services
   - services/finalizers
+  - endpoints
   verbs:
-  - create
   - get
+  - create
   - update
   - delete
 - apiGroups:
@@ -77,6 +75,14 @@ rules:
   - ""
   resources:
   - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
   verbs:
   - get
   - list

--- a/config/prow/cluster/monitoring/prow_alertmanager.yaml
+++ b/config/prow/cluster/monitoring/prow_alertmanager.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: prow-monitoring
 spec:
   replicas: 3
-  baseImage: docker.io/prom/alertmanager
+  image: docker.io/prom/alertmanager
   listenLocal: false
   nodeSelector: {}
   securityContext:

--- a/config/prow/cluster/monitoring/prow_prometheus.yaml
+++ b/config/prow/cluster/monitoring/prow_prometheus.yaml
@@ -33,7 +33,7 @@ spec:
     - key: app
       operator: Exists
   version: v2.7.1
-  baseImage: docker.io/prom/prometheus
+  image: docker.io/prom/prometheus
   externalLabels: {}
   listenLocal: false
   nodeSelector: {}

--- a/load.bzl
+++ b/load.bzl
@@ -66,18 +66,22 @@ def repositories():
     )
 
     new_git_repository(
-        name = "com_github_operator_framework_community_operators",
+        name = "com_github_prometheus_operator",
         build_file_content = """
 exports_files([
-    "upstream-community-operators/prometheus/alertmanager.crd.yaml",
-    "upstream-community-operators/prometheus/prometheus.crd.yaml",
-    "upstream-community-operators/prometheus/prometheusrule.crd.yaml",
-    "upstream-community-operators/prometheus/servicemonitor.crd.yaml",
+    "example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml",
+    "example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml",
+    "example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml",
+    "example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml",
+    "example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml",
+    "example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml",
+    "example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml",
+    "example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml",
 ])
 """,
-        commit = "efda5dc98fd580ab5f1115a50a28825ae4fe6562",
-        remote = "https://github.com/operator-framework/community-operators.git",
-        shallow_since = "1568320223 +0200",
+        commit = "5555f492df250168657b72bb8cb60bec071de71f",  # Latest of release-0.45 branch
+        remote = "https://github.com/prometheus-operator/prometheus-operator.git",
+        shallow_since = "1610438400 +0200",
     )
 
     http_archive(


### PR DESCRIPTION
This reverts commit ddc935d8d75c565a9ff13b2f038215b95fd14727. Corresponding to PR https://github.com/kubernetes/test-infra/pull/21290

Improvements on top of previous attmpt:
- Explicitly define each individual CRDs (The previous attempt used `bundle.yaml` from https://github.com/prometheus-operator/prometheus-operator/blob/release-0.45/bundle.yaml, github UI tricked me by not fully displaying the entire file, and there were many stuff that we don't need in the not displayed part).
- Removed unneeded RBAC since operator doesn't create CRDs any more.