### PR TITLE
Deflake TestBranchProtectionMergeMergesAnythingWithoutAnError

### DIFF
--- a/prow/config/branch_protection.go
+++ b/prow/config/branch_protection.go
@@ -221,7 +221,7 @@ func (bp *BranchProtection) merge(additional *BranchProtection) error {
 		}
 		if isPolicySet(bp.Orgs[org].Policy) && isPolicySet(additional.Orgs[org].Policy) {
 			errs = append(errs, fmt.Errorf("both branchprotection configs define a policy for org %s", org))
-		} else if isPolicySet(additional.Orgs[org].Policy) {
+		} else if _, ok := additional.Orgs[org]; ok && !isPolicySet(bp.Orgs[org].Policy) {
 			orgSettings := bp.Orgs[org]
 			orgSettings.Policy = additional.Orgs[org].Policy
 			bp.Orgs[org] = orgSettings
@@ -235,7 +235,7 @@ func (bp *BranchProtection) merge(additional *BranchProtection) error {
 			}
 			if isPolicySet(bp.Orgs[org].Repos[repo].Policy) && isPolicySet(additional.Orgs[org].Repos[repo].Policy) {
 				errs = append(errs, fmt.Errorf("both branchprotection configs define a policy for repo %s/%s", org, repo))
-			} else if isPolicySet(additional.Orgs[org].Repos[repo].Policy) {
+			} else if _, ok := additional.Orgs[org].Repos[repo]; ok && !isPolicySet(bp.Orgs[org].Repos[repo].Policy) {
 				repoSettings := bp.Orgs[org].Repos[repo]
 				repoSettings.Policy = additional.Orgs[org].Repos[repo].Policy
 				bp.Orgs[org].Repos[repo] = repoSettings
@@ -250,7 +250,7 @@ func (bp *BranchProtection) merge(additional *BranchProtection) error {
 
 				if isPolicySet(bp.Orgs[org].Repos[repo].Branches[branch].Policy) && isPolicySet(additional.Orgs[org].Repos[repo].Branches[branch].Policy) {
 					errs = append(errs, fmt.Errorf("both branchprotection configs define a policy for branch %s in repo %s/%s", branch, org, repo))
-				} else if isPolicySet(additional.Orgs[org].Repos[repo].Branches[branch].Policy) {
+				} else if _, ok := additional.Orgs[org].Repos[repo].Branches[branch]; ok && !isPolicySet(bp.Orgs[org].Repos[repo].Branches[branch].Policy) {
 					branchSettings := bp.Orgs[org].Repos[repo].Branches[branch]
 					branchSettings.Policy = additional.Orgs[org].Repos[repo].Branches[branch].Policy
 					bp.Orgs[org].Repos[repo].Branches[branch] = branchSettings


### PR DESCRIPTION
The merging logic used to only check if a policy was set for a Branch
and if not, do nothing. This made the test fail when an empty policy was
set, because a map with a key and an empty value differs from a map with
no key.

I also have to say I am disappointed at the fuzzing here, I didn't manage to reproduce it without the explicit fuzzing funcs even when running 10k rounds of the test (maybe the seed which is `time.Now().UnixNano()` by default has too little entropy?).

Fixes https://github.com/kubernetes/test-infra/issues/21507
/cc @stevekuznetsov @chaodaiG @stevekuznetsov 