### PR TITLE
Adjust prow stale alert to be day of week based, and more strict

### DIFF
--- a/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
@@ -80,8 +80,9 @@ local config = {
   // How long we go during work hours without seeing a webhook before alerting.
   webhookMissingAlertInterval: '10m',
 
-  // How many days prow hasn't been bumped.
-  prowImageStaleByDays: {daysStale: 7, eventDuration: '24h'},
+  // How many work days prow hasn't been bumped, the alert rule using this value
+  // understands to adjust based on day of week so weekends are considered.
+  prowImageStaleByDays: {daysStale: 2, eventDuration: '24h'},
 
   kubernetesExternalSecretServiceAccount: "kubernetes-external-secrets-sa@k8s-prow.iam.gserviceaccount.com",
 };

--- a/config/prow/cluster/monitoring/mixins/prometheus/stale_alerts.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/stale_alerts.libsonnet
@@ -6,9 +6,14 @@
         rules: [
           {
             alert: 'Prow images are stale',
+            # Set day of week based stale alert, so that it can be stricter than 7 days, since k8s prow is automatically deployed now.
+            # Considering that there might be days that there is no prow update(which might be rare but could be true), the alert should at least
+            # be 2 work days. In considering weekends, monday and tuesdays will be +2 days.
             expr: |||
-              time()-max(prow_version) > %d * 24 * 3600
-            ||| % $._config.prowImageStaleByDays.daysStale,
+              ((time()-max(prow_version) > %d * 24 * 3600) and (day_of_week()<6) and (day_of_week()>2))
+              or ((time()-max(prow_version) > %d * 24 * 3600) and (day_of_week()==1))
+              or ((time()-max(prow_version) > %d * 24 * 3600) and (day_of_week()==2))
+            ||| % [$._config.prowImageStaleByDays.daysStale, $._config.prowImageStaleByDays.daysStale+2, $._config.prowImageStaleByDays.daysStale+2],
             'for': $._config.prowImageStaleByDays.eventDuration,
             labels: {
               severity: 'critical',


### PR DESCRIPTION
Since k8s prow is auto-deployed now, it's much more predictable that there should be at least one bump in 48 hours. Adjusting the prometheus alert rule to 2 days, and let it relax +2 days if Monday or Tuesday