### PR TITLE
releng: Update cross image presubmit to push to the correct staging project

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -108,6 +108,8 @@ presubmits:
           env:
             - name: LOG_TO_STDOUT
               value: "y"
+            - name: REGISTRY
+              value: gcr.io/k8s-staging-releng-test
           resources:
             requests:
               cpu: 1000m


### PR DESCRIPTION
as discussed here: https://github.com/kubernetes/k8s.io/issues/1772 we should try to push the image to the project that is running on.
Later I will check about the `--local` flag

/assign @spiffxp @justaugustus 