### PR TITLE
Kops - migrate all kubetest2 jobs to kubekins master image

### DIFF
--- a/config/jobs/kubernetes/kops/build_grid.py
+++ b/config/jobs/kubernetes/kops/build_grid.py
@@ -68,7 +68,7 @@ kubetest2_template = """
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: {{kops_ssh_user}}
-      image: {{e2e_image}}
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -235,7 +235,6 @@ def build_test(cloud='aws',
 
     test_package_bucket = ''
     test_package_dir = ''
-    e2e_image = 'gcr.io/k8s-testimages/kubekins-e2e:latest-master'
     if k8s_version == 'latest':
         marker = 'latest.txt'
         k8s_deploy_url = "https://storage.googleapis.com/kubernetes-release/release/latest.txt"
@@ -250,13 +249,8 @@ def build_test(cloud='aws',
     elif k8s_version:
         marker = f"stable-{k8s_version}.txt"
         k8s_deploy_url = f"https://storage.googleapis.com/kubernetes-release/release/stable-{k8s_version}.txt" # pylint: disable=line-too-long
-        e2e_image = f"gcr.io/k8s-testimages/kubekins-e2e:latest-{k8s_version}"
     else:
         raise Exception('missing required k8s_version')
-
-    # temporary test before migrating all jobs to use this image
-    if k8s_version in ['1.15', '1.16']:
-        e2e_image = 'gcr.io/k8s-testimages/kubekins-e2e:latest-master'
 
     create_args = f"--channel={kops_channel} --networking=" + (networking or "kubenet")
 
@@ -311,7 +305,6 @@ def build_test(cloud='aws',
     y = y.replace('{{create_args}}', create_args)
     y = y.replace('{{k8s_deploy_url}}', k8s_deploy_url)
     y = y.replace('{{kops_deploy_url}}', kops_deploy_url)
-    y = y.replace('{{e2e_image}}', e2e_image)
     y = y.replace('{{test_parallelism}}', str(test_parallelism))
     y = y.replace('{{job_timeout}}', str(test_timeout_minutes + 30) + 'm')
     y = y.replace('{{test_timeout}}', str(test_timeout_minutes) + 'm')

--- a/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
@@ -47,7 +47,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -112,7 +112,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -177,7 +177,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -242,7 +242,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -307,7 +307,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: centos
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -372,7 +372,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: centos
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -437,7 +437,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -502,7 +502,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -567,7 +567,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -632,7 +632,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -47,7 +47,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -112,7 +112,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -177,7 +177,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -242,7 +242,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -307,7 +307,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -372,7 +372,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -437,7 +437,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -502,7 +502,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -567,7 +567,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -632,7 +632,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -697,7 +697,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -762,7 +762,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -827,7 +827,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -892,7 +892,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -957,7 +957,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1022,7 +1022,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1087,7 +1087,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1152,7 +1152,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1217,7 +1217,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1282,7 +1282,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1347,7 +1347,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1412,7 +1412,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1477,7 +1477,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1542,7 +1542,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1607,7 +1607,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1672,7 +1672,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1737,7 +1737,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1802,7 +1802,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1867,7 +1867,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1932,7 +1932,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1997,7 +1997,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2062,7 +2062,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2127,7 +2127,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2192,7 +2192,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2257,7 +2257,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2322,7 +2322,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2387,7 +2387,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2452,7 +2452,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2517,7 +2517,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2582,7 +2582,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2647,7 +2647,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2712,7 +2712,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2777,7 +2777,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2842,7 +2842,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2907,7 +2907,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2972,7 +2972,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3037,7 +3037,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3102,7 +3102,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3167,7 +3167,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3232,7 +3232,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3297,7 +3297,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3362,7 +3362,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3427,7 +3427,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3492,7 +3492,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3557,7 +3557,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3622,7 +3622,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3687,7 +3687,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3752,7 +3752,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3817,7 +3817,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3882,7 +3882,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3947,7 +3947,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4012,7 +4012,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4077,7 +4077,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4142,7 +4142,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4207,7 +4207,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4272,7 +4272,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4337,7 +4337,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4402,7 +4402,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4467,7 +4467,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4532,7 +4532,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4597,7 +4597,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4662,7 +4662,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4727,7 +4727,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4792,7 +4792,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4857,7 +4857,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4922,7 +4922,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4987,7 +4987,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5052,7 +5052,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5117,7 +5117,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5182,7 +5182,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5247,7 +5247,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5312,7 +5312,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5377,7 +5377,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5442,7 +5442,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5507,7 +5507,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5572,7 +5572,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5637,7 +5637,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5702,7 +5702,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5767,7 +5767,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5832,7 +5832,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5897,7 +5897,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5962,7 +5962,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6027,7 +6027,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6092,7 +6092,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6157,7 +6157,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6222,7 +6222,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6287,7 +6287,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6352,7 +6352,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6417,7 +6417,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6482,7 +6482,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6547,7 +6547,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6612,7 +6612,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6677,7 +6677,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6742,7 +6742,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6807,7 +6807,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6872,7 +6872,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6937,7 +6937,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7002,7 +7002,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7067,7 +7067,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7132,7 +7132,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7197,7 +7197,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7262,7 +7262,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7327,7 +7327,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7392,7 +7392,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7457,7 +7457,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7522,7 +7522,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7587,7 +7587,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7652,7 +7652,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7717,7 +7717,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7782,7 +7782,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7847,7 +7847,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7912,7 +7912,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7977,7 +7977,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -8042,7 +8042,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -8107,7 +8107,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -8172,7 +8172,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -8237,7 +8237,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -8302,7 +8302,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -8367,7 +8367,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -8432,7 +8432,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -8497,7 +8497,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -8562,7 +8562,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -8627,7 +8627,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -8692,7 +8692,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -8757,7 +8757,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -8822,7 +8822,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -8887,7 +8887,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -8952,7 +8952,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9017,7 +9017,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9082,7 +9082,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9147,7 +9147,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9212,7 +9212,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9277,7 +9277,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9342,7 +9342,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9407,7 +9407,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9472,7 +9472,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9537,7 +9537,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9602,7 +9602,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9667,7 +9667,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9732,7 +9732,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9797,7 +9797,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9862,7 +9862,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9927,7 +9927,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9992,7 +9992,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10057,7 +10057,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10122,7 +10122,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10187,7 +10187,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10252,7 +10252,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10317,7 +10317,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10382,7 +10382,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10447,7 +10447,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10512,7 +10512,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10577,7 +10577,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10642,7 +10642,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10707,7 +10707,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10772,7 +10772,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10837,7 +10837,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10902,7 +10902,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10967,7 +10967,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11032,7 +11032,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11097,7 +11097,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11162,7 +11162,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11227,7 +11227,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11292,7 +11292,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11357,7 +11357,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11422,7 +11422,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11487,7 +11487,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11552,7 +11552,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11617,7 +11617,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11682,7 +11682,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11747,7 +11747,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11812,7 +11812,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11877,7 +11877,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11942,7 +11942,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12007,7 +12007,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12072,7 +12072,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12137,7 +12137,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12202,7 +12202,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12267,7 +12267,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12332,7 +12332,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12397,7 +12397,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12462,7 +12462,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12527,7 +12527,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12592,7 +12592,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12657,7 +12657,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12722,7 +12722,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12787,7 +12787,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12852,7 +12852,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12917,7 +12917,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12982,7 +12982,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13047,7 +13047,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13112,7 +13112,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13177,7 +13177,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13242,7 +13242,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13307,7 +13307,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13372,7 +13372,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13437,7 +13437,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13502,7 +13502,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13567,7 +13567,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13632,7 +13632,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13697,7 +13697,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13762,7 +13762,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13827,7 +13827,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13892,7 +13892,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13957,7 +13957,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14022,7 +14022,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14087,7 +14087,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14152,7 +14152,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14217,7 +14217,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14282,7 +14282,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14347,7 +14347,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14412,7 +14412,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14477,7 +14477,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14542,7 +14542,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14607,7 +14607,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14672,7 +14672,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14737,7 +14737,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14802,7 +14802,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14867,7 +14867,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14932,7 +14932,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14997,7 +14997,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15062,7 +15062,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15127,7 +15127,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15192,7 +15192,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15257,7 +15257,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15322,7 +15322,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15387,7 +15387,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15452,7 +15452,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15517,7 +15517,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15582,7 +15582,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15647,7 +15647,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15712,7 +15712,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15777,7 +15777,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15842,7 +15842,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15907,7 +15907,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15972,7 +15972,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16037,7 +16037,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16102,7 +16102,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16167,7 +16167,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16232,7 +16232,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16297,7 +16297,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16362,7 +16362,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16427,7 +16427,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16492,7 +16492,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16557,7 +16557,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16622,7 +16622,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16687,7 +16687,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16752,7 +16752,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16817,7 +16817,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16882,7 +16882,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16947,7 +16947,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17012,7 +17012,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17077,7 +17077,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17142,7 +17142,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17207,7 +17207,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17272,7 +17272,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17337,7 +17337,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17402,7 +17402,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17467,7 +17467,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17532,7 +17532,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17597,7 +17597,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17662,7 +17662,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17727,7 +17727,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17792,7 +17792,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17857,7 +17857,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17922,7 +17922,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17987,7 +17987,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18052,7 +18052,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18117,7 +18117,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18182,7 +18182,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18247,7 +18247,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18312,7 +18312,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18377,7 +18377,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18442,7 +18442,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18507,7 +18507,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18572,7 +18572,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18637,7 +18637,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18702,7 +18702,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18767,7 +18767,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18832,7 +18832,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18897,7 +18897,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18962,7 +18962,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19027,7 +19027,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19092,7 +19092,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19157,7 +19157,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19222,7 +19222,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19287,7 +19287,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19352,7 +19352,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19417,7 +19417,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19482,7 +19482,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19547,7 +19547,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19612,7 +19612,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19677,7 +19677,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19742,7 +19742,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19807,7 +19807,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19872,7 +19872,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19937,7 +19937,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20002,7 +20002,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20067,7 +20067,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20132,7 +20132,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20197,7 +20197,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20262,7 +20262,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20327,7 +20327,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20392,7 +20392,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20457,7 +20457,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20522,7 +20522,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20587,7 +20587,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20652,7 +20652,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20717,7 +20717,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20782,7 +20782,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20847,7 +20847,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20912,7 +20912,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20977,7 +20977,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21042,7 +21042,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21107,7 +21107,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21172,7 +21172,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21237,7 +21237,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21302,7 +21302,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21367,7 +21367,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21432,7 +21432,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21497,7 +21497,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21562,7 +21562,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21627,7 +21627,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21692,7 +21692,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21757,7 +21757,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21822,7 +21822,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21887,7 +21887,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21952,7 +21952,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22017,7 +22017,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22082,7 +22082,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22147,7 +22147,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22212,7 +22212,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22277,7 +22277,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22342,7 +22342,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22407,7 +22407,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22472,7 +22472,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22537,7 +22537,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22602,7 +22602,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22667,7 +22667,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22732,7 +22732,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22797,7 +22797,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22862,7 +22862,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22927,7 +22927,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22992,7 +22992,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23057,7 +23057,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23122,7 +23122,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23187,7 +23187,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23252,7 +23252,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23317,7 +23317,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23382,7 +23382,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23447,7 +23447,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23512,7 +23512,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23577,7 +23577,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23642,7 +23642,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23707,7 +23707,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23772,7 +23772,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23837,7 +23837,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23902,7 +23902,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23967,7 +23967,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24032,7 +24032,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24097,7 +24097,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24162,7 +24162,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24227,7 +24227,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24292,7 +24292,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24357,7 +24357,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24422,7 +24422,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24487,7 +24487,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24552,7 +24552,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24617,7 +24617,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24682,7 +24682,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24747,7 +24747,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24812,7 +24812,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24877,7 +24877,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24942,7 +24942,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25007,7 +25007,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25072,7 +25072,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25137,7 +25137,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25202,7 +25202,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25267,7 +25267,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25332,7 +25332,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25397,7 +25397,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25462,7 +25462,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25527,7 +25527,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25592,7 +25592,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25657,7 +25657,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25722,7 +25722,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25787,7 +25787,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25852,7 +25852,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25917,7 +25917,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25982,7 +25982,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26047,7 +26047,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26112,7 +26112,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26177,7 +26177,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26242,7 +26242,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26307,7 +26307,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26372,7 +26372,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26437,7 +26437,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26502,7 +26502,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26567,7 +26567,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26632,7 +26632,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26697,7 +26697,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26762,7 +26762,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26827,7 +26827,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26892,7 +26892,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26957,7 +26957,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27022,7 +27022,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27087,7 +27087,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27152,7 +27152,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27217,7 +27217,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27282,7 +27282,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27347,7 +27347,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27412,7 +27412,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27477,7 +27477,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27542,7 +27542,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27607,7 +27607,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27672,7 +27672,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27737,7 +27737,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27802,7 +27802,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27867,7 +27867,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27932,7 +27932,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27997,7 +27997,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28062,7 +28062,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28127,7 +28127,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28192,7 +28192,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28257,7 +28257,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28322,7 +28322,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28387,7 +28387,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28452,7 +28452,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28517,7 +28517,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28582,7 +28582,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28647,7 +28647,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28712,7 +28712,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28777,7 +28777,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28842,7 +28842,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28907,7 +28907,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28972,7 +28972,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29037,7 +29037,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29102,7 +29102,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29167,7 +29167,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29232,7 +29232,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29297,7 +29297,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29362,7 +29362,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29427,7 +29427,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29492,7 +29492,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29557,7 +29557,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29622,7 +29622,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29687,7 +29687,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29752,7 +29752,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29817,7 +29817,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29882,7 +29882,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29947,7 +29947,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30012,7 +30012,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30077,7 +30077,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30142,7 +30142,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30207,7 +30207,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30272,7 +30272,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30337,7 +30337,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30402,7 +30402,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30467,7 +30467,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30532,7 +30532,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30597,7 +30597,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30662,7 +30662,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30727,7 +30727,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30792,7 +30792,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30857,7 +30857,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30922,7 +30922,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30987,7 +30987,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31052,7 +31052,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31117,7 +31117,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31182,7 +31182,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31247,7 +31247,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31312,7 +31312,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31377,7 +31377,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31442,7 +31442,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31507,7 +31507,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31572,7 +31572,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31637,7 +31637,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31702,7 +31702,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31767,7 +31767,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31832,7 +31832,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31897,7 +31897,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31962,7 +31962,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32027,7 +32027,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32092,7 +32092,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32157,7 +32157,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32222,7 +32222,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32287,7 +32287,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32352,7 +32352,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32417,7 +32417,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32482,7 +32482,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32547,7 +32547,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32612,7 +32612,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32677,7 +32677,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32742,7 +32742,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32807,7 +32807,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32872,7 +32872,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32937,7 +32937,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -33002,7 +33002,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -33067,7 +33067,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -33132,7 +33132,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -33197,7 +33197,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -33262,7 +33262,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -33327,7 +33327,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -33392,7 +33392,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -33457,7 +33457,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -33522,7 +33522,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -33587,7 +33587,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -33652,7 +33652,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -33717,7 +33717,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -33782,7 +33782,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -33847,7 +33847,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -33912,7 +33912,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -33977,7 +33977,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -34042,7 +34042,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -34107,7 +34107,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -34172,7 +34172,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -34237,7 +34237,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -34302,7 +34302,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -34367,7 +34367,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -34432,7 +34432,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -34497,7 +34497,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -34562,7 +34562,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -34627,7 +34627,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -34692,7 +34692,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -34757,7 +34757,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -34822,7 +34822,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -34887,7 +34887,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -34952,7 +34952,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -35017,7 +35017,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -35082,7 +35082,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -35147,7 +35147,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -35212,7 +35212,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -35277,7 +35277,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -35342,7 +35342,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -35407,7 +35407,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -35472,7 +35472,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -35537,7 +35537,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -35602,7 +35602,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -35667,7 +35667,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -35732,7 +35732,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -35797,7 +35797,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -35862,7 +35862,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -35927,7 +35927,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -35992,7 +35992,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -36057,7 +36057,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -36122,7 +36122,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -36187,7 +36187,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -36252,7 +36252,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -36317,7 +36317,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -36382,7 +36382,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -47,7 +47,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -113,7 +113,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -180,7 +180,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -248,7 +248,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -313,7 +313,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -379,7 +379,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -447,7 +447,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -516,7 +516,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -585,7 +585,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -653,7 +653,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -719,7 +719,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:

--- a/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
@@ -47,7 +47,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -113,7 +113,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -179,7 +179,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -245,7 +245,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -311,7 +311,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -377,7 +377,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -443,7 +443,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -509,7 +509,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:

--- a/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
@@ -50,7 +50,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -115,7 +115,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -180,7 +180,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -245,7 +245,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -310,7 +310,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -375,7 +375,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -440,7 +440,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:

--- a/config/jobs/kubernetes/kops/kops-pipeline.yaml
+++ b/config/jobs/kubernetes/kops/kops-pipeline.yaml
@@ -49,7 +49,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -116,7 +116,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -183,7 +183,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       imagePullPolicy: Always
       resources:
         limits:


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/21365 was a success so this updates every other kubetest2 job to use kubekins master.