### PR TITLE
add kind dual presubmits

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
@@ -1,10 +1,12 @@
 presubmits:
   kubernetes/kubernetes:
-  - name: pull-kubernetes-e2e-kind-dual-canary
+  - name: pull-kubernetes-e2e-kind-dual
     optional: true
-    always_run: false
-    skip_report: false
+    always_run: true
+    skip_report: true
     decorate: true
+    skip_branches:
+    - release-\d+\.\d+ # per-release settings
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -49,11 +51,14 @@ presubmits:
       testgrid-tab-name: pr-sig-network-kind, dual
       description: Runs tests against a Dual Stack Kubernetes in Docker cluster
       testgrid-alert-email: antonio.ojea.garcia@gmail.com
-  - name: pull-kubernetes-e2e-kind-ipvs-dual-canary
+  - name: pull-kubernetes-e2e-kind-ipvs-dual
     optional: true
     always_run: false
     skip_report: false
     decorate: true
+    run_if_changed: '^pkg/.*/ipvs/'
+    skip_branches:
+    - release-\d+\.\d+ # per-release settings
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"

--- a/config/testgrids/kubernetes/presubmits/config.yaml
+++ b/config/testgrids/kubernetes/presubmits/config.yaml
@@ -100,11 +100,11 @@ dashboards:
   - name: pull-kubernetes-e2e-kind-ipv6-canary
     test_group_name: pull-kubernetes-e2e-kind-ipv6-canary
     base_options: width=10
-  - name: pull-kubernetes-e2e-kind-dual-canary
-    test_group_name: pull-kubernetes-e2e-kind-dual-canary
+  - name: pull-kubernetes-e2e-kind-dual
+    test_group_name: pull-kubernetes-e2e-kind-dual
     base_options: width=10
-  - name: pull-kubernetes-e2e-kind-ipvs-dual-canary
-    test_group_name: pull-kubernetes-e2e-kind-ipvs-dual-canary
+  - name: pull-kubernetes-e2e-kind-ipvs-dual
+    test_group_name: pull-kubernetes-e2e-kind-ipvs-dual
     base_options: width=10
   - name: pull-kubernetes-e2e-aks-engine-conformance
     test_group_name: pull-kubernetes-e2e-aks-engine-conformance

--- a/gubernator/config.yaml
+++ b/gubernator/config.yaml
@@ -32,6 +32,7 @@ jobs:
   - pull-kubernetes-e2e-gce-100-performance
   - pull-kubernetes-e2e-gce-ubuntu-containerd
   - pull-kubernetes-e2e-kind
+  - pull-kubernetes-e2e-kind-dual
   - pull-kubernetes-e2e-kind-ipv6
   - pull-kubernetes-integration
   - pull-kubernetes-node-crio-e2e


### PR DESCRIPTION
Now that dualstack is supported in KIND "officially" , and that those jobs were running for a while without issues we can run them in presubmits.

https://testgrid.k8s.io/sig-network-kind#sig-network-kind,%20dual,%20master&width=20

There are 2 dual-stack presubmit jobs depending on the kube-proxy implementation.
The ipvs one will run only if some ipvs code has changed.
The iptables one will run on every commit, but it will be optional without reporting status to let it soak.

xref: https://github.com/kubernetes-sigs/kind/issues/2172