### PR TITLE
Kops - set binary path on kubetest2 presubmit jobs

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -125,6 +125,7 @@ presubmit_template = """
             --cloud-provider=aws \\
             --create-args="{{create_args}}" \\
             --kubernetes-version={{k8s_deploy_url}} \\
+            --kops-binary-path=/home/prow/go/src/k8s.io/kops/bazel-bin/cmd/kops/linux-amd64/kops \\
             {%- if terraform_version %}
             --terraform-version={{terraform_version}} \\
             {%- endif %}

--- a/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
@@ -37,6 +37,7 @@ presubmits:
             --cloud-provider=aws \
             --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210325' --channel=alpha --networking=amazonvpc --container-runtime=containerd --node-size=t3.large" \
             --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
+            --kops-binary-path=/home/prow/go/src/k8s.io/kops/bazel-bin/cmd/kops/linux-amd64/kops \
             --test=kops \
             -- \
             --ginkgo-args="--debug" \
@@ -103,6 +104,7 @@ presubmits:
             --cloud-provider=aws \
             --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210325' --channel=alpha --networking=calico --container-runtime=containerd --node-size=t3.large" \
             --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
+            --kops-binary-path=/home/prow/go/src/k8s.io/kops/bazel-bin/cmd/kops/linux-amd64/kops \
             --test=kops \
             -- \
             --ginkgo-args="--debug" \
@@ -169,6 +171,7 @@ presubmits:
             --cloud-provider=aws \
             --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210325' --channel=alpha --networking=canal --container-runtime=containerd --node-size=t3.large" \
             --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
+            --kops-binary-path=/home/prow/go/src/k8s.io/kops/bazel-bin/cmd/kops/linux-amd64/kops \
             --test=kops \
             -- \
             --ginkgo-args="--debug" \
@@ -235,6 +238,7 @@ presubmits:
             --cloud-provider=aws \
             --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210325' --channel=alpha --networking=cilium --container-runtime=containerd --node-size=t3.large" \
             --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
+            --kops-binary-path=/home/prow/go/src/k8s.io/kops/bazel-bin/cmd/kops/linux-amd64/kops \
             --test=kops \
             -- \
             --ginkgo-args="--debug" \
@@ -301,6 +305,7 @@ presubmits:
             --cloud-provider=aws \
             --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210325' --channel=alpha --networking=flannel --container-runtime=containerd --node-size=t3.large" \
             --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
+            --kops-binary-path=/home/prow/go/src/k8s.io/kops/bazel-bin/cmd/kops/linux-amd64/kops \
             --test=kops \
             -- \
             --ginkgo-args="--debug" \
@@ -367,6 +372,7 @@ presubmits:
             --cloud-provider=aws \
             --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210325' --channel=alpha --networking=kube-router --container-runtime=containerd --node-size=t3.large" \
             --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
+            --kops-binary-path=/home/prow/go/src/k8s.io/kops/bazel-bin/cmd/kops/linux-amd64/kops \
             --test=kops \
             -- \
             --ginkgo-args="--debug" \
@@ -433,6 +439,7 @@ presubmits:
             --cloud-provider=aws \
             --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210325' --channel=alpha --networking=weave --container-runtime=containerd --node-size=t3.large" \
             --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
+            --kops-binary-path=/home/prow/go/src/k8s.io/kops/bazel-bin/cmd/kops/linux-amd64/kops \
             --test=kops \
             -- \
             --ginkgo-args="--debug" \


### PR DESCRIPTION
should fix this: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kops/10577/pull-kops-e2e-kubernetes-aws-kubetest2/1349569379242610688

using [this](https://github.com/kubernetes/kops/pull/10577/commits/59c312ff5f7b170a51f256ee2544a388aebfbee7#diff-85db1201c1f581dee306a7610e28fe4dde3fc291d12d76e3cd7950e411cc7b07R36) as a reference