### PR TITLE
CAPDO: bump golangci-lint

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
@@ -56,7 +56,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: golangci/golangci-lint:v1.21.0
+      - image: golangci/golangci-lint:v1.32.2
         command:
         - make
         args:


### PR DESCRIPTION
This PR bump golangci-lint to match with the current golangci-lint version used on the project
posibility fixes failure jobs on https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/pull/254

/cc @cpanato @timoreimann 