### PR TITLE
Bump testgrid to support junit error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/Azure/azure-storage-blob-go v0.8.0
 	github.com/Azure/go-autorest/autorest v0.11.1
 	github.com/Azure/go-autorest/autorest/adal v0.9.5
-	github.com/GoogleCloudPlatform/testgrid v0.0.56
+	github.com/GoogleCloudPlatform/testgrid v0.0.58
 	github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
 	github.com/andygrunwald/go-gerrit v0.0.0-20190120104749-174420ebee6c
 	github.com/andygrunwald/go-jira v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -168,8 +168,8 @@ github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20190822182118-27a4ced3
 github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20190822182118-27a4ced34534/go.mod h1:iroGtC8B3tQiqtds1l+mgk/BBOrxbqjH+eUfFQYRc14=
 github.com/GoogleCloudPlatform/testgrid v0.0.1-alpha.3/go.mod h1:f96W2HYy3tiBNV5zbbRc+NczwYHgG1PHXMQfoEWv680=
 github.com/GoogleCloudPlatform/testgrid v0.0.7/go.mod h1:lmtHGBL0M/MLbu1tR9BWV7FGZ1FEFIdPqmJiHNCL7y8=
-github.com/GoogleCloudPlatform/testgrid v0.0.56 h1:UmRXvBWXqxfM0vtluwYZc5Y8o6N3whOtKEP+vEH1/eY=
-github.com/GoogleCloudPlatform/testgrid v0.0.56/go.mod h1:SIRhudHYGiAUqMwKorBp2Kb5yJKhMq/nEMzFpYlKHVk=
+github.com/GoogleCloudPlatform/testgrid v0.0.58 h1:3EU+HN15EHbCKtqU+3I8UXGFY0ZIHK4uG9B+YTTV41M=
+github.com/GoogleCloudPlatform/testgrid v0.0.58/go.mod h1:SIRhudHYGiAUqMwKorBp2Kb5yJKhMq/nEMzFpYlKHVk=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd h1:sjQovDkwrZp8u+gxLtPgKGjk5hCxuy2hrRejBTA9xFU=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=

--- a/prow/spyglass/lenses/junit/lens.go
+++ b/prow/spyglass/lenses/junit/lens.go
@@ -99,7 +99,7 @@ func (jr JunitResult) Status() testStatus {
 	res := passedStatus
 	if jr.Skipped != nil {
 		res = skippedStatus
-	} else if jr.Failure != nil {
+	} else if jr.Failure != nil || jr.Errored != nil {
 		res = failedStatus
 	}
 	return res

--- a/prow/spyglass/lenses/junit/lens_test.go
+++ b/prow/spyglass/lenses/junit/lens_test.go
@@ -92,6 +92,10 @@ func TestGetJvd(t *testing.T) {
 		" failure message 0 ",
 		" failure message 1 ",
 	}
+	errorMsgs := []string{
+		" error message 0 ",
+		" error message 1 ",
+	}
 
 	tests := []struct {
 		name       string
@@ -122,6 +126,39 @@ func TestGetJvd(t *testing.T) {
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
 									Failure:   &failureMsgs[0],
+								},
+							},
+						},
+						Link: "linknotfound.io/404",
+					},
+				},
+				Skipped: nil,
+				Flaky:   nil,
+			},
+		}, {
+			"Errored",
+			[][]byte{
+				[]byte(`
+				<testsuites>
+					<testsuite>
+						<testcase classname="fake_class_0" name="fake_test_0">
+							<error message="Error" type=""> error message 0 </error>
+						</testcase>
+					</testsuite>
+				</testsuites>
+				`),
+			},
+			JVD{
+				NumTests: 1,
+				Passed:   nil,
+				Failed: []TestResult{
+					{
+						Junit: []JunitResult{
+							{
+								junit.Result{
+									Name:      "fake_test_0",
+									ClassName: "fake_class_0",
+									Errored:   &errorMsgs[0],
 								},
 							},
 						},

--- a/repos.bzl
+++ b/repos.bzl
@@ -2118,8 +2118,8 @@ def go_repositories():
         build_file_generation = "off",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/GoogleCloudPlatform/testgrid",
-        sum = "h1:UmRXvBWXqxfM0vtluwYZc5Y8o6N3whOtKEP+vEH1/eY=",
-        version = "v0.0.56",
+        sum = "h1:3EU+HN15EHbCKtqU+3I8UXGFY0ZIHK4uG9B+YTTV41M=",
+        version = "v0.0.58",
     )
 
     go_repository(


### PR DESCRIPTION
The junit xml can report a problematic test with "error" test case,
latest testgrid support this. This change bumps testgrid dep so prow
spyglass can parse "error" junit testcases.

Signed-off-by: Quique Llorente <ellorent@redhat.com>