### PR TITLE
azure: use lower case for resource group name

### DIFF
--- a/kubetest/aksengine.go
+++ b/kubetest/aksengine.go
@@ -318,7 +318,7 @@ func checkParams() error {
 		return fmt.Errorf("no credentials file path specified")
 	}
 	if *aksResourceName == "" {
-		*aksResourceName = "kubetest-" + randString(8)
+		*aksResourceName = "kubetest-" + strings.ToLower(randString(8))
 	}
 	if *aksResourceGroupName == "" {
 		*aksResourceGroupName = *aksResourceName


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

Fixes failure in https://testgrid.k8s.io/provider-azure-master-signal#aks-engine-azure-file. Looks like the azure file volume name (which has the resource group name as the prefix during the test) only accepts a lower case string.

/assign @nilo19 @feiskyer 