### PR TITLE
Prow prometheus monitors kube-state-metrics

### DIFF
--- a/config/prow/cluster/monitoring/BUILD.bazel
+++ b/config/prow/cluster/monitoring/BUILD.bazel
@@ -22,6 +22,7 @@ release(
     component("monitoring-prow-k8s-io", "managedcertificate"),
     component("additional-scrape-configs", "secret"),
     component("blackbox_prober", MULTI_KIND),
+    component("kube-state-metrics_servicemonitors", MULTI_KIND),
 )
 
 load("@io_bazel_rules_k8s//k8s:object.bzl", "k8s_object")

--- a/config/prow/cluster/monitoring/kube-state-metrics_servicemonitors.yaml
+++ b/config/prow/cluster/monitoring/kube-state-metrics_servicemonitors.yaml
@@ -1,0 +1,32 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 1.9.7
+  name: kube-state-metrics
+  namespace: prow-monitoring
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    bearerTokenSecret:
+      key: ""
+    honorLabels: true
+    interval: 2m
+    port: https-main
+    scheme: https
+    scrapeTimeout: 2m
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    bearerTokenSecret:
+      key: ""
+    interval: 2m
+    port: https-self
+    scheme: https
+    scrapeTimeout: 2m
+  jobLabel: app.kubernetes.io/name
+  namespaceSelector:
+    matchNames:
+    - kube-system
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics


### PR DESCRIPTION
This was from https://github.com/openshift/release/blob/ac1b4f17255011592a2fb104d121668fd6b85ef5/clusters/app.ci/prow-monitoring/kube-state-metrics.yaml and https://github.com/prometheus-operator/kube-prometheus/blob/release-0.7/manifests/kube-state-metrics-serviceMonitor.yaml, not sure whether this will work or not. But shouldn't break anything, I think