### PR TITLE
CAPI: Add release blocking label

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -347,10 +347,10 @@ milestone_applier:
     release-1.17: v1.17
     release-1.16: v1.16
   kubernetes-sigs/cluster-api:
-    master: v0.4.x
-    release-0.4: v0.4.x
-    operator-0.4: v0.4.x # Remove this when it gets merged back.
-    release-0.3: v0.3.x
+    master: v0.4
+    release-0.4: v0.4
+    operator-0.4: v0.4 # Remove this when it gets merged back.
+    release-0.3: v0.3
   kubernetes-sigs/cluster-api-provider-azure:
     master: v0.5.0
     release-0.4: v0.4.14

--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -192,6 +192,7 @@ larger set of contributors to apply/remove them.
 | <a id="area/upgrades" href="#area/upgrades">`area/upgrades`</a> | Issues or PRs related to upgrades| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="area/ux" href="#area/ux">`area/ux`</a> | Issues or PRs related to UX| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="kind/proposal" href="#kind/proposal">`kind/proposal`</a> | Issues or PRs related to proposals.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="release-blocking" href="#release-blocking">`release-blocking`</a> | Issues or PRs that need to be closed before the next CAPI release| approvers |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 
 ## Labels that apply to kubernetes-sigs/cluster-api-provider-aws, for both issues and PRs
 

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -1554,6 +1554,12 @@ repos:
         target: both
         prowPlugin: label
         addedBy: anyone
+      - color: f6c5d8
+        description: Issues or PRs that need to be closed before the next CAPI release
+        name: release-blocking
+        target: both
+        prowPlugin: label
+        addedBy: approvers
   kubernetes-sigs/cluster-api-provider-azure:
     labels:
       - color: c7def8


### PR DESCRIPTION
Adds a release blocking label and renames milestones
- v0.4.0 -> v0.4
- v0.4.x -> v0.4
- v0.3.x -> v0.3