### PR TITLE
Update cluster-api-provider-aws owners

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/OWNERS
@@ -11,6 +11,7 @@ reviewers:
 - luxas
 - randomvariable
 - richardcase
+- sedefsavas
 - timothysc
 - vincepri
 approvers:
@@ -24,6 +25,7 @@ approvers:
 - luxas
 - randomvariable
 - richardcase
+- sedefsavas
 - timothysc
 - vincepri
 emeritus_reviewers:


### PR DESCRIPTION
Added CAPA maintainers/reviewers to the OWNERS for the CAPA prow jobs.

/cc @randomvariable
/cc @richardcase 