### PR TITLE
prow/pipeline: don't panic when a build cluster is not reachable

### DIFF
--- a/prow/cmd/pipeline/main.go
+++ b/prow/cmd/pipeline/main.go
@@ -156,8 +156,10 @@ func main() {
 			logrus.WithError(err).Infof("Ignoring cluster context %s: tekton pipeline CRD not deployed", context)
 			continue
 		}
+		// Don't panic when a build cluster cannot be reached
 		if err != nil {
-			logrus.WithError(err).Fatalf("Failed to create %s pipeline client", context)
+			logrus.WithError(err).Warningf("Failed to create %s pipeline client", context)
+			continue
 		}
 		pipelineConfigs[context] = *bc
 	}


### PR DESCRIPTION
Part of: https://github.com/kubernetes/test-infra/issues/21317

The build cluster named k8s-tpu-operator had been unreachable in the past day, this shouldn't make pipeline crashlooping