### PR TITLE
fix image-builder validate-all test

### DIFF
--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
@@ -79,6 +79,8 @@ presubmits:
           command:
           - make
           args:
+          - -C
+          - ./images/capi
           - validate-all
           env:
           - name: AZURE_LOCATION


### PR DESCRIPTION
Need to point to Makefile in images/capi folder

/assign @CecileRobertMichon 

Me working constantly with a `CWD` of `images/capi` bites me again...