### PR TITLE
Crier gerrit reporter: skip reporting if job from newer patchset already exists

### DIFF
--- a/prow/crier/reporters/gerrit/reporter.go
+++ b/prow/crier/reporters/gerrit/reporter.go
@@ -20,6 +20,7 @@ package gerrit
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -136,28 +137,58 @@ func (c *Client) ShouldReport(ctx context.Context, log *logrus.Entry, pj *v1.Pro
 		return true
 	}
 
-	// Only report when all jobs of the same type on the same revision finished
-	selector := map[string]string{
-		client.GerritRevision:    pj.ObjectMeta.Labels[client.GerritRevision],
-		kube.ProwJobTypeLabel:    pj.ObjectMeta.Labels[kube.ProwJobTypeLabel],
-		client.GerritReportLabel: pj.ObjectMeta.Labels[client.GerritReportLabel],
+	allPJAgreeReport := func(labels []string, singlePRAgree func(pj *v1.ProwJob) bool) bool {
+		selector := map[string]string{}
+		for _, l := range labels {
+			selector[l] = pj.ObjectMeta.Labels[l]
+		}
+
+		var pjs v1.ProwJobList
+		if err := c.lister.List(ctx, &pjs, ctrlruntimeclient.MatchingLabels(selector)); err != nil {
+			log.WithError(err).Errorf("Cannot list prowjob with selector %v", selector)
+			return false
+		}
+
+		for _, pjob := range pjs.Items {
+			if !singlePRAgree(&pjob) {
+				return false
+			}
+		}
+
+		return true
 	}
 
-	var pjs v1.ProwJobList
-	if err := c.lister.List(ctx, &pjs, ctrlruntimeclient.MatchingLabels(selector)); err != nil {
-		log.WithError(err).Errorf("Cannot list prowjob with selector %v", selector)
-		return false
+	// patchsetNumFromPJ converts value of "prow.k8s.io/gerrit-patchset" to
+	// integer, the value is used for evaluating whether a newer patchset for
+	// current CR was already established. It may accidentally omit reporting if
+	// current prowjob doesn't have this label or has an invalid value, this
+	// will be reflected as warning message in prow.
+	patchsetNumFromPJ := func(pj *v1.ProwJob) int {
+		ps, ok := pj.ObjectMeta.Labels[client.GerritPatchset]
+		if !ok {
+			log.Warnf("Label %s not found in prowjob %s", client.GerritPatchset, pj.Name)
+			return -1
+		}
+		intPs, err := strconv.Atoi(ps)
+		if err != nil {
+			log.Warnf("Found non integer label for %s: %s in prowjob %s", client.GerritPatchset, ps, pj.Name)
+			return -1
+		}
+		return intPs
 	}
+	patchsetNum := patchsetNumFromPJ(pj)
 
-	for _, pjob := range pjs.Items {
-		if pjob.Status.State == v1.TriggeredState || pjob.Status.State == v1.PendingState {
+	return allPJAgreeReport([]string{client.GerritRevision, kube.ProwJobTypeLabel, client.GerritReportLabel}, func(pj *v1.ProwJob) bool {
+		if pj.Status.State == v1.TriggeredState || pj.Status.State == v1.PendingState {
 			// other jobs with same label are still running on this revision, skip report
 			log.Info("Other jobs with same label are still running on this revision")
 			return false
 		}
-	}
-
-	return true
+		return true
+	}) && allPJAgreeReport([]string{kube.OrgLabel, kube.RepoLabel, kube.PullLabel}, func(pj *v1.ProwJob) bool {
+		// Newer patchset exists, skip report
+		return patchsetNumFromPJ(pj) <= patchsetNum
+	})
 }
 
 // Report will send the current prowjob status as a gerrit review

--- a/prow/crier/reporters/gerrit/reporter_test.go
+++ b/prow/crier/reporters/gerrit/reporter_test.go
@@ -1037,7 +1037,7 @@ func TestReport(t *testing.T) {
 			numExpectedReport: 2,
 		},
 		{
-			name: "2 jobs, both failed, newer batch job pending, should not report",
+			name: "2 jobs, both failed, job from newer patchset pending, should not report",
 			pj: &v1.ProwJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -1173,7 +1173,7 @@ func TestReport(t *testing.T) {
 			expectReport: false,
 		},
 		{
-			name: "2 jobs, both failed, newer batch job failed, should not report",
+			name: "2 jobs, both failed, job from newer patchset failed, should not report",
 			pj: &v1.ProwJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{

--- a/prow/crier/reporters/gerrit/reporter_test.go
+++ b/prow/crier/reporters/gerrit/reporter_test.go
@@ -1036,6 +1036,278 @@ func TestReport(t *testing.T) {
 			expectLabel:       map[string]string{"same-label": lbtm},
 			numExpectedReport: 2,
 		},
+		{
+			name: "2 jobs, both failed, newer batch job pending, should not report",
+			pj: &v1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						client.GerritRevision:    "abc",
+						kube.ProwJobTypeLabel:    presubmit,
+						client.GerritReportLabel: "same-label",
+						client.GerritPatchset:    "5",
+						kube.OrgLabel:            "same-org",
+						kube.RepoLabel:           "same-repo",
+						kube.PullLabel:           "123456",
+					},
+					Annotations: map[string]string{
+						client.GerritID:       "123-abc",
+						client.GerritInstance: "gerrit",
+					},
+					CreationTimestamp: metav1.Time{
+						Time: timeNow,
+					},
+				},
+				Status: v1.ProwJobStatus{
+					State: v1.SuccessState,
+					URL:   "guber/foo",
+				},
+				Spec: v1.ProwJobSpec{
+					Type: v1.PresubmitJob,
+					Refs: &v1.Refs{
+						Repo: "foo",
+					},
+					Job: "ci-foo",
+				},
+			},
+			existingPJs: []*v1.ProwJob{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							client.GerritRevision:    "abc",
+							kube.ProwJobTypeLabel:    presubmit,
+							client.GerritReportLabel: "same-label",
+							client.GerritPatchset:    "5",
+							kube.OrgLabel:            "same-org",
+							kube.RepoLabel:           "same-repo",
+							kube.PullLabel:           "123456",
+						},
+						Annotations: map[string]string{
+							client.GerritID:       "123-abc",
+							client.GerritInstance: "gerrit",
+						},
+						CreationTimestamp: metav1.Time{
+							Time: timeNow.Add(-time.Hour),
+						},
+					},
+					Status: v1.ProwJobStatus{
+						State: v1.FailureState,
+						URL:   "guber/bar",
+						PrevReportStates: map[string]v1.ProwJobState{
+							"gerrit-reporter": v1.FailureState,
+						},
+					},
+					Spec: v1.ProwJobSpec{
+						Refs: &v1.Refs{
+							Repo: "bar",
+						},
+						Job:  "ci-bar",
+						Type: v1.PresubmitJob,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							client.GerritRevision:    "abc",
+							kube.ProwJobTypeLabel:    presubmit,
+							client.GerritReportLabel: "same-label",
+							client.GerritPatchset:    "5",
+							kube.OrgLabel:            "same-org",
+							kube.RepoLabel:           "same-repo",
+							kube.PullLabel:           "123456",
+						},
+						Annotations: map[string]string{
+							client.GerritID:       "123-abc",
+							client.GerritInstance: "gerrit",
+						},
+						CreationTimestamp: metav1.Time{
+							Time: timeNow.Add(-time.Hour),
+						},
+					},
+					Status: v1.ProwJobStatus{
+						State: v1.FailureState,
+						URL:   "guber/foo",
+						PrevReportStates: map[string]v1.ProwJobState{
+							"gerrit-reporter": v1.FailureState,
+						},
+					},
+					Spec: v1.ProwJobSpec{
+						Refs: &v1.Refs{
+							Repo: "foo",
+						},
+						Job:  "ci-foo",
+						Type: v1.PresubmitJob,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							client.GerritRevision:    "def",
+							kube.ProwJobTypeLabel:    presubmit,
+							client.GerritReportLabel: "same-label",
+							client.GerritPatchset:    "6",
+							kube.OrgLabel:            "same-org",
+							kube.RepoLabel:           "same-repo",
+							kube.PullLabel:           "123456",
+						},
+						Annotations: map[string]string{
+							client.GerritID:       "123-def",
+							client.GerritInstance: "gerrit",
+						},
+						CreationTimestamp: metav1.Time{
+							Time: timeNow.Add(-time.Hour),
+						},
+					},
+					Status: v1.ProwJobStatus{
+						State: v1.PendingState,
+						URL:   "guber/foo",
+					},
+					Spec: v1.ProwJobSpec{
+						Refs: &v1.Refs{
+							Repo: "foo",
+						},
+						Job:  "ci-foo",
+						Type: v1.PresubmitJob,
+					},
+				},
+			},
+			expectReport: false,
+		},
+		{
+			name: "2 jobs, both failed, newer batch job failed, should not report",
+			pj: &v1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						client.GerritRevision:    "abc",
+						kube.ProwJobTypeLabel:    presubmit,
+						client.GerritReportLabel: "same-label",
+						client.GerritPatchset:    "5",
+						kube.OrgLabel:            "same-org",
+						kube.RepoLabel:           "same-repo",
+						kube.PullLabel:           "123456",
+					},
+					Annotations: map[string]string{
+						client.GerritID:       "123-abc",
+						client.GerritInstance: "gerrit",
+					},
+					CreationTimestamp: metav1.Time{
+						Time: timeNow,
+					},
+				},
+				Status: v1.ProwJobStatus{
+					State: v1.SuccessState,
+					URL:   "guber/foo",
+				},
+				Spec: v1.ProwJobSpec{
+					Type: v1.PresubmitJob,
+					Refs: &v1.Refs{
+						Repo: "foo",
+					},
+					Job: "ci-foo",
+				},
+			},
+			existingPJs: []*v1.ProwJob{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							client.GerritRevision:    "abc",
+							kube.ProwJobTypeLabel:    presubmit,
+							client.GerritReportLabel: "same-label",
+							client.GerritPatchset:    "5",
+							kube.OrgLabel:            "same-org",
+							kube.RepoLabel:           "same-repo",
+							kube.PullLabel:           "123456",
+						},
+						Annotations: map[string]string{
+							client.GerritID:       "123-abc",
+							client.GerritInstance: "gerrit",
+						},
+						CreationTimestamp: metav1.Time{
+							Time: timeNow.Add(-time.Hour),
+						},
+					},
+					Status: v1.ProwJobStatus{
+						State: v1.FailureState,
+						URL:   "guber/bar",
+						PrevReportStates: map[string]v1.ProwJobState{
+							"gerrit-reporter": v1.FailureState,
+						},
+					},
+					Spec: v1.ProwJobSpec{
+						Refs: &v1.Refs{
+							Repo: "bar",
+						},
+						Job:  "ci-bar",
+						Type: v1.PresubmitJob,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							client.GerritRevision:    "abc",
+							kube.ProwJobTypeLabel:    presubmit,
+							client.GerritReportLabel: "same-label",
+							client.GerritPatchset:    "5",
+							kube.OrgLabel:            "same-org",
+							kube.RepoLabel:           "same-repo",
+							kube.PullLabel:           "123456",
+						},
+						Annotations: map[string]string{
+							client.GerritID:       "123-abc",
+							client.GerritInstance: "gerrit",
+						},
+						CreationTimestamp: metav1.Time{
+							Time: timeNow.Add(-time.Hour),
+						},
+					},
+					Status: v1.ProwJobStatus{
+						State: v1.FailureState,
+						URL:   "guber/foo",
+						PrevReportStates: map[string]v1.ProwJobState{
+							"gerrit-reporter": v1.FailureState,
+						},
+					},
+					Spec: v1.ProwJobSpec{
+						Refs: &v1.Refs{
+							Repo: "foo",
+						},
+						Job:  "ci-foo",
+						Type: v1.PresubmitJob,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							client.GerritRevision:    "def",
+							kube.ProwJobTypeLabel:    presubmit,
+							client.GerritReportLabel: "same-label",
+							client.GerritPatchset:    "6",
+							kube.OrgLabel:            "same-org",
+							kube.RepoLabel:           "same-repo",
+							kube.PullLabel:           "123456",
+						},
+						Annotations: map[string]string{
+							client.GerritID:       "123-def",
+							client.GerritInstance: "gerrit",
+						},
+						CreationTimestamp: metav1.Time{
+							Time: timeNow.Add(-time.Hour),
+						},
+					},
+					Status: v1.ProwJobStatus{
+						State: v1.FailureState,
+						URL:   "guber/foo",
+					},
+					Spec: v1.ProwJobSpec{
+						Refs: &v1.Refs{
+							Repo: "foo",
+						},
+						Job:  "ci-foo",
+						Type: v1.PresubmitJob,
+					},
+				},
+			},
+			expectReport: false,
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
In a gerrit PR, when a new change is pushed to it, the previous batch of presubmit jobs were aborted, if all jobs haven't finished by the time of abortion then gerrit won't report because aborted state wouldn't trigger a report. But if there was a single job failed before the abortion then crier wouldn't report the failed prowjob because by the time of failure the other jobs were still running, this is also expected, this job wouldn't be reported when the abortion happen either, this is also expected. However, I have observed lately that these earlier failed jobs were reported long time later, in the range of 3-12 hours according to my observation. It perhaps is related to prow bump that restarted crier which makes it reconcile all prowjobs and triggered the reporting of prowjob failed long time ago.

This PR is fixing this problem by stopping crier from reporting if there are prowjobs exist for the same PR that are from a later patchset