### PR TITLE
Revert "Make Cluster API make-main target optional"

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -22,8 +22,7 @@ presubmits:
   - name: pull-cluster-api-make-main
     decorate: true
     path_alias: sigs.k8s.io/cluster-api
-    always_run: false
-    optional: true
+    always_run: true
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"


### PR DESCRIPTION
This reverts commit d45708d75656bd263540942d4186a96aa6c5d37d.

Keep the make-main target required until we can rely on the github action.

/assign @vincepri @fabriziopandini 