### PR TITLE
[Kettle] Edit the error handling of large requests

### DIFF
--- a/kettle/stream.py
+++ b/kettle/stream.py
@@ -100,9 +100,10 @@ def retry(func, *args, **kwargs):
             traceback.print_exc()
             time.sleep(1.4 ** attempt)
         except api_exceptions.BadRequest as err:
-            args_str = ','.join(map(str, args))
+            args_size = sys.getsizeof(args)
             kwargs_str = ','.join('{}={}'.format(k, v) for k, v in kwargs.items())
-            print(f"Error running {func.__name__}({','.join([args_str, kwargs_str])}) : {err}")
+            print(f"Error running {func.__name__} \
+                   ([bytes in args]{','.join([args_size, kwargs_str])}) : {err}")
             return None # Skip
     return func(*args, **kwargs)  # one last attempt
 


### PR DESCRIPTION
I am seeing errors in handling the BadRequest Exception:
```
UnicodeEncodeError: 'ascii' codec can't encode characters in position 4717021-4717023: ordinal not in range(128)
```
The fact that the character position is that large reenforces the thought that we are attempting to send some chunks that have FAR too much data

/area kettle

at minimum this should stop kettle from erroring out. I should think of a way to report what jobs are getting this much data collected
