### PR TITLE
releng: fix wrong image directory

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -321,7 +321,7 @@ presubmits:
             - --scratch-bucket=gs://k8s-staging-releng-test
             - --build-dir=.
             - --env-passthrough=PULL_BASE_REF,REGISTRY
-            - images/releng/k8s-ci-builder
+            - images/k8s-cloud-builder
           env:
             - name: LOG_TO_STDOUT
               value: "y"


### PR DESCRIPTION
A wrong image directory was introduced in the job created by this PR https://github.com/kubernetes/test-infra/pull/21344


it should use `images/k8s-cloud-builder` instead of `images/releng/k8s-ci-builder`.

The `images/releng/k8s-ci-builder` is the next job to be created.
/kind bug
/assign @justaugustus @saschagrunert @hasheddan 