### PR TITLE
prow.k8s.io bumping PR automatically merged

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -568,6 +568,21 @@ tide:
     - do-not-merge/hold
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
+  - author: k8s-ci-robot
+    labels: # k8s-ci-robot should only create autobump PR with this label
+    - auto/trusted-pullrequest
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/blocked-paths
+    - do-not-merge/contains-merge-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-commit-message
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/release-note-label-needed
+    - do-not-merge/work-in-progress
+    - needs-rebase
+    repos:
+    - kubernetes/test-infra
 
   merge_method:
     kubernetes-client/csharp: squash

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -570,7 +570,8 @@ tide:
     - do-not-merge/work-in-progress
   - author: k8s-ci-robot
     labels: # k8s-ci-robot should only create autobump PR with this label
-    - auto/trusted-pullrequest
+    - skip-review
+    - "cncf-cla: yes"
     missingLabels:
     - do-not-merge
     - do-not-merge/blocked-paths


### PR DESCRIPTION
This PR enables PR created by k8s-ci-robot with trusted label to be automatically merged. Since k8s-ci-robot automatically creates autobump PRs, there is no more manual step needed any more for bumping prow.k8s.io.

Part of: https://github.com/kubernetes/enhancements/tree/master/keps/sig-testing/2539-continuously-deploy-k8s-prow

/hold
Will not merge this until:
- Announced widely in k8s-dev community
- KEP was moved to implementable phase