### PR TITLE
remove ocp 4.6 ipv6 job from assisted-installer view

### DIFF
--- a/config/testgrids/openshift/assisted-installer.yaml
+++ b/config/testgrids/openshift/assisted-installer.yaml
@@ -28,33 +28,6 @@ dashboards:
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
-  - name: periodic-ci-openshift-release-master-nightly-4.6-e2e-metal-assisted-ipv6
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.6-e2e-metal-assisted-ipv6
-    base_options: width=10
-    open_test_template:
-      url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
-    file_bug_template:
-      options:
-      - key: classification
-        value: Red Hat
-      - key: product
-        value: OpenShift Container Platform
-      - key: cf_internal_whiteboard
-        value: buildcop
-      - key: short_desc
-        value: 'test: <test-name>'
-      - key: cf_environment
-        value: 'test: <test-name>'
-      - key: comment
-        value: 'test: <test-name> failed, see job: <test-url>'
-      url: https://bugzilla.redhat.com/enter_bug.cgi
-    open_bug_template:
-      url: https://github.com/openshift/origin/issues/
-    results_url_template:
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: https://github.com/openshift/origin/search
-    code_search_url_template:
-      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
   - name: periodic-ci-openshift-release-master-nightly-4.7-e2e-metal-assisted
     test_group_name: periodic-ci-openshift-release-master-nightly-4.7-e2e-metal-assisted
     base_options: width=10


### PR DESCRIPTION
Seems like we don't really need to show/run this job at all.
/hold