### PR TITLE
security-profiles-operator: standardize lgtm/approve workflows

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -87,6 +87,7 @@ approve:
   - kubernetes-sigs/kubetest2
   - kubernetes-sigs/mdtoc
   - kubernetes-sigs/release-notes
+  - kubernetes-sigs/security-profiles-operator
   - kubernetes-sigs/slack-infra
   - kubernetes-sigs/zeitgeist
   - kubernetes/community
@@ -135,6 +136,7 @@ lgtm:
   - kubernetes-sigs/kubetest2
   - kubernetes-sigs/mdtoc
   - kubernetes-sigs/release-notes
+  - kubernetes-sigs/security-profiles-operator
   - kubernetes-sigs/zeitgeist
   - kubernetes/k8s.io
   - kubernetes/kops
@@ -982,6 +984,9 @@ plugins:
 
   kubernetes-sigs/security-profiles-operator:
     plugins:
+    - mergecommitblocker
+    - milestone
+    - override
     - release-note
 
   kubernetes-sigs/k8s-container-image-promoter:


### PR DESCRIPTION
We now use the same lgtm/approve workflows described in
https://github.com/kubernetes/test-infra/pull/20819.

Beside that, we also use the plugins `mergecommitblocker`, `milestone`
and `override`.

cc @pjbgf @hasheddan @cmurphy @JAORMX @jhrozek