### PR TITLE
Revert "Prometheus: service monitor also monitors label app.kubernete…

### DIFF
--- a/config/prow/cluster/monitoring/prow_prometheus.yaml
+++ b/config/prow/cluster/monitoring/prow_prometheus.yaml
@@ -32,8 +32,6 @@ spec:
     matchExpressions:
     - key: app
       operator: Exists
-    - key: app.kubernetes.io/name
-      operator: Exists
   version: v2.7.1
   image: docker.io/prom/prometheus
   externalLabels: {}


### PR DESCRIPTION
…s.io/name"

This reverts commit 4667228810f0fdb70864e121775e651a36fc0978.

Saw multiple alerts `grafanaDown`, `prometheusDown` etc. right after the PR #21375 , reverting it for now