### PR TITLE
Needs rebase: Better cope with 1k Github search result size limit

### DIFF
--- a/prow/external-plugins/needs-rebase/plugin/BUILD.bazel
+++ b/prow/external-plugins/needs-rebase/plugin/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//prow/plugins:go_default_library",
         "@com_github_shurcool_githubv4//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/errors:go_default_library",
     ],
 )
 


### PR DESCRIPTION
GitHub has a 1k results per query hard limit:
https://github.community/t/graphql-github-api-how-to-get-more-than-1000-pull-requests/13838/10

We currently hit this in the prow.k8s.io instance, which is why the
periodic rescan doesn't properly update all PRs. This change fixes that
by:
* Using a distinct query per org and one for all repos (if any)
* Making k/k its special snowflake that doesn't get only one but two
  unique queries, as the repo alone has currently 1.1k open PRs

Fixes https://github.com/kubernetes/test-infra/issues/21006
/assign @chaodaiG 
/cc @ehashman @nikhita 