### PR TITLE
cluster-api-provider-openstack: enable and enforce e2e tests on PR

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
@@ -47,9 +47,8 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
-    # TODO(sbueringer): always_run: true, optional: false after test has been merged on CAPO master
-    always_run: false
-    optional: true
+    always_run: true
+    optional: false
     decorate: true
     decoration_config:
       timeout: 5h


### PR DESCRIPTION
The idea is to run the e2e tests on every PR and make them mandatory for merge. I would keep conformance tests optional. They can be run if somebody wants to, but we don't start them automatically and they are not required for merging. (they are ran periodically, see: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-openstack#periodic-conformance-test-master)