### PR TITLE
Separate scheduler-plugins CI Jobs For Each Release Branch

### DIFF
--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-master.yaml
@@ -1,0 +1,55 @@
+# sigs.k8s.io/scheduler-plugins presubmits
+presubmits:
+  kubernetes-sigs/scheduler-plugins:
+  - name: pull-scheduler-plugins-verify-gofmt-master
+    decorate: true
+    path_alias: sigs.k8s.io/scheduler-plugins
+    branches:
+    - ^master$
+    always_run: true
+    spec:
+      containers:
+      - image: golang:1.15.10
+        command:
+        - make
+        args:
+        - verify-gofmt
+  - name: pull-scheduler-plugins-verify-build-master
+    decorate: true
+    path_alias: sigs.k8s.io/scheduler-plugins
+    branches:
+    - ^master$
+    always_run: true
+    spec:
+      containers:
+      - image: golang:1.15.10
+        command:
+        - make
+        args:
+        - build
+  - name: pull-scheduler-plugins-unit-test-master
+    decorate: true
+    path_alias: sigs.k8s.io/scheduler-plugins
+    branches:
+    - ^master$
+    always_run: true
+    spec:
+      containers:
+      - image: golang:1.15.10
+        command:
+        - make
+        args:
+        - unit-test
+  - name: pull-scheduler-plugins-integration-test-master
+    decorate: true
+    path_alias: sigs.k8s.io/scheduler-plugins
+    branches:
+    - ^master$
+    always_run: true
+    spec:
+      containers:
+      - image: golang:1.15.10
+        command:
+        - make
+        args:
+        - integration-test

--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.18.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.18.yaml
@@ -1,0 +1,55 @@
+# sigs.k8s.io/scheduler-plugins presubmits
+presubmits:
+  kubernetes-sigs/scheduler-plugins:
+  - name: pull-scheduler-plugins-verify-gofmt-release-1-18
+    decorate: true
+    path_alias: sigs.k8s.io/scheduler-plugins
+    branches:
+    - ^release-1.18$
+    always_run: true
+    spec:
+      containers:
+      - image: golang:1.15.0
+        command:
+        - make
+        args:
+        - verify-gofmt
+  - name: pull-scheduler-plugins-verify-build-release-1-18
+    decorate: true
+    path_alias: sigs.k8s.io/scheduler-plugins
+    branches:
+    - ^release-1.18$
+    always_run: true
+    spec:
+      containers:
+      - image: golang:1.15.0
+        command:
+        - make
+        args:
+        - build
+  - name: pull-scheduler-plugins-unit-test-release-1-18
+    decorate: true
+    path_alias: sigs.k8s.io/scheduler-plugins
+    branches:
+    - ^release-1.18$
+    always_run: true
+    spec:
+      containers:
+      - image: golang:1.15.0
+        command:
+        - make
+        args:
+        - unit-test
+  - name: pull-scheduler-plugins-integration-test-release-1-18
+    decorate: true
+    path_alias: sigs.k8s.io/scheduler-plugins
+    branches:
+    - ^release-1.18$
+    always_run: true
+    spec:
+      containers:
+      - image: golang:1.15.0
+        command:
+        - make
+        args:
+        - integration-test

--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.19.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.19.yaml
@@ -1,9 +1,11 @@
 # sigs.k8s.io/scheduler-plugins presubmits
 presubmits:
   kubernetes-sigs/scheduler-plugins:
-  - name: pull-scheduler-plugins-verify-gofmt
+  - name: pull-scheduler-plugins-verify-gofmt-release-1-19
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
+    branches:
+    - ^release-1.19$
     always_run: true
     spec:
       containers:
@@ -12,9 +14,11 @@ presubmits:
         - make
         args:
         - verify-gofmt
-  - name: pull-scheduler-plugins-verify-build
+  - name: pull-scheduler-plugins-verify-build-release-1-19
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
+    branches:
+    - ^release-1.19$
     always_run: true
     spec:
       containers:
@@ -23,9 +27,11 @@ presubmits:
         - make
         args:
         - build
-  - name: pull-scheduler-plugins-unit-test
+  - name: pull-scheduler-plugins-unit-test-release-1-19
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
+    branches:
+    - ^release-1.19$
     always_run: true
     spec:
       containers:
@@ -34,9 +40,11 @@ presubmits:
         - make
         args:
         - unit-test
-  - name: pull-scheduler-plugins-integration-test
+  - name: pull-scheduler-plugins-integration-test-release-1-19
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
+    branches:
+    - ^release-1.19$
     always_run: true
     spec:
       containers:


### PR DESCRIPTION
Each release branch in the scheduler-plugins repo is using a different
version of Go. This change creates a separate set of CI jobs for each
release branch, so that the Go version for each branch can be updated
and tested separately.

Also, bumps the Go version for the master branch from 1.15.8 to
1.15.10.

This is modeled after the CI jobs for the descheduler:
https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes-sigs/descheduler