### PR TITLE
[releng] 1.21: Add milestone requirements to release-1.21

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -540,6 +540,7 @@ tide:
     milestone: v1.21
     includedBranches:
     - master
+    - release-1.21
     labels:
     - lgtm
     - approved


### PR DESCRIPTION
RelEng: Apply milestone v1.21 requirements to release-1.21 to extend Code Freeze to cover the new branch.

v1.21 Release Cut issue: kubernetes/sig-release#1489

To remain on hold until `release-1.21` branch is cut.
/hold

/sig release
/area release-eng
cc: @kubernetes/release-engineering

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>