### PR TITLE
plugins/bugzilla: improve handleClose behavior

### DIFF
--- a/prow/bugzilla/client_test.go
+++ b/prow/bugzilla/client_test.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -335,6 +336,55 @@ func TestGetComments(t *testing.T) {
 	}
 	if invalidIDBug != nil {
 		t.Errorf("expected no bug, got: %v", invalidIDBug)
+	}
+}
+
+func TestCreateComment(t *testing.T) {
+	testServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-BUGZILLA-API-KEY") != "api-key" {
+			t.Error("did not get api-key passed in X-BUGZILLA-API-KEY header")
+			http.Error(w, "403 Forbidden", http.StatusForbidden)
+			return
+		}
+		if r.URL.Query().Get("api_key") != "api-key" {
+			t.Error("did not get api-key passed in api_key query parameter")
+			http.Error(w, "403 Forbidden", http.StatusForbidden)
+			return
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("incorrect method to create a comment: %s", r.Method)
+			http.Error(w, "400 Bad Request", http.StatusBadRequest)
+			return
+		}
+		if !regexp.MustCompile(`^/rest/bug/\d+/comment$`).MatchString(r.URL.Path) {
+			t.Errorf("incorrect path to create a comment: %s", r.URL.Path)
+			http.Error(w, "400 Bad Request", http.StatusBadRequest)
+			return
+		}
+		raw, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read request body: %v", err)
+			http.Error(w, "500 Server Error", http.StatusInternalServerError)
+			return
+		}
+		payload := &CommentCreate{}
+		if err := json.Unmarshal(raw, &payload); err != nil {
+			t.Errorf("malformed JSONRPC payload: %s", string(raw))
+			http.Error(w, "400 Bad Request", http.StatusBadRequest)
+			return
+		}
+		if _, err := w.Write([]byte(`{"id" : 12345}`)); err != nil {
+			t.Fatalf("failed to send JSONRPC response: %v", err)
+		}
+	}))
+	defer testServer.Close()
+	client := clientForUrl(testServer.URL)
+
+	// this should create a new comment
+	if id, err := client.CreateComment(&CommentCreate{ID: 2, Comment: "This is a test bug"}); err != nil {
+		t.Errorf("expected no error, but got one: %v", err)
+	} else if id != 12345 {
+		t.Errorf("expected id of 12345, got %d", id)
 	}
 }
 

--- a/prow/bugzilla/fake.go
+++ b/prow/bugzilla/fake.go
@@ -228,6 +228,27 @@ func (c *Fake) CreateBug(bug *BugCreate) (int, error) {
 	return newID, nil
 }
 
+func (c *Fake) CreateComment(comment *CommentCreate) (int, error) {
+	// add new comment one ID newer than highest existing CommentID
+	newCommentID := 0
+	for _, comments := range c.BugComments {
+		for _, comment := range comments {
+			if comment.ID >= newCommentID {
+				newCommentID = comment.ID + 1
+			}
+		}
+	}
+	newComment := Comment{
+		ID:        newCommentID,
+		BugID:     comment.ID,
+		Count:     len(c.BugComments[comment.ID]),
+		Text:      comment.Comment,
+		IsPrivate: comment.IsPrivate,
+	}
+	c.BugComments[comment.ID] = append(c.BugComments[comment.ID], newComment)
+	return newCommentID, nil
+}
+
 // GetComments retrieves the bug comments, if registered, or an error, if set,
 // or responds with an error that matches IsNotFound
 func (c *Fake) GetComments(id int) ([]Comment, error) {

--- a/prow/bugzilla/types.go
+++ b/prow/bugzilla/types.go
@@ -189,6 +189,16 @@ type Comment struct {
 	Tags []string `json:"tags,omitempty"`
 }
 
+// CommentCreate holds information needed to create a comment
+type CommentCreate struct {
+	// ID is the ID of the bug this comment is on.
+	ID int `json:"id,omitempty"`
+	// Comment is the text of the comment being created.
+	Comment string `json:"comment,omitempty"`
+	// IsPrivate is true if this comment is private (only visible to a certain group called the "insidergroup"), false otherwise.
+	IsPrivate bool `json:"is_private,omitempty"`
+}
+
 // User holds information about a user
 type User struct {
 	// The user ID for this user.


### PR DESCRIPTION
This PR changes the behavior of the bugzilla plugin to prevent reopening
closed bugs when a linked PR for the bug is closed. It also adds the
ability to create comments to the bugzilla client and uses this to leave
a comment on bugs when their state is changed due to a closed and
unlinked PR.

/cc @stevekuznetsov 