### PR TITLE
Align CAPI reviewers and approvers with the project owner file

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api/OWNERS
@@ -1,20 +1,25 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
+- CecileRobertMichon
 - davidewatson
 - detiber
+- fabriziopandini
+- JoelSpeed
 - justinsb
-- luxas
 - timothysc
 - vincepri
 approvers:
+- CecileRobertMichon
 - davidewatson
 - detiber
+- fabriziopandini
 - justinsb
-- luxas
 - timothysc
 - vincepri
 emeritus_reviewers:
-  - ncdc
+- luxas
+- ncdc
 emeritus_approvers:
-  - ncdc
+- luxas
+- ncdc


### PR DESCRIPTION
This PR aligns the CAPI owner file to the project owner file https://github.com/kubernetes-sigs/cluster-api/blob/master/OWNERS_ALIASES 

/assign @vincepri 