### PR TITLE
Prometheus servcie monitor: use consistent ports names as kube-state-metrics service

### DIFF
--- a/config/prow/cluster/monitoring/kube-state-metrics_servicemonitors.yaml
+++ b/config/prow/cluster/monitoring/kube-state-metrics_servicemonitors.yaml
@@ -14,14 +14,14 @@ spec:
       key: ""
     honorLabels: true
     interval: 2m
-    port: https-main
+    port: http-metrics
     scheme: https
     scrapeTimeout: 2m
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     bearerTokenSecret:
       key: ""
     interval: 2m
-    port: https-self
+    port: telemetry
     scheme: https
     scrapeTimeout: 2m
   jobLabel: app.kubernetes.io/name

--- a/config/prow/cluster/monitoring/kube-state-metrics_servicemonitors.yaml
+++ b/config/prow/cluster/monitoring/kube-state-metrics_servicemonitors.yaml
@@ -15,14 +15,14 @@ spec:
     honorLabels: true
     interval: 2m
     port: http-metrics
-    scheme: https
+    scheme: http
     scrapeTimeout: 2m
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     bearerTokenSecret:
       key: ""
     interval: 2m
     port: telemetry
-    scheme: https
+    scheme: http
     scrapeTimeout: 2m
   jobLabel: app.kubernetes.io/name
   namespaceSelector:


### PR DESCRIPTION
Prometheus still not get metrics from kube-state-metrcis after #21382 , this might be the reason