### PR TITLE
prow/cluster-api-provider-openstack: enable periodic and postsubmit conformance tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics.yaml
@@ -1,0 +1,94 @@
+periodics:
+- name: periodic-cluster-api-provider-openstack-e2e-test-master
+  labels:
+    preset-service-account: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  interval: 12h
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-openstack
+    base_ref: master
+    path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
+  - org: kubernetes-sigs
+    repo: image-builder
+    base_ref: master
+    path_alias: "sigs.k8s.io/image-builder"
+  max_concurrency: 1
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
+      env:
+        - name: "BOSKOS_HOST"
+          value: "boskos.test-pods.svc.cluster.local"
+      command:
+        - "runner.sh"
+        - "./scripts/ci-e2e.sh"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
+    testgrid-tab-name: periodic-e2e-test-master
+- name: periodic-cluster-api-provider-openstack-conformance-test-master-with-k8s-ci-artifacts
+  labels:
+    preset-service-account: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  interval: 12h
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-openstack
+      base_ref: master
+      path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
+    - org: kubernetes-sigs
+      repo: image-builder
+      base_ref: master
+      path_alias: "sigs.k8s.io/image-builder"
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+  max_concurrency: 1
+  spec:
+    containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
+        env:
+          - name: "BOSKOS_HOST"
+            value: "boskos.test-pods.svc.cluster.local"
+          - name: E2E_ARGS
+            value: "-kubetest.use-ci-artifacts"
+        command:
+          - "runner.sh"
+          - "./scripts/ci-conformance.sh"
+          - "--use-ci-artifacts"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            # these are both a bit below peak usage during build
+            # this is mostly for building kubernetes
+            memory: "9000Mi"
+            # during the tests more like 3-20m is used
+            cpu: 2000m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
+    testgrid-tab-name: periodic-conformance-test-master

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics.yaml
@@ -24,11 +24,11 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
       env:
-        - name: "BOSKOS_HOST"
-          value: "boskos.test-pods.svc.cluster.local"
+      - name: "BOSKOS_HOST"
+        value: "boskos.test-pods.svc.cluster.local"
       command:
-        - "runner.sh"
-        - "./scripts/ci-e2e.sh"
+      - "runner.sh"
+      - "./scripts/ci-e2e.sh"
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
@@ -54,41 +54,41 @@ periodics:
     timeout: 5h
   interval: 12h
   extra_refs:
-    - org: kubernetes-sigs
-      repo: cluster-api-provider-openstack
-      base_ref: master
-      path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
-    - org: kubernetes-sigs
-      repo: image-builder
-      base_ref: master
-      path_alias: "sigs.k8s.io/image-builder"
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-openstack
+    base_ref: master
+    path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
+  - org: kubernetes-sigs
+    repo: image-builder
+    base_ref: master
+    path_alias: "sigs.k8s.io/image-builder"
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
   max_concurrency: 1
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
-        env:
-          - name: "BOSKOS_HOST"
-            value: "boskos.test-pods.svc.cluster.local"
-          - name: E2E_ARGS
-            value: "-kubetest.use-ci-artifacts"
-        command:
-          - "runner.sh"
-          - "./scripts/ci-conformance.sh"
-          - "--use-ci-artifacts"
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
+      env:
+      - name: "BOSKOS_HOST"
+        value: "boskos.test-pods.svc.cluster.local"
+      - name: E2E_ARGS
+        value: "-kubetest.use-ci-artifacts"
+      command:
+      - "runner.sh"
+      - "./scripts/ci-conformance.sh"
+      - "--use-ci-artifacts"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
     testgrid-tab-name: periodic-conformance-test-master

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-postsubmits.yaml
@@ -1,85 +1,85 @@
 postsubmits:
   kubernetes-sigs/cluster-api-provider-openstack:
-    - name: ci-cluster-api-provider-openstack-e2e-test
-      labels:
-        preset-service-account: "true"
-        preset-bazel-scratch-dir: "true"
-        preset-bazel-remote-cache-enabled: "true"
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-      path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: image-builder
-          base_ref: master
-          path_alias: "sigs.k8s.io/image-builder"
-      max_concurrency: 1
-      spec:
-        containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
-            env:
-              - name: "BOSKOS_HOST"
-                value: "boskos.test-pods.svc.cluster.local"
-            command:
-              - "runner.sh"
-              - "./scripts/ci-e2e.sh"
-          # we need privileged mode in order to do docker in docker
-            securityContext:
-              privileged: true
-            resources:
-              requests:
-                # these are both a bit below peak usage during build
-                # this is mostly for building kubernetes
-                memory: "9000Mi"
-                # during the tests more like 3-20m is used
-                cpu: 2000m
-      annotations:
+  - name: ci-cluster-api-provider-openstack-e2e-test
+    labels:
+      preset-service-account: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: image-builder
+      base_ref: master
+      path_alias: "sigs.k8s.io/image-builder"
+    max_concurrency: 1
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
+        env:
+        - name: "BOSKOS_HOST"
+          value: "boskos.test-pods.svc.cluster.local"
+        command:
+        - "runner.sh"
+        - "./scripts/ci-e2e.sh"
+      # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            # these are both a bit below peak usage during build
+            # this is mostly for building kubernetes
+            memory: "9000Mi"
+            # during the tests more like 3-20m is used
+            cpu: 2000m
+    annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
       testgrid-tab-name: ci-e2e-test
-    - name: ci-cluster-api-provider-openstack-conformance-test
-      labels:
-        preset-service-account: "true"
-        preset-bazel-scratch-dir: "true"
-        preset-bazel-remote-cache-enabled: "true"
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-      path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: image-builder
-          base_ref: master
-          path_alias: "sigs.k8s.io/image-builder"
-        - org: kubernetes
-          repo: kubernetes
-          base_ref: master
-          path_alias: k8s.io/kubernetes
-      max_concurrency: 1
-      spec:
-        containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
-            env:
-              - name: "BOSKOS_HOST"
-                value: "boskos.test-pods.svc.cluster.local"
-            command:
-              - "runner.sh"
-              - "./scripts/ci-conformance.sh"
-              - "--use-ci-artifacts"
-            # we need privileged mode in order to do docker in docker
-            securityContext:
-              privileged: true
-            resources:
-              requests:
-                # these are both a bit below peak usage during build
-                # this is mostly for building kubernetes
-                memory: "9000Mi"
-                # during the tests more like 3-20m is used
-                cpu: 2000m
-      annotations:
+  - name: ci-cluster-api-provider-openstack-conformance-test
+    labels:
+      preset-service-account: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: image-builder
+      base_ref: master
+      path_alias: "sigs.k8s.io/image-builder"
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+    max_concurrency: 1
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
+        env:
+        - name: "BOSKOS_HOST"
+          value: "boskos.test-pods.svc.cluster.local"
+        command:
+        - "runner.sh"
+        - "./scripts/ci-conformance.sh"
+        - "--use-ci-artifacts"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            # these are both a bit below peak usage during build
+            # this is mostly for building kubernetes
+            memory: "9000Mi"
+            # during the tests more like 3-20m is used
+            cpu: 2000m
+    annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
       testgrid-tab-name: ci-conformance-test

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-postsubmits.yaml
@@ -1,0 +1,85 @@
+postsubmits:
+  kubernetes-sigs/cluster-api-provider-openstack:
+    - name: ci-cluster-api-provider-openstack-e2e-test
+      labels:
+        preset-service-account: "true"
+        preset-bazel-scratch-dir: "true"
+        preset-bazel-remote-cache-enabled: "true"
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+      path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
+      decorate: true
+      decoration_config:
+        timeout: 5h
+      extra_refs:
+        - org: kubernetes-sigs
+          repo: image-builder
+          base_ref: master
+          path_alias: "sigs.k8s.io/image-builder"
+      max_concurrency: 1
+      spec:
+        containers:
+          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
+            env:
+              - name: "BOSKOS_HOST"
+                value: "boskos.test-pods.svc.cluster.local"
+            command:
+              - "runner.sh"
+              - "./scripts/ci-e2e.sh"
+          # we need privileged mode in order to do docker in docker
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                # these are both a bit below peak usage during build
+                # this is mostly for building kubernetes
+                memory: "9000Mi"
+                # during the tests more like 3-20m is used
+                cpu: 2000m
+      annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
+      testgrid-tab-name: ci-e2e-test
+    - name: ci-cluster-api-provider-openstack-conformance-test
+      labels:
+        preset-service-account: "true"
+        preset-bazel-scratch-dir: "true"
+        preset-bazel-remote-cache-enabled: "true"
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+      path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
+      decorate: true
+      decoration_config:
+        timeout: 5h
+      extra_refs:
+        - org: kubernetes-sigs
+          repo: image-builder
+          base_ref: master
+          path_alias: "sigs.k8s.io/image-builder"
+        - org: kubernetes
+          repo: kubernetes
+          base_ref: master
+          path_alias: k8s.io/kubernetes
+      max_concurrency: 1
+      spec:
+        containers:
+          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
+            env:
+              - name: "BOSKOS_HOST"
+                value: "boskos.test-pods.svc.cluster.local"
+            command:
+              - "runner.sh"
+              - "./scripts/ci-conformance.sh"
+              - "--use-ci-artifacts"
+            # we need privileged mode in order to do docker in docker
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                # these are both a bit below peak usage during build
+                # this is mostly for building kubernetes
+                memory: "9000Mi"
+                # during the tests more like 3-20m is used
+                cpu: 2000m
+      annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
+      testgrid-tab-name: ci-conformance-test

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
@@ -52,7 +52,7 @@ presubmits:
     optional: true
     decorate: true
     decoration_config:
-      timeout: 3h
+      timeout: 5h
     extra_refs:
       - org: kubernetes-sigs
         repo: image-builder
@@ -80,8 +80,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
       testgrid-tab-name: pr-e2e-test
-  # conformance test against kubernetes master branch with `kind` + cluster-api-provider-openstack
-  - name: pull-cluster-api-provider-openstack-make-conformance
+  - name: pull-cluster-api-provider-openstack-conformance-test
     labels:
       preset-service-account: "true"
       preset-bazel-scratch-dir: "true"
@@ -93,7 +92,7 @@ presubmits:
     optional: true
     decorate: true
     decoration_config:
-      timeout: 3h
+      timeout: 5h
     extra_refs:
       - org: kubernetes-sigs
         repo: image-builder
@@ -125,4 +124,4 @@ presubmits:
               cpu: 2000m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
-      testgrid-tab-name: pr-conformance
+      testgrid-tab-name: pr-conformance-test

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
@@ -54,19 +54,19 @@ presubmits:
     decoration_config:
       timeout: 5h
     extra_refs:
-      - org: kubernetes-sigs
-        repo: image-builder
-        base_ref: master
-        path_alias: "sigs.k8s.io/image-builder"
+    - org: kubernetes-sigs
+      repo: image-builder
+      base_ref: master
+      path_alias: "sigs.k8s.io/image-builder"
     spec:
       containers:
         - image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
           env:
-            - name: "BOSKOS_HOST"
-              value: "boskos.test-pods.svc.cluster.local"
+          - name: "BOSKOS_HOST"
+            value: "boskos.test-pods.svc.cluster.local"
           command:
-            - "runner.sh"
-            - "./scripts/ci-e2e.sh"
+          - "runner.sh"
+          - "./scripts/ci-e2e.sh"
           # we need privileged mode in order to do docker in docker
           securityContext:
             privileged: true
@@ -94,24 +94,24 @@ presubmits:
     decoration_config:
       timeout: 5h
     extra_refs:
-      - org: kubernetes-sigs
-        repo: image-builder
-        base_ref: master
-        path_alias: "sigs.k8s.io/image-builder"
-      - org: kubernetes
-        repo: kubernetes
-        base_ref: master
-        path_alias: k8s.io/kubernetes
+    - org: kubernetes-sigs
+      repo: image-builder
+      base_ref: master
+      path_alias: "sigs.k8s.io/image-builder"
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     spec:
       containers:
         - image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
           env:
-            - name: "BOSKOS_HOST"
-              value: "boskos.test-pods.svc.cluster.local"
+          - name: "BOSKOS_HOST"
+            value: "boskos.test-pods.svc.cluster.local"
           command:
-            - "runner.sh"
-            - "./scripts/ci-conformance.sh"
-            - "--use-ci-artifacts"
+          - "runner.sh"
+          - "./scripts/ci-conformance.sh"
+          - "--use-ci-artifacts"
           # we need privileged mode in order to do docker in docker
           securityContext:
             privileged: true

--- a/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
+++ b/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
@@ -42,9 +42,6 @@ dashboards:
 - name: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
 - name: sig-cluster-lifecycle-cluster-api-provider-vsphere
 - name: sig-cluster-lifecycle-cluster-api-provider-openstack
-  dashboard_tab:
-    - name: capo-conformance-stable-k8s-master
-      test_group_name: ci-cluster-api-provider-openstack-make-conformance-stable-k8s-ci-artifacts
 - name: sig-cluster-lifecycle-cluster-api-bootstrap-provider-kubeadm
 - name: sig-cluster-lifecycle-cluster-api-provider-docker
 - name: sig-cluster-lifecycle-kops
@@ -55,8 +52,6 @@ dashboards:
 - name: sig-cluster-lifecycle-image-builder
 
 test_groups:
-- name: ci-cluster-api-provider-openstack-make-conformance-stable-k8s-ci-artifacts
-  gcs_prefix: k8s-conform-capi-openstack/periodic-logs/ci-cluster-api-provider-openstack-stable-acceptance-test-master
 - name: periodic-cluster-api-provider-azure-coverage
   gcs_prefix: kubernetes-jenkins/logs/periodic-cluster-api-provider-azure-coverage
   short_text_metric: coverage


### PR DESCRIPTION
This adds post-submit and periodic tests like the other CAPI providers have (but we test a bit less frequently (i.e. higher intervals).

The test results will then be available here: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-openstack