### PR TITLE
Prometheus: service monitor also monitors label app.kubernetes.io/name

### DIFF
--- a/config/prow/cluster/monitoring/prow_prometheus.yaml
+++ b/config/prow/cluster/monitoring/prow_prometheus.yaml
@@ -32,6 +32,8 @@ spec:
     matchExpressions:
     - key: app
       operator: Exists
+    - key: app.kubernetes.io/name
+      operator: Exists
   version: v2.7.1
   image: docker.io/prom/prometheus
   externalLabels: {}


### PR DESCRIPTION
This is the default label of kube state metrics. Prefer to make prometheus monitor this label instead of renaming this label to avoid complication on the kube state metrics service itself