### PR TITLE
Make gerrit adapter's job triggered comments link to results on deck.

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -558,6 +558,9 @@ type Gerrit struct {
 	// RateLimit defines how many changes to query per gerrit API call
 	// default is 5
 	RateLimit int `json:"ratelimit,omitempty"`
+	// DeckURL is the root URL of Deck. This is used to construct links to
+	// job runs for a given CL.
+	DeckURL string `json:"deck_url,omitempty"`
 }
 
 // JenkinsOperator is config for the jenkins-operator controller.
@@ -1378,9 +1381,13 @@ func (c *Config) validateComponentConfig() error {
 			}, ""))
 		}
 	}
+	if c.Gerrit.DeckURL != "" {
+		if _, err := url.Parse(c.Gerrit.DeckURL); err != nil {
+			return fmt.Errorf(`Invalid value for gerrit.deck_url: %v`, err)
+		}
+	}
 
 	var validationErrs []error
-
 	if c.ManagedWebhooks.OrgRepoConfig != nil {
 		for repoName, repoValue := range c.ManagedWebhooks.OrgRepoConfig {
 			if repoValue.TokenCreatedAfter.After(time.Now()) {

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -388,6 +388,10 @@ deck:
 # no timeout is configured at the job level. This value is set to 24 hours.
 default_job_timeout: 0s
 gerrit:
+    # DeckURL is the root URL of Deck. This is used to construct links to
+    # job runs for a given CL.
+    deck_url: ' '
+
     # TickInterval is how often we do a sync with binded gerrit instance
     tick_interval: 0s
 

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -328,20 +328,49 @@ func (c *Controller) processChange(logger logrus.FieldLogger, instance string, c
 
 	// comment back to gerrit if Report is set for any of the jobs
 	var reportingJobs int
-	var message string
+	var jobList string
 	for _, job := range triggeredJobs {
 		if job.report {
-			message += fmt.Sprintf("\n  * Name: %s", job.name)
+			jobList += fmt.Sprintf("\n  * Name: %s", job.name)
 			reportingJobs++
 		}
 	}
 
 	if reportingJobs > 0 {
-		message = fmt.Sprintf("Triggered %d prow jobs (%d suppressed reporting):", len(triggeredJobs), len(triggeredJobs)-reportingJobs) + message
+		message := fmt.Sprintf("Triggered %d prow jobs (%d suppressed reporting): ", len(triggeredJobs), len(triggeredJobs)-reportingJobs)
+		// If we have a Deck URL, link to all results for the CL, otherwise list the triggered jobs.
+		link, err := deckLinkForPR(c.config().Gerrit.DeckURL, refs, change.Status)
+		if err != nil {
+			logger.WithError(err).Error("Failed to generate link to job results on Deck.")
+		}
+		if link != "" && err == nil {
+			message = message + link
+		} else {
+			message = message + jobList
+		}
 		if err := c.gc.SetReview(instance, change.ID, change.CurrentRevision, message, nil); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func deckLinkForPR(deckURL string, refs prowapi.Refs, changeStatus string) (string, error) {
+	if deckURL == "" || changeStatus == client.Merged {
+		return "", nil
+	}
+
+	parsed, err := url.Parse(deckURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse gerrit.deck_url (impossible: this should have been caught at load time): %v", err)
+	}
+	query := parsed.Query()
+	query.Set("repo", fmt.Sprintf("%s/%s", refs.Org, refs.Repo))
+	if len(refs.Pulls) != 1 {
+		return "", fmt.Errorf("impossible: triggered jobs for a Gerrit change, but refs.pulls was empty")
+	}
+	query.Set("pull", strconv.Itoa(refs.Pulls[0].Number))
+	parsed.RawQuery = query.Encode()
+	return parsed.String(), nil
 }


### PR DESCRIPTION
Currently we only link to job results when reporting job completion and if users want to inspect job results while a job is running they must find the jobs by filtering on the Prow front end manually. This change updates the "Triggered %d jobs" comment to also link to the Prow front end with a filter for all jobs run on the PR. 
Linking to every job's spyglass page individually was considered, but without proper link formatting it was considered too verbose/difficult to read. Additionally, at trigger time we don't have a build ID so we cannot link to individual job runs in spyglass at that time, we'd need to instead have the gerrit reporter provide that information when the job transitions to the pending state.

/assign @fejta @chaodaiG 