### PR TITLE
Retry GetRepos() as for user when it fails for org

### DIFF
--- a/prow/pluginhelp/hook/BUILD.bazel
+++ b/prow/pluginhelp/hook/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//prow/pluginhelp/externalplugins:go_default_library",
         "//prow/plugins:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
     ],
 )

--- a/prow/pluginhelp/hook/hook.go
+++ b/prow/pluginhelp/hook/hook.go
@@ -31,8 +31,9 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-
+	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+
 	prowconfig "k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
@@ -110,7 +111,7 @@ func (ha *HelpAgent) generateExternalPluginHelp(config *plugins.Configuration, r
 	for _, ext := range externals {
 		allPlugins = append(allPlugins, ext.Name)
 		go func(ext plugins.ExternalPlugin) {
-			help, err := externalHelpProvider(ha.log, ext.Endpoint)(revMap[ext.Name])
+			help, err := externalHelpProvider(ext.Endpoint)(revMap[ext.Name])
 			if err != nil {
 				ha.log.WithError(err).Errorf("Getting help from external plugin %q.", ext.Name)
 				help = nil
@@ -197,7 +198,7 @@ func allRepos(config *plugins.Configuration, orgToRepos map[string]sets.String) 
 	return flattened.List()
 }
 
-func externalHelpProvider(log *logrus.Entry, endpoint string) externalplugins.ExternalPluginHelpProvider {
+func externalHelpProvider(endpoint string) externalplugins.ExternalPluginHelpProvider {
 	return func(enabledRepos []prowconfig.OrgRepo) (*pluginhelp.PluginHelp, error) {
 		u, err := url.Parse(endpoint)
 		if err != nil {
@@ -303,6 +304,22 @@ func (oa *orgAgent) orgToReposMap(config *plugins.Configuration) map[string]sets
 	return oa.orgToRepos
 }
 
+func reposForOrgOrUser(ghc githubClient, orgOrUser string) ([]github.Repo, error) {
+	var errs [2]error
+	inError := map[bool]string{true: "user", false: "org"}
+
+	// Check as an org first, it is more likely in normal use case
+	for i, isUser := range []bool{false, true} {
+		if repos, err := ghc.GetRepos(orgOrUser, isUser); err == nil {
+			return repos, nil
+		} else {
+			errs[i] = fmt.Errorf("failed to get repos for %s %s: %w", inError[isUser], orgOrUser, err)
+		}
+	}
+
+	return nil, errors.NewAggregate(errs[:])
+}
+
 func (oa *orgAgent) sync(config *plugins.Configuration) {
 
 	// QUESTION: If we fail to list repos for a single org should we reuse the old orgToRepos or just
@@ -313,9 +330,9 @@ func (oa *orgAgent) sync(config *plugins.Configuration) {
 	orgs := orgsInConfig(config)
 	orgToRepos := map[string]sets.String{}
 	for _, org := range orgs.List() {
-		repos, err := oa.ghc.GetRepos(org, false /*isUser*/)
+		repos, err := reposForOrgOrUser(oa.ghc, org)
 		if err != nil {
-			oa.log.WithError(err).Errorf("Getting repos in org: %s.", org)
+			oa.log.WithError(err).Errorf("Getting repos for org or user: %s.", org)
 			// Remove 'org' from 'orgs' here to force future resync?
 			continue
 		}


### PR DESCRIPTION
The code assumes the "owner" is an org, but nothing prevents it from
being a username instead, where the API call is unfortunately different
and we would fail on it.

We can retry the call for a user if it fails for an org. This increases
consumption of tokens when there are real errors and/or when there are
user repos configured (but these previously failed, so IMO it's worth
it).

Took the opportunity and removed an unused param from an unexported
method.