### PR TITLE
[Kettle] Typo in Error string of api_exceptions.BadRequest

### DIFF
--- a/kettle/stream.py
+++ b/kettle/stream.py
@@ -112,7 +112,7 @@ def retry(func, *args, **kwargs):
             args_size = sys.getsizeof(args)
             kwargs_str = ','.join('{}={}'.format(k, v) for k, v in kwargs.items())
             print(f"Error running {func.__name__} \
-                   ([bytes in args]{args_size} with {kwargs_str]}) : {err}")
+                   ([bytes in args]{args_size} with {kwargs_str}) : {err}")
             return None # Skip
     return func(*args, **kwargs)  # one last attempt
 

--- a/kettle/stream.py
+++ b/kettle/stream.py
@@ -112,7 +112,7 @@ def retry(func, *args, **kwargs):
             args_size = sys.getsizeof(args)
             kwargs_str = ','.join('{}={}'.format(k, v) for k, v in kwargs.items())
             print(f"Error running {func.__name__} \
-                   ([bytes in args]{','.join([args_size, kwargs_str])}) : {err}")
+                   ([bytes in args]{args_size} with {kwargs_str]}) : {err}")
             return None # Skip
     return func(*args, **kwargs)  # one last attempt
 


### PR DESCRIPTION
Saw this snuck in. Tried to write tests for it but because `from google.api_core import exceptions as api_exceptions` is not an import that can be downloaded from pip I can't raise it in the test. I tried mocking but it got increasingly complicated to attempt to mock the import. 