### PR TITLE
Add a strictUnmarshal option for configurator, and use it in presubmit test

### DIFF
--- a/config/tests/testgrids/BUILD.bazel
+++ b/config/tests/testgrids/BUILD.bazel
@@ -37,7 +37,8 @@ genrule(
            --prow-job-config=config/jobs \
            --default=$(location //config:testgrid_default) \
            --output=$@ \
-           --oneshot",
+           --oneshot \
+           --strict-unmarshal",
     tools = [
         "//testgrid/cmd/configurator",
     ],

--- a/testgrid/cmd/configurator/main.go
+++ b/testgrid/cmd/configurator/main.go
@@ -68,6 +68,7 @@ type options struct {
 	defaultYAML                string
 	updateDescription          bool
 	prowJobURLPrefix           string
+	strictUnmarshal            bool
 }
 
 func (o *options) gatherOptions(fs *flag.FlagSet, args []string) error {
@@ -85,6 +86,7 @@ func (o *options) gatherOptions(fs *flag.FlagSet, args []string) error {
 	fs.StringVar(&o.defaultYAML, "default", "", "path to default settings; required for proto outputs")
 	fs.BoolVar(&o.updateDescription, "update-description", false, "add prowjob info to description even if non-empty")
 	fs.StringVar(&o.prowJobURLPrefix, "prowjob-url-prefix", "", "for prowjob_config_url in descriptions: {prowjob-url-prefix}/{prowjob.sourcepath}")
+	fs.BoolVar(&o.strictUnmarshal, "strict-unmarshal", false, "whether or not we want to be strict when unmarshalling configs")
 
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -198,7 +200,7 @@ func write(ctx context.Context, client *storage.Client, path string, bytes []byt
 func doOneshot(ctx context.Context, client *storage.Client, opt options, prowConfigAgent *prowConfig.Agent) error {
 
 	// Read Data Sources: Default, YAML configs, Prow Annotations
-	c, err := yamlcfg.ReadConfig(opt.inputs, opt.defaultYAML, false)
+	c, err := yamlcfg.ReadConfig(opt.inputs, opt.defaultYAML, opt.strictUnmarshal)
 	if err != nil {
 		return fmt.Errorf("could not read testgrid config: %v", err)
 	}


### PR DESCRIPTION
Follow up to https://github.com/GoogleCloudPlatform/testgrid/pull/273. Presubmit test will now fail to build if config file has invalid fields. 

Error looks like:
```
...gathering config: Failed to walk through config/testgrids: failed to merge {CONFIG PATH} into config: error unmarshaling JSON: while decoding JSON: json: unknown field ...

FAILED: Build did NOT complete successfully
```

/assign @chases2 
/assign @michelle192837 