### PR TITLE
Deploy kubernetes external secrets on prow cluster

### DIFF
--- a/config/prow/cluster/BUILD.bazel
+++ b/config/prow/cluster/BUILD.bazel
@@ -48,6 +48,7 @@ release(
     component("horologium", "deployment", "rbac", "service"),
     component("ing", "ingress"),
     component("kube-state-metrics", "deployment", "rbac", "service"),
+    component("kubernetes-external-secrets", "deployment", "rbac", "service", "crd"),
     component(
         "mem-limit-range",
         "limitrange",

--- a/config/prow/cluster/kubernetes-external-secrets_crd.yaml
+++ b/config/prow/cluster/kubernetes-external-secrets_crd.yaml
@@ -1,0 +1,138 @@
+---
+# From https://github.com/external-secrets/kubernetes-external-secrets/tree/f866e34e0319d9c54ea17d07f5d5818a28d9d0f6
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: externalsecrets.kubernetes-client.io
+  annotations:
+    # for helm v2 backwards compatibility
+    helm.sh/hook: crd-install
+    # used in e2e testing
+    app.kubernetes.io/managed-by: helm
+spec:
+  group: kubernetes-client.io
+  version: v1
+  scope: Namespaced
+
+  names:
+    shortNames:
+      - es
+    kind: ExternalSecret
+    plural: externalsecrets
+    singular: externalsecret
+
+  additionalPrinterColumns:
+    - JSONPath: .status.lastSync
+      name: Last Sync
+      type: date
+    - JSONPath: .status.status
+      name: status
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            template:
+              description: Template which will be deep merged without mutating
+                any existing fields. into generated secret, can be used to
+                set for example annotations or type on the generated secret
+              type: object
+            backendType:
+              type: string
+              enum:
+                - secretsManager
+                - systemManager
+                - vault
+                - azureKeyVault
+                - gcpSecretsManager
+                - alicloudSecretsManager
+            vaultRole:
+              type: string
+            vaultMountPoint:
+              type: string
+            kvVersion:
+              description: Vault K/V version either 1 or 2, default = 2
+              type: integer
+              minimum: 1
+              maximum: 2
+            keyVaultName:
+              type: string
+            key:
+              type: string
+            dataFrom:
+              type: array
+              items:
+                type: string
+            data:
+              type: array
+              items:
+                type: object
+                anyOf:
+                  - properties:
+                      key:
+                        description: Secret key in backend
+                        type: string
+                      name:
+                        description: Name set for this key in the generated secret
+                        type: string
+                      property:
+                        description: Property to extract if secret in backend is a JSON object
+                      isBinary:
+                        description: >-
+                          Whether the backend secret shall be treated as binary data
+                          represented by a base64-encoded string. You must set this to true
+                          for any base64-encoded binary data in the backend - to ensure it
+                          is not encoded in base64 again. Default is false.
+                        type: boolean
+                    required:
+                      - key
+                      - name
+                  - properties:
+                      path:
+                        description: >-
+                          Path from SSM to scrape secrets
+                          This will fetch all secrets and use the key from the secret as variable name
+                      recursive:
+                        description: Allow to recurse thru all child keys on a given path
+                        type: boolean
+                    required:
+                      - path
+            roleArn:
+              type: string
+          oneOf:
+            - properties:
+                backendType:
+                  enum:
+                    - secretsManager
+                    - systemManager
+            - properties:
+                backendType:
+                  enum:
+                    - vault
+            - properties:
+                backendType:
+                  enum:
+                    - azureKeyVault
+              required:
+                - keyVaultName
+            - properties:
+                backendType:
+                  enum:
+                    - gcpSecretsManager
+            - properties:
+                backendType:
+                  enum:
+                    - alicloudSecretsManager
+          anyOf:
+            - required:
+                - data
+            - required:
+                - dataFrom
+  subresources:
+    status: {}

--- a/config/prow/cluster/kubernetes-external-secrets_deployment.yaml
+++ b/config/prow/cluster/kubernetes-external-secrets_deployment.yaml
@@ -1,0 +1,41 @@
+---
+# Source: kubernetes-external-secrets/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubernetes-external-secrets
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: kubernetes-external-secrets
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubernetes-external-secrets
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kubernetes-external-secrets
+    spec:
+      serviceAccountName: kubernetes-external-secrets-sa
+      containers:
+        - name: kubernetes-external-secrets
+          image: "ghcr.io/external-secrets/kubernetes-external-secrets:6.4.0"
+          ports:
+          - name: prometheus
+            containerPort: 3001
+          imagePullPolicy: IfNotPresent
+          resources:
+            {}
+          env:
+          - name: "LOG_LEVEL"
+            value: "info"
+          - name: "METRICS_PORT"
+            value: "3001"
+          - name: "POLLER_INTERVAL_MILLISECONDS"
+            value: "10000"
+          - name: "WATCH_TIMEOUT"
+            value: "60000"
+          # Params for env vars populated from k8s secrets
+      securityContext:
+        runAsNonRoot: true

--- a/config/prow/cluster/kubernetes-external-secrets_rbac.yaml
+++ b/config/prow/cluster/kubernetes-external-secrets_rbac.yaml
@@ -1,0 +1,60 @@
+---
+# Source: kubernetes-external-secrets/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubernetes-external-secrets
+  labels:
+    app.kubernetes.io/name: kubernetes-external-secrets
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "update"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    resourceNames: ["externalsecrets.kubernetes-client.io"]
+    verbs: ["get", "update"]
+  - apiGroups: ["kubernetes-client.io"]
+    resources: ["externalsecrets"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["kubernetes-client.io"]
+    resources: ["externalsecrets/status"]
+    verbs: ["get", "update"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create"]
+---
+# Source: kubernetes-external-secrets/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernetes-external-secrets
+  labels:
+    app.kubernetes.io/name: kubernetes-external-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubernetes-external-secrets
+subjects:
+  - name: kubernetes-external-secrets-sa
+    namespace: "default"
+    kind: ServiceAccount
+---
+# Source: kubernetes-external-secrets/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernetes-external-secrets-auth
+  labels:
+    app.kubernetes.io/name: kubernetes-external-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- name: kubernetes-external-secrets-sa
+  namespace: "default"
+  kind: ServiceAccount

--- a/config/prow/cluster/kubernetes-external-secrets_service.yaml
+++ b/config/prow/cluster/kubernetes-external-secrets_service.yaml
@@ -1,0 +1,17 @@
+---
+# Source: kubernetes-external-secrets/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubernetes-external-secrets
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: kubernetes-external-secrets
+spec:
+  selector:
+    app.kubernetes.io/name: kubernetes-external-secrets
+  ports:
+    - protocol: TCP
+      port: 3001
+      name: prometheus
+      targetPort: prometheus

--- a/config/prow/cluster/trusted_serviceaccounts.yaml
+++ b/config/prow/cluster/trusted_serviceaccounts.yaml
@@ -38,6 +38,14 @@ metadata:
     iam.gke.io/gcp-service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod-bak.iam.gserviceaccount.com
   name: k8s-infra-gcr-promoter-bak
   namespace: test-pods
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: kubernetes-external-secrets-sa@k8s-prow.iam.gserviceaccount.com
+  name: kubernetes-external-secrets-sa
+  namespace: default
 # TODO(fejta): https://github.com/kubernetes/test-infra/issues/15806
 # * Run experiment/workload-identity/bind-service-accounts.sh on the above
 # * Config service account on job

--- a/prow/prow_secrets.md
+++ b/prow/prow_secrets.md
@@ -1,0 +1,57 @@
+# Prow Secrets Management
+
+Prow secrets are managed with Kubernetes External Secrets
+
+## Set Up (Prow maintainers)
+
+This is performed by prow service/build clusters maintainer.
+
+1. Create a GKE cluster and enable workload identity by
+   following [`workload-identity`](/workload-identity/README.md), using
+   `kubernetes-external-secrets-sa` as service account name, and
+   `kubernetes-external-secrets-sa@@k8s-prow.iam.gserviceaccount.com` service
+   account created in `k8s-prow` GCP project
+1. Deploy `kubernetes-external-secrets_crd.yaml`,
+   `kubernetes-external-secrets_deployment.yaml`,
+   `kubernetes-external-secrets_rbac.yaml`,
+   and  `kubernetes-external-secrets_service.yaml` under
+   [`config/prow/cluster`](/config/prow/cluster). The deployment file assumes
+   using the same service account name as in step #1
+
+## Usage (Prow clients)
+
+This is performed by prow clients, presumably teams managing their own build cluster(s).
+
+1. In the GCP project that stores secrets with google secret manager, grant the
+   `roles/secretmanager.viewer` permission to the GCP service account used in
+   step #1
+1. Create secret in google secret manager, assume it's named `my-precious-secret`
+1. Create kubernetes external secrets custom resource by:
+   ```
+   apiVersion: kubernetes-client.io/v1
+   kind: ExternalSecret
+   metadata:
+     name: <my-precious-secret-kes-name>    # name of the k8s external secret and the k8s secret
+     namespace:  <ns-where-secret-is-used>
+   spec:
+     backendType: gcpSecretsManager
+     projectId: <my-gsm-secret-project>
+     data:
+     - key: <my-gsm-secret-name>     # name of the GCP secret
+       name: <my-kubernetes-secret-name>   # key name in the k8s secret
+       version: latest    # version of the GCP secret
+       # Property to extract if secret in backend is a JSON object,
+       # remove this line if using the GCP secret value straight
+       property: value
+   ```
+
+Within 10 seconds, a secret will be created automatically:
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <my-precious-secret-kes-name>
+  namespace:  <ns-where-secret-is-used>
+data:
+  <my-kubernetes-secret-name>: <value_read_from_gsm>
+```

--- a/prow/prow_secrets.md
+++ b/prow/prow_secrets.md
@@ -1,30 +1,35 @@
 # Prow Secrets Management
 
-Prow secrets are managed with Kubernetes External Secrets
+Secrets in prow service/build clusters are managed with Kubernetes External
+Secrets, which is responsible for one-way syncing secret values from major
+secret manager providers such as GCP, Azure, and AWS secret managers into
+kubernetes clusters, based on `ExternalSecret` custom resource defined in
+cluster (As shown in example below).
+
+_Note: the instructions below are only for GCP secret manager, for
+authenticating with other providers please refer to
+https://github.com/external-secrets/kubernetes-external-secrets#backends_
 
 ## Set Up (Prow maintainers)
 
 This is performed by prow service/build clusters maintainer.
 
 1. Create a GKE cluster and enable workload identity by
-   following [`workload-identity`](/workload-identity/README.md), using
-   `kubernetes-external-secrets-sa` as service account name, and
-   `kubernetes-external-secrets-sa@@k8s-prow.iam.gserviceaccount.com` service
-   account created in `k8s-prow` GCP project
+   following [`workload-identity`](/workload-identity/README.md).
 1. Deploy `kubernetes-external-secrets_crd.yaml`,
    `kubernetes-external-secrets_deployment.yaml`,
    `kubernetes-external-secrets_rbac.yaml`,
    and  `kubernetes-external-secrets_service.yaml` under
    [`config/prow/cluster`](/config/prow/cluster). The deployment file assumes
-   using the same service account name as in step #1
+   using the same service account name as used in step #1
 
 ## Usage (Prow clients)
 
-This is performed by prow clients, presumably teams managing their own build cluster(s).
+This is performed by prow serving/build cluster clients.
 
 1. In the GCP project that stores secrets with google secret manager, grant the
-   `roles/secretmanager.viewer` permission to the GCP service account used in
-   step #1
+   `roles/secretmanager.viewer` and `roles/secretmanager.secretAccessor`
+   permission to the GCP service account used above
 1. Create secret in google secret manager, assume it's named `my-precious-secret`
 1. Create kubernetes external secrets custom resource by:
    ```


### PR DESCRIPTION
Part of https://docs.google.com/document/d/1Jo8dyNiJ1fnYh30M_6Gq2XDU9B3bGFmkD2QokyKYwEg/edit as discussed earlier on sig-testing meeting today.

Generated via helm as documented at https://github.com/external-secrets/kubernetes-external-secrets#install-with-kubectl
