### PR TITLE
Add windows upstream test job for capz

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
@@ -31,6 +31,41 @@ periodics:
     testgrid-tab-name: capz-periodic-conformance-v1alpha4-main
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
     description: Runs conformance & node conformance tests on a stable k8s version with latest cluster-api-provider-azure
+- name: periodic-cluster-api-provider-azure-upstream-v1alpha4-windows
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  interval: 12h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: master
+      path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+  spec:
+    containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210312-67f589a-go-canary
+        command:
+        - "runner.sh"
+        - "./scripts/ci-conformance.sh"
+        env:
+        - name: WINDOWS
+          value: "true"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 2
+            memory: "9Gi"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+    testgrid-tab-name: capz-periodic-upstream-v1alpha4-main-windows
+    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+    description: Runs windows upstream e2e on a stable k8s version with latest cluster-api-provider-azure
 - name: periodic-cluster-api-provider-azure-conformance-v1alpha4-with-ci-artifacts
   decorate: true
   decoration_config:


### PR DESCRIPTION
This enabled running the tests periodically that were added as part of https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1119

/sig windows
/assign @CecileRobertMichon 

Will hold until the above merges
/hold