### PR TITLE
Kops - ignore additional tests in 1.15 job

### DIFF
--- a/config/jobs/kubernetes/kops/build_grid.py
+++ b/config/jobs/kubernetes/kops/build_grid.py
@@ -638,6 +638,8 @@ def generate_versions():
     ]
     for version in ['1.20', '1.19', '1.18', '1.17', '1.16', '1.15']:
         distro = 'deb9' if version in ['1.17', '1.16', '1.15'] else 'u2004'
+        if version == '1.15':
+            skip_regex += r'|Services.*rejected.*endpoints'
         results.append(
             build_test(
                 container_runtime='containerd',

--- a/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
@@ -434,7 +434,7 @@ periodics:
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=stable-1.15.txt \
           --parallel=25 \
-          --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler"
+          --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*rejected.*endpoints"
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private


### PR DESCRIPTION
Migrating this job to kubetest2 caused a few tests to be no longer ignored. This ignores the one test that is failing. see https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-k8s-1-15/1370766359528476672