### PR TITLE
Improve fuzztest by printing seed and re-using fuzzer

### DIFF
--- a/prow/apis/prowjobs/v1/types_test.go
+++ b/prow/apis/prowjobs/v1/types_test.go
@@ -245,10 +245,14 @@ func TestDecorationDefaultingDoesntOverwrite(t *testing.T) {
 
 func TestApplyDefaultsAppliesDefaultsForAllFields(t *testing.T) {
 	t.Parallel()
+	seed := time.Now().UnixNano()
+	// Print the seed so failures can easily be reproduced
+	t.Logf("Seed: %d", seed)
+	fuzzer := fuzz.NewWithSeed(seed)
 	for i := 0; i < 100; i++ {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			def := &DecorationConfig{}
-			fuzz.New().Fuzz(def)
+			fuzzer.Fuzz(def)
 
 			// Each of those three has its own DeepCopy and in case it is nil,
 			// we just call that and return. In order to make this test verify

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -3952,10 +3952,14 @@ func TestCheckRunNodesToContexts(t *testing.T) {
 }
 
 func TestDeduplicateContestsDoesntLoseData(t *testing.T) {
+	seed := time.Now().UnixNano()
+	// Print the seed so failures can easily be reproduced
+	t.Logf("Seed: %d", seed)
+	fuzzer := fuzz.NewWithSeed(seed)
 	for i := 0; i < 100; i++ {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			context := Context{}
-			fuzz.New().Fuzz(&context)
+			fuzzer.Fuzz(&context)
 			res := deduplicateContexts([]Context{context})
 			if diff := cmp.Diff(context, res[0]); diff != "" {
 				t.Errorf("deduplicateContexts lost data, new object differs: %s", diff)


### PR DESCRIPTION
Printing the seed allows us to reproduce issues we see in CI, which
should make understanding them easier. Suggested by Chao in
https://github.com/kubernetes/test-infra/pull/21525#issuecomment-807109286.

Re-using the fuzzer should give us more entropy, because it internally
uses a PRNG that gets initialized with a seed. The PRNG should yield
more entropy when we continue using it, rather than re-initializing it
all the time with a seed that is only slightly different.

/assign @chaodaiG 