### PR TITLE
Added support for full set of repository permissions in Peribolos

### DIFF
--- a/prow/cmd/peribolos/main_test.go
+++ b/prow/cmd/peribolos/main_test.go
@@ -2349,13 +2349,13 @@ func TestConfigureTeamRepos(t *testing.T) {
 			},
 			existingRepos: map[int][]github.Repo{1: {
 				{Name: "read", Permissions: github.RepoPermissions{Pull: true}},
-				{Name: "write", Permissions: github.RepoPermissions{Pull: true, Push: true}},
-				{Name: "admin", Permissions: github.RepoPermissions{Pull: true, Push: true, Admin: true}},
+				{Name: "write", Permissions: github.RepoPermissions{Pull: true, Triage: true, Push: true}},
+				{Name: "admin", Permissions: github.RepoPermissions{Pull: true, Triage: true, Push: true, Maintain: true, Admin: true}},
 			}},
 			expected: map[int][]github.Repo{1: {
 				{Name: "read", Permissions: github.RepoPermissions{Pull: true}},
-				{Name: "write", Permissions: github.RepoPermissions{Pull: true, Push: true}},
-				{Name: "admin", Permissions: github.RepoPermissions{Pull: true, Push: true, Admin: true}},
+				{Name: "write", Permissions: github.RepoPermissions{Pull: true, Triage: true, Push: true}},
+				{Name: "admin", Permissions: github.RepoPermissions{Pull: true, Triage: true, Push: true, Maintain: true, Admin: true}},
 			}},
 		},
 		{
@@ -2372,14 +2372,14 @@ func TestConfigureTeamRepos(t *testing.T) {
 			},
 			existingRepos: map[int][]github.Repo{1: {
 				{Name: "read", Permissions: github.RepoPermissions{Pull: true}},
-				{Name: "write", Permissions: github.RepoPermissions{Pull: true, Push: true}},
-				{Name: "admin", Permissions: github.RepoPermissions{Pull: true, Push: true, Admin: true}},
+				{Name: "write", Permissions: github.RepoPermissions{Pull: true, Triage: true, Push: true}},
+				{Name: "admin", Permissions: github.RepoPermissions{Pull: true, Triage: true, Push: true, Maintain: true, Admin: true}},
 			}},
 			expected: map[int][]github.Repo{1: {
 				{Name: "read", Permissions: github.RepoPermissions{Pull: true}},
-				{Name: "write", Permissions: github.RepoPermissions{Pull: true, Push: true}},
-				{Name: "admin", Permissions: github.RepoPermissions{Pull: true, Push: true, Admin: true}},
-				{Name: "other-admin", Permissions: github.RepoPermissions{Pull: true, Push: true, Admin: true}},
+				{Name: "write", Permissions: github.RepoPermissions{Pull: true, Triage: true, Push: true}},
+				{Name: "admin", Permissions: github.RepoPermissions{Pull: true, Triage: true, Push: true, Maintain: true, Admin: true}},
+				{Name: "other-admin", Permissions: github.RepoPermissions{Pull: true, Triage: true, Push: true, Maintain: true, Admin: true}},
 			}},
 		},
 		{
@@ -2395,12 +2395,12 @@ func TestConfigureTeamRepos(t *testing.T) {
 			},
 			existingRepos: map[int][]github.Repo{1: {
 				{Name: "read", Permissions: github.RepoPermissions{Pull: true}},
-				{Name: "write", Permissions: github.RepoPermissions{Pull: true, Push: true}},
-				{Name: "admin", Permissions: github.RepoPermissions{Pull: true, Push: true, Admin: true}},
+				{Name: "write", Permissions: github.RepoPermissions{Pull: true, Triage: true, Push: true}},
+				{Name: "admin", Permissions: github.RepoPermissions{Pull: true, Triage: true, Push: true, Maintain: true, Admin: true}},
 			}},
 			expected: map[int][]github.Repo{1: {
 				{Name: "read", Permissions: github.RepoPermissions{Pull: true}},
-				{Name: "write", Permissions: github.RepoPermissions{Pull: true, Push: true}},
+				{Name: "write", Permissions: github.RepoPermissions{Pull: true, Triage: true, Push: true}},
 				{Name: "admin", Permissions: github.RepoPermissions{Pull: true}},
 			}},
 		},
@@ -2416,11 +2416,11 @@ func TestConfigureTeamRepos(t *testing.T) {
 			},
 			existingRepos: map[int][]github.Repo{1: {
 				{Name: "read", Permissions: github.RepoPermissions{Pull: true}},
-				{Name: "write", Permissions: github.RepoPermissions{Pull: true, Push: true}},
-				{Name: "admin", Permissions: github.RepoPermissions{Pull: true, Push: true, Admin: true}},
+				{Name: "write", Permissions: github.RepoPermissions{Pull: true, Triage: true, Push: true}},
+				{Name: "admin", Permissions: github.RepoPermissions{Pull: true, Triage: true, Push: true, Maintain: true, Admin: true}},
 			}},
 			expected: map[int][]github.Repo{1: {
-				{Name: "write", Permissions: github.RepoPermissions{Pull: true, Push: true}},
+				{Name: "write", Permissions: github.RepoPermissions{Pull: true, Triage: true, Push: true}},
 				{Name: "admin", Permissions: github.RepoPermissions{Pull: true}},
 			}},
 		},
@@ -2472,14 +2472,14 @@ func TestConfigureTeamRepos(t *testing.T) {
 			},
 			existingRepos: map[int][]github.Repo{2: {
 				{Name: "read", Permissions: github.RepoPermissions{Pull: true}},
-				{Name: "write", Permissions: github.RepoPermissions{Pull: true, Push: true}},
-				{Name: "admin", Permissions: github.RepoPermissions{Pull: true, Push: true, Admin: true}},
+				{Name: "write", Permissions: github.RepoPermissions{Pull: true, Triage: true, Push: true}},
+				{Name: "admin", Permissions: github.RepoPermissions{Pull: true, Triage: true, Push: true, Maintain: true, Admin: true}},
 			}},
 			expected: map[int][]github.Repo{2: {
 				{Name: "read", Permissions: github.RepoPermissions{Pull: true}},
-				{Name: "write", Permissions: github.RepoPermissions{Pull: true, Push: true}},
-				{Name: "admin", Permissions: github.RepoPermissions{Pull: true, Push: true, Admin: true}},
-				{Name: "other-admin", Permissions: github.RepoPermissions{Pull: true, Push: true, Admin: true}},
+				{Name: "write", Permissions: github.RepoPermissions{Pull: true, Triage: true, Push: true}},
+				{Name: "admin", Permissions: github.RepoPermissions{Pull: true, Triage: true, Push: true, Maintain: true, Admin: true}},
+				{Name: "other-admin", Permissions: github.RepoPermissions{Pull: true, Triage: true, Push: true, Maintain: true, Admin: true}},
 			}},
 		},
 		{

--- a/prow/github/helpers.go
+++ b/prow/github/helpers.go
@@ -74,8 +74,12 @@ func ImageTooBig(url string) (bool, error) {
 func LevelFromPermissions(permissions RepoPermissions) RepoPermissionLevel {
 	if permissions.Admin {
 		return Admin
+	} else if permissions.Maintain {
+		return Maintain
 	} else if permissions.Push {
 		return Write
+	} else if permissions.Triage {
+		return Triage
 	} else if permissions.Pull {
 		return Read
 	} else {
@@ -88,10 +92,14 @@ func PermissionsFromTeamPermission(permission TeamPermission) RepoPermissions {
 	switch permission {
 	case RepoPull:
 		return RepoPermissions{Pull: true}
+	case RepoTriage:
+		return RepoPermissions{Pull: true, Triage: true}
 	case RepoPush:
-		return RepoPermissions{Pull: true, Push: true}
+		return RepoPermissions{Pull: true, Triage: true, Push: true}
+	case RepoMaintain:
+		return RepoPermissions{Pull: true, Triage: true, Push: true, Maintain: true}
 	case RepoAdmin:
-		return RepoPermissions{Pull: true, Push: true, Admin: true}
+		return RepoPermissions{Pull: true, Triage: true, Push: true, Maintain: true, Admin: true}
 	default:
 		// Should never happen unless the type gets new value
 		return RepoPermissions{}

--- a/prow/github/helpers_test.go
+++ b/prow/github/helpers_test.go
@@ -34,8 +34,16 @@ func TestRepoPermissionLevel(t *testing.T) {
 			get(Admin),
 		},
 		{
+			"maintain",
+			get(Maintain),
+		},
+		{
 			"write",
 			get(Write),
+		},
+		{
+			"triage",
+			get(Triage),
 		},
 		{
 			"read",
@@ -82,11 +90,19 @@ func TestLevelFromPermissions(t *testing.T) {
 			level:       Read,
 		},
 		{
-			permissions: RepoPermissions{Pull: true, Push: true},
+			permissions: RepoPermissions{Pull: true, Triage: true},
+			level:       Triage,
+		},
+		{
+			permissions: RepoPermissions{Pull: true, Triage: true, Push: true},
 			level:       Write,
 		},
 		{
-			permissions: RepoPermissions{Pull: true, Push: true, Admin: true},
+			permissions: RepoPermissions{Pull: true, Triage: true, Push: true, Maintain: true},
+			level:       Maintain,
+		},
+		{
+			permissions: RepoPermissions{Pull: true, Triage: true, Push: true, Maintain: true, Admin: true},
 			level:       Admin,
 		},
 	}
@@ -112,12 +128,20 @@ func TestPermissionsFromTeamPermission(t *testing.T) {
 			permissions: RepoPermissions{Pull: true},
 		},
 		{
+			level:       RepoTriage,
+			permissions: RepoPermissions{Pull: true, Triage: true},
+		},
+		{
 			level:       RepoPush,
-			permissions: RepoPermissions{Pull: true, Push: true},
+			permissions: RepoPermissions{Pull: true, Triage: true, Push: true},
+		},
+		{
+			level:       RepoMaintain,
+			permissions: RepoPermissions{Pull: true, Triage: true, Push: true, Maintain: true},
 		},
 		{
 			level:       RepoAdmin,
-			permissions: RepoPermissions{Pull: true, Push: true, Admin: true},
+			permissions: RepoPermissions{Pull: true, Triage: true, Push: true, Maintain: true, Admin: true},
 		},
 	}
 

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -461,10 +461,12 @@ func (r RepoUpdateRequest) Defined() bool {
 // repo. At most one of the booleans here should be true.
 type RepoPermissions struct {
 	// Pull is equivalent to "Read" permissions in the web UI
-	Pull bool `json:"pull"`
+	Pull   bool `json:"pull"`
+	Triage bool `json:"triage"`
 	// Push is equivalent to "Edit" permissions in the web UI
-	Push  bool `json:"push"`
-	Admin bool `json:"admin"`
+	Push     bool `json:"push"`
+	Maintain bool `json:"maintain"`
+	Admin    bool `json:"admin"`
 }
 
 // RepoPermissionLevel is admin, write, read or none.
@@ -472,11 +474,20 @@ type RepoPermissions struct {
 // See https://developer.github.com/v3/repos/collaborators/#review-a-users-permission-level
 type RepoPermissionLevel string
 
+// For more information on access levels, see:
+// https://docs.github.com/en/github/setting-up-and-managing-organizations-and-teams/repository-permission-levels-for-an-organization
 const (
 	// Read allows pull but not push
 	Read RepoPermissionLevel = "read"
+	// Triage allows Read and managing issues
+	// pull requests but not push
+	Triage RepoPermissionLevel = "triage"
 	// Write allows Read plus push
 	Write RepoPermissionLevel = "write"
+	// Maintain allows Write along with managing
+	// repository without access to sensitive or
+	// destructive instructions.
+	Maintain RepoPermissionLevel = "maintain"
 	// Admin allows Write plus change others' rights.
 	Admin RepoPermissionLevel = "admin"
 	// None disallows everything
@@ -484,10 +495,12 @@ const (
 )
 
 var repoPermissionLevels = map[RepoPermissionLevel]bool{
-	Read:  true,
-	Write: true,
-	Admin: true,
-	None:  true,
+	Read:     true,
+	Triage:   true,
+	Write:    true,
+	Maintain: true,
+	Admin:    true,
+	None:     true,
 }
 
 // MarshalText returns the byte representation of the permission
@@ -508,9 +521,11 @@ func (l *RepoPermissionLevel) UnmarshalText(text []byte) error {
 type TeamPermission string
 
 const (
-	RepoPull  TeamPermission = "pull"
-	RepoPush  TeamPermission = "push"
-	RepoAdmin TeamPermission = "admin"
+	RepoPull     TeamPermission = "pull"
+	RepoTriage   TeamPermission = "triage"
+	RepoMaintain TeamPermission = "maintain"
+	RepoPush     TeamPermission = "push"
+	RepoAdmin    TeamPermission = "admin"
 )
 
 // Branch contains general branch information.


### PR DESCRIPTION
- Added `triage` and `maintain` as `RepoPermission`s and `RepoPermissionLevel`s.
- Updated the `LevelFromPermissions` and `PermissionsFromTeamPermission` functions and added tests for the same.

Signed-off-by: Madhav Jivrajani <madhav.jiv@gmail.com>

Fix #21380 