### PR TITLE
Kops - Set GOPATH on kubetest2 presubmit jobs

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -151,6 +151,8 @@ presubmit_template = """
           value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: {{kops_ssh_user}}
+        - name: GOPATH
+          value: /home/prow/go
         resources:
           requests:
             cpu: "2"

--- a/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
@@ -51,6 +51,8 @@ presubmits:
           value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
+        - name: GOPATH
+          value: /home/prow/go
         resources:
           requests:
             cpu: "2"
@@ -115,6 +117,8 @@ presubmits:
           value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
+        - name: GOPATH
+          value: /home/prow/go
         resources:
           requests:
             cpu: "2"
@@ -179,6 +183,8 @@ presubmits:
           value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
+        - name: GOPATH
+          value: /home/prow/go
         resources:
           requests:
             cpu: "2"
@@ -243,6 +249,8 @@ presubmits:
           value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
+        - name: GOPATH
+          value: /home/prow/go
         resources:
           requests:
             cpu: "2"
@@ -307,6 +315,8 @@ presubmits:
           value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
+        - name: GOPATH
+          value: /home/prow/go
         resources:
           requests:
             cpu: "2"
@@ -371,6 +381,8 @@ presubmits:
           value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
+        - name: GOPATH
+          value: /home/prow/go
         resources:
           requests:
             cpu: "2"
@@ -435,6 +447,8 @@ presubmits:
           value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
+        - name: GOPATH
+          value: /home/prow/go
         resources:
           requests:
             cpu: "2"


### PR DESCRIPTION
aiming to fix this failure: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kops/11166/pull-kops-e2e-cni-canal/1377681279767547904