### PR TITLE
Update capdo milestone applier

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -355,9 +355,8 @@ milestone_applier:
     master: v0.5.0
     release-0.4: v0.4.14
   kubernetes-sigs/cluster-api-provider-digitalocean:
-    master: v0.4
-    release-0.4: v0.4
-    release-0.3: v0.3
+    master: v0.5.0
+    release-0.4: v0.4.3
   kubernetes-sigs/cluster-api-provider-gcp:
     master: v0.4
     release-0.4: v0.4


### PR DESCRIPTION
This PR update capdo milestone applier
- default master branch to v0.5.0
- default release-0.4 branch to v0.4.3

/cc @cpanato @timoreimann @MorrisLaw 