### PR TITLE
releng: Update go-runner image presubmit/postsubmit to push to the correct staging project

### DIFF
--- a/config/jobs/image-pushing/releng/k8s-staging-build-image.yaml
+++ b/config/jobs/image-pushing/releng/k8s-staging-build-image.yaml
@@ -103,10 +103,13 @@ postsubmits:
               - --project=k8s-staging-build-image
               - --scratch-bucket=gs://k8s-staging-build-image-gcb
               - --build-dir=.
+              - --env-passthrough=REGISTRY
               - images/build/go-runner
             env:
               - name: LOG_TO_STDOUT
                 value: "y"
+              - name: REGISTRY
+                value: "gcr.io/k8s-staging-build-image"
       rerun_auth_config:
         github_team_ids:
           - 2241179 # release-managers

--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -124,6 +124,42 @@ presubmits:
       testgrid-num-failures-to-alert: '10'
       testgrid-alert-email: release-managers+alerts@kubernetes.io
       testgrid-num-columns-recent: '30'
+  - name: pull-release-image-go-runner
+    optional: true
+    cluster: k8s-infra-prow-build
+    decorate: true
+    run_if_changed: '^images\/build\/go-runner\/'
+    path_alias: k8s.io/release
+    spec:
+      serviceAccountName: gcb-builder-releng-test
+      containers:
+        - image: gcr.io/k8s-testimages/image-builder:v20210302-aa40187
+          command:
+            - /run.sh
+          args:
+            - --project=k8s-staging-releng-test
+            - --scratch-bucket=gs://k8s-staging-releng-test
+            - --build-dir=.
+            - --env-passthrough=REGISTRY
+            - images/build/go-runner
+          env:
+            - name: LOG_TO_STDOUT
+              value: "y"
+            - name: REGISTRY
+              value: "gcr.io/k8s-staging-releng-test"
+          resources:
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+    annotations:
+      testgrid-dashboards: sig-release-releng-presubmits
+      testgrid-tab-name: release-image-go-runner
+      testgrid-num-failures-to-alert: '10'
+      testgrid-alert-email: release-managers+alerts@kubernetes.io
+      testgrid-num-columns-recent: '30'
 periodics:
 # package tests
 - name: periodic-release-verify-packages-debs


### PR DESCRIPTION
before merge this we need the change https://github.com/kubernetes/release/pull/1945

/assign @justaugustus @saschagrunert @hasheddan 

tracking issue: https://github.com/kubernetes/release/issues/1850


/hold