### PR TITLE
[releng] 1.21: Add Prow configuration for branch release-1.21

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -540,6 +540,7 @@ tide:
     milestone: v1.21
     includedBranches:
     - master
+    - release-1.21
     labels:
     - lgtm
     - approved

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -328,6 +328,7 @@ milestone_applier:
     master: v1.21
   kubernetes/kubernetes:
     master: v1.21
+    release-1.21: v1.21
     release-1.20: v1.20
     release-1.19: v1.19
     release-1.18: v1.18

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -282,6 +282,15 @@ slack:
             - saschagrunert # subproject owner / Release Manager
             - justaugustus # subproject owner / Release Manager
             - xmudrii # Release Manager
+        release-1.21:
+            - cpanato # Release Manager
+            - feiskyer # Release Manager
+            - hasheddan # subproject owner / Release Manager
+            - idealhack # Release Manager
+            - puerco # Release Manager
+            - saschagrunert # subproject owner / Release Manager
+            - justaugustus # subproject owner / Release Manager
+            - xmudrii # Release Manager
         feature-serverside-apply:
             - lavalamp # feature-serverside-apply "branch manager"
             - apelisse # feature-serverside-apply "branch manager"


### PR DESCRIPTION
RelEng: This PR adds a the following changes to prow config files in preparation for the `release-1.21` branch creation:

- Add exemptions to the current Release Managers to the Slack events Prow plugin.
- Configure the milestone_applier rule on branch release-1.21.
- Add milestone requirements to release-1.21

v1.21 Release Cut issue: https://github.com/kubernetes/sig-release/issues/1489

To remain on hold until `release-1.21` branch is cut.
/hold

/sig release
/area release-eng
cc: @kubernetes/release-engineering

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>