### PR TITLE
Tide: Prioritize batches with pre-existing tests when picking

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -3,6 +3,9 @@
 ## New features
 
 New features added to each component:
+  - *March 9th, 2021* Tide batchtesting will now continue to test a given batch even
+    when more PRs became eligible while a test failed. You can disable this by setting
+    `tide.prioritize_existing_batches.<org or org/repo>: false` in your Prow config.
   - *March 3, 2021* `plank.default_decoration_configs` can optionally be replaced with
     `plank.default_decoration_config_entries` which supports a new format
     that is a slice of filters with associated decoration configs rather than a

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -907,8 +907,7 @@ slack_reporter_configs:
 status_error_link: ' '
 tide:
     # BatchSizeLimitMap is a key/value pair of an org or org/repo as the key and
-    # integer batch size limit as the value. The empty string key can be used as
-    # a global default.
+    # integer batch size limit as the value. Use "*" as key to set a global default.
     # Special values:
     # 0 => unlimited batch size
     # -1 => batch merging disabled :(
@@ -1007,6 +1006,14 @@ tide:
     # mapped by org or org/repo level.
     pr_status_base_urls:
         "": ""
+
+    # PrioritizeExistingBatches configures on org or org/repo level if Tide should continue
+    # testing pre-existing batches instead of immediately including new PRs as they become
+    # eligible. Continuing on an old batch allows to re-use all existing test results whereas
+    # starting a new one requires to start new instances of all tests.
+    # Use '*' as key to set this globally. Defaults to true.
+    prioritize_existing_batches:
+        "": false
 
     # Priority is an ordered list of sets of labels that would be prioritized before other PRs
     # PRs should match all labels contained in a set to be prioritized. The first entry has

--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -145,8 +145,7 @@ type Tide struct {
 	ContextOptions TideContextPolicyOptions `json:"context_options,omitempty"`
 
 	// BatchSizeLimitMap is a key/value pair of an org or org/repo as the key and
-	// integer batch size limit as the value. The empty string key can be used as
-	// a global default.
+	// integer batch size limit as the value. Use "*" as key to set a global default.
 	// Special values:
 	//  0 => unlimited batch size
 	// -1 => batch merging disabled :(
@@ -156,6 +155,28 @@ type Tide struct {
 	// PRs should match all labels contained in a set to be prioritized. The first entry has
 	// the highest priority.
 	Priority []TidePriority `json:"priority,omitempty"`
+
+	// PrioritizeExistingBatches configures on org or org/repo level if Tide should continue
+	// testing pre-existing batches instead of immediately including new PRs as they become
+	// eligible. Continuing on an old batch allows to re-use all existing test results whereas
+	// starting a new one requires to start new instances of all tests.
+	// Use '*' as key to set this globally. Defaults to true.
+	PrioritizeExistingBatchesMap map[string]bool `json:"prioritize_existing_batches,omitempty"`
+}
+
+func (t *Tide) PrioritizeExistingBatches(repo OrgRepo) bool {
+	if val, set := t.PrioritizeExistingBatchesMap[repo.String()]; set {
+		return val
+	}
+	if val, set := t.PrioritizeExistingBatchesMap[repo.Org]; set {
+		return val
+	}
+
+	if val, set := t.PrioritizeExistingBatchesMap["*"]; set {
+		return val
+	}
+
+	return true
 }
 
 func (t *Tide) BatchSizeLimit(repo OrgRepo) int {


### PR DESCRIPTION
Currently, tide will always pick the biggest possible batch. This is
suboptimal in high-traffic repos, because there is a good chance that
new PRs become merge-eligible in the timeframe it takes for tests to
fail. This means that we will have to completely start over, even if
only a single test failed in the previous attempt.

This change changes that logic to prioritize batches by number of past
successful job runs or if none exists by number of currently pending
job runs. The rationale is that:
* If we have past successful runs and assume all jobs have a non-zero
  flakerate, the likelihood of succeeding is increased
* Tide will omit the creation of jobs that already exist and are not
  failed, so this reduces the overall number of jobs we run
* If there is already an existing pending job, it is guaranteed to
  finish quicker than a new job for a new batch

The main argument against this change is that it means that we continue
testing smaller batches when a bigger one is available. In the grand
scheme of things this doesn't really make a difference though, because
if a new batch n+1 is bigger than the existing n batch, the batch
following that (n+2) will be smaller by the same number of PRs batch n+1
was bigger than n.

A nice sideeffect is that this makes reasoning easier when a subset of
jobs consistently fails (i.E. due to PRs in the batch being incompatible
or the job being broken) because one doesn't have to find the subset of
jobs that fails consistently in different batches anymore.

/cc @BenTheElder 
for thoughts on the idea

/assign @chaodaiG @cjwagner 
for thoughs and review