### PR TITLE
Prometheus alert: reduce noise by not alerting on expected errors

### DIFF
--- a/config/prow/cluster/monitoring/mixins/prometheus/ghproxy_alerts.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/ghproxy_alerts.libsonnet
@@ -32,8 +32,49 @@
           },
           {
             alert: 'ghproxy-specific-status-code-4xx',
+            // Paths that contains error codes expected by prow(Grabbed from previous prow alerts):
+            //  - "/repos/:owner/:repo/pulls/:pullId/requested_reviewers" 422 (https://github.com/kubernetes/test-infra/blob/e84a6897b7fae65ba295a4c370057e4a216345ef/prow/github/client.go#L2712)
+            //  - "/search/issues" 403 (Permission denied, very likely not prow error)
+            //  - "/repos/:owner/:repo/pulls/:pullId/merge" 405 (https://github.com/kubernetes/test-infra/blob/e84a6897b7fae65ba295a4c370057e4a216345ef/prow/github/client.go#L3472)
+            //  These paths + statuscode combinations are excluded from alerts to reduce noise.
             expr: |||
-              sum(rate(github_request_duration_count{status=~"4..",status!="404",status!="410"}[30m])) by (status,path) / ignoring(status) group_left sum(rate(github_request_duration_count[30m])) by (path) * 100 > 10
+               sum by(status, path) (rate(github_request_duration_count{status!="404",status!="410",status=~"4..",path!="/repos/:owner/:repo/pulls/:pullId/requested_reviewers",path!="/search/issues",path!="/repos/:owner/:repo/pulls/:pullId/merge",path!="/repos/:owner/:repo/statuses/:statusId"}[30m])) / ignoring(status) group_left() sum by(path) (rate(github_request_duration_count[30m])) * 100 > 10
+            |||,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: '{{ $value | humanize }}%% of all requests for {{ $labels.path }} through the GitHub proxy are erroring with code {{ $labels.status }}. Check %s.' % [monitoringLink('/d/%s/github-cache?orgId=1&refresh=1m&fullscreen&panelId=9' % [dashboardID], 'the ghproxy dashboard')],
+            },
+          },
+          {
+            alert: 'ghproxy-specific-status-code-not-422',
+            expr: |||
+               sum by(status, path) (rate(github_request_duration_count{status!="404",status!="410", status!="422", status=~"4..",path="/repos/:owner/:repo/pulls/:pullId/requested_reviewers"}[30m])) / ignoring(status) group_left() sum by(path) (rate(github_request_duration_count[30m])) * 100 > 10
+            |||,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: '{{ $value | humanize }}%% of all requests for {{ $labels.path }} through the GitHub proxy are erroring with code {{ $labels.status }}. Check %s.' % [monitoringLink('/d/%s/github-cache?orgId=1&refresh=1m&fullscreen&panelId=9' % [dashboardID], 'the ghproxy dashboard')],
+            },
+          },
+          {
+            alert: 'ghproxy-specific-status-code-not-403',
+            expr: |||
+               sum by(status, path) (rate(github_request_duration_count{status!="404",status!="410", status!="403", status=~"4..",path="/search/issues"}[30m])) / ignoring(status) group_left() sum by(path) (rate(github_request_duration_count[30m])) * 100 > 10
+            |||,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: '{{ $value | humanize }}%% of all requests for {{ $labels.path }} through the GitHub proxy are erroring with code {{ $labels.status }}. Check %s.' % [monitoringLink('/d/%s/github-cache?orgId=1&refresh=1m&fullscreen&panelId=9' % [dashboardID], 'the ghproxy dashboard')],
+            },
+          },
+          {
+            alert: 'ghproxy-specific-status-code-not-405',
+            expr: |||
+               sum by(status, path) (rate(github_request_duration_count{status!="404",status!="410", status!="405", status=~"4..",path="/repos/:owner/:repo/pulls/:pullId/merge"}[30m])) / ignoring(status) group_left() sum by(path) (rate(github_request_duration_count[30m])) * 100 > 10
             |||,
             labels: {
               severity: 'warning',


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/21192 doesn't seem to be sufficient on reducing the noise level. There were already 2 alerts showed up in 2 hours after the changes went in effect. Also retrospectively queried previous data and revealed that it'll still be spammy with expected errors. Explicitly stop alerting on these errors in this PR.