### PR TITLE
Add 'validate-all' test to k-sigs/image-builder

### DIFF
--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
@@ -65,3 +65,32 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-image-builder
       testgrid-tab-name: pr-json-sort-check
+  - name: packer-validate
+    decorate: true
+    always_run: false
+    optional: true
+    decoration_config:
+      timeout: 20m
+    max_concurrency: 5
+    path_alias: sigs.k8s.io/image-builder
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210311-0d43454-master
+          command:
+          - make
+          args:
+          - validate-all
+          env:
+          - name: AZURE_LOCATION
+            value: "fake"
+          - name: RESOURCE_GROUP_NAME
+            value: "fake"
+          - name: STORAGE_ACCOUNT_NAME
+            value: "fake"
+          - name: DIGITALOCEAN_ACCESS_TOKEN
+            value: "fake"
+          - name: GCP_PROJECT_ID
+            value: "fake"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-image-builder
+      testgrid-tab-name: pr-packer-validate


### PR DESCRIPTION
This patch adds a new pre-submit for `kubernetes-sigs/image-builder` that runs `make validate-all` upon relevant file changes.

Some env vars needs to be set to fake values for the tests to pass.

/assign @CecileRobertMichon 
/cc @perithompson @kkeshavamurthy 