### PR TITLE
Add branch name to structured logging CI job tab

### DIFF
--- a/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-kind-periodics.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-kind-periodics.yaml
@@ -4,7 +4,7 @@ periodics:
   name: ci-kubernetes-kind-e2e-json-logging
   annotations:
     testgrid-dashboards: sig-instrumentation-tests, sig-testing-kind
-    testgrid-tab-name: kind-json-logging
+    testgrid-tab-name: kind-json-logging-master
     description: Smoke tests Kubelet with JSON logging enabled using sigs.k8s.io/kind
     # TODO: anyone else?
     testgrid-alert-email: bentheelder@google.com,siarkowicz@google.com


### PR DESCRIPTION
The kind-json-logging job causes issues when forked per release as
duplicate names are present on a single dashboard. This updates the tab
name such that config forker will replace with appropriate release
branch.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Follow up to https://github.com/kubernetes/test-infra/pull/21332
Unblocks https://github.com/kubernetes/test-infra/pull/21557

/assign @BenTheElder
/cc @puerco 