### PR TITLE
Switch ci-containerd-node-e2e and ci-containerd-node-e2e-1-4 to the latest 1.21 branch

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -207,7 +207,7 @@ periodics:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20210327-170ffe2-master
       args:
       - --root=/go/src
-      - --repo=k8s.io/kubernetes=release-1.20
+      - --repo=k8s.io/kubernetes=release-1.21
       - --repo=github.com/containerd/cri=release/1.4
       - --timeout=90
       - --scenario=kubernetes_e2e
@@ -267,7 +267,7 @@ periodics:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20210327-170ffe2-master
       args:
       - --root=/go/src
-      - --repo=k8s.io/kubernetes=release-1.20
+      - --repo=k8s.io/kubernetes=release-1.21
       - --repo=github.com/containerd/cri=release/1.4
       - --timeout=90
       - --scenario=kubernetes_e2e


### PR DESCRIPTION
As of last friday we have the `release-1.21` branch. So let's use that.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>