### PR TITLE
Persist job runs past max_prowjob_age by storing them in the GH status description

### DIFF
--- a/prow/github/report/BUILD.bazel
+++ b/prow/github/report/BUILD.bazel
@@ -14,6 +14,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
     ],
 )
@@ -24,6 +25,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/github/report",
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/plugins:go_default_library",
     ],


### PR DESCRIPTION
Currently, Tide always has to retest if a test result is older than
max_prowjob_age because it can not determine anymore what baserevision
the test run ran against.

While it is possible to optimize Sinker to be able to keep presubmits
longer, the bigger Prow instances like the Kubernetes or Openshift one
will never be able to keep ProwJobs for more than a couple of days.
This is not sufficient for for example backports, where PRs regularly
wait for a week or more until they can be merged.

This PR makes us (ab-)use the GitHub status context description to store
the baseSHA and makes Tide's accumulate construct virtual ProwJob
objects out of these. This allows us to store past presubmit results
pretty much indefinitely.

Apart from the included unittests I also manually deployed this and verified that Tide merges without creating a new Prowjob when the baseSHA is current and continues to create the ProwJob if not.

The status now looks like this on GitHub:
<img width="649" alt="gh_basesha" src="https://user-images.githubusercontent.com/6496100/112387402-19417480-8cc8-11eb-873f-0151acfefb72.png">



This approach was discussed in Slack: https://kubernetes.slack.com/archives/CDECRSC5U/p1616509899019900
Supersedes and thereby closes https://github.com/kubernetes/test-infra/pull/21453

I recommend disabling whitespace changes to reduce the diff. Most of the change in this PR is tests, because the PR object tide uses has very deeply nested substructs.


/assign @chaodaiG @cjwagner @stevekuznetsov 