### PR TITLE
kOps - Use golang instead of bazel image for kubetest2 experiments

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -118,8 +118,8 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/cloud-marketplace-containers/google/bazel:3.5.0
-        imagePullPolicy: Always
+      - image: golang:1.16.2
+        imagePullPolicy: IfNotPresent
         command:
         - bash
         args:


### PR DESCRIPTION
/cc @olemarkus @rifelpet 