### PR TITLE
Update testgrid sig-windows-networking jobs

### DIFF
--- a/config/testgrids/kubernetes/sig-windows/config.yaml
+++ b/config/testgrids/kubernetes/sig-windows/config.yaml
@@ -20,46 +20,66 @@ dashboards:
 - name: sig-windows-azure
 - name: sig-windows-networking
   dashboard_tab:
-  - name: flannel-l2bridge-windows-master
-    description: Runs Windows e2e tests on K8s clusters on Openstack vms with Flannel CNI in l2bridge network mode.
+  - name: ltsc2019-docker-flannel-winbridge-dsr-disabled-master
+    description: Runs Windows (LTSC 2019 with Docker) E2E tests on master branch K8s clusters (with WinDSR disabled) and latest Flannel CNI release in l2bridge network mode.
+    test_group_name: ci-kubernetes-e2e-winbridge-docker-dsr-disabled-master-windows
+  - name: ltsc2019-docker-flannel-winoverlay-dsr-disabled-master
+    description: Runs Windows (LTSC 2019 with Docker) E2E tests on master branch K8s clusters (with WinDSR disabled) and latest Flannel CNI release in overlay network mode.
+    test_group_name: ci-kubernetes-e2e-winoverlay-docker-dsr-disabled-master-windows
+  - name: ltsc2019-docker-flannel-winbridge-master
+    description: Runs Windows (LTSC 2019 with Docker) E2E tests on master branch K8s clusters and latest Flannel CNI release in l2bridge network mode.
     test_group_name: ci-kubernetes-e2e-flannel-l2bridge-master-windows
-  - name: flannel-overlay-windows-master
-    description: Runs Windows e2e tests on K8s clusters on Openstack vms with Flannel CNI in overlay network mode.
+  - name: ltsc2019-docker-flannel-winoverlay-master
+    description: Runs Windows (LTSC 2019 with Docker) E2E tests on master branch K8s clusters and latest Flannel CNI release in overlay network mode.
     test_group_name: ci-kubernetes-e2e-flannel-overlay-master-windows
-  - name: containerd-l2bridge-windows-master
-    description: Runs Windows e2e tests on K8s clusters with Containerd and Flannel CNI in l2bridge network mode.
+  - name: ltsc2019-containerd-flannel-sdnbridge-master
+    description: Runs Windows (LTSC 2019 with Containerd) E2E tests on master branch K8s clusters and latest Flannel CNI release in l2bridge network mode.
     test_group_name: ci-kubernetes-e2e-sdnbridge-ctrd-master-windows
-  - name: containerd-overlay-windows-master
-    description: Runs Windows e2e tests on K8s clusters with Containerd and Flannel CNI in overlay network mode.
+  - name: ltsc2019-containerd-flannel-sdnoverlay-master
+    description: Runs Windows (LTSC 2019 with Containerd) E2E tests on master branch K8s clusters and latest Flannel CNI release in overlay network mode.
     test_group_name: ci-kubernetes-e2e-sdnoverlay-ctrd-master-windows
-  - name: containerd-windows-sac1909-sdnbridge
-    description: Runs Windows (SAC 1909) e2e tests on stable K8s clusters with Containerd and latest Flannel CNI in l2bridge network mode.
+  - name: ltsc2019-containerd-flannel-sdnbridge-stable
+    description: Runs Windows (LTSC 2019 with Containerd) E2E tests on stable branch K8s clusters and latest Flannel CNI release in l2bridge network mode.
+    test_group_name: ci-kubernetes-e2e-sdnbridge-ctrd-stable-windows
+  - name: ltsc2019-containerd-flannel-sdnoverlay-stable
+    description: Runs Windows (LTSC 2019 with Containerd) E2E tests on stable branch K8s clusters and latest Flannel CNI release in overlay network mode.
+    test_group_name: ci-kubernetes-e2e-sdnoverlay-ctrd-stable-windows
+  - name: sac1909-containerd-flannel-sdnbridge-stable
+    description: Runs Windows (SAC 1909 with Containerd) E2E tests on stable branch K8s clusters and latest Flannel CNI release in l2bridge network mode.
     test_group_name: containerd-windows-sac1909-sdnbridge
-  - name: containerd-windows-sac1909-sdnoverlay
-    description: Runs Windows (SAC 1909) e2e tests on stable K8s clusters with Containerd and latest Flannel CNI in overlay network mode.
+  - name: sac1909-containerd-flannel-sdnoverlay-stable
+    description: Runs Windows (SAC 1909 with Containerd) E2E tests on stable branch K8s clusters and latest Flannel CNI release in overlay network mode.
     test_group_name: containerd-windows-sac1909-sdnoverlay
-  - name: containerd-windows-sac2004-sdnbridge
-    description: Runs Windows (SAC 2004) e2e tests on stable K8s clusters with Containerd and latest Flannel CNI in l2bridge network mode.
+  - name: sac2004-containerd-flannel-sdnbridge-stable
+    description: Runs Windows (SAC 2004 with Containerd) E2E tests on stable branch K8s clusters and latest Flannel CNI release in l2bridge network mode.
     test_group_name: containerd-windows-sac2004-sdnbridge
-  - name: containerd-windows-sac2004-sdnoverlay
-    description: Runs Windows (SAC 2004) e2e tests on stable K8s clusters with Containerd and latest Flannel CNI in overlay network mode.
+  - name: sac2004-containerd-flannel-sdnoverlay-stable
+    description: Runs Windows (SAC 2004 with Containerd) E2E tests on stable branch K8s clusters and latest Flannel CNI release in overlay network mode.
     test_group_name: containerd-windows-sac2004-sdnoverlay
 
 test_groups:
 # Flannel CNI on Windows test groups
+- name: ci-kubernetes-e2e-winbridge-docker-dsr-disabled-master-windows
+  gcs_prefix: logs/k8s-ovn/ci-kubernetes-e2e-winbridge-docker-dsr-disabled-master-windows
+- name: ci-kubernetes-e2e-winoverlay-docker-dsr-disabled-master-windows
+  gcs_prefix: logs/k8s-ovn/ci-kubernetes-e2e-winoverlay-docker-dsr-disabled-master-windows
 - name: ci-kubernetes-e2e-flannel-l2bridge-master-windows
-  gcs_prefix: k8s-ovn/ci-kubernetes-e2e-flannel-l2bridge-master-windows
+  gcs_prefix: logs/k8s-ovn/ci-kubernetes-e2e-flannel-l2bridge-master-windows
 - name: ci-kubernetes-e2e-flannel-overlay-master-windows
-  gcs_prefix: k8s-ovn/ci-kubernetes-e2e-flannel-overlay-master-windows
-- name: ci-kubernetes-e2e-sdnoverlay-ctrd-master-windows
-  gcs_prefix: k8s-ovn/ci-kubernetes-e2e-sdnoverlay-ctrd-master-windows
+  gcs_prefix: logs/k8s-ovn/ci-kubernetes-e2e-flannel-overlay-master-windows
 - name: ci-kubernetes-e2e-sdnbridge-ctrd-master-windows
-  gcs_prefix: k8s-ovn/ci-kubernetes-e2e-sdnbridge-ctrd-master-windows
+  gcs_prefix: logs/k8s-ovn/ci-kubernetes-e2e-sdnbridge-ctrd-master-windows
+- name: ci-kubernetes-e2e-sdnoverlay-ctrd-master-windows
+  gcs_prefix: logs/k8s-ovn/ci-kubernetes-e2e-sdnoverlay-ctrd-master-windows
+- name: ci-kubernetes-e2e-sdnbridge-ctrd-stable-windows
+  gcs_prefix: logs/k8s-ovn/ci-kubernetes-e2e-sdnbridge-ctrd-stable-windows
+- name: ci-kubernetes-e2e-sdnoverlay-ctrd-stable-windows
+  gcs_prefix: logs/k8s-ovn/ci-kubernetes-e2e-sdnoverlay-ctrd-stable-windows
 - name: containerd-windows-sac1909-sdnbridge
-  gcs_prefix: k8s-ovn/containerd-windows-sac1909-sdnbridge
+  gcs_prefix: logs/k8s-ovn/containerd-windows-sac1909-sdnbridge
 - name: containerd-windows-sac1909-sdnoverlay
-  gcs_prefix: k8s-ovn/containerd-windows-sac1909-sdnoverlay
+  gcs_prefix: logs/k8s-ovn/containerd-windows-sac1909-sdnoverlay
 - name: containerd-windows-sac2004-sdnbridge
-  gcs_prefix: k8s-ovn/containerd-windows-sac2004-sdnbridge
+  gcs_prefix: logs/k8s-ovn/containerd-windows-sac2004-sdnbridge
 - name: containerd-windows-sac2004-sdnoverlay
-  gcs_prefix: k8s-ovn/containerd-windows-sac2004-sdnoverlay
+  gcs_prefix: logs/k8s-ovn/containerd-windows-sac2004-sdnoverlay


### PR DESCRIPTION
* Add the following new jobs:
  * `ci-kubernetes-e2e-winbridge-docker-dsr-disabled-master-windows`
  * `ci-kubernetes-e2e-winoverlay-docker-dsr-disabled-master-windows`
  * `ci-kubernetes-e2e-sdnbridge-ctrd-stable-windows`
  * `ci-kubernetes-e2e-sdnoverlay-ctrd-stable-windows`
* Use consistent naming for the jobs group names.
* Update jobs descriptions to clearly reflect the test cases.
* The Prow environment for the `sig-windows-networking` CI was updated
  to use the `crier` component for logs / artifacts publishing.
  Therefore, `gcs_prefix` is adjusted to match the location used by
  the `crier`.