### PR TITLE
Check --runtime-config before appending on Node tests runner

### DIFF
--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -598,8 +598,11 @@ func nodeTest(nodeArgs []string, testArgs, nodeTestArgs, project, zone, runtimeC
 		fmt.Sprintf("--ssh-key=%s", sshKeyPath),
 		fmt.Sprintf("--ginkgo-flags=%s", testArgs),
 		fmt.Sprintf("--test_args=%s", nodeTestArgs),
-		fmt.Sprintf("--runtime-config=%s", runtimeConfig),
 		fmt.Sprintf("--test-timeout=%s", timeout.String()),
+	}
+
+	if runtimeConfig != "" {
+		runner = append(runner, fmt.Sprintf("--runtime-config=%s", runtimeConfig))
 	}
 
 	runner = append(runner, nodeArgs...)


### PR DESCRIPTION
The flag needs to be backported for older release branches before being forwarded

Fixes https://github.com/kubernetes/kubernetes/issues/100124