### PR TITLE
Use K8S_RELEASE latest-1.21 to build kubekins-e2e

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -28,7 +28,7 @@ variants:
   '1.21':
     CONFIG: '1.21'
     GO_VERSION: 1.16.1
-    K8S_RELEASE: stable-1.21
+    K8S_RELEASE: latest-1.21
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.20':


### PR DESCRIPTION
There is not a stable marker for v1.21. Switch to `latest` to build the kubekins e2e image

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>