### PR TITLE
pull-release-cluster-up: Only run when push-build.sh is modified

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -1,7 +1,7 @@
 presubmits:
   kubernetes/release:
   - name: pull-release-cluster-up
-    always_run: true
+    run_if_changed: '^push-build.sh'
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"


### PR DESCRIPTION
IIUC, the original intent of this job was to ensure changes to the
k/release shell library did not result in breakages in jobs using
bootstrap scenarios.

Now that push-build.sh is legacy (and self-contained), we only need to
trigger this cluster job when that file is changed.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @hasheddan @puerco 