### PR TITLE
Needs rebase: Scan for PRs every six hour instead of 24h

### DIFF
--- a/config/prow/cluster/needs-rebase_deployment.yaml
+++ b/config/prow/cluster/needs-rebase_deployment.yaml
@@ -39,6 +39,7 @@ spec:
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --github-token-path=/etc/github/oauth
+        - --update-period=6h
         ports:
           - name: http
             containerPort: 8888


### PR DESCRIPTION
This changes the needs-rebase plugin to scan for open PRs every six
hours instead of the default 24h. This shouldn't be an issue tokenwise,
because the main token usage is for the v4/graphql api plus up to two
tokens per PR that needs rebasing. By running more often, the average
number of PRs per run where we need to do something will go down,
though.

The main motivation is that the 24h scan might often not happen if we change Prow too often and end up redeploying it before the 24h interval.

Sidenote: It seems https://monitoring.prow.k8s.io/d/d72fe8d0400b2912e319b1e95d0ab1b3/github-cache?orgId=1&refresh=1m has no data for the token usage on the v4 api?

/assign @chaodaiG 