### PR TITLE
pod-utils: sidecar: use sub-struct for censoring options

### DIFF
--- a/prow/sidecar/censor.go
+++ b/prow/sidecar/censor.go
@@ -42,10 +42,10 @@ const defaultBufferSize = 10 * 1024 * 1024
 
 func (o Options) censor() error {
 	var concurrency int64
-	if o.CensoringConcurrency == nil {
+	if o.CensoringOptions.CensoringConcurrency == nil {
 		concurrency = int64(10)
 	} else {
-		concurrency = *o.CensoringConcurrency
+		concurrency = *o.CensoringOptions.CensoringConcurrency
 	}
 	logrus.WithField("concurrency", concurrency).Debug("Censoring artifacts.")
 	sem := semaphore.NewWeighted(concurrency)
@@ -61,7 +61,7 @@ func (o Options) censor() error {
 		errLock.Unlock()
 	}()
 
-	secrets, err := loadSecrets(o.SecretDirectories)
+	secrets, err := loadSecrets(o.CensoringOptions.SecretDirectories)
 	if err != nil {
 		return fmt.Errorf("could not load secrets: %w", err)
 	}
@@ -70,8 +70,8 @@ func (o Options) censor() error {
 	censorer.RefreshBytes(secrets...)
 
 	bufferSize := defaultBufferSize
-	if o.CensoringBufferSize != nil {
-		bufferSize = *o.CensoringBufferSize
+	if o.CensoringOptions.CensoringBufferSize != nil {
+		bufferSize = *o.CensoringOptions.CensoringBufferSize
 	}
 	if largest := censorer.LargestSecret(); 2*largest > bufferSize {
 		bufferSize = 2 * largest

--- a/prow/sidecar/censor_test.go
+++ b/prow/sidecar/censor_test.go
@@ -161,9 +161,11 @@ func TestCensorIntegration(t *testing.T) {
 			{ProcessLog: filepath.Join(tempDir, "logs/one.log")},
 			{ProcessLog: filepath.Join(tempDir, "logs/two.log")},
 		},
-		SecretDirectories: []string{"testdata/secrets"},
-		// this will be smaller than the size of a secret, so this tests our buffer calculation
-		CensoringBufferSize: &bufferSize,
+		CensoringOptions: &CensoringOptions{
+			SecretDirectories: []string{"testdata/secrets"},
+			// this will be smaller than the size of a secret, so this tests our buffer calculation
+			CensoringBufferSize: &bufferSize,
+		},
 	}
 	if err := options.censor(); err != nil {
 		t.Fatalf("got an error from censoring: %v", err)

--- a/prow/sidecar/run.go
+++ b/prow/sidecar/run.go
@@ -115,7 +115,7 @@ func (o Options) Run(ctx context.Context) (int, error) {
 	// uploading, so we ignore the signals.
 	signal.Ignore(os.Interrupt, syscall.SIGTERM)
 
-	if len(o.SecretDirectories) > 0 {
+	if o.CensoringOptions != nil {
 		if err := o.censor(); err != nil {
 			logrus.Warnf("Failed to censor data: %v", err)
 		}


### PR DESCRIPTION
We're about to add a bunch of new options and we should use a sub-struct
here for clarity.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @BenTheElder @cjwagner 

I will follow this up with a pull to actually use the new options once we've deployed this code, and a follow-up after that to remove the old ones. This is a prerequisite to adding options for path globbing.