### PR TITLE
Stop using extensions/v1beta1 in scalability tests

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -217,7 +217,7 @@ presets:
       apps/v1/Deployment
       apps/v1/ReplicaSet
       apps/v1/StatefulSet
-      extensions/v1beta1/Ingress
+      networking.k8s.io/v1beta1/Ingress
   # Switch to using log-dump.sh script included in the kubekins-e2e image
   # instead of relying on the deprecated one from k/k repository.
   - name: USE_TEST_INFRA_LOG_DUMPING


### PR DESCRIPTION
This is to fix issues spotted in experimental PR removing extensions/v1beta1: https://github.com/kubernetes/kubernetes/pull/99840

/assign @mborsz 