### PR TITLE
Reuse existing CI ssh keys in kubetest2 jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/kubetest2/kubetest2-canaries.yaml
+++ b/config/jobs/kubernetes-sigs/kubetest2/kubetest2-canaries.yaml
@@ -6,6 +6,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-service-account: "true"
+      preset-k8s-ssh: "true"
     annotations:
       testgrid-dashboards: sig-testing-canaries
     extra_refs:

--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
@@ -9,6 +9,7 @@ periodics:
     description: Runs conformance tests using kubetest2 against cloud-provider-gcp master on GCE
   labels:
     preset-service-account: "true"
+    preset-k8s-ssh: "true"
   extra_refs:
   - org: kubernetes
     repo: cloud-provider-gcp

--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -30,6 +30,7 @@ presubmits:
     path_alias: k8s.io/cloud-provider-gcp
     labels:
       preset-service-account: "true"
+      preset-k8s-ssh: "true"
     annotations:
       testgrid-dashboards: provider-gcp-presubmits
       description: End to end cluster creation test using kubetest2 based on kubernetes/cloud-provider-gcp.

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
@@ -48,6 +48,7 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
+    preset-k8s-ssh: "true"
   decorate: true
   decoration_config:
     timeout: 220m

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -117,6 +117,7 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
     annotations:
       testgrid-dashboards: presubmits-kubernetes-nonblocking
       testgrid-tab-name: pull-kubernetes-e2e-gce-kubetest2

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -651,6 +651,10 @@ presets:
     value: /etc/ssh-key-secret/ssh-private
   - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
     value: /etc/ssh-key-secret/ssh-public
+  - name: GCE_SSH_PRIVATE_KEY_FILE
+    value: /etc/ssh-key-secret/ssh-private
+  - name: GCE_SSH_PUBLIC_KEY_FILE
+    value: /etc/ssh-key-secret/ssh-public
   volumes:
   - name: ssh
     secret:


### PR DESCRIPTION
xref: https://github.com/kubernetes-sigs/kubetest2/issues/109

xref: https://github.com/kubernetes/enhancements/issues/2464

/cc @BenTheElder @spiffxp 