### PR TITLE
pull-publishing-bot-validate: revert to use go1.13

### DIFF
--- a/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
+++ b/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
@@ -40,7 +40,7 @@ presubmits:
       path_alias: k8s.io/publishing-bot
     spec:
       containers:
-      - image: golang:1.16
+      - image: golang:1.13
         command:
         - go
         args:


### PR DESCRIPTION
See update to go1.16 in https://github.com/kubernetes/test-infra/pull/21446. The job failed after the update to go1.16.

Failure - https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/100616/pull-publishing-bot-validate/1376464585715879936

I'd like to revert to use go1.13 and investigate why the move to go1.16 broke as a follow-up to unblock https://github.com/kubernetes/kubernetes/pull/100616

/assign @xmudrii 
cc @cpanato 