### PR TITLE
bump pull-kind-e2e timeout

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -62,7 +62,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     path_alias: sigs.k8s.io/kind
     decoration_config:
-      timeout: 40m
+      timeout: 60m
       grace_period: 15m
     spec:
       containers:


### PR DESCRIPTION
The job is timing out, the last 3 success were achieved in 39m54s, 38m12s and 38m42s

Bumping the timeout to 60 mins, same that the k/k presubmit jobs