### PR TITLE
Fix autobumper consistency check flakey after manual bumps

### DIFF
--- a/prow/cmd/generic-autobumper/bumper/bumper_test.go
+++ b/prow/cmd/generic-autobumper/bumper/bumper_test.go
@@ -959,6 +959,20 @@ func TestGetVersionsAndCheckConsistency(t *testing.T) {
 			err:              false,
 			expectedVersions: map[string][]string{"newtag1": {"gcr.io/k8s-prow/test:tag1", "gcr.io/k8s-prow/test2:tag1"}},
 		},
+		{
+			name:             "prefix was not consistent before bump and now is",
+			prefixes:         []Prefix{prowPrefix},
+			images:           map[string]string{"gcr.io/k8s-prow/test:tag1": "newtag1", "gcr.io/k8s-prow/test2:tag2": "newtag1"},
+			err:              false,
+			expectedVersions: map[string][]string{"newtag1": {"gcr.io/k8s-prow/test:tag1", "gcr.io/k8s-prow/test2:tag2"}},
+		},
+		{
+			name:             "prefix was not consistent before bump one was bumped ahead manually",
+			prefixes:         []Prefix{prowPrefix},
+			images:           map[string]string{"gcr.io/k8s-prow/test:tag1": "newtag1", "gcr.io/k8s-prow/test2:newtag1": "newtag1"},
+			err:              false,
+			expectedVersions: map[string][]string{"newtag1": {"gcr.io/k8s-prow/test:tag1"}},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
This is a speculative fix for the oss autobump job failing this morning. I am still not sure why it failed, but the check consistency code was 1. confusing, and 2. had weird/flakey behavior if one of the images had been manually bumped before the autobump job ran. This implementation is a bit easier to follow and fixes this flakey testcase. Hopefully this was the cause of the oss autobump failure

/assign @michelle192837 