### PR TITLE
Allow sig-release jobs to use preset-azure-cred

### DIFF
--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -426,6 +426,7 @@ func TestTrustedJobSecretsRestricted(t *testing.T) {
 		"kubernetes-sigs/sig-windows":                          {secrets: getSecretsFromPreset(labels{"preset-azure-cred": "true"}), allowedInPresubmit: true},
 		"kubernetes/sig-cloud-provider":                        {secrets: getSecretsFromPreset(labels{"preset-azure-cred": "true"}), allowedInPresubmit: true},
 		"kubernetes/sig-network":                               {secrets: getSecretsFromPreset(labels{"preset-azure-cred": "true"}), allowedInPresubmit: true},
+		"kubernetes/sig-release":                               {secrets: getSecretsFromPreset(labels{"preset-azure-cred": "true"})},
 		"kubernetes-sigs/cluster-api-provider-azure":           {secrets: getSecretsFromPreset(labels{"preset-azure-cred-only": "true"}), allowedInPresubmit: true},
 	}
 	allSecrets := sets.String{}


### PR DESCRIPTION
Updates the restricted secrets list to allow for sig-release jobs to use
preset-azure-cred in periodic release informing jobs.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

/assign @spiffxp @chewong 
/cc @puerco @kubernetes/release-engineering 

Unblocks https://github.com/kubernetes/test-infra/pull/21557
Ref https://github.com/kubernetes/test-infra/pull/21457 https://github.com/kubernetes/test-infra/pull/20536

https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/test-infra/21557/pull-test-infra-bazel/1376909270888484864#1:build-log.txt%3A6388