### PR TITLE
Prow bump: add an auto label to distinguish it from other bumps

### DIFF
--- a/config/prow/autobump-config/prow-component-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-component-autobump-config.yaml
@@ -15,7 +15,7 @@ excludedConfigPaths:
   - "config/prow-staging"
 targetVersion: "latest"
 labels:
-  - "auto/trusted-pullrequest" # This label is used by tide for identifying trusted PR
+  - "skip-review" # This label is used by tide for identifying trusted PR
 prefixes:
   - name: "Prow"
     prefix: "gcr.io/k8s-prow/"

--- a/config/prow/autobump-config/prow-component-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-component-autobump-config.yaml
@@ -14,6 +14,8 @@ includedConfigPaths:
 excludedConfigPaths:
   - "config/prow-staging"
 targetVersion: "latest"
+labels:
+  - "auto/trusted-pullrequest" # This label is used by tide for identifying trusted PR
 prefixes:
   - name: "Prow"
     prefix: "gcr.io/k8s-prow/"

--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -27,6 +27,7 @@
 - [Labels that apply to kubernetes/release, for both issues and PRs](#labels-that-apply-to-kubernetesrelease-for-both-issues-and-prs)
 - [Labels that apply to kubernetes/sig-release, for both issues and PRs](#labels-that-apply-to-kubernetessig-release-for-both-issues-and-prs)
 - [Labels that apply to kubernetes/test-infra, for both issues and PRs](#labels-that-apply-to-kubernetestest-infra-for-both-issues-and-prs)
+- [Labels that apply to kubernetes/test-infra, only for PRs](#labels-that-apply-to-kubernetestest-infra-only-for-prs)
 - [Labels that apply to kubernetes/website, for both issues and PRs](#labels-that-apply-to-kuberneteswebsite-for-both-issues-and-prs)
 
 
@@ -407,6 +408,12 @@ larger set of contributors to apply/remove them.
 | <a id="area/release-eng" href="#area/release-eng">`area/release-eng`</a> | Issues or PRs related to the Release Engineering subproject <br><br> This was previously `area/release-infra`, | label | |
 | <a id="area/robots" href="#area/robots">`area/robots`</a> | Issues or PRs related to code in /robots| label | |
 | <a id="kind/oncall-hotlist" href="#kind/oncall-hotlist">`kind/oncall-hotlist`</a> | Categorizes issue or PR as tracked by test-infra oncall.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+
+## Labels that apply to kubernetes/test-infra, only for PRs
+
+| Name | Description | Added By | Prow Plugin |
+| ---- | ----------- | -------- | --- |
+| <a id="skip-review" href="#skip-review">`skip-review`</a> | Indicates a PR is trusted, used by tide for auto-merging PRs.| autobump bot | |
 
 ## Labels that apply to kubernetes/website, for both issues and PRs
 

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -1336,6 +1336,11 @@ repos:
           - name: area/release-infra
         target: both
         addedBy: label
+      - color: 0ffa16
+        description: Indicates a PR is trusted, used by tide for auto-merging PRs.
+        name: skip-review
+        target: prs
+        addedBy: autobump bot
       - color: f7c6c7
         description: Categorizes issue or PR as tracked by test-infra oncall.
         name: kind/oncall-hotlist


### PR DESCRIPTION
In preparing for tide auto-merging prow autobump PRs