### PR TITLE
kubernetes-csi: more jobs for distributed provisioning and storage capacity

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-manual-job-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-manual-job-config.yaml
@@ -97,6 +97,52 @@ presubmits:
         resources:
           requests:
             cpu: 2000m
-
-# TODO once https://github.com/kubernetes-csi/csi-driver-host-path/pull/248 is merged:
-# enable periodic testing
+periodics:
+- interval: 6h
+  name: ci-kubernetes-csi-distributed-on-kubernetes-master
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi-ci
+    testgrid-tab-name: distributed-on-master
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: periodic Kubernetes-CSI job for distributed provisioning on Kubernetes master, with CSIStorageCapacity
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210226-c001921-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "latest"
+      - name: CSI_PROW_USE_BAZEL
+        value: "false"
+      - name: CSI_SNAPSHOTTER_VERSION
+        value: "master"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel serial-alpha parallel-alpha"
+      - name: CSI_PROW_SANITY_POD
+        value: csi-hostpath-socat-0
+      - name: CSI_PROW_SANITY_CONTAINER
+        value: socat
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-distributed"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+        resources:
+          requests:
+            cpu: 2000m

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-manual-job-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-manual-job-config.yaml
@@ -1,0 +1,56 @@
+# Derived from external-provisioner-config.yaml, modified and maintained manually.
+
+presubmits:
+  kubernetes-csi/external-provisioner:
+  - name: pull-kubernetes-csi-external-provisioner-distributed-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-provisioner
+      testgrid-tab-name: distributed-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo external-provisioner for distributed provisioning, with CSIStorageCapacity
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210226-c001921-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_USE_BAZEL
+          value: "false"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.5.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel serial-alpha parallel-alpha"
+        - name: CSI_PROW_SANITY_POD
+          value: csi-hostpath-socat-0
+        - name: CSI_PROW_SANITY_CONTAINER
+          value: socat
+        - name: CSI_PROW_DEPLOYMENT
+          value: "kubernetes-distributed"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m


### PR DESCRIPTION
The periodic job runs in the hostpath driver repo, like the others,
but uses the "distributed provisioning" YAML files for deployment.

The optional pre-merge job for external-provisioner is important
because otherwise we have no coverage of the distributed provisioning
and storage capacity tracking code before merging a PR.