### PR TITLE
external secret: add azure-cred

### DIFF
--- a/config/prow/cluster/BUILD.bazel
+++ b/config/prow/cluster/BUILD.bazel
@@ -58,6 +58,11 @@ release(
         cluster = BUILD_CLUSTER,
     ),
     component(
+        "build_kubernetes-external-secrets_customresource",
+        MULTI_KIND,
+        cluster = BUILD_CLUSTER,
+    ),
+    component(
         "mem-limit-range",
         "limitrange",
         cluster = BUILD_CLUSTER,

--- a/config/prow/cluster/build_kubernetes-external-secrets_customresource.yaml
+++ b/config/prow/cluster/build_kubernetes-external-secrets_customresource.yaml
@@ -1,0 +1,15 @@
+# This is a place holder for adding kubernetes external secrets to the prow build cluster, please add the
+# ExternalSecret CR here, separated by `---`.
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: azure-cred
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: kubernetes-upstream
+  data:
+  - key: azure-cred
+    name: credentials
+    version: latest


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

Fixes https://github.com/kubernetes/k8s.io/issues/1673

Followed the steps below from https://github.com/kubernetes/test-infra/blob/master/prow/prow_secrets.md to create an external secrets for `azure-cred`:

- [x] In the GCP project that stores secrets with google secret manager, grant the `roles/secretmanager.viewer` and `roles/secretmanager.secretAccessor` permission
- [x] Create the secret in Google secret manager
- [x] Create a Kubernetes external secrets custom resource


/assign @chaodaiG 