### PR TITLE
Kube-state-metrics: use a version that works with k8s v1.16

### DIFF
--- a/config/prow/cluster/kube-state-metrics_deployment.yaml
+++ b/config/prow/cluster/kube-state-metrics_deployment.yaml
@@ -15,10 +15,10 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: kube-state-metrics
-        app.kubernetes.io/version: 2.0.0-beta
+        app.kubernetes.io/version: 1.9.7
     spec:
       containers:
-      - image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0-beta
+      - image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v1.9.7
         args:
         - --metric-allowlist="kube_pod_container_status_restarts_total"
         livenessProbe:


### PR DESCRIPTION
K8s prow is on v1.16 and it's not compatible with current rube-state-metrics version https://github.com/kubernetes/kube-state-metrics#compatibility-matrix, downgrade to make it work