### PR TITLE
Replace k8s-testimages/generic_autobump with new k8s-prow/generic-autobump image

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -877,9 +877,9 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/generic_autobump:v20210308-634c5e5
+    - image: gcr.io/k8s-prow/generic-autobumper:v20210318-ffb8032f91
       command:
-      - /generic_autobump
+      - /app/prow/cmd/generic-autobumper/app.binary
       args:
       - --config=config/prow/autobump-config/prow-component-autobump-config.yaml
       volumeMounts:
@@ -910,9 +910,9 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/generic_autobump:v20210308-634c5e5
+    - image: gcr.io/k8s-prow/generic-autobumper:v20210318-ffb8032f91
       command:
-      - /generic_autobump
+      - /app/prow/cmd/generic-autobumper/app.binary
       args:
       - --config=config/prow/autobump-config/prow-job-autobump-config.yaml
       volumeMounts:


### PR DESCRIPTION
This change is a follow up to https://github.com/kubernetes/test-infra/pull/20813 