### PR TITLE
Checkconfig: Add check if supplemental prow configs are in org/repo structure

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,7 +19,7 @@ _repo_infra_repos()
 load("@io_k8s_repo_infra//:repos.bzl", "configure")
 
 configure(
-    go_version = "1.16",
+    go_version = "1.16.2",
     nogo = "@//:nogo_vet",
 )
 

--- a/load.bzl
+++ b/load.bzl
@@ -27,6 +27,15 @@ def repositories():
         )
 
     http_archive(
+        name = "io_bazel_rules_go",
+        sha256 = "69de5c704a05ff37862f7e0f5534d4f479418afc21806c887db544a316f3cb6b",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
+            "https://github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
+        ],
+    )
+
+    http_archive(
         name = "io_bazel_rules_docker",
         sha256 = "4521794f0fba2e20f3bf15846ab5e01d5332e587e9ce81629c7f96c793bb7036",
         strip_prefix = "rules_docker-0.14.4",

--- a/prow/config/BUILD.bazel
+++ b/prow/config/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
         "@com_github_tektoncd_pipeline//pkg/apis/pipeline/v1alpha1:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/equality:go_default_library",
+        "@io_k8s_apimachinery//pkg/labels:go_default_library",
         "@io_k8s_apimachinery//pkg/util/diff:go_default_library",
         "@io_k8s_apimachinery//pkg/util/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",


### PR DESCRIPTION
This PR adds a new, off-by-default check to checkconfig that verifies
that additional prow configs are in an org/repo hirarchy and only
contain config that is allowed at that level.