### PR TITLE
Fix gcb-docker-gcloud image build

### DIFF
--- a/images/gcb-docker-gcloud/Dockerfile
+++ b/images/gcb-docker-gcloud/Dockerfile
@@ -30,7 +30,7 @@ ENV PATH=/google-cloud-sdk/bin:/workspace:${PATH} \
 WORKDIR /workspace
 
 RUN echo http://dl-cdn.alpinelinux.org/alpine/latest-stable/community >> /etc/apk/repositories && \
-    apk --no-cache add curl python py-crcmod bash libc6-compat openssh-client git gnupg docker-cli make && \
+    apk --no-cache add curl python3 py-crcmod bash libc6-compat openssh-client git gnupg docker-cli make && \
     curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz && \
     tar xzf google-cloud-sdk.tar.gz -C / && \
     rm google-cloud-sdk.tar.gz && \


### PR DESCRIPTION
Fixup PR for #21549

Apparently there's only a python2 or python3 package available in Alpine 3.13.3 (which is the one used by the go image). I assume python3 is okay.

Build log of my local test: https://gist.github.com/sbueringer/0df661a1e2a04a9460ee8e8b7d10471f