### PR TITLE
Tide: Document order of priority setting

### DIFF
--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -991,7 +991,8 @@ tide:
         "": ""
 
     # Priority is an ordered list of sets of labels that would be prioritized before other PRs
-    # PRs should match all labels contained in a set to be prioritized
+    # PRs should match all labels contained in a set to be prioritized. The first entry has
+    # the highest priority.
     priority:
       - labels:
           - ""

--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -153,7 +153,8 @@ type Tide struct {
 	BatchSizeLimitMap map[string]int `json:"batch_size_limit,omitempty"`
 
 	// Priority is an ordered list of sets of labels that would be prioritized before other PRs
-	// PRs should match all labels contained in a set to be prioritized
+	// PRs should match all labels contained in a set to be prioritized. The first entry has
+	// the highest priority.
 	Priority []TidePriority `json:"priority,omitempty"`
 }
 


### PR DESCRIPTION
This isn't really obvious, we have other places where the last element
has the highest priority. I had to look into the code to figure this
out, that shouldn't be needed.

/assign @matthyx 