### PR TITLE
Kops - Ignore some failing GCE tests

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
@@ -32,7 +32,7 @@ periodics:
       - --kops-zones=us-central1-c
       - --provider=gce
       - --timeout=140m
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Firewall|Dashboard|Services.*functioning.*NodePort
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Firewall|Dashboard|Services.*functioning.*NodePort|kube-dns|run.a.Pod.requesting.a.RuntimeClass|should.set.TCP.CLOSE_WAIT|Services.*rejected.*endpoints
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210403-e49d2c6-master
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-kops-gce, kops-gce
@@ -70,7 +70,7 @@ periodics:
       - --kops-zones=us-central1-c
       - --provider=gce
       - --timeout=140m
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Firewall|Dashboard|Services.*functioning.*NodePort
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Firewall|Dashboard|Services.*functioning.*NodePort|kube-dns|run.a.Pod.requesting.a.RuntimeClass|should.set.TCP.CLOSE_WAIT|Services.*rejected.*endpoints
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
       imagePullPolicy: Always
   annotations:
@@ -115,7 +115,7 @@ periodics:
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=latest.txt \
           --parallel=25 \
-          --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Firewall|Dashboard|RuntimeClass|RuntimeHandler"
+          --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Firewall|Dashboard|RuntimeClass|RuntimeHandler|kube-dns|run.a.Pod.requesting.a.RuntimeClass|should.set.TCP.CLOSE_WAIT|Services.*rejected.*endpoints"
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/ssh-key-secret/ssh-private

--- a/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
@@ -120,7 +120,7 @@ periodics:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/ssh-key-secret/ssh-private
       - name: KUBE_SSH_USER
-        value: ubuntu
+        value: prow
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210403-e49d2c6-master
       imagePullPolicy: Always
       resources:


### PR DESCRIPTION
https://testgrid.k8s.io/kops-gce#kops-gce-latest

Skip kube-dns and some runtimeclass tests. Clusters default to CoreDNS now so the kube-dns tests are not applicable. 

The runtime class tests aren't applicable with containerd either, so we ignore the failing ones now. (In AWS we [ignore all RuntimeClass tests](https://github.com/kubernetes/test-infra/blob/cb7f50b1f05215188508e8598d77abf56e76f6a2/config/jobs/kubernetes/kops/build_jobs.py#L361) but after looking them over in this GCE job, some of them could still be of value and should pass on containerd like they do here on the GCE tests, so we can look into updating the regex used in the AWS jobs to match this)

The GCE jobs use cilium, so also ignore the networking/service tests that we ignore on cilium AWS jobs.

Also updating kubetest2's GCE SSH user. I noticed in certain GCE test outputs that the e2e suite uses the prow user. The [kubetest2 job is currently failing to SSH into hosts](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-gce-kubetest2/1379113611695230976#1:build-log.txt%3A326) with the ubuntu user, so I'm trying prow to see if that works. See the failing flexvolumes test output [here](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-gce-latest/1379105320437026816)




