### PR TITLE
sidecar: place temp files on the same device

### DIFF
--- a/prow/sidecar/censor.go
+++ b/prow/sidecar/censor.go
@@ -260,7 +260,9 @@ func validRelPath(p string) bool {
 
 // archive re-packs the dir into the destination
 func archive(srcDir, destArchive string) error {
-	output, err := ioutil.TempFile("", "tmp-archive")
+	// we want the temporary file we use for output to be in the same directory as the real destination, so
+	// we can be certain that our final os.Rename() call will not have to operate across a device boundary
+	output, err := ioutil.TempFile(filepath.Dir(destArchive), "tmp-archive")
 	if err != nil {
 		return fmt.Errorf("failed to create temporary file for archive: %w", err)
 	}
@@ -327,7 +329,9 @@ func handleFile(path string, censorer secretutil.Censorer, bufferSize int) error
 		return fmt.Errorf("could not open file for censoring: %w", err)
 	}
 
-	output, err := ioutil.TempFile("", "tmp-censor")
+	// we want the temporary file we use for output to be in the same directory as the real destination, so
+	// we can be certain that our final os.Rename() call will not have to operate across a device boundary
+	output, err := ioutil.TempFile(filepath.Dir(path), "tmp-censor")
 	if err != nil {
 		return fmt.Errorf("could not create temporary file for censoring: %w", err)
 	}


### PR DESCRIPTION
We want to be able to do a simple rename to overwrite the source file
with the censored data, and we can't do that across device boundaries,
which exist between volume mounts in a k8s Pod. Placing temporary files
in the same directory as the files they will eventually replace ensures
that renames never happen across device boundaries.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>