### PR TITLE
Add config test to mergelists

### DIFF
--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -53,6 +53,7 @@ filegroup(
         "//config/prow-staging:all-srcs",
         "//config/tests/jobs:all-srcs",
         "//config/tests/lint:all-srcs",
+        "//config/tests/mergelists:all-srcs",
         "//config/tests/testgrids:all-srcs",
     ],
     tags = ["automanaged"],

--- a/config/testgrids/kubevirt/default.yaml
+++ b/config/testgrids/kubevirt/default.yaml
@@ -1,5 +1,0 @@
-default_dashboard_tab:
-  open_test_template:
-    url: https://prow.apps.ovirt.org/view/gs/<gcs_prefix>/<changelist>
-  results_url_template:
-    url: https://prow.apps.ovirt.org/job-history/<gcs_prefix>

--- a/config/tests/mergelists/BUILD.bazel
+++ b/config/tests/mergelists/BUILD.bazel
@@ -1,0 +1,26 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "go_default_test",
+    srcs = ["mergelist_test.go"],
+    args = ["-list='$(locations //config/mergelists)'"],
+    data = ["//config/mergelists"],
+    rundir = ".",
+    deps = ["@com_github_googlecloudplatform_testgrid//pkg/merger:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/config/tests/mergelists/mergelist_test.go
+++ b/config/tests/mergelists/mergelist_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mergelist_test
+
+import (
+	"flag"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/testgrid/pkg/merger"
+)
+
+var lists = flag.String("list", "", "Space-delimited list of mergelists to test")
+
+func TestMergelist(t *testing.T) {
+	files := strings.Split(*lists, " ")
+
+	for _, filename := range files {
+		t.Run(filename, func(t *testing.T) {
+			file, err := ioutil.ReadFile(filename)
+			if err != nil {
+				t.Errorf("Can't read file: %v", err)
+			}
+
+			_, err = merger.ParseAndCheck(file)
+			if err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/Azure/azure-storage-blob-go v0.8.0
 	github.com/Azure/go-autorest/autorest v0.11.1
 	github.com/Azure/go-autorest/autorest/adal v0.9.5
-	github.com/GoogleCloudPlatform/testgrid v0.0.30
+	github.com/GoogleCloudPlatform/testgrid v0.0.56
 	github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
 	github.com/andygrunwald/go-gerrit v0.0.0-20190120104749-174420ebee6c
 	github.com/andygrunwald/go-jira v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -168,8 +168,8 @@ github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20190822182118-27a4ced3
 github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20190822182118-27a4ced34534/go.mod h1:iroGtC8B3tQiqtds1l+mgk/BBOrxbqjH+eUfFQYRc14=
 github.com/GoogleCloudPlatform/testgrid v0.0.1-alpha.3/go.mod h1:f96W2HYy3tiBNV5zbbRc+NczwYHgG1PHXMQfoEWv680=
 github.com/GoogleCloudPlatform/testgrid v0.0.7/go.mod h1:lmtHGBL0M/MLbu1tR9BWV7FGZ1FEFIdPqmJiHNCL7y8=
-github.com/GoogleCloudPlatform/testgrid v0.0.30 h1:Os7plKvCWxu37kdaqaHC+pvCva1nvsRuhVvMSPyhEqA=
-github.com/GoogleCloudPlatform/testgrid v0.0.30/go.mod h1:KGQ3wqPuX1xCqeSHvcGmAafuMtV7cRNST9hZS7VCahA=
+github.com/GoogleCloudPlatform/testgrid v0.0.56 h1:UmRXvBWXqxfM0vtluwYZc5Y8o6N3whOtKEP+vEH1/eY=
+github.com/GoogleCloudPlatform/testgrid v0.0.56/go.mod h1:SIRhudHYGiAUqMwKorBp2Kb5yJKhMq/nEMzFpYlKHVk=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd h1:sjQovDkwrZp8u+gxLtPgKGjk5hCxuy2hrRejBTA9xFU=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=
@@ -2287,6 +2287,7 @@ k8s.io/api v0.0.0-20180904230853-4e7be11eab3f/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j
 k8s.io/api v0.0.0-20181018013834-843ad2d9b9ae/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
 k8s.io/api v0.0.0-20190918195907-bd6ac527cfd2/go.mod h1:AOxZTnaXR/xiarlQL0JUfwQPxjmKDvVYoRp58cA7lUo=
 k8s.io/api v0.16.4/go.mod h1:AtzMnsR45tccQss5q8RnF+W8L81DH6XwXwo/joEx9u0=
+k8s.io/api v0.16.13/go.mod h1:QWu8UWSTiuQZMMeYjwLs6ILu5O74qKSJ0c+4vrchDxs=
 k8s.io/api v0.17.0/go.mod h1:npsyOePkeP0CPwyGfXDHxvypiYMJxBWAMpQxCaJ4ZxI=
 k8s.io/api v0.17.2/go.mod h1:BS9fjjLc4CMuqfSO8vgbHPKMt5+SF0ET6u/RVDihTo4=
 k8s.io/api v0.17.3/go.mod h1:YZ0OTkuw7ipbe305fMpIdf3GLXZKRigjtZaV5gzC2J0=
@@ -2308,6 +2309,7 @@ k8s.io/apimachinery v0.0.0-20190816221834-a9f1d8a9c101/go.mod h1:ccL7Eh7zubPUSh9
 k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d/go.mod h1:3jediapYqJ2w1BFw7lAZPCx7scubsTfosqHkhXCWJKw=
 k8s.io/apimachinery v0.16.4/go.mod h1:llRdnznGEAqC3DcNm6yEj472xaFVfLM7hnYofMb12tQ=
 k8s.io/apimachinery v0.16.5-beta.1/go.mod h1:llRdnznGEAqC3DcNm6yEj472xaFVfLM7hnYofMb12tQ=
+k8s.io/apimachinery v0.16.13/go.mod h1:4HMHS3mDHtVttspuuhrJ1GGr/0S9B6iWYWZ57KnnZqQ=
 k8s.io/apimachinery v0.17.0/go.mod h1:b9qmWdKlLuU9EBh+06BtLcSf/Mu89rWL33naRxs1uZg=
 k8s.io/apimachinery v0.17.1/go.mod h1:b9qmWdKlLuU9EBh+06BtLcSf/Mu89rWL33naRxs1uZg=
 k8s.io/apimachinery v0.17.2/go.mod h1:b9qmWdKlLuU9EBh+06BtLcSf/Mu89rWL33naRxs1uZg=
@@ -2385,6 +2387,7 @@ k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a/go.mod h1:1TqjTSzOxsLGIKf
 k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
 k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
 k8s.io/kube-openapi v0.0.0-20200410145947-bcb3869e6f29/go.mod h1:F+5wygcW0wmRTnM3cOgIqGivxkwSWIWT5YdsDbeAOaU=
+k8s.io/kube-openapi v0.0.0-20200410163147-594e756bea31/go.mod h1:1TqjTSzOxsLGIKfj0lK8EeCP7K1iUG65v09OM0/WG5E=
 k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd h1:sOHNzJIkytDF6qadMNKhhDRpc6ODik8lVC6nOur7B2c=
 k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd/go.mod h1:WOJ3KddDSol4tAGcJo0Tvi+dK12EcqSLqcWsryKMpfM=
 k8s.io/kubectl v0.17.2 h1:QZR8Q6lWiVRjwKslekdbN5WPMp53dS/17j5e+oi5XVU=

--- a/prow/spyglass/lenses/junit/lens.go
+++ b/prow/spyglass/lenses/junit/lens.go
@@ -158,7 +158,7 @@ func (lens Lens) getJvd(artifacts []api.Artifact) JVD {
 				resultChan <- result
 				return
 			}
-			var suites junit.Suites
+			var suites *junit.Suites
 			suites, result.err = junit.Parse(contents)
 			if result.err != nil {
 				logrus.WithError(result.err).WithField("artifact", artifact.CanonicalLink()).Info("Error parsing junit file.")

--- a/repos.bzl
+++ b/repos.bzl
@@ -2118,8 +2118,8 @@ def go_repositories():
         build_file_generation = "off",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/GoogleCloudPlatform/testgrid",
-        sum = "h1:Os7plKvCWxu37kdaqaHC+pvCva1nvsRuhVvMSPyhEqA=",
-        version = "v0.0.30",
+        sum = "h1:UmRXvBWXqxfM0vtluwYZc5Y8o6N3whOtKEP+vEH1/eY=",
+        version = "v0.0.56",
     )
 
     go_repository(

--- a/testgrid/cmd/configurator/main.go
+++ b/testgrid/cmd/configurator/main.go
@@ -198,7 +198,7 @@ func write(ctx context.Context, client *storage.Client, path string, bytes []byt
 func doOneshot(ctx context.Context, client *storage.Client, opt options, prowConfigAgent *prowConfig.Agent) error {
 
 	// Read Data Sources: Default, YAML configs, Prow Annotations
-	c, err := yamlcfg.ReadConfig(opt.inputs, opt.defaultYAML)
+	c, err := yamlcfg.ReadConfig(opt.inputs, opt.defaultYAML, false)
 	if err != nil {
 		return fmt.Errorf("could not read testgrid config: %v", err)
 	}


### PR DESCRIPTION
Updates TestGrid version as well.
The version update caused unit testing to enforce requirements on local default files. This may fix https://github.com/kubernetes/test-infra/issues/20756

/assign @fgimenez 
I'm looking for feedback on the default file. Now that https://github.com/kubernetes/test-infra/pull/20902 is in, should the default file be updated (as shown) or removed entirely?

/assign @mpherman2 
The strict default config option was set to "false" for now.

Follow-up to https://github.com/kubernetes/test-infra/pull/20986

/lint