### PR TITLE
CAPI: rename release-blocking label to kind/release-blocking

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -192,7 +192,7 @@ larger set of contributors to apply/remove them.
 | <a id="area/upgrades" href="#area/upgrades">`area/upgrades`</a> | Issues or PRs related to upgrades| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="area/ux" href="#area/ux">`area/ux`</a> | Issues or PRs related to UX| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="kind/proposal" href="#kind/proposal">`kind/proposal`</a> | Issues or PRs related to proposals.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
-| <a id="release-blocking" href="#release-blocking">`release-blocking`</a> | Issues or PRs that need to be closed before the next CAPI release| approvers |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="kind/release-blocking" href="#kind/release-blocking">`kind/release-blocking`</a> | Issues or PRs that need to be closed before the next CAPI release| approvers |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 
 ## Labels that apply to kubernetes-sigs/cluster-api-provider-aws, for both issues and PRs
 

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -1483,6 +1483,12 @@ repos:
         target: both
         prowPlugin: label
         addedBy: anyone
+      - color: f6c5d8
+        description: Issues or PRs that need to be closed before the next CAPI release
+        name: kind/release-blocking
+        target: both
+        prowPlugin: label
+        addedBy: approvers
       - color: 0052cc
         description: Issues or PRs related to clusterctl
         name: area/clusterctl
@@ -1554,12 +1560,6 @@ repos:
         target: both
         prowPlugin: label
         addedBy: anyone
-      - color: f6c5d8
-        description: Issues or PRs that need to be closed before the next CAPI release
-        name: release-blocking
-        target: both
-        prowPlugin: label
-        addedBy: approvers
   kubernetes-sigs/cluster-api-provider-azure:
     labels:
       - color: c7def8


### PR DESCRIPTION
Apply the suggestion from https://github.com/kubernetes/test-infra/issues/6095#issuecomment-805453215

> Add a kind/release-blocker instead since there can be multiple kind labels

/assign @ashish-amarnath @vincepri 