### PR TITLE
[releng] 1.21: Add milestone_applier rule to release-1.21

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -328,6 +328,7 @@ milestone_applier:
     master: v1.21
   kubernetes/kubernetes:
     master: v1.21
+    release-1.21: v1.21
     release-1.20: v1.20
     release-1.19: v1.19
     release-1.18: v1.18


### PR DESCRIPTION
RelEng: Configure the milestone_applier rule on branch `release-1.21`.

v1.21 Release Cut issue: kubernetes/sig-release#1489

To remain on hold until `release-1.21` branch is cut.
/hold

/sig release
/area release-eng
cc: @kubernetes/release-engineering



Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>