### PR TITLE
CAPI main upgrades should use go canary images

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
@@ -12,7 +12,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-cc9840e-1.19
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-go-canary
       args:
         - runner.sh
         - "./scripts/ci-e2e.sh"
@@ -52,7 +52,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-cc9840e-1.19
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-go-canary
       args:
         - runner.sh
         - "./scripts/ci-e2e.sh"
@@ -92,7 +92,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-cc9840e-1.19
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-go-canary
       args:
         - runner.sh
         - "./scripts/ci-e2e.sh"
@@ -132,7 +132,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210201-cc9840e-1.19
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-go-canary
       args:
         - runner.sh
         - "./scripts/ci-e2e.sh"


### PR DESCRIPTION
Fixes

```
Detected go version: go version go1.15.5 linux/amd64.
Kubernetes requires go1.16.0 or greater.
Please install go1.16.0 or later.
```

In CAPI main upgrades

/cc @srm09 