### PR TITLE
azure: disable runUnattendedUpgradesOnBootstrap by default

### DIFF
--- a/kubetest/aksengine.go
+++ b/kubetest/aksengine.go
@@ -602,6 +602,9 @@ func (c *aksEngineDeployer) populateAPIModelTemplate() error {
 		}
 	}
 
+	// disable runUnattendedUpgradesOnBootstrap to avoid health check during node reboot
+	v.Properties.LinuxProfile.RunUnattendedUpgradesOnBootstrap = false
+
 	apiModel, _ := json.MarshalIndent(v, "", "    ")
 	c.apiModelPath = path.Join(c.outputDir, "kubernetes.json")
 	err = ioutil.WriteFile(c.apiModelPath, apiModel, 0644)

--- a/kubetest/aksengine_helpers.go
+++ b/kubetest/aksengine_helpers.go
@@ -73,8 +73,9 @@ type ServicePrincipalProfile struct {
 }
 
 type LinuxProfile struct {
-	AdminUsername string `json:"adminUsername"`
-	SSHKeys       *SSH   `json:"ssh"`
+	RunUnattendedUpgradesOnBootstrap bool   `json:"runUnattendedUpgradesOnBootstrap"`
+	AdminUsername                    string `json:"adminUsername"`
+	SSHKeys                          *SSH   `json:"ssh"`
 }
 
 type SSH struct {


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

Since aks-engine enables runUnattendedUpgradesOnBootstrap by default, the cluster will be offline for around 5 minutes after it is provisioned, failing the health check performed by kubetest and causing it to exit prematurely. This PR will disable that option by default.

/assign @marosset @feiskyer 