### PR TITLE
kube-state-metrics: Add 'app:' label so that prometheus can access it…

### DIFF
--- a/config/prow/cluster/monitoring/kube-state-metrics_servicemonitors.yaml
+++ b/config/prow/cluster/monitoring/kube-state-metrics_servicemonitors.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/version: 1.9.7
+    app: kube-state-metrics
   name: kube-state-metrics
   namespace: prow-monitoring
 spec:


### PR DESCRIPTION
…s metrics