### PR TITLE
return err from `batchOnboardNewTokenForRepos`

### DIFF
--- a/prow/cmd/hmac/main.go
+++ b/prow/cmd/hmac/main.go
@@ -425,6 +425,7 @@ func (c *client) batchOnboardNewTokenForRepos() error {
 			} else {
 				delete(c.currentHMACMap, repo)
 			}
+			return err
 		}
 	}
 


### PR DESCRIPTION
- To exit HMAC reconciler with non-zero error code on non-recoverable error
    - Non-zero exit takes place through `handleConfigUpdate()` in `main()` using `.Fatal()`

Fix #21171 