### PR TITLE
[Kettle] Move kettle to filtered subscription 

### DIFF
--- a/kettle/deployment.yaml
+++ b/kettle/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - name: DEPLOYMENT
           value: prod
         - name: SUBSCRIPTION_PATH
-          value: kubernetes-jenkins/gcs-changes/kettle
+          value: kubernetes-jenkins/gcs-changes/kettle-filtered
         volumeMounts:
         - name: service
           mountPath: /etc/service-account

--- a/kettle/stream.py
+++ b/kettle/stream.py
@@ -59,11 +59,10 @@ def process_changes(results, buckets):
     todo = []  # (id, job, build) of builds to grab
     # process results, find finished builds to process
     for rec_message in results:
-        eventType = rec_message.message.attributes['eventType']
         object_id = rec_message.message.attributes['objectId']
         bucket_id = rec_message.message.attributes['bucketId']
         exclude = should_exclude(object_id, bucket_id, buckets)
-        if eventType != 'OBJECT_FINALIZE' or not object_id.endswith('/finished.json') or exclude:
+        if not object_id.endswith('/finished.json') or exclude:
             ack_ids.append(rec_message.ack_id)
             continue
         job, build = object_id[:-len('/finished.json')].rsplit('/', 1)

--- a/kettle/stream_test.py
+++ b/kettle/stream_test.py
@@ -153,26 +153,6 @@ class StreamTest(unittest.TestCase):
             ])
         ),
         (
-            "Non-Final object",
-            [
-                FakeReceivedMessage(
-                    'a', FakePubSubMessage(
-                        'no_data', {
-                            'eventType': 'OBJECT_DELETE',
-                            'objectId': 'pr-logs/pull/100038/pull-kubernetes-bazel-test/136941941204137164A/finished.json',
-                            'bucketId': 'kubernetes-jenkins'})),
-                FakeReceivedMessage(
-                    'b', FakePubSubMessage(
-                        'no_data2', {
-                            'eventType': 'OBJECT_FINALIZE',
-                            'objectId': 'pr-logs/pull/100038/pull-kubernetes-bazel-test/136941941204137164B/finished.json',
-                            'bucketId': 'kubernetes-jenkins'}))
-            ],
-            (['a'], [
-                ('b', "gs://kubernetes-jenkins/pr-logs/pull/100038/pull-kubernetes-bazel-test", "136941941204137164B"),
-            ])
-        ),
-        (
             "Object not finsihed",
             [
                 FakeReceivedMessage(
@@ -224,16 +204,6 @@ class StreamTest(unittest.TestCase):
         db = model.Database(':memory:')
         fake_sub = FakeSub(
             [
-                FakePullResponse(
-                    [FakeReceivedMessage(
-                        'a',
-                        FakePubSubMessage(
-                            'no_data',
-                            {'eventType': 'OBJECT_DELETE',
-                             'objectId': 'logs/fake/123/finished.json',
-                             'bucketId': 'kubernetes-jenkins'})
-                    )]
-                ),
                 FakePullResponse(
                     [FakeReceivedMessage(
                         'b',
@@ -288,8 +258,6 @@ class StreamTest(unittest.TestCase):
             fake_sub.trace,
             [['pull', fake_sub_path, False],
              ['pull', fake_sub_path, True],
-             ['pull', fake_sub_path, True],
-             ['ack', fake_sub_path, ['a']],
              ['modify-ack', fake_sub_path, ['b'], 180],
              ['ack', fake_sub_path, ['b']],
              ['pull', fake_sub_path, False],


### PR DESCRIPTION
This is a follow-up to #20383 which was abandoned after the branch got stale and in a bad state.

I created a new filtered subscription: `kettle-filtered` and will remove `kettle` subscription at the point Prod is stable with the change.
/label tide/merge-method-squash
/area kettle
/cc @amwat 