### PR TITLE
releng: fix wrong parameter for presubmit job pull-release-image-k8s-cloud-builder

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -312,7 +312,6 @@ presubmits:
           args:
             - --project=k8s-staging-releng-test
             - --scratch-bucket=gs://k8s-staging-releng-test
-            - --build-dir=.
             - --env-passthrough=PULL_BASE_REF,REGISTRY
             - images/k8s-cloud-builder
           env:


### PR DESCRIPTION
Fix wrong paramenter to the job `pull-release-image-k8s-cloud-builder`

testing PR to validate this job: https://github.com/kubernetes/release/pull/1954

/kind bug

/assign @justaugustus @hasheddan @saschagrunert 