### PR TITLE
Bump golang version used in gcb-docker-gcloud to 1.16.2

### DIFF
--- a/images/gcb-docker-gcloud/cloudbuild.yaml
+++ b/images/gcb-docker-gcloud/cloudbuild.yaml
@@ -9,6 +9,6 @@ steps:
     dir: images/gcb-docker-gcloud/
 substitutions:
   _GIT_TAG: '12345'
-  _GO_VERSION: 1.13.5
+  _GO_VERSION: 1.16.2
 images:
   - 'gcr.io/$PROJECT_ID/gcb-docker-gcloud:$_GIT_TAG'


### PR DESCRIPTION
Hi,

I would like to create a new verison of the image with Golang 1.16.2. Not sure how the image is build after this PR has been merged.


xref: https://github.com/kubernetes-sigs/cluster-api/issues/4383