### PR TITLE
Switch to newer pipeline for ubuntu images (for containerd tests) - take II

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -784,7 +784,7 @@ periodics:
       - --gcp-node-image=ubuntu
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=30
-      - --image-family=pipeline-2
+      - --image-family=pipeline-1-20
       - --image-project=ubuntu-os-gke-cloud
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8


### PR DESCRIPTION
follow up to https://github.com/kubernetes/test-infra/pull/21628

Currently using `pipeline-2` we end up picking up an old image.
`ubuntu-gke-1804-1-16-v20200824`

(from https://storage.googleapis.com/kubernetes-jenkins/logs/ci-cos-containerd-node-e2e/1377996000248991744/build-log.txt)

We should be using newer images:
```
davanum@cloudshell:~ (kubernetes-development-244305)$ gcloud compute images list --project ubuntu-os-gke-cloud | grep pipeline-1-20
ubuntu-gke-1804-1-20-v20210308                        ubuntu-os-gke-cloud  pipeline-1-20                                 READY
ubuntu-gke-1804-1-20-v20210309                        ubuntu-os-gke-cloud  pipeline-1-20                                 READY
ubuntu-gke-1804-1-20-v20210310                        ubuntu-os-gke-cloud  pipeline-1-20                                 READY
ubuntu-gke-1804-1-20-v20210316                        ubuntu-os-gke-cloud  pipeline-1-20                                 READY
ubuntu-gke-1804-1-20-v20210319                        ubuntu-os-gke-cloud  pipeline-1-20                                 READY
ubuntu-gke-1804-1-20-v20210323a                       ubuntu-os-gke-cloud  pipeline-1-20                                 READY
ubuntu-gke-1804-1-20-v20210325                        ubuntu-os-gke-cloud  pipeline-1-20                                 READY
ubuntu-gke-1804-1-20-v20210401                        ubuntu-os-gke-cloud  pipeline-1-20                                 READY
ubuntu-gke-2004-1-20-v20210308                        ubuntu-os-gke-cloud  pipeline-1-20                                 READY
ubuntu-gke-2004-1-20-v20210309                        ubuntu-os-gke-cloud  pipeline-1-20                                 READY
ubuntu-gke-2004-1-20-v20210310                        ubuntu-os-gke-cloud  pipeline-1-20                                 READY
ubuntu-gke-2004-1-20-v20210311                        ubuntu-os-gke-cloud  pipeline-1-20                                 READY
ubuntu-gke-2004-1-20-v20210322a                       ubuntu-os-gke-cloud  pipeline-1-20                                 READY
ubuntu-gke-2004-1-20-v20210323                        ubuntu-os-gke-cloud  pipeline-1-20                                 READY
ubuntu-gke-2004-1-20-v20210325                        ubuntu-os-gke-cloud  pipeline-1-20                                 READY
ubuntu-gke-2004-1-20-v20210401                        ubuntu-os-gke-cloud  pipeline-1-20                                 READY
```

Signed-off-by: Davanum Srinivas <davanum@gmail.com>

Signed-off-by: Davanum Srinivas <davanum@gmail.com>