### PR TITLE
Kops - test using kubekins master on some kubetest2 jobs

### DIFF
--- a/config/jobs/kubernetes/kops/build_grid.py
+++ b/config/jobs/kubernetes/kops/build_grid.py
@@ -254,6 +254,10 @@ def build_test(cloud='aws',
     else:
         raise Exception('missing required k8s_version')
 
+    # temporary test before migrating all jobs to use this image
+    if k8s_version in ['1.15', '1.16']:
+        e2e_image = 'gcr.io/k8s-testimages/kubekins-e2e:latest-master'
+
     create_args = f"--channel={kops_channel} --networking=" + (networking or "kubenet")
 
     if container_runtime:

--- a/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
@@ -375,7 +375,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -440,7 +440,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
       resources:
         limits:


### PR DESCRIPTION
These jobs dont use bazel at all because they download a precompiled kops binary.

They only use the go binary to install kubetest2 and deps, which are always from kops' master branch.
Therefore we shouldn't need to use minor-version specific kubekins image variants.
If this works I'll roll it out to all jobs, and will help with our moving off of kubekins altogether.

should fix these failures:
https://testgrid.k8s.io/kops-versions#kops-aws-k8s-1-15
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-k8s-1-15/1370721063045959680