### PR TITLE
sidecar: emit debug logs by default

### DIFF
--- a/prow/cmd/sidecar/main.go
+++ b/prow/cmd/sidecar/main.go
@@ -28,6 +28,7 @@ import (
 
 func main() {
 	logrusutil.ComponentInit()
+	logrus.SetLevel(logrus.DebugLevel)
 
 	o := sidecar.NewOptions()
 	if err := options.Load(o); err != nil {


### PR DESCRIPTION
Anyone looking at the logs for this utility will need them anyway, we
run by default with logging at debug in production for the rest of Prow
today so this matches that pattern.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>