### PR TITLE
sig-windows: create release signal dashboard on testgrid

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/presets.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/presets.yaml
@@ -1,0 +1,33 @@
+presets:
+- labels:
+    preset-azure-windows: "true"
+  env:
+  - name: WIN_BUILD
+    value: https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/build/build-windows-k8s.sh
+  - name: K8S_SSH_PUBLIC_KEY_PATH
+    value: /etc/ssh-key-secret/ssh-public # from preset-k8s-ssh label
+  - name: K8S_SSH_PRIVATE_KEY_PATH
+    value: /etc/ssh-key-secret/ssh-private # from preset-k8s-ssh label
+  - name: GINKGO_FOCUS_PARALLEL
+    value: \[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
+  - name: GINKGO_SKIP_PARALLEL
+    value: \[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
+  - name: GINKGO_FOCUS_SERIAL
+    value: (\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-autoscaling\].\[Feature:HPA\]|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])
+  - name: GINKGO_SKIP_SERIAL
+    value: \[LinuxOnly\]|device.plugin.for.Windows
+- labels:
+    preset-windows-repo-list: "true"
+  env:
+  - name: KUBE_TEST_REPO_LIST_DOWNLOAD_LOCATION
+    value: https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list
+- labels:
+    preset-windows-repo-list-master: "true"
+  env:
+  - name: KUBE_TEST_REPO_LIST_DOWNLOAD_LOCATION
+    value: https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list-master
+- labels:
+    preset-windows-repo-list-2004: "true"
+  env:
+  - name: KUBE_TEST_REPO_LIST_DOWNLOAD_LOCATION
+    value: https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list-2004

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.18-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.18-windows.yaml
@@ -1,6 +1,6 @@
 presubmits:
   kubernetes/kubernetes:
-  - name: pull-kubernetes-e2e-azure-disk-windows
+  - name: pull-kubernetes-e2e-aks-engine-azure-disk-windows-dockershim
     decorate: true
     always_run: false
     optional: true
@@ -59,7 +59,7 @@ presubmits:
           value: kubernetes.io/azure-disk # In-tree Azure disk storage class
         - name: TEST_WINDOWS
           value: "true"
-  - name: pull-kubernetes-e2e-azure-file-windows
+  - name: pull-kubernetes-e2e-aks-engine-azure-file-windows-dockershim
     decorate: true
     always_run: false
     optional: true

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.18-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.18-windows.yaml
@@ -164,13 +164,13 @@ periodics:
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
       # Specific test args
-      - --test_args=--node-os-distro=windows --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Slow\]|Guestbook.application.should.create.and.stop.a.working.application
+      - --test_args=--node-os-distro=windows --ginkgo.focus=$(GINKGO_FOCUS_PARALLEL) --ginkgo.skip=$(GINKGO_SKIP_PARALLEL)
       - --ginkgo-parallel=4
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows-releases, sig-windows-azure, sig-release-1.18-informing
-    testgrid-tab-name: aks-engine-azure-1-18-windows
+    testgrid-dashboards: sig-release-1.18-informing, sig-windows-1.18-release
+    testgrid-tab-name: aks-engine-windows-dockershim
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s 1.18 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 24h
@@ -218,12 +218,12 @@ periodics:
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
       # Specific test args
-      - --test_args=--node-os-distro=windows --ginkgo.focus=(\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-autoscaling\].\[Feature:HPA\]|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\]) --ginkgo.skip=\[LinuxOnly\]
+      - --test_args=--node-os-distro=windows --ginkgo.focus=$(GINKGO_FOCUS_SERIAL) --ginkgo.skip=$(GINKGO_SKIP_SERIAL)
       - --ginkgo-parallel=1
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows-releases, sig-windows-azure
-    testgrid-tab-name: aks-engine-azure-1-18-windows-serial-slow
+    testgrid-dashboards: sig-windows-1.18-release
+    testgrid-tab-name: aks-engine-windows-dockershim-serial-slow
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release serial tests on K8s 1.18 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.18-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.18-windows.yaml
@@ -170,7 +170,7 @@ periodics:
         privileged: true
   annotations:
     testgrid-dashboards: sig-release-1.18-informing, sig-windows-1.18-release
-    testgrid-tab-name: aks-engine-windows-dockershim
+    testgrid-tab-name: aks-engine-windows-dockershim-1.18
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s 1.18 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 24h
@@ -224,6 +224,6 @@ periodics:
         privileged: true
   annotations:
     testgrid-dashboards: sig-windows-1.18-release
-    testgrid-tab-name: aks-engine-windows-dockershim-serial-slow
+    testgrid-tab-name: aks-engine-windows-dockershim-serial-slow-1.18
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release serial tests on K8s 1.18 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.19-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.19-windows.yaml
@@ -1,6 +1,6 @@
 presubmits:
   kubernetes/kubernetes:
-  - name: pull-kubernetes-e2e-azure-disk-windows
+  - name: pull-kubernetes-e2e-aks-engine-azure-disk-windows-dockershim
     decorate: true
     always_run: false
     optional: true
@@ -59,7 +59,7 @@ presubmits:
           value: kubernetes.io/azure-disk # In-tree Azure disk storage class
         - name: TEST_WINDOWS
           value: "true"
-  - name: pull-kubernetes-e2e-azure-file-windows
+  - name: pull-kubernetes-e2e-aks-engine-azure-file-windows-dockershim
     decorate: true
     always_run: false
     optional: true

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.19-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.19-windows.yaml
@@ -170,7 +170,7 @@ periodics:
         privileged: true
   annotations:
     testgrid-dashboards: sig-release-1.19-informing, sig-windows-1.19-release
-    testgrid-tab-name: aks-engine-windows-dockershim
+    testgrid-tab-name: aks-engine-windows-dockershim-1.19
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s 1.19 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 24h
@@ -224,7 +224,7 @@ periodics:
         privileged: true
   annotations:
     testgrid-dashboards: sig-windows-1.19-release
-    testgrid-tab-name: aks-engine-windows-dockershim-serial-slow
+    testgrid-tab-name: aks-engine-windows-dockershim-serial-slow-1.19
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release serial tests on K8s 1.19 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 24h
@@ -278,7 +278,7 @@ periodics:
         privileged: true
   annotations:
     testgrid-dashboards: sig-windows-1.19-release
-    testgrid-tab-name: aks-engine-windows-containerd
+    testgrid-tab-name: aks-engine-windows-containerd-1.19
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs Windows tests on a Kubernetes cluster running containerd provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 24h
@@ -332,6 +332,6 @@ periodics:
         privileged: true
   annotations:
     testgrid-dashboards: sig-windows-1.19-release
-    testgrid-tab-name: aks-engine-windows-containerd-serial-slow
+    testgrid-tab-name: aks-engine-windows-containerd-serial-slow-1.19
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs serial Windows tests on a Kubernetes cluster running containerd provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.19-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.19-windows.yaml
@@ -164,13 +164,13 @@ periodics:
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
       # Specific test args
-      - --test_args=--node-os-distro=windows --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Slow\]|Guestbook.application.should.create.and.stop.a.working.application
+      - --test_args=--node-os-distro=windows --ginkgo.focus=$(GINKGO_FOCUS_PARALLEL) --ginkgo.skip=$(GINKGO_SKIP_PARALLEL)
       - --ginkgo-parallel=4
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows-releases, sig-windows-azure, sig-release-1.19-informing
-    testgrid-tab-name: aks-engine-azure-1-19-windows
+    testgrid-dashboards: sig-release-1.19-informing, sig-windows-1.19-release
+    testgrid-tab-name: aks-engine-windows-dockershim
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s 1.19 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 24h
@@ -218,13 +218,13 @@ periodics:
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
       # Specific test args
-      - --test_args=--node-os-distro=windows --ginkgo.focus=(\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-autoscaling\].\[Feature:HPA\]|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\]) --ginkgo.skip=\[LinuxOnly\]
+      - --test_args=--node-os-distro=windows --ginkgo.focus=$(GINKGO_FOCUS_SERIAL) --ginkgo.skip=$(GINKGO_SKIP_SERIAL)
       - --ginkgo-parallel=1
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows-releases, sig-windows-azure
-    testgrid-tab-name: aks-engine-azure-1-19-windows-serial-slow
+    testgrid-dashboards: sig-windows-1.19-release
+    testgrid-tab-name: aks-engine-windows-dockershim-serial-slow
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release serial tests on K8s 1.19 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 24h
@@ -272,13 +272,13 @@ periodics:
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
       # Specific test args
-      - --test_args=--node-os-distro=windows --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Slow\]|Guestbook.application.should.create.and.stop.a.working.application
+      - --test_args=--node-os-distro=windows --ginkgo.focus=$(GINKGO_FOCUS_PARALLEL) --ginkgo.skip=$(GINKGO_SKIP_PARALLEL)
       - --ginkgo-parallel=4
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows-containerd, sig-windows-azure
-    testgrid-tab-name: aks-engine-azure-windows-1-19-containerd
+    testgrid-dashboards: sig-windows-1.19-release
+    testgrid-tab-name: aks-engine-windows-containerd
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs Windows tests on a Kubernetes cluster running containerd provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 24h
@@ -326,12 +326,12 @@ periodics:
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
       # Specific test args
-      - --test_args=--node-os-distro=windows --ginkgo.focus=(\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-autoscaling\].\[Feature:HPA\]|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\]) --ginkgo.skip=\[LinuxOnly\]
+      - --test_args=--node-os-distro=windows --ginkgo.focus=$(GINKGO_FOCUS_SERIAL) --ginkgo.skip=$(GINKGO_SKIP_SERIAL)
       - --ginkgo-parallel=1
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows-containerd, sig-windows-azure
-    testgrid-tab-name: aks-engine-azure-windows-1-19-containerd-serial-slow
+    testgrid-dashboards: sig-windows-1.19-release
+    testgrid-tab-name: aks-engine-windows-containerd-serial-slow
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs serial Windows tests on a Kubernetes cluster running containerd provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.20-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.20-windows.yaml
@@ -1,6 +1,6 @@
 presubmits:
   kubernetes/kubernetes:
-  - name: pull-kubernetes-e2e-azure-disk-windows
+  - name: pull-kubernetes-e2e-aks-engine-azure-disk-windows-dockershim
     decorate: true
     always_run: false
     optional: true
@@ -59,7 +59,7 @@ presubmits:
           value: kubernetes.io/azure-disk # In-tree Azure disk storage class
         - name: TEST_WINDOWS
           value: "true"
-  - name: pull-kubernetes-e2e-azure-file-windows
+  - name: pull-kubernetes-e2e-aks-engine-azure-file-windows-dockershim
     decorate: true
     always_run: false
     optional: true

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.20-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.20-windows.yaml
@@ -164,13 +164,13 @@ periodics:
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
       # Specific test args
-      - --test_args=--node-os-distro=windows --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Slow\]|Guestbook.application.should.create.and.stop.a.working.application
+      - --test_args=--node-os-distro=windows --ginkgo.focus=$(GINKGO_FOCUS_PARALLEL) --ginkgo.skip=$(GINKGO_SKIP_PARALLEL)
       - --ginkgo-parallel=4
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows-releases, sig-windows-azure, sig-release-1.20-informing
-    testgrid-tab-name: aks-engine-azure-1-20-windows
+    testgrid-dashboards: sig-release-1.20-informing, sig-windows-1.20-release
+    testgrid-tab-name: aks-engine-windows-containerd
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s 1.20 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 24h
@@ -218,12 +218,12 @@ periodics:
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
       # Specific test args
-      - --test_args=--node-os-distro=windows --ginkgo.focus=(\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-autoscaling\].\[Feature:HPA\]|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\]) --ginkgo.skip=\[LinuxOnly\]|\[sig-scheduling\].SchedulerPredicates.\[Serial\].validates.that.there.is.no.conflict.between.pods.with.same.hostPort
+      - --test_args=--node-os-distro=windows --ginkgo.focus=$(GINKGO_FOCUS_SERIAL) --ginkgo.skip=$(GINKGO_SKIP_SERIAL)
       - --ginkgo-parallel=1
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows-releases, sig-windows-azure
-    testgrid-tab-name: aks-engine-azure-1-20-windows-serial-slow
+    testgrid-dashboards: sig-windows-1.20-release
+    testgrid-tab-name: aks-engine-windows-containerd-serial-slow
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release serial tests on K8s 1.20 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.20-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.20-windows.yaml
@@ -170,7 +170,7 @@ periodics:
         privileged: true
   annotations:
     testgrid-dashboards: sig-release-1.20-informing, sig-windows-1.20-release
-    testgrid-tab-name: aks-engine-windows-containerd
+    testgrid-tab-name: aks-engine-windows-containerd-1.20
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s 1.20 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 24h
@@ -218,12 +218,12 @@ periodics:
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
       # Specific test args
-      - --test_args=--node-os-distro=windows --ginkgo.focus=$(GINKGO_FOCUS_SERIAL) --ginkgo.skip=$(GINKGO_SKIP_SERIAL)
+      - --test_args=--node-os-distro=windows --ginkgo.focus=$(GINKGO_FOCUS_SERIAL) --ginkgo.skip=$(GINKGO_SKIP_SERIAL)|\[sig-scheduling\].SchedulerPredicates.\[Serial\].validates.that.there.is.no.conflict.between.pods.with.same.hostPort
       - --ginkgo-parallel=1
       securityContext:
         privileged: true
   annotations:
     testgrid-dashboards: sig-windows-1.20-release
-    testgrid-tab-name: aks-engine-windows-containerd-serial-slow
+    testgrid-tab-name: aks-engine-windows-containerd-serial-slow-1.20
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release serial tests on K8s 1.20 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -1,37 +1,3 @@
-presets:
-- labels:
-    preset-azure-windows: "true"
-  env:
-  - name: WIN_BUILD
-    value: https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/build/build-windows-k8s.sh
-  - name: K8S_SSH_PUBLIC_KEY_PATH
-    value: /etc/ssh-key-secret/ssh-public # from preset-k8s-ssh label
-  - name: K8S_SSH_PRIVATE_KEY_PATH
-    value: /etc/ssh-key-secret/ssh-private # from preset-k8s-ssh label
-  - name: GINKGO_FOCUS_PARALLEL
-    value: \[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
-  - name: GINKGO_SKIP_PARALLEL
-    value: \[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
-  - name: GINKGO_FOCUS_SERIAL
-    value: (\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-autoscaling\].\[Feature:HPA\]|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])
-  - name: GINKGO_SKIP_SERIAL
-    value: \[LinuxOnly\]|device.plugin.for.Windows
-- labels:
-    preset-windows-repo-list: "true"
-  env:
-  - name: KUBE_TEST_REPO_LIST_DOWNLOAD_LOCATION
-    value: https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list
-- labels:
-    preset-windows-repo-list-master: "true"
-  env:
-  - name: KUBE_TEST_REPO_LIST_DOWNLOAD_LOCATION
-    value: https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list-master
-- labels:
-    preset-windows-repo-list-2004: "true"
-  env:
-  - name: KUBE_TEST_REPO_LIST_DOWNLOAD_LOCATION
-    value: https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list-2004
-
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-aks-engine-windows-dockershim
@@ -73,7 +39,7 @@ presubmits:
         - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
         - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
         - --aksengine-winZipBuildScript=$(WIN_BUILD)
-        - --aksengine-orchestratorRelease=1.20
+        - --aksengine-orchestratorRelease=1.21
         - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_release_staging.json
         - --aksengine-win-binaries
         - --aksengine-deploy-custom-k8s
@@ -127,7 +93,7 @@ presubmits:
         - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
         - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
         - --aksengine-winZipBuildScript=$(WIN_BUILD)
-        - --aksengine-orchestratorRelease=1.20
+        - --aksengine-orchestratorRelease=1.21
         - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_master.json
         - --aksengine-win-binaries
         - --aksengine-deploy-custom-k8s
@@ -187,7 +153,7 @@ presubmits:
         - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
         - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
         - --aksengine-winZipBuildScript=$(WIN_BUILD)
-        - --aksengine-orchestratorRelease=1.20
+        - --aksengine-orchestratorRelease=1.21
         - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_in_tree_volume_plugins.json
         - --aksengine-win-binaries
         - --aksengine-deploy-custom-k8s
@@ -250,7 +216,7 @@ presubmits:
         - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
         - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
         - --aksengine-winZipBuildScript=$(WIN_BUILD)
-        - --aksengine-orchestratorRelease=1.20
+        - --aksengine-orchestratorRelease=1.21
         - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_in_tree_volume_plugins.json
         - --aksengine-win-binaries
         - --aksengine-deploy-custom-k8s
@@ -307,7 +273,7 @@ presubmits:
         - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
         - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
         - --aksengine-winZipBuildScript=$(WIN_BUILD)
-        - --aksengine-orchestratorRelease=1.20
+        - --aksengine-orchestratorRelease=1.21
         - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_docker_gpu_master.json
         - --aksengine-win-binaries
         - --aksengine-deploy-custom-k8s
@@ -367,7 +333,7 @@ presubmits:
         - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
         - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
         - --aksengine-winZipBuildScript=$(WIN_BUILD)
-        - --aksengine-orchestratorRelease=1.20
+        - --aksengine-orchestratorRelease=1.21
         - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_csi_proxy.json
         - --aksengine-win-binaries
         - --aksengine-deploy-custom-k8s
@@ -429,7 +395,7 @@ presubmits:
         - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
         - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
         - --aksengine-winZipBuildScript=$(WIN_BUILD)
-        - --aksengine-orchestratorRelease=1.20
+        - --aksengine-orchestratorRelease=1.21
         - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_csi_proxy.json
         - --aksengine-win-binaries
         - --aksengine-deploy-custom-k8s
@@ -488,7 +454,7 @@ periodics:
       - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
       - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
       - --aksengine-winZipBuildScript=$(WIN_BUILD)
-      - --aksengine-orchestratorRelease=1.20
+      - --aksengine-orchestratorRelease=1.21
       - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_release_staging.json
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
@@ -499,7 +465,7 @@ periodics:
         privileged: true
   annotations:
     testgrid-dashboards: sig-windows-master-release
-    testgrid-tab-name: aks-engine-windows-dockershim
+    testgrid-tab-name: aks-engine-windows-dockershim-master
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Staging job for new Windows tests on a Kubernetes cluster provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 24h
@@ -542,7 +508,7 @@ periodics:
       - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
       - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
       - --aksengine-winZipBuildScript=$(WIN_BUILD)
-      - --aksengine-orchestratorRelease=1.20
+      - --aksengine-orchestratorRelease=1.21
       - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_release_staging_serial.json
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
@@ -553,7 +519,7 @@ periodics:
         privileged: true
   annotations:
     testgrid-dashboards: sig-windows-master-release
-    testgrid-tab-name: aks-engine-windows-dockershim-serial-slow
+    testgrid-tab-name: aks-engine-windows-dockershim-serial-slow-master
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Staging job for new Windows tests on a Kubernetes cluster provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 3h
@@ -596,7 +562,7 @@ periodics:
       - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
       - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
       - --aksengine-winZipBuildScript=$(WIN_BUILD)
-      - --aksengine-orchestratorRelease=1.20
+      - --aksengine-orchestratorRelease=1.21
       - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_master.json
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
@@ -608,7 +574,7 @@ periodics:
   annotations:
     fork-per-release: "true"
     testgrid-dashboards: sig-release-master-informing, sig-windows-signal, sig-windows-master-release
-    testgrid-tab-name: aks-engine-windows-containerd
+    testgrid-tab-name: aks-engine-windows-containerd-master
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs Windows tests on a Kubernetes cluster running containerd provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 24h
@@ -651,7 +617,7 @@ periodics:
       - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
       - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
       - --aksengine-winZipBuildScript=$(WIN_BUILD)
-      - --aksengine-orchestratorRelease=1.20
+      - --aksengine-orchestratorRelease=1.21
       - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_master_serial.json
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
@@ -662,117 +628,9 @@ periodics:
         privileged: true
   annotations:
     testgrid-dashboards: sig-windows-master-release
-    testgrid-tab-name: aks-engine-windows-containerd-serial-slow
+    testgrid-tab-name: aks-engine-windows-containerd-serial-slow-master
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs serial Windows tests on a Kubernetes cluster running containerd provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
-- interval: 48h
-  name: ci-kubernetes-e2e-aks-engine-azure-master-windows-containerd-hyperv
-  decorate: true
-  decoration_config:
-    timeout: 3h
-  labels:
-    preset-service-account: "true"
-    preset-azure-cred: "true"
-    preset-azure-windows: "true"
-    preset-windows-repo-list-master: "true"
-    preset-k8s-ssh: "true"
-    preset-dind-enabled: "true"
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
-      command:
-      - runner.sh
-      - kubetest
-      args:
-      # Generic e2e test args
-      - --test
-      - --up
-      - --down
-      - --build=quick
-      - --dump=$(ARTIFACTS)
-      # Azure-specific test args
-      - --deployment=aksengine
-      - --provider=skeleton
-      - --aksengine-admin-username=azureuser
-      - --aksengine-admin-password=AdminPassw0rd
-      - --aksengine-creds=$(AZURE_CREDENTIALS)
-      - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/nightly/aks-engine-nightly-linux-amd64.tar.gz
-      - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
-      - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
-      - --aksengine-winZipBuildScript=$(WIN_BUILD)
-      - --aksengine-orchestratorRelease=1.20
-      - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_hyperv.json
-      - --aksengine-win-binaries
-      - --aksengine-deploy-custom-k8s
-      # Specific test args
-      - --test_args=--node-os-distro=windows --ginkgo.focus=$(GINKGO_FOCUS_PARALLEL) --ginkgo.skip=$(GINKGO_SKIP_PARALLEL)
-      - --ginkgo-parallel=3
-      securityContext:
-        privileged: true
-  annotations:
-    testgrid-dashboards: sig-windows-master-release
-    testgrid-tab-name: aks-engine-windows-containerd-hyperv
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
-    description: Runs Windows tests on a Kubernetes cluster running containerd with HyperV isolation provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
-- interval: 48h
-  name: ci-kubernetes-e2e-aks-engine-azure-master-windows-containerd-hyperv-serial-slow
-  decorate: true
-  decoration_config:
-    timeout: 5h
-  labels:
-    preset-service-account: "true"
-    preset-azure-cred: "true"
-    preset-azure-windows: "true"
-    preset-windows-repo-list-master: "true"
-    preset-k8s-ssh: "true"
-    preset-dind-enabled: "true"
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
-      command:
-      - runner.sh
-      - kubetest
-      args:
-      # Generic e2e test args
-      - --test
-      - --up
-      - --down
-      - --build=quick
-      - --dump=$(ARTIFACTS)
-      # Azure-specific test args
-      - --deployment=aksengine
-      - --provider=skeleton
-      - --aksengine-admin-username=azureuser
-      - --aksengine-admin-password=AdminPassw0rd
-      - --aksengine-creds=$(AZURE_CREDENTIALS)
-      - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/nightly/aks-engine-nightly-linux-amd64.tar.gz
-      - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
-      - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
-      - --aksengine-winZipBuildScript=$(WIN_BUILD)
-      - --aksengine-orchestratorRelease=1.20
-      - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_hyperv.json
-      - --aksengine-win-binaries
-      - --aksengine-deploy-custom-k8s
-      # Specific test args
-      - --test_args=--node-os-distro=windows --ginkgo.focus=$(GINKGO_FOCUS_SERIAL) --ginkgo.skip==$(GINKGO_SKIP_SERIAL)
-      - --ginkgo-parallel=1
-      securityContext:
-        privileged: true
-  annotations:
-    testgrid-dashboards: sig-windows-master-release
-    testgrid-tab-name: aks-engine-windows-containerd-hyperv-serial-slow
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
-    description: Runs serial Windows tests on a Kubernetes cluster running containerd with HyperV isolation provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 48h
   name: ci-kubernetes-e2e-azure-disk-windows
   decorate: true
@@ -817,7 +675,7 @@ periodics:
       - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
       - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
       - --aksengine-winZipBuildScript=$(WIN_BUILD)
-      - --aksengine-orchestratorRelease=1.20
+      - --aksengine-orchestratorRelease=1.21
       - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_in_tree_volume_plugins.json
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
@@ -833,7 +691,7 @@ periodics:
         value: "true"
   annotations:
     testgrid-dashboards: sig-windows-master-release
-    testgrid-tab-name: aks-engine-windows-dockershim-azure-disk
+    testgrid-tab-name: aks-engine-windows-dockershim-azure-disk-master
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure Disk e2e test with Azure Disk in-tree volume plugin in a Windows cluster.
 - interval: 48h
@@ -880,7 +738,7 @@ periodics:
       - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
       - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
       - --aksengine-winZipBuildScript=$(WIN_BUILD)
-      - --aksengine-orchestratorRelease=1.20
+      - --aksengine-orchestratorRelease=1.21
       - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_csi_proxy.json
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
@@ -894,7 +752,7 @@ periodics:
         value: "true"
   annotations:
     testgrid-dashboards: sig-windows-master-release
-    testgrid-tab-name: aks-engine-windows-containerd-azure-disk
+    testgrid-tab-name: aks-engine-windows-containerd-azure-disk-master
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure Disk e2e test with Azure Disk in a Windows cluster configured with CSI proxy and containerd.
 - interval: 48h
@@ -941,7 +799,7 @@ periodics:
       - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
       - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
       - --aksengine-winZipBuildScript=$(WIN_BUILD)
-      - --aksengine-orchestratorRelease=1.20
+      - --aksengine-orchestratorRelease=1.21
       - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_in_tree_volume_plugins.json
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
@@ -957,7 +815,7 @@ periodics:
         value: "true"
   annotations:
     testgrid-dashboards: sig-windows-master-release
-    testgrid-tab-name: aks-engine-windows-dockershim-azure-file
+    testgrid-tab-name: aks-engine-windows-dockershim-azure-file-master
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure File e2e test with Azure File in-tree volume plugin in a Windows cluster.
 - interval: 48h
@@ -1004,7 +862,7 @@ periodics:
       - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
       - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
       - --aksengine-winZipBuildScript=$(WIN_BUILD)
-      - --aksengine-orchestratorRelease=1.20
+      - --aksengine-orchestratorRelease=1.21
       - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_csi_proxy.json
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
@@ -1018,6 +876,6 @@ periodics:
         value: "true"
   annotations:
     testgrid-dashboards: sig-windows-master-release
-    testgrid-tab-name: aks-engine-windows-containerd-azure-file
+    testgrid-tab-name: aks-engine-windows-containerd-azure-file-master
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure File e2e test with Azure File in a Windows cluster configured with CSI proxy and containerd.

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -8,6 +8,14 @@ presets:
     value: /etc/ssh-key-secret/ssh-public # from preset-k8s-ssh label
   - name: K8S_SSH_PRIVATE_KEY_PATH
     value: /etc/ssh-key-secret/ssh-private # from preset-k8s-ssh label
+  - name: GINKGO_FOCUS_PARALLEL
+    value: \[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
+  - name: GINKGO_SKIP_PARALLEL
+    value: \[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
+  - name: GINKGO_FOCUS_SERIAL
+    value: (\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-autoscaling\].\[Feature:HPA\]|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])
+  - name: GINKGO_SKIP_SERIAL
+    value: \[LinuxOnly\]|device.plugin.for.Windows
 - labels:
     preset-windows-repo-list: "true"
   env:
@@ -19,11 +27,6 @@ presets:
   - name: KUBE_TEST_REPO_LIST_DOWNLOAD_LOCATION
     value: https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list-master
 - labels:
-    preset-windows-repo-list-pr: "true"
-  env:
-  - name: KUBE_TEST_REPO_LIST_DOWNLOAD_LOCATION
-    value: https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list-pr
-- labels:
     preset-windows-repo-list-2004: "true"
   env:
   - name: KUBE_TEST_REPO_LIST_DOWNLOAD_LOCATION
@@ -31,7 +34,7 @@ presets:
 
 presubmits:
   kubernetes/kubernetes:
-  - name: pull-kubernetes-e2e-aks-engine-azure-windows
+  - name: pull-kubernetes-e2e-aks-engine-windows-dockershim
     always_run: false
     optional: true
     decorate: true
@@ -76,13 +79,13 @@ presubmits:
         - --aksengine-deploy-custom-k8s
         - --aksengine-agentpoolcount=2
         # Specific test args
-        - --test_args=--node-os-distro=windows --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
+        - --test_args=--node-os-distro=windows --ginkgo.focus=$(GINKGO_FOCUS_PARALLEL) --ginkgo.skip=$(GINKGO_SKIP_PARALLEL)
         - --ginkgo-parallel=4
         securityContext:
           privileged: true
     annotations:
       testgrid-dashboards: sig-windows-presubmit
-      testgrid-tab-name: pr-aks-engine-azure-windows
+      testgrid-tab-name: pull-kubernetes-e2e-aks-engine-windows-dockershim
       description: Presubmit job for Windows tests on k8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
       testgrid-num-columns-recent: '30'
   - name: pull-kubernetes-e2e-aks-engine-windows-containerd
@@ -130,68 +133,13 @@ presubmits:
         - --aksengine-deploy-custom-k8s
         - --aksengine-agentpoolcount=2
         # Specific test args
-        - --test_args=--node-os-distro=windows --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
+        - --test_args=--node-os-distro=windows --ginkgo.focus=$(GINKGO_FOCUS_PARALLEL) --ginkgo.skip=$(GINKGO_SKIP_PARALLEL)
         - --ginkgo-parallel=4
         securityContext:
           privileged: true
     annotations:
       testgrid-dashboards: sig-windows-presubmit
-      testgrid-tab-name: pr-aks-engine-azure-windows-containerd
-      description: Presubmit job for Windows tests on k8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) using containerd
-      testgrid-num-columns-recent: '30'
-  - name: pull-kubernetes-e2e-aks-engine-windows-containerd-test-images
-    always_run: false
-    optional: true
-    decorate: true
-    run_if_changed: '^test\/utils\/image\/manifest.go$'
-    decoration_config:
-      timeout: 3h
-    path_alias: k8s.io/kubernetes
-    branches:
-    - master
-    labels:
-      preset-service-account: "true"
-      preset-azure-cred: "true"
-      preset-azure-windows: "true"
-      preset-windows-repo-list-pr: "true"
-      preset-k8s-ssh: "true"
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
-        command:
-        - runner.sh
-        - kubetest
-        args:
-        # Generic e2e test args
-        - --test
-        - --up
-        - --down
-        - --build=quick
-        - --dump=$(ARTIFACTS)
-        # Azure-specific test args
-        - --deployment=aksengine
-        - --provider=skeleton
-        - --aksengine-admin-username=azureuser
-        - --aksengine-admin-password=AdminPassw0rd
-        - --aksengine-creds=$(AZURE_CREDENTIALS)
-        - --aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz
-        - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
-        - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
-        - --aksengine-winZipBuildScript=$(WIN_BUILD)
-        - --aksengine-orchestratorRelease=1.20
-        - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_master.json
-        - --aksengine-win-binaries
-        - --aksengine-deploy-custom-k8s
-        - --aksengine-agentpoolcount=2
-        # Specific test args
-        - --test_args=--node-os-distro=windows --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
-        - --ginkgo-parallel=4
-        securityContext:
-          privileged: true
-    annotations:
-      testgrid-dashboards: sig-windows-presubmit
-      testgrid-tab-name: pr-aks-engine-azure-windows-containerd-test-images
+      testgrid-tab-name: pull-kubernetes-e2e-aks-engine-windows-containerd
       description: Presubmit job for Windows tests on k8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) using containerd
       testgrid-num-columns-recent: '30'
   - name: pull-kubernetes-e2e-azure-disk-windows
@@ -254,8 +202,8 @@ presubmits:
         - name: TEST_WINDOWS
           value: "true"
     annotations:
-      testgrid-dashboards: sig-windows-azure, sig-windows-presubmit
-      testgrid-tab-name: pr-k8s-azure-disk-e2e-master-windows
+      testgrid-dashboards: sig-windows-presubmit
+      testgrid-tab-name: pull-kubernetes-e2e-azure-disk-windows
       description: Run Azure Disk e2e test with Azure Disk in-tree volume plugin in a Windows cluster.
   - name: pull-kubernetes-e2e-azure-file-windows
     decorate: true
@@ -317,10 +265,10 @@ presubmits:
         - name: TEST_WINDOWS
           value: "true"
     annotations:
-      testgrid-dashboards: sig-windows-azure, sig-windows-presubmit
-      testgrid-tab-name: pr-k8s-azure-file-e2e-master-windows
+      testgrid-dashboards: sig-windows-presubmit
+      testgrid-tab-name: pull-kubernetes-e2e-azure-file-windows
       description: Run Azure File e2e test with Azure File in-tree volume plugin in a Windows cluster.
-  - name: pull-kubernetes-e2e-aks-engine-windows-gpu
+  - name: pull-kubernetes-e2e-aks-engine-windows-dockershim-gpu
     always_run: false
     optional: true
     decorate: true
@@ -372,7 +320,7 @@ presubmits:
           privileged: true
     annotations:
       testgrid-dashboards: sig-windows-presubmit
-      testgrid-tab-name: pr-aks-engine-windows-gpu
+      testgrid-tab-name: pull-kubernetes-e2e-aks-engine-windows-dockershim-gpu
       description: Presubmit job for Windows tests on k8s clusters with assignable GPUs provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
       testgrid-num-columns-recent: '30'
   - name: pull-kubernetes-e2e-azure-disk-windows-containerd
@@ -434,8 +382,8 @@ presubmits:
         - name: TEST_WINDOWS
           value: "true"
     annotations:
-      testgrid-dashboards: sig-windows-azure, sig-windows-presubmit
-      testgrid-tab-name: pr-k8s-azure-disk-e2e-master-windows-containerd
+      testgrid-dashboards: sig-windows-presubmit
+      testgrid-tab-name: pull-kubernetes-e2e-azure-disk-windows-containerd
       description: Run Azure Disk e2e test with Azure Disk in-tree volume plugin in a Windows cluster with containerd runtime.
   - name: pull-kubernetes-e2e-azure-file-windows-containerd
     decorate: true
@@ -496,9 +444,9 @@ presubmits:
         - name: TEST_WINDOWS
           value: "true"
     annotations:
-      testgrid-dashboards: sig-windows-azure, sig-windows-presubmit
-      testgrid-tab-name: pr-k8s-azure-file-e2e-master-windows-containerd
-      description: Run Azure File e2e test with Azure File in-tree volume plugin in a Windows cluster with containerd runtime.
+      testgrid-dashboards: sig-windows-presubmit
+      testgrid-tab-name: pull-kubernetes-e2e-azure-file-windows-containerd
+      description: Run Azure File e2e test with Azure File in-tree volume plugin in a Windows cluster with containerd runtime.w
 periodics:
 - interval: 8h
   name: ci-kubernetes-e2e-aks-engine-azure-master-staging-windows
@@ -545,13 +493,13 @@ periodics:
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
       # Specific test args
-      - --test_args=--node-os-distro=windows --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
+      - --test_args=--node-os-distro=windows --ginkgo.focus=$(GINKGO_FOCUS_PARALLEL) --ginkgo.skip=$(GINKGO_SKIP_PARALLEL)
       - --ginkgo-parallel=4
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows-azure
-    testgrid-tab-name: aks-engine-azure-windows-master-staging
+    testgrid-dashboards: sig-windows-master-release
+    testgrid-tab-name: aks-engine-windows-dockershim
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Staging job for new Windows tests on a Kubernetes cluster provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 24h
@@ -599,13 +547,13 @@ periodics:
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
       # Specific test args
-      - --test_args=--node-os-distro=windows --ginkgo.focus=(\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-autoscaling\].\[Feature:HPA\]|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\]) --ginkgo.skip=\[LinuxOnly\]|device.plugin.for.Windows
+      - --test_args=--node-os-distro=windows --ginkgo.focus=$(GINKGO_FOCUS_SERIAL) --ginkgo.skip==$(GINKGO_SKIP_SERIAL)
       - --ginkgo-parallel=1
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows-azure
-    testgrid-tab-name: aks-engine-azure-windows-master-staging-serial-slow
+    testgrid-dashboards: sig-windows-master-release
+    testgrid-tab-name: aks-engine-windows-dockershim-serial-slow
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Staging job for new Windows tests on a Kubernetes cluster provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 3h
@@ -653,14 +601,14 @@ periodics:
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
       # Specific test args
-      - --test_args=--node-os-distro=windows --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
+      - --test_args=--node-os-distro=windows --ginkgo.focus=$(GINKGO_FOCUS_PARALLEL) --ginkgo.skip=$(GINKGO_SKIP_PARALLEL)
       - --ginkgo-parallel=4
       securityContext:
         privileged: true
   annotations:
     fork-per-release: "true"
-    testgrid-dashboards: sig-windows-containerd, sig-windows-azure, sig-release-master-informing, sig-windows-signal
-    testgrid-tab-name: aks-engine-azure-windows-master-containerd
+    testgrid-dashboards: sig-release-master-informing, sig-windows-signal, sig-windows-master-release
+    testgrid-tab-name: aks-engine-windows-containerd
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs Windows tests on a Kubernetes cluster running containerd provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 24h
@@ -708,13 +656,13 @@ periodics:
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
       # Specific test args
-      - --test_args=--node-os-distro=windows --ginkgo.focus=(\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-autoscaling\].\[Feature:HPA\]|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\]) --ginkgo.skip=\[LinuxOnly\]|device.plugin.for.Windows
+      - --test_args=--node-os-distro=windows --ginkgo.focus=$(GINKGO_FOCUS_SERIAL) --ginkgo.skip=$(GINKGO_SKIP_SERIAL)
       - --ginkgo-parallel=1
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows-containerd, sig-windows-azure
-    testgrid-tab-name: aks-engine-azure-windows-master-containerd-serial-slow
+    testgrid-dashboards: sig-windows-master-release
+    testgrid-tab-name: aks-engine-windows-containerd-serial-slow
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs serial Windows tests on a Kubernetes cluster running containerd provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 48h
@@ -762,13 +710,13 @@ periodics:
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
       # Specific test args
-      - --test_args=--node-os-distro=windows --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
+      - --test_args=--node-os-distro=windows --ginkgo.focus=$(GINKGO_FOCUS_PARALLEL) --ginkgo.skip=$(GINKGO_SKIP_PARALLEL)
       - --ginkgo-parallel=3
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows-containerd, sig-windows-azure
-    testgrid-tab-name: aks-engine-azure-windows-master-containerd-hyperv
+    testgrid-dashboards: sig-windows-master-release
+    testgrid-tab-name: aks-engine-windows-containerd-hyperv
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs Windows tests on a Kubernetes cluster running containerd with HyperV isolation provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 48h
@@ -816,13 +764,13 @@ periodics:
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
       # Specific test args
-      - --test_args=--node-os-distro=windows --ginkgo.focus=(\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-autoscaling\].\[Feature:HPA\]|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\]) --ginkgo.skip=\[LinuxOnly\]|device.plugin.for.Windows
+      - --test_args=--node-os-distro=windows --ginkgo.focus=$(GINKGO_FOCUS_SERIAL) --ginkgo.skip==$(GINKGO_SKIP_SERIAL)
       - --ginkgo-parallel=1
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows-containerd, sig-windows-azure
-    testgrid-tab-name: aks-engine-azure-windows-master-containerd-hyperv-serial-slow
+    testgrid-dashboards: sig-windows-master-release
+    testgrid-tab-name: aks-engine-windows-containerd-hyperv-serial-slow
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs serial Windows tests on a Kubernetes cluster running containerd with HyperV isolation provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 48h
@@ -884,8 +832,8 @@ periodics:
       - name: TEST_WINDOWS
         value: "true"
   annotations:
-    testgrid-dashboards: sig-windows-azure
-    testgrid-tab-name: aks-engine-azure-windows-azure-disk
+    testgrid-dashboards: sig-windows-master-release
+    testgrid-tab-name: aks-engine-windows-dockershim-azure-disk
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure Disk e2e test with Azure Disk in-tree volume plugin in a Windows cluster.
 - interval: 48h
@@ -945,8 +893,8 @@ periodics:
       - name: TEST_WINDOWS
         value: "true"
   annotations:
-    testgrid-dashboards: sig-windows-azure
-    testgrid-tab-name: aks-engine-azure-windows-azure-disk-containerd
+    testgrid-dashboards: sig-windows-master-release
+    testgrid-tab-name: aks-engine-windows-containerd-azure-disk
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure Disk e2e test with Azure Disk in a Windows cluster configured with CSI proxy and containerd.
 - interval: 48h
@@ -1008,8 +956,8 @@ periodics:
       - name: TEST_WINDOWS
         value: "true"
   annotations:
-    testgrid-dashboards: sig-windows-azure
-    testgrid-tab-name: aks-engine-azure-windows-azure-file
+    testgrid-dashboards: sig-windows-master-release
+    testgrid-tab-name: aks-engine-windows-dockershim-azure-file
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure File e2e test with Azure File in-tree volume plugin in a Windows cluster.
 - interval: 48h
@@ -1069,7 +1017,7 @@ periodics:
       - name: TEST_WINDOWS
         value: "true"
   annotations:
-    testgrid-dashboards: sig-windows-azure
-    testgrid-tab-name: aks-engine-azure-windows-azure-file-containerd
+    testgrid-dashboards: sig-windows-master-release
+    testgrid-tab-name: aks-engine-windows-containerd-azure-file
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure File e2e test with Azure File in a Windows cluster configured with CSI proxy and containerd.

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -108,7 +108,7 @@ presubmits:
       testgrid-tab-name: pull-kubernetes-e2e-aks-engine-windows-containerd
       description: Presubmit job for Windows tests on k8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) using containerd
       testgrid-num-columns-recent: '30'
-  - name: pull-kubernetes-e2e-azure-disk-windows
+  - name: pull-kubernetes-e2e-aks-engine-azure-disk-windows-dockershim
     decorate: true
     decoration_config:
       timeout: 2h
@@ -169,9 +169,9 @@ presubmits:
           value: "true"
     annotations:
       testgrid-dashboards: sig-windows-presubmit
-      testgrid-tab-name: pull-kubernetes-e2e-azure-disk-windows
+      testgrid-tab-name: pull-kubernetes-e2e-aks-engine-azure-disk-windows-dockershim
       description: Run Azure Disk e2e test with Azure Disk in-tree volume plugin in a Windows cluster.
-  - name: pull-kubernetes-e2e-azure-file-windows
+  - name: pull-kubernetes-e2e-aks-engine-azure-file-windows-dockershim
     decorate: true
     decoration_config:
       timeout: 2h
@@ -232,9 +232,9 @@ presubmits:
           value: "true"
     annotations:
       testgrid-dashboards: sig-windows-presubmit
-      testgrid-tab-name: pull-kubernetes-e2e-azure-file-windows
+      testgrid-tab-name: pull-kubernetes-e2e-aks-engine-azure-file-windows-dockershim
       description: Run Azure File e2e test with Azure File in-tree volume plugin in a Windows cluster.
-  - name: pull-kubernetes-e2e-aks-engine-windows-dockershim-gpu
+  - name: pull-kubernetes-e2e-aks-engine-gpu-windows-dockershim
     always_run: false
     optional: true
     decorate: true
@@ -286,10 +286,10 @@ presubmits:
           privileged: true
     annotations:
       testgrid-dashboards: sig-windows-presubmit
-      testgrid-tab-name: pull-kubernetes-e2e-aks-engine-windows-dockershim-gpu
+      testgrid-tab-name: pull-kubernetes-e2e-aks-engine-gpu-windows-dockershim
       description: Presubmit job for Windows tests on k8s clusters with assignable GPUs provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
       testgrid-num-columns-recent: '30'
-  - name: pull-kubernetes-e2e-azure-disk-windows-containerd
+  - name: pull-kubernetes-e2e-aks-engine-azure-disk-windows-containerd
     decorate: true
     decoration_config:
       timeout: 2h
@@ -349,9 +349,9 @@ presubmits:
           value: "true"
     annotations:
       testgrid-dashboards: sig-windows-presubmit
-      testgrid-tab-name: pull-kubernetes-e2e-azure-disk-windows-containerd
+      testgrid-tab-name: pull-kubernetes-e2e-aks-engine-azure-disk-windows-containerd
       description: Run Azure Disk e2e test with Azure Disk in-tree volume plugin in a Windows cluster with containerd runtime.
-  - name: pull-kubernetes-e2e-azure-file-windows-containerd
+  - name: pull-kubernetes-e2e-aks-engine-azure-file-windows-containerd
     decorate: true
     decoration_config:
       timeout: 2h
@@ -411,7 +411,7 @@ presubmits:
           value: "true"
     annotations:
       testgrid-dashboards: sig-windows-presubmit
-      testgrid-tab-name: pull-kubernetes-e2e-azure-file-windows-containerd
+      testgrid-tab-name: pull-kubernetes-e2e-aks-engine-azure-file-windows-containerd
       description: Run Azure File e2e test with Azure File in-tree volume plugin in a Windows cluster with containerd runtime.w
 periodics:
 - interval: 8h

--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-containerd-hyperv.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-containerd-hyperv.yaml
@@ -1,0 +1,109 @@
+periodics:
+- interval: 48h
+  name: ci-kubernetes-e2e-aks-engine-azure-master-windows-containerd-hyperv
+  decorate: true
+  decoration_config:
+    timeout: 3h
+  labels:
+    preset-service-account: "true"
+    preset-azure-cred: "true"
+    preset-azure-windows: "true"
+    preset-windows-repo-list-master: "true"
+    preset-k8s-ssh: "true"
+    preset-dind-enabled: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
+      command:
+      - runner.sh
+      - kubetest
+      args:
+      # Generic e2e test args
+      - --test
+      - --up
+      - --down
+      - --build=quick
+      - --dump=$(ARTIFACTS)
+      # Azure-specific test args
+      - --deployment=aksengine
+      - --provider=skeleton
+      - --aksengine-admin-username=azureuser
+      - --aksengine-admin-password=AdminPassw0rd
+      - --aksengine-creds=$(AZURE_CREDENTIALS)
+      - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/nightly/aks-engine-nightly-linux-amd64.tar.gz
+      - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
+      - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
+      - --aksengine-winZipBuildScript=$(WIN_BUILD)
+      - --aksengine-orchestratorRelease=1.21
+      - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_hyperv.json
+      - --aksengine-win-binaries
+      - --aksengine-deploy-custom-k8s
+      # Specific test args
+      - --test_args=--node-os-distro=windows --ginkgo.focus=$(GINKGO_FOCUS_PARALLEL) --ginkgo.skip=$(GINKGO_SKIP_PARALLEL)
+      - --ginkgo-parallel=3
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-windows-containerd-hyperv
+    testgrid-tab-name: aks-engine-windows-containerd-hyperv-master
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    description: Runs Windows tests on a Kubernetes cluster running containerd with HyperV isolation provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
+- interval: 48h
+  name: ci-kubernetes-e2e-aks-engine-azure-master-windows-containerd-hyperv-serial-slow
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-service-account: "true"
+    preset-azure-cred: "true"
+    preset-azure-windows: "true"
+    preset-windows-repo-list-master: "true"
+    preset-k8s-ssh: "true"
+    preset-dind-enabled: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
+      command:
+      - runner.sh
+      - kubetest
+      args:
+      # Generic e2e test args
+      - --test
+      - --up
+      - --down
+      - --build=quick
+      - --dump=$(ARTIFACTS)
+      # Azure-specific test args
+      - --deployment=aksengine
+      - --provider=skeleton
+      - --aksengine-admin-username=azureuser
+      - --aksengine-admin-password=AdminPassw0rd
+      - --aksengine-creds=$(AZURE_CREDENTIALS)
+      - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/nightly/aks-engine-nightly-linux-amd64.tar.gz
+      - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
+      - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
+      - --aksengine-winZipBuildScript=$(WIN_BUILD)
+      - --aksengine-orchestratorRelease=1.21
+      - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_hyperv.json
+      - --aksengine-win-binaries
+      - --aksengine-deploy-custom-k8s
+      # Specific test args
+      - --test_args=--node-os-distro=windows --ginkgo.focus=$(GINKGO_FOCUS_SERIAL) --ginkgo.skip==$(GINKGO_SKIP_SERIAL)
+      - --ginkgo-parallel=1
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-windows-containerd-hyperv
+    testgrid-tab-name: aks-engine-windows-containerd-hyperv-serial-slow-master
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    description: Runs serial Windows tests on a Kubernetes cluster running containerd with HyperV isolation provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud

--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-kubeadm.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-kubeadm.yaml
@@ -26,7 +26,7 @@ periodics:
       - "runner.sh"
       - "./kubeadm/hack/ci-e2e.sh"
   annotations:
-    testgrid-dashboards: sig-windows-gce, sig-windows-releases
+    testgrid-dashboards: sig-windows-gce, sig-windows-master-release
     testgrid-tab-name: kubeadm-windows-gcp-k8s-stable
     description: Periodic job that runs conformance tests on a Linux/Windows cluster created with kubeadm (stable k8s version)"
     testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-sac.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-sac.yaml
@@ -46,13 +46,13 @@ periodics:
       - --aksengine-deploy-custom-k8s
       - --aksengine-agentpoolcount=2
       # Specific test args
-      - --test_args=--node-os-distro=windows --docker-config-file=$(DOCKER_CONFIG_FILE) --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice  --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application
+      - --test_args=--node-os-distro=windows --docker-config-file=$(DOCKER_CONFIG_FILE) --ginkgo.focus=$(GINKGO_FOCUS_PARALLEL) --ginkgo.skip=$(GINKGO_SKIP_PARALLEL)
       - --ginkgo-parallel=4
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows-sac, sig-windows-azure
-    testgrid-tab-name: aks-engine-azure-windows-2004-master
+    testgrid-dashboards: sig-windows-master-release
+    testgrid-tab-name: aks-engine-windows-2004-dockershim
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 24h
@@ -102,13 +102,13 @@ periodics:
       - --aksengine-deploy-custom-k8s
       - --aksengine-agentpoolcount=2
       # Specific test args
-      - --test_args=--node-os-distro=windows --docker-config-file=$(DOCKER_CONFIG_FILE) --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice  --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application
+      - --test_args=--node-os-distro=windows --docker-config-file=$(DOCKER_CONFIG_FILE) --ginkgo.focus=$(GINKGO_FOCUS_PARALLEL) --ginkgo.skip=$(GINKGO_SKIP_PARALLEL)
       - --ginkgo-parallel=4
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows-sac, sig-windows-containerd, sig-windows-azure
-    testgrid-tab-name: aks-engine-azure-windows-2004-master-containerd
+    testgrid-dashboards: sig-windows-master-release
+    testgrid-tab-name: aks-engine-windows-2004-containerd
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 48h
@@ -156,13 +156,13 @@ periodics:
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
       # Specific test args
-      - --test_args=--node-os-distro=windows --ginkgo.focus=(\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-autoscaling\].\[Feature:HPA\]|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\]) --ginkgo.skip=\[LinuxOnly\]
+      - --test_args=--node-os-distro=windows --ginkgo.focus=$(GINKGO_FOCUS_PARALLEL) --ginkgo.skip=$(GINKGO_SKIP_PARALLEL)
       - --ginkgo-parallel=1
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows-sac, sig-windows-containerd, sig-windows-azure
-    testgrid-tab-name: aks-engine-azure-windows-master-2004-containerd-serial-slow
+    testgrid-dashboards: sig-windows-master-release
+    testgrid-tab-name: aks-engine-windows-2004-containerd-serial-slow
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs serial Windows tests on a Kubernetes cluster running containerd provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 24h
@@ -212,13 +212,13 @@ periodics:
       - --aksengine-deploy-custom-k8s
       - --aksengine-agentpoolcount=2
       # Specific test args
-      - --test_args=--node-os-distro=windows --docker-config-file=$(DOCKER_CONFIG_FILE) --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice  --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application
+      - --test_args=--node-os-distro=windows --docker-config-file=$(DOCKER_CONFIG_FILE) --ginkgo.focus=$(GINKGO_FOCUS_PARALLEL)  --ginkgo.skip=$(GINKGO_SKIP_PARALLEL)
       - --ginkgo-parallel=4
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows-sac, sig-windows-containerd, sig-windows-azure
-    testgrid-tab-name: aks-engine-azure-windows-20h2-master-containerd
+    testgrid-dashboards: sig-windows-master-release
+    testgrid-tab-name: aks-engine-windows-20h2-containerd
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 48h
@@ -266,12 +266,12 @@ periodics:
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
       # Specific test args
-      - --test_args=--node-os-distro=windows --ginkgo.focus=(\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-autoscaling\].\[Feature:HPA\]|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\]) --ginkgo.skip=\[LinuxOnly\]
+      - --test_args=--node-os-distro=windows --ginkgo.focus=$(GINKGO_FOCUS_SERIAL) --ginkgo.skip=$(GINKGO_SKIP_SERIAL)
       - --ginkgo-parallel=1
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows-sac, sig-windows-containerd, sig-windows-azure
-    testgrid-tab-name: aks-engine-azure-windows-master-20h2-containerd-serial-slow
+    testgrid-dashboards: sig-windows-master-release
+    testgrid-tab-name: aks-engine-windows-20h2-containerd-serial-slow
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs serial Windows tests on a Kubernetes cluster running containerd provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud

--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-sac.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-sac.yaml
@@ -51,8 +51,8 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows-master-release
-    testgrid-tab-name: aks-engine-windows-2004-dockershim
+    testgrid-dashboards: sig-windows-sac
+    testgrid-tab-name: aks-engine-windows-2004-dockershim-master
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 24h
@@ -107,8 +107,8 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows-master-release
-    testgrid-tab-name: aks-engine-windows-2004-containerd
+    testgrid-dashboards: sig-windows-sac
+    testgrid-tab-name: aks-engine-windows-2004-containerd-master
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 48h
@@ -161,8 +161,8 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows-master-release
-    testgrid-tab-name: aks-engine-windows-2004-containerd-serial-slow
+    testgrid-dashboards: sig-windows-sac
+    testgrid-tab-name: aks-engine-windows-2004-containerd-serial-slow-master
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs serial Windows tests on a Kubernetes cluster running containerd provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 24h
@@ -217,8 +217,8 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows-master-release
-    testgrid-tab-name: aks-engine-windows-20h2-containerd
+    testgrid-dashboards: sig-windows-sac
+    testgrid-tab-name: aks-engine-windows-20h2-containerd-master
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 48h
@@ -271,7 +271,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows-master-release
-    testgrid-tab-name: aks-engine-windows-20h2-containerd-serial-slow
+    testgrid-dashboards: sig-windows-sac
+    testgrid-tab-name: aks-engine-windows-20h2-containerd-serial-slow-master
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs serial Windows tests on a Kubernetes cluster running containerd provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -590,7 +590,7 @@ periodics:
       securityContext:
         privileged: true
 - annotations:
-    testgrid-dashboards: google-windows, sig-windows-releases, sig-windows-gce
+    testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-1.18-release
     testgrid-tab-name: gce-windows-2019-1.18
   decorate: true
   extra_refs:
@@ -632,7 +632,7 @@ periodics:
       name: ""
       resources: {}
 - annotations:
-    testgrid-dashboards: google-windows, sig-windows-releases, sig-windows-gce, sig-release-1.18-informing
+    testgrid-dashboards: google-windows, sig-windows-gce, sig-release-1.18-informing, sig-windows-1.18-release
     testgrid-tab-name: gce-windows-1909-1.18
   decorate: true
   extra_refs:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -541,7 +541,7 @@ periodics:
       securityContext:
         privileged: true
 - annotations:
-    testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-releases, sig-release-1.19-informing
+    testgrid-dashboards: google-windows, sig-windows-gce, sig-release-1.19-informing, sig-windows-1.19-release
     testgrid-tab-name: gce-windows-2019-1.19
   decorate: true
   extra_refs:
@@ -583,7 +583,7 @@ periodics:
       name: ""
       resources: {}
 - annotations:
-    testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-releases, sig-windows-sac, sig-release-1.19-informing
+    testgrid-dashboards: google-windows, sig-windows-gce, sig-release-1.19-informing, sig-windows-1.19-release
     testgrid-tab-name: gce-windows-1909-1.19
   decorate: true
   extra_refs:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
@@ -539,7 +539,7 @@ periodics:
       securityContext:
         privileged: true
 - annotations:
-    testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-releases, sig-release-1.20-informing
+    testgrid-dashboards: google-windows, sig-windows-gce, sig-release-1.20-informing, sig-windows-1.20-release
     testgrid-tab-name: gce-windows-2019-1.20
   decorate: true
   extra_refs:
@@ -582,7 +582,7 @@ periodics:
       name: ""
       resources: {}
 - annotations:
-    testgrid-dashboards: google-windows, sig-windows-sac, sig-windows-gce, sig-release-1.20-informing
+    testgrid-dashboards: google-windows, sig-windows-gce, sig-release-1.20-informing, sig-windows-1.20-release
     testgrid-tab-name: gce-windows-1909-1.20
   decorate: true
   extra_refs:

--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -141,7 +141,7 @@ periodics:
   annotations:
     fork-per-release: "true"
     fork-per-release-replacements: "--extract=ci/latest -> --extract=ci/latest-{{.Version}}"
-    testgrid-dashboards: google-windows, sig-windows-sac, sig-windows-gce, sig-release-master-informing, sig-windows-signal
+    testgrid-dashboards: google-windows, sig-windows-gce, sig-release-master-informing, sig-windows-signal, sig-windows-master-release
     testgrid-tab-name: gce-windows-20h2-master
     description: Runs tests on a Kubernetes cluster with Windows 20H2 nodes on GCE
 
@@ -189,7 +189,7 @@ periodics:
   annotations:
     fork-per-release: "true"
     fork-per-release-replacements: "--extract=ci/latest -> --extract=ci/latest-{{.Version}}"
-    testgrid-dashboards: google-windows, sig-windows-sac, sig-windows-gce, sig-release-master-informing
+    testgrid-dashboards: google-windows, sig-windows-gce, sig-release-master-informing, sig-windows-master-release
     testgrid-tab-name: gce-windows-2004-master
     description: Runs tests on a Kubernetes cluster with Windows 2004 nodes on GCE
 
@@ -324,7 +324,7 @@ periodics:
         value: "prepull-head.yaml"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
   annotations:
-    testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-containerd, sig-node-containerd
+    testgrid-dashboards: google-windows, sig-windows-gce, sig-node-containerd, sig-windows-master-release
     testgrid-tab-name: gce-windows-2019-containerd-master
     description: Runs tests on a Kubernetes cluster with Windows containerd nodes on GCE
 
@@ -374,7 +374,7 @@ periodics:
       name: ""
       resources: {}
   annotations:
-    testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-containerd, sig-node-containerd
+    testgrid-dashboards: google-windows, sig-windows-gce, sig-node-containerd, sig-windows-master-release
     testgrid-tab-name: gce-windows-2019-containerd-1.20
 
 - name: ci-kubernetes-e2e-windows-node-throughput

--- a/config/testgrids/kubernetes/sig-windows/config.yaml
+++ b/config/testgrids/kubernetes/sig-windows/config.yaml
@@ -8,6 +8,8 @@ dashboard_groups:
     - sig-windows-master-release
     - sig-windows-presubmit
     - sig-windows-gce
+    - sig-windows-sac
+    - sig-windows-containerd-hyperv
     - sig-windows-networking
 
 dashboards:
@@ -18,6 +20,8 @@ dashboards:
 - name: sig-windows-master-release
 - name: sig-windows-presubmit
 - name: sig-windows-gce
+- name: sig-windows-sac
+- name: sig-windows-containerd-hyperv
 - name: sig-windows-networking
   dashboard_tab:
   - name: flannel-l2bridge-windows-master

--- a/config/testgrids/kubernetes/sig-windows/config.yaml
+++ b/config/testgrids/kubernetes/sig-windows/config.yaml
@@ -2,22 +2,22 @@ dashboard_groups:
 - name: sig-windows
   dashboard_names:
     - sig-windows-signal
-    - sig-windows-releases
-    - sig-windows-sac
-    - sig-windows-containerd
+    - sig-windows-1.18-release
+    - sig-windows-1.19-release
+    - sig-windows-1.20-release
+    - sig-windows-master-release
     - sig-windows-presubmit
     - sig-windows-gce
-    - sig-windows-azure
     - sig-windows-networking
 
 dashboards:
 - name: sig-windows-signal
-- name: sig-windows-releases
-- name: sig-windows-sac
-- name: sig-windows-containerd
+- name: sig-windows-1.18-release
+- name: sig-windows-1.19-release
+- name: sig-windows-1.20-release
+- name: sig-windows-master-release
 - name: sig-windows-presubmit
 - name: sig-windows-gce
-- name: sig-windows-azure
 - name: sig-windows-networking
   dashboard_tab:
   - name: flannel-l2bridge-windows-master


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

The goal of this PR is to mimic https://testgrid.k8s.io/sig-release by removing redundant sig-windows testgrid dashboards and breaking them down into releases so we can have a clearer signal for each supported release

- removed the following testgrid dashboards:
  - sig-windows-releases
  - sig-windows-containerd
  - sig-windows-azure
- created the following testgrid dashboards:
  - sig-windows-1.18-release
  - sig-windows-1.19-release
  - sig-windows-1.20-release
  - sig-windows-master-release
  - sig-windows-containerd-hyperv
- move all presets to `presets.yaml`
- enforce presubmit job name - `pull-<cluster provisioning tool>-<what the job is testisng>-<OS>-<container runtime>`