### PR TITLE
Skips GPUDevicePlugin test for Windows test runs

### DIFF
--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -233,8 +233,8 @@ periodics:
       - --gcp-nodes=2
       - --test=false
       - --test-cmd=$GOPATH/src/sigs.k8s.io/windows-testing/gce/run-e2e.sh
-      - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\] --minStartupPods=8
-      - --test-cmd-args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\] --minStartupPods=8
+      - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:GPUDevicePlugin\] --minStartupPods=8
+      - --test-cmd-args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --test-cmd-args=--node-os-distro=windows
       - --test-cmd-args=--docker-config-file=$(DOCKER_CONFIG_FILE)
       - --timeout=180m


### PR DESCRIPTION
Most jobs are already skipping the test [1] by specifying it by name in their regex. Recently [2], the tag ``[Feature:GPUDevicePlugin]`` was added to the test name, which means that most of the GCE tests will also skip it since they have ``\[Feature:.+\]`` in their
skip regex, with the exception of the ``ci-kubernetes-e2e-windows-gce-alpha-features`` job.

This commit adds ``\[Feature:GPUDevicePlugin\]`` to the mentioned job's regex, so it will be skipped there as well.

[1]: ``[sig-windows] Device Plugin should be able to create a functioning device plugin for Windows``
[2]: https://github.com/kubernetes/kubernetes/pull/100815