### PR TITLE
kind dualstack presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -210,7 +210,7 @@ presubmits:
         - name: PARALLEL
           value: "true"
         - name: IP_FAMILY
-          value: DualStack
+          value: dual
         # enable IPV6 in bootstrap image
         - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
           value: "true"


### PR DESCRIPTION
We use "dual" in the API intead of "DualStack" to be consistent with the other ipfamily modes "ipv4" and "ipv6"