### PR TITLE
Define a team/katacoda label for k/website

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -30,6 +30,7 @@
 - [Labels that apply to kubernetes/test-infra, for both issues and PRs](#labels-that-apply-to-kubernetestest-infra-for-both-issues-and-prs)
 - [Labels that apply to kubernetes/test-infra, only for PRs](#labels-that-apply-to-kubernetestest-infra-only-for-prs)
 - [Labels that apply to kubernetes/website, for both issues and PRs](#labels-that-apply-to-kuberneteswebsite-for-both-issues-and-prs)
+- [Labels that apply to kubernetes/website, only for issues](#labels-that-apply-to-kuberneteswebsite-only-for-issues)
 
 
 ## Intro
@@ -450,5 +451,11 @@ larger set of contributors to apply/remove them.
 | <a id="language/uk" href="#language/uk">`language/uk`</a> | Issues or PRs related to Ukrainian language| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="language/vi" href="#language/vi">`language/vi`</a> | Issues or PRs related to Vietnamese language| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="language/zh" href="#language/zh">`language/zh`</a> | Issues or PRs related to Chinese language <br><br> This was previously `language/cn`, | anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+
+## Labels that apply to kubernetes/website, only for issues
+
+| Name | Description | Added By | Prow Plugin |
+| ---- | ----------- | -------- | --- |
+| <a id="team/katacoda" href="#team/katacoda">`team/katacoda`</a> | Issues with the Katacoda infrastructure for tutorials| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 
 

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -1494,6 +1494,12 @@ repos:
         target: both
         prowPlugin: label
         addedBy: anyone
+      - color: d2b48c
+        description: Issues with the Katacoda infrastructure for tutorials
+        name: team/katacoda
+        target: issues
+        prowPlugin: label
+        addedBy: anyone
   kubernetes-sigs/cluster-api:
     labels:
       - color: c7def8


### PR DESCRIPTION
[Katacoda](https://www.katacoda.com/) provide hosted Kubernetes learning environments for https://kubernetes.io/docs/tutorials/ - this label will filtering on those specific issues.

We already have the label, but it's manually-managed and Prow doesn't recognize it.