### PR TITLE
Update test package version for cloud-provider-gcp conformance test

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
@@ -40,4 +40,4 @@ periodics:
         go get sigs.k8s.io/kubetest2@latest;
         go get sigs.k8s.io/kubetest2/kubetest2-gce@latest;
         go get sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
-        kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo -- --test-package-version=v1.19.0 --focus-regex='\[Conformance\]'
+        kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo -- --test-package-version=v1.20.0 --focus-regex='\[Conformance\]'


### PR DESCRIPTION
Since cloud-provider-gcp is updated with v1.20, update the related test package version as well.