### PR TITLE
(Second attempt)Kube-state-metrics: use a version that works with k8s v1.16

### DIFF
--- a/config/prow/cluster/kube-state-metrics_deployment.yaml
+++ b/config/prow/cluster/kube-state-metrics_deployment.yaml
@@ -15,10 +15,10 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: kube-state-metrics
-        app.kubernetes.io/version: 1.9.7
+        app.kubernetes.io/version: 2.0.0-alpha.1
     spec:
       containers:
-      - image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v1.9.7
+      - image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:2.0.0-alpha.1
         args:
         - --metric-allowlist="kube_pod_container_status_restarts_total"
         livenessProbe:


### PR DESCRIPTION
ok... the v1.9.7 tag mentioned in https://github.com/kubernetes/kube-state-metrics#compatibility-matrix doesn't really exist. And the v2.0.0-alpha tag doesn't exist either, however 2.0.0-alpha exist. Trying it out