### PR TITLE
Use 2004 Image Repo List for GCE's 20H2 test runs.

### DIFF
--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -110,7 +110,7 @@ periodics:
     preset-service-account: "true"
     preset-common-gce-windows: "true"
     preset-e2e-gce-windows: "true"
-    preset-windows-repo-list-master: "true"
+    preset-windows-repo-list-2004: "true"
     preset-windows-private-registry-cred: "true"
   spec:
     containers:


### PR DESCRIPTION
This change effectively moves the private image repo from gcr.io to e2eprivate which supports 20H2.