### PR TITLE
Kops - update GCE jobs to use cilium instead of calico

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
@@ -25,7 +25,7 @@ periodics:
       # Creates a state store bucket in the project, let's use the GCP default service account for the nodes
       # until we have a dedicated node account.
       # - --kops-args=--gce-service-account=pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com
-      - --kops-args=--networking=calico
+      - --kops-args=--networking=cilium
       - --kops-feature-flags=GoogleCloudBucketACL
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -63,7 +63,7 @@ periodics:
       - --ginkgo-parallel
       # Temporarily use default service account: https://github.com/kubernetes/test-infra/issues/17558
       #- --kops-args=--gce-service-account=pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com
-      - --kops-args=--networking=calico
+      - --kops-args=--networking=cilium
       - --kops-feature-flags=GoogleCloudBucketACL
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt


### PR DESCRIPTION
calico is using hostPath volume mounts that are a read-only filesystem on the host. Until we get a chance to troubleshoot the issue, switch the jobs to cilium to see if we can get the GCE jobs passing