### PR TITLE
Adds a CNI arg for gce periodics

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
@@ -25,6 +25,7 @@ periodics:
       # Creates a state store bucket in the project, let's use the GCP default service account for the nodes
       # until we have a dedicated node account.
       # - --kops-args=--gce-service-account=pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com
+      - --kops-args=--networking=calico
       - --kops-feature-flags=GoogleCloudBucketACL
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -62,6 +63,7 @@ periodics:
       - --ginkgo-parallel
       # Temporarily use default service account: https://github.com/kubernetes/test-infra/issues/17558
       #- --kops-args=--gce-service-account=pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com
+      - --kops-args=--networking=calico
       - --kops-feature-flags=GoogleCloudBucketACL
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt


### PR DESCRIPTION
I'm seeing a failure to load CNI in the logs for nodes coming up for testing such as https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-gce-stable/1370460638043705344/artifacts/master-us-central1-c-mqb3/journal.log
I also ran into trouble in my test env when i didn't specify a CNI. Let's see if choosing a CNI helps get us further.