### PR TITLE
chore: set pull-secrets-store-csi-driver-e2e-windows to always run

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -165,7 +165,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 3h
-    always_run: false
+    always_run: true
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     optional: true
     branches:


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

fixes https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/492

Setting windows test to `always_run` for all PRs in the Secrets Store CSI driver. It is still non-blocking because it's optional. We can make it PR blocking after few test runs. 

/assign @ritazh
/cc @tam7t 