### PR TITLE
make test timeout is proportional to count

### DIFF
--- a/config/jobs/kubernetes/sig-testing/make-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/make-test.yaml
@@ -173,4 +173,4 @@ periodics:
             - bash
             - -c
           args:
-            - 'make test KUBE_RACE=-race KUBE_TIMEOUT=--timeout=300s GOFLAGS=-count=10'
+            - 'make test KUBE_RACE=-race KUBE_TIMEOUT=--timeout=600s GOFLAGS=-count=10'


### PR DESCRIPTION
We don't want unit test to go beyond a specific threshold, I think that 30 seconds for an unit test is a good and reasonable limit, that is what current parameters does, but it is unfeasible to do it in one shot.
Let's iterate and give now a 1 min per execution margin, once we got there we cut it to the finally 30 seconds per test