### PR TITLE
Prow monitoring: set up alert for kubernetes external secret

### DIFF
--- a/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
@@ -82,6 +82,8 @@ local config = {
 
   // How many days prow hasn't been bumped.
   prowImageStaleByDays: {daysStale: 7, eventDuration: '24h'},
+
+  kubernetesExternalSecretServiceAccount: "kubernetes-external-secrets-sa@k8s-prow.iam.gserviceaccount.com",
 };
 
 // Generate the real config by adding in constant fields and defaulting where needed.

--- a/config/prow/cluster/monitoring/mixins/prometheus/external_secret_alerts.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/external_secret_alerts.libsonnet
@@ -1,0 +1,26 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'external-secret-sync',
+        rules: [
+          {
+            # https://github.com/external-secrets/kubernetes-external-secrets/blob/master/README.md#metrics
+            alert: 'Failed-syncing-external-secret',
+            # Prometheus scrapes kubernetes external secrets every 30 seconds as defined in servicemonitor, so this counts failures between scrape intervals.
+            # Since kubernetes secret manager runs every 10 seconds, there should be at least 2 runs in every 30s, so this will only report consecutive failures.
+            expr: |||
+              increase(kubernetes_external_secrets_sync_calls_count{job="kubernetes-external-secrets",status!="success"}[1m]) > 1.5
+            |||,
+            labels: {
+              severity: 'user-warning',
+            },
+            annotations: {
+              message: 'ExternalSecret {{ $labels.namespace }}/{{ $labels.name }} failed to be synced. does %s have `roles/secretmanager.viewer` and `roles/secretmanager.secretAccessor` permissions on the google secret manager secret used for this cluster secret?' % $._config.kubernetesExternalSecretServiceAccount,
+            },
+          }
+        ],
+      },
+    ],
+  },
+}

--- a/config/prow/cluster/monitoring/mixins/prometheus/prometheus.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/prometheus.libsonnet
@@ -13,4 +13,5 @@
 (import 'boskos_alerts.libsonnet') +
 (import 'plank_alerts.libsonnet') +
 (import 'slo_recordrules.libsonnet') +
-(import 'prow_alerts.libsonnet')
+(import 'prow_alerts.libsonnet') +
+(import 'external_secret_alerts.libsonnet')

--- a/config/prow/cluster/monitoring/prow_servicemonitors.yaml
+++ b/config/prow/cluster/monitoring/prow_servicemonitors.yaml
@@ -209,3 +209,23 @@ spec:
   selector:
     matchLabels:
       app: crier
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: kubernetes-external-secrets
+    app: kubernetes-external-secrets
+  name: kubernetes-external-secrets
+  namespace: prow-monitoring
+spec:
+  endpoints:
+  - interval: 30s
+    port: prometheus
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - default
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubernetes-external-secrets


### PR DESCRIPTION
These errors could either be from cluster or user, so far park it under 'user-warning', will decide where to post these alerts later