### PR TITLE
kOps - Use bazel 3.5.0 for kubetest2 experiments

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -118,7 +118,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
+      - image: gcr.io/cloud-marketplace-containers/google/bazel:3.5.0
         imagePullPolicy: Always
         command:
         - runner.sh


### PR DESCRIPTION
/cc @rifelpet 