### PR TITLE
Slack token secret synced from google secret manager

### DIFF
--- a/config/prow/cluster/kubernetes_external_secrets.yaml
+++ b/config/prow/cluster/kubernetes_external_secrets.yaml
@@ -1,2 +1,29 @@
 # This is a place holder for adding kubernetes external secrets, please add the
 # ExternalSecret CR here, separated by `---`.
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: prometheus-alert-slack-post-prow-alerts-secret-url
+  namespace: prow-monitoring
+spec:
+  backendType: gcpSecretsManager
+  projectId: k8s-prow
+  data:
+  - key: prometheus-alert-slack-post-prow-alerts-secret-url
+    name: url
+    version: latest
+
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: prometheus-alert-slack-post-testing-ops-secret-url
+  namespace: prow-monitoring
+spec:
+  backendType: gcpSecretsManager
+  projectId: k8s-prow
+  data:
+  - key: prometheus-alert-slack-post-testing-ops-secret-url
+    name: url
+    version: latest


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/21610 added a place holder file for kubernetes external secret, and failed prow deployment job as `kubectl apply -f` doesn't like empty file. This PR fixes forward, and by the way make it possible for automatically deploying prow monitoring stack without manual effort.