### PR TITLE
Security Profiles Operator: Increase memory limit for test pod

### DIFF
--- a/config/jobs/kubernetes-sigs/security-profiles-operator/seccomp-operator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/security-profiles-operator/seccomp-operator-presubmits.yaml
@@ -80,6 +80,9 @@ presubmits:
           requests:
             memory: 9000Mi
             cpu: 7500m
+          limits:
+            memory: 10000Mi
+            cpu: 7500m
         command:
         - runner.sh
         args:


### PR DESCRIPTION
We're hitting some issues regarding the pod running out of memory.
This tries to address that.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>