### PR TITLE
Skip serial tests in ci-kubernetes-local-e2e

### DIFF
--- a/config/jobs/kubernetes/sig-testing/local-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/local-e2e.yaml
@@ -65,7 +65,7 @@ periodics:
       - --extract-source
       - --ginkgo-parallel=1
       - --provider=local
-      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[sig\-apps\]\sDaemon\sset\s\[Serial\]\sshould\srollback\swithout\sunnecessary\srestarts\s\[Conformance\]
+      - --test_args=--ginkgo.focus=\[Conformance\] --ginkgo.skip=Serial
       - --timeout=120m
       # docker-in-docker needs privileged mode
       securityContext:


### PR DESCRIPTION
There are some more tests that fail because local-up-cluster does not
have 2 minimum nodes. So let's skip all Serial tests.

https://testgrid.k8s.io/conformance-all#local-up-cluster,%20master%20(dev)

Signed-off-by: Davanum Srinivas <davanum@gmail.com>