### PR TITLE
Prow autobumper: support labels override as cmd arg

### DIFF
--- a/prow/cmd/generic-autobumper/BUILD.bazel
+++ b/prow/cmd/generic-autobumper/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//prow/cmd/generic-autobumper/bumper:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_github_spf13_pflag//:go_default_library",
         "@in_gopkg_yaml_v2//:go_default_library",
     ],
 )

--- a/prow/cmd/generic-autobumper/main.go
+++ b/prow/cmd/generic-autobumper/main.go
@@ -17,9 +17,10 @@ limitations under the License.
 package main
 
 import (
-	"flag"
 	"fmt"
 	"io/ioutil"
+
+	flag "github.com/spf13/pflag"
 
 	"github.com/sirupsen/logrus"
 
@@ -30,8 +31,10 @@ import (
 
 func parseOptions() (*bumper.Options, error) {
 	var config string
+	var labelsOverride []string
 
 	flag.StringVar(&config, "config", "", "The path to the config file for the autobumber.")
+	flag.StringSliceVar(&labelsOverride, "labels-override", nil, "Override labels to be added to PR.")
 	flag.Parse()
 
 	var o bumper.Options
@@ -45,6 +48,9 @@ func parseOptions() (*bumper.Options, error) {
 		return nil, fmt.Errorf("Failed to parse yaml file, %s", err)
 	}
 
+	if labelsOverride != nil {
+		o.Labels = labelsOverride
+	}
 	return &o, nil
 }
 


### PR DESCRIPTION
The problem we might run into while rolling back prow autobump PR, is that there is no existing autobump PR for oncall to put hold on for pausing prow auto deployment process. Since the autobumper runs every 6 hours, oncall might need to wait for 6 hours or wake up at exactly the time when autobumper runs next morning. As I can imagine this will be very annoying.

One way to solve this (The only way I can think about right now) is having autobumper job runs every hour, and only adds 'skip-review' label on 9:05 and 15:05 each day. Instead of wrangling this logic in autobumper code, I would perfer creating two separate prow jobs, one runs continuously without labeling, while the other runs 9:05 and 15:05 on week days and add label on PR. By going this approach, there should always be a new autobump PR created within an hour after rollback