### PR TITLE
chore: add release jobs for csi-secrets-store

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -121,9 +121,7 @@ presubmits:
         - bash
         - -c
         - >-
-          apt-get update && apt-get install bats && apt-get install gettext-base -y &&
-          make e2e-bootstrap &&
-          make e2e-vault
+          make e2e-bootstrap e2e-helm-deploy e2e-vault
         securityContext:
           privileged: true
     annotations:
@@ -155,9 +153,7 @@ presubmits:
         - bash
         - -c
         - >-
-          apt-get update && apt-get install bats && apt-get install gettext-base -y &&
-          make e2e-bootstrap &&
-          make e2e-azure
+          make e2e-bootstrap e2e-helm-deploy e2e-azure
         securityContext:
           privileged: true
     annotations:
@@ -246,9 +242,7 @@ presubmits:
         - bash
         - -c
         - >-
-          apt-get update && apt-get install bats && apt-get install gettext-base -y &&
-          make e2e-bootstrap &&
-          make e2e-gcp
+          make e2e-bootstrap e2e-helm-deploy e2e-gcp
         securityContext:
           privileged: true
     annotations:
@@ -256,15 +250,22 @@ presubmits:
       testgrid-tab-name: pr-secrets-store-csi-driver-e2e-gcp
       description: "Run e2e test with gcp provider for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
-  - name: pull-secrets-store-csi-driver-build
+
+  # release jobs
+  - name: release-secrets-store-csi-driver-e2e-vault
     decorate: true
     decoration_config:
-      timeout: 10m
-    always_run: true
+      timeout: 25m
+    always_run: false
+    run_if_changed: "charts/.*"
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
     - master
     labels:
+      # this is required because we want to run kind in docker
+      preset-dind-enabled: "true"
+      # this is required to make CNI installation to succeed for kind
+      preset-kind-volume-mounts: "true"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
@@ -274,11 +275,88 @@ presubmits:
         - bash
         - -c
         - >-
-          make build build-windows
+          make e2e-bootstrap e2e-helm-deploy-release e2e-vault
+        securityContext:
+          privileged: true
+        env:
+          - name: RELEASE
+            value: "true"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver
-      testgrid-tab-name: pr-secrets-store-csi-driver-build
-      description: "Run make build build-windows for Secrets Store CSI driver."
+      testgrid-tab-name: release-secrets-store-csi-driver-e2e-vault
+      description: "Run e2e test with vault provider for Secrets Store CSI driver release."
+      testgrid-num-columns-recent: '30'
+  - name: release-secrets-store-csi-driver-e2e-azure
+    decorate: true
+    decoration_config:
+      timeout: 25m
+    always_run: false
+    run_if_changed: "charts/.*"
+    path_alias: sigs.k8s.io/secrets-store-csi-driver
+    branches:
+    - master
+    labels:
+      # this is required because we want to run kind in docker
+      preset-dind-enabled: "true"
+      # this is required to make CNI installation to succeed for kind
+      preset-kind-volume-mounts: "true"
+      # sets up the azure keyvault parameters used for testing
+      preset-azure-secrets-store-creds: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
+        command:
+        - runner.sh
+        args:
+        - bash
+        - -c
+        - >-
+          make e2e-bootstrap e2e-helm-deploy-release e2e-azure
+        securityContext:
+          privileged: true
+        env:
+          - name: RELEASE
+            value: "true"
+    annotations:
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver
+      testgrid-tab-name: release-secrets-store-csi-driver-e2e-azure
+      description: "Run e2e test with azure provider for Secrets Store CSI driver release."
+      testgrid-num-columns-recent: '30'
+  - name: release-secrets-store-csi-driver-e2e-gcp
+    decorate: true
+    decoration_config:
+      timeout: 25m
+    always_run: false
+    run_if_changed: "charts/.*"
+    path_alias: sigs.k8s.io/secrets-store-csi-driver
+    branches:
+    - master
+    labels:
+      # this is required because we want to run kind in docker
+      preset-dind-enabled: "true"
+      # this is required to make CNI installation to succeed for kind
+      preset-kind-volume-mounts: "true"
+      # sets up the gcp parameters used for testing
+      preset-gcp-secrets-store-creds: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-master
+        command:
+        - runner.sh
+        args:
+        - bash
+        - -c
+        - >-
+          make e2e-bootstrap e2e-helm-deploy-release e2e-gcp
+        securityContext:
+          privileged: true
+        env:
+          - name: RELEASE
+            value: "true"
+    annotations:
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver
+      testgrid-tab-name: release-secrets-store-csi-driver-e2e-gcp
+      description: "Run e2e test with gcp provider for Secrets Store CSI driver release."
       testgrid-num-columns-recent: '30'
 
 postsubmits:
@@ -305,9 +383,7 @@ postsubmits:
         - bash
         - -c
         - >-
-          apt-get update && apt-get install bats && apt-get install gettext-base -y &&
-          make e2e-bootstrap &&
-          make e2e-vault
+          make e2e-bootstrap e2e-helm-deploy e2e-vault
         securityContext:
           privileged: true
     annotations:
@@ -343,9 +419,7 @@ postsubmits:
         - bash
         - -c
         - >-
-          apt-get update && apt-get install bats && apt-get install gettext-base -y &&
-          make e2e-bootstrap &&
-          make e2e-azure
+          make e2e-bootstrap e2e-helm-deploy e2e-azure
         securityContext:
           privileged: true
     annotations:
@@ -381,9 +455,7 @@ postsubmits:
         - bash
         - -c
         - >-
-          apt-get update && apt-get install bats && apt-get install gettext-base -y &&
-          make e2e-bootstrap &&
-          make e2e-gcp
+          make e2e-bootstrap e2e-helm-deploy e2e-gcp
         securityContext:
           privileged: true
     annotations:


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

- Adding prow jobs to trigger based on changes in `charts/` dir. These jobs will deploy the helm release package and run e2e tests with all supported providers. 