### PR TITLE
Switch to newer pipeline for ubuntu images (for containerd tests)

### DIFF
--- a/jobs/e2e_node/containerd/image-config.yaml
+++ b/jobs/e2e_node/containerd/image-config.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image_family: pipeline-2
+    image_family: pipeline-1-20
     project: ubuntu-os-gke-cloud
     metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"
   cos-stable:


### PR DESCRIPTION
Currently using `pipeline-2` we end up picking up an old image.
`ubuntu-gke-1804-1-16-v20200824`

(from https://storage.googleapis.com/kubernetes-jenkins/logs/ci-cos-containerd-node-e2e/1377996000248991744/build-log.txt)

We should be using newer images:
```
davanum@cloudshell:~ (kubernetes-development-244305)$ gcloud compute images list --project ubuntu-os-gke-cloud | grep pipeline-1-20
ubuntu-gke-1804-1-20-v20210308                        ubuntu-os-gke-cloud  pipeline-1-20                                 READY
ubuntu-gke-1804-1-20-v20210309                        ubuntu-os-gke-cloud  pipeline-1-20                                 READY
ubuntu-gke-1804-1-20-v20210310                        ubuntu-os-gke-cloud  pipeline-1-20                                 READY
ubuntu-gke-1804-1-20-v20210316                        ubuntu-os-gke-cloud  pipeline-1-20                                 READY
ubuntu-gke-1804-1-20-v20210319                        ubuntu-os-gke-cloud  pipeline-1-20                                 READY
ubuntu-gke-1804-1-20-v20210323a                       ubuntu-os-gke-cloud  pipeline-1-20                                 READY
ubuntu-gke-1804-1-20-v20210325                        ubuntu-os-gke-cloud  pipeline-1-20                                 READY
ubuntu-gke-1804-1-20-v20210401                        ubuntu-os-gke-cloud  pipeline-1-20                                 READY
ubuntu-gke-2004-1-20-v20210308                        ubuntu-os-gke-cloud  pipeline-1-20                                 READY
ubuntu-gke-2004-1-20-v20210309                        ubuntu-os-gke-cloud  pipeline-1-20                                 READY
ubuntu-gke-2004-1-20-v20210310                        ubuntu-os-gke-cloud  pipeline-1-20                                 READY
ubuntu-gke-2004-1-20-v20210311                        ubuntu-os-gke-cloud  pipeline-1-20                                 READY
ubuntu-gke-2004-1-20-v20210322a                       ubuntu-os-gke-cloud  pipeline-1-20                                 READY
ubuntu-gke-2004-1-20-v20210323                        ubuntu-os-gke-cloud  pipeline-1-20                                 READY
ubuntu-gke-2004-1-20-v20210325                        ubuntu-os-gke-cloud  pipeline-1-20                                 READY
ubuntu-gke-2004-1-20-v20210401                        ubuntu-os-gke-cloud  pipeline-1-20                                 READY
```

Signed-off-by: Davanum Srinivas <davanum@gmail.com>