### PR TITLE
Update kops python files in autobump config

### DIFF
--- a/config/prow/autobump-config/prow-job-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-job-autobump-config.yaml
@@ -15,8 +15,7 @@ includedConfigPaths:
 extraFiles:
   - "config/jobs/image-pushing/k8s-staging-e2e-test-images.sh"
   - "config/jobs/image-pushing/k8s-staging-sig-storage.sh"
-  - "config/jobs/kubernetes/kops/build_grid.py"
-  - "config/jobs/kubernetes/kops/build_pipeline.py"
+  - "config/jobs/kubernetes/kops/build_jobs.py"
   - "releng/generate_tests.py"
   - "images/kubekins-e2e/Dockerfile"
 targetVersion: "latest"


### PR DESCRIPTION
As a part of some ongoing work and kubetest2 migrations, kops' two python scripts are being consolidated into a new build_jobs.py file.

This updates the autobumper's config to match. [Both the old files and new file exist](https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes/kops), so this should be backwards compatible. Once this is merged I'll delete the old files.