### PR TITLE
kubernetes-csi: promote testing on 1.20 to mandatory

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
@@ -188,7 +188,7 @@ presubmits:
           cpu: 2000m
   - name: pull-kubernetes-csi-csi-driver-host-path-1-20-on-kubernetes-1-20
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: []
@@ -229,13 +229,9 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+        resources:
+          requests:
+            cpu: 2000m
   - name: pull-kubernetes-csi-csi-driver-host-path-1-20-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -325,13 +321,9 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+        resources:
+          requests:
+            cpu: 2000m
   - name: pull-kubernetes-csi-csi-driver-host-path-unit
     always_run: true
     decorate: true

--- a/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
+++ b/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
@@ -188,7 +188,7 @@ presubmits:
           cpu: 2000m
   - name: pull-kubernetes-csi-external-attacher-1-20-on-kubernetes-1-20
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|v0.1.0)$"]
@@ -229,13 +229,9 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+        resources:
+          requests:
+            cpu: 2000m
   - name: pull-kubernetes-csi-external-attacher-1-20-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -325,13 +321,9 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+        resources:
+          requests:
+            cpu: 2000m
   - name: pull-kubernetes-csi-external-attacher-unit
     always_run: true
     decorate: true

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
@@ -188,7 +188,7 @@ presubmits:
           cpu: 2000m
   - name: pull-kubernetes-csi-external-provisioner-1-20-on-kubernetes-1-20
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|v0.1.0)$"]
@@ -229,13 +229,9 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+        resources:
+          requests:
+            cpu: 2000m
   - name: pull-kubernetes-csi-external-provisioner-1-20-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -325,13 +321,9 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+        resources:
+          requests:
+            cpu: 2000m
   - name: pull-kubernetes-csi-external-provisioner-unit
     always_run: true
     decorate: true

--- a/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
+++ b/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
@@ -188,7 +188,7 @@ presubmits:
           cpu: 2000m
   - name: pull-kubernetes-csi-external-resizer-1-20-on-kubernetes-1-20
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: []
@@ -229,13 +229,9 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+        resources:
+          requests:
+            cpu: 2000m
   - name: pull-kubernetes-csi-external-resizer-1-20-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -325,13 +321,9 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+        resources:
+          requests:
+            cpu: 2000m
   - name: pull-kubernetes-csi-external-resizer-unit
     always_run: true
     decorate: true

--- a/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
+++ b/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
@@ -188,7 +188,7 @@ presubmits:
           cpu: 2000m
   - name: pull-kubernetes-csi-external-snapshotter-1-20-on-kubernetes-1-20
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: ["^(k8s_1.12.0-beta.1|release-0.4|release-1.0)$"]
@@ -229,13 +229,9 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+        resources:
+          requests:
+            cpu: 2000m
   - name: pull-kubernetes-csi-external-snapshotter-1-20-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -325,13 +321,9 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+        resources:
+          requests:
+            cpu: 2000m
   - name: pull-kubernetes-csi-external-snapshotter-unit
     always_run: true
     decorate: true

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -38,7 +38,7 @@ deployment_versions="
 "
 
 # The experimental version for which jobs are optional.
-experimental_k8s_version="1.20"
+experimental_k8s_version=""
 
 # The latest stable Kubernetes version for testing alpha jobs
 latest_stable_k8s_version="1.20"
@@ -47,7 +47,7 @@ latest_stable_k8s_version="1.20"
 hostpath_driver_version="v1.5.0"
 
 # We need this image because it has Docker in Docker and go.
-dind_image="gcr.io/k8s-testimages/kubekins-e2e:v20210226-c001921-master"
+dind_image="gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master"
 
 # All kubernetes-csi repos which are part of the hostpath driver example.
 # For these repos we generate the full test matrix. For each entry here

--- a/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
+++ b/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
@@ -188,7 +188,7 @@ presubmits:
           cpu: 2000m
   - name: pull-kubernetes-csi-livenessprobe-1-20-on-kubernetes-1-20
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: ["^(release-0.4|release-1.0)$"]
@@ -229,13 +229,9 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+        resources:
+          requests:
+            cpu: 2000m
   - name: pull-kubernetes-csi-livenessprobe-1-20-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -325,13 +321,9 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+        resources:
+          requests:
+            cpu: 2000m
   - name: pull-kubernetes-csi-livenessprobe-unit
     always_run: true
     decorate: true

--- a/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
+++ b/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
@@ -188,7 +188,7 @@ presubmits:
           cpu: 2000m
   - name: pull-kubernetes-csi-node-driver-registrar-1-20-on-kubernetes-1-20
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: ["^(release-1.0)$"]
@@ -229,13 +229,9 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+        resources:
+          requests:
+            cpu: 2000m
   - name: pull-kubernetes-csi-node-driver-registrar-1-20-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -325,13 +321,9 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+        resources:
+          requests:
+            cpu: 2000m
   - name: pull-kubernetes-csi-node-driver-registrar-unit
     always_run: true
     decorate: true


### PR DESCRIPTION
The various components should now pass testing on 1.20.