### PR TITLE
[releng] 1.21: Add kubekins-e2e variant for v1.21

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -25,6 +25,12 @@ variants:
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
+  '1.21':
+    CONFIG: '1.21'
+    GO_VERSION: 1.16.1
+    K8S_RELEASE: stable-1.21
+    BAZEL_VERSION: 3.4.1
+    OLD_BAZEL_VERSION: 2.2.0
   '1.20':
     CONFIG: '1.20'
     GO_VERSION: 1.15.8


### PR DESCRIPTION
This PR adds a new  1.21  kubekins e2e variant by cloning the master variant and setting K8S_RELEASE to `stable-1.21`


v1.21 Release Cut issue: kubernetes/sig-release#1489

To remain on hold until `release-1.21` branch is cut.
/hold

/sig release
/area release-eng
cc: @kubernetes/release-engineering



Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>