### PR TITLE
Tide: Set github status to success prior to merging

### DIFF
--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -80,6 +80,11 @@ type statusController struct {
 	// the minimum status update period.
 	lastSyncStart time.Time
 
+	// dontUpdateStatus contains all PRs for which the Tide sync controller
+	// updated the status to success prior to merging. As the name suggests,
+	// the status controller must not update their status.
+	dontUpdateStatus threadSafePRSet
+
 	sync.Mutex
 	poolPRs          map[string]PullRequest
 	requiredContexts map[string][]string
@@ -385,7 +390,7 @@ func (sc *statusController) setStatuses(all []PullRequest, pool map[string]PullR
 			log.WithField("original-desc", original).Warn("GitHub status description needed to be truncated to fit GH API limit")
 		}
 		actualState = githubql.StatusState(strings.ToLower(string(actualState)))
-		if wantState != string(actualState) || wantDesc != actualDesc {
+		if !sc.dontUpdateStatus.has(string(pr.Repository.Owner.Login), string(pr.Repository.Name), int(pr.Number)) && (wantState != string(actualState) || wantDesc != actualDesc) {
 			if err := sc.ghc.CreateStatus(
 				org,
 				repo,
@@ -641,4 +646,37 @@ func contextCheckerGetterFactory(cfg *config.Config, gc git.ClientFactory, org, 
 		contextPolicy.RequiredContexts = requiredContexts
 		return contextPolicy, nil
 	}
+}
+
+type pullRequestIdentifier struct {
+	org    string
+	repo   string
+	number int
+}
+
+type threadSafePRSet struct {
+	data map[pullRequestIdentifier]struct{}
+	lock sync.RWMutex
+}
+
+func (s *threadSafePRSet) reset() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.data = map[pullRequestIdentifier]struct{}{}
+}
+
+func (s *threadSafePRSet) has(org, repo string, number int) bool {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	_, ok := s.data[pullRequestIdentifier{org: org, repo: repo, number: number}]
+	return ok
+}
+
+func (s *threadSafePRSet) insert(org, repo string, number int) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.data == nil {
+		s.data = map[pullRequestIdentifier]struct{}{}
+	}
+	s.data[pullRequestIdentifier{org: org, repo: repo, number: number}] = struct{}{}
 }

--- a/prow/tide/status_test.go
+++ b/prow/tide/status_test.go
@@ -738,10 +738,11 @@ func TestSetStatuses(t *testing.T) {
 	testcases := []struct {
 		name string
 
-		inPool     bool
-		hasContext bool
-		state      githubql.StatusState
-		desc       string
+		inPool          bool
+		hasContext      bool
+		inDontSetStatus bool
+		state           githubql.StatusState
+		desc            string
 
 		shouldSet bool
 	}{
@@ -782,6 +783,17 @@ func TestSetStatuses(t *testing.T) {
 			desc:       statusInPool,
 
 			shouldSet: true,
+		},
+		{
+			name: "in pool with wrong state but set to not update status",
+
+			inPool:          true,
+			hasContext:      true,
+			inDontSetStatus: true,
+			state:           githubql.StatusStatePending,
+			desc:            statusInPool,
+
+			shouldSet: false,
 		},
 		{
 			name: "not in pool with proper context",
@@ -845,6 +857,9 @@ func TestSetStatuses(t *testing.T) {
 		sc, err := newStatusController(context.Background(), log, fc, newFakeManager(), nil, ca.Config, nil, "", mmc)
 		if err != nil {
 			t.Fatalf("failed to get statusController: %v", err)
+		}
+		if tc.inDontSetStatus {
+			sc.dontUpdateStatus = threadSafePRSet{data: map[pullRequestIdentifier]struct{}{{}: {}}}
 		}
 		sc.setStatuses([]PullRequest{pr}, pool, blockers.Blockers{}, nil, nil)
 		if str, err := log.String(); err != nil {


### PR DESCRIPTION
This PR changes Tide to set its status context to success prior to merging. It is https://github.com/kubernetes/test-infra/pull/20892 plus a second commit to synchronize this with the status controller, ref https://github.com/kubernetes/test-infra/pull/20892#discussion_r578693503

Unblocks https://github.com/kubernetes/test-infra/issues/6289
Supersedes and thereby closes https://github.com/kubernetes/test-infra/pull/20892
Fixes https://github.com/kubernetes/test-infra/issues/16472
Fixes https://github.com/kubernetes/test-infra/issues/18782

/assign @cjwagner 