### PR TITLE
Use pre-existing kubetest2 binaries in pull-kubernetes-e2e-gce-kubetest2

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -123,7 +123,7 @@ presubmits:
       testgrid-tab-name: pull-kubernetes-e2e-gce-kubetest2
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-experimental
         resources:
           requests:
             cpu: 4
@@ -136,32 +136,20 @@ presubmits:
         command:
         - runner.sh
         args:
-        - "/bin/bash"
-        - "-c"
-        # Please note that the semicolon after the \ is necessary due to how
-        # parsing works out when embedding a bash script in a string like this
-        - set -o errexit;
-          set -o nounset;
-          set -o pipefail;
-          set -o xtrace;
-          REPO_ROOT=$PWD;
-          cd;
-          export GO111MODULE=on;
-          go get sigs.k8s.io/kubetest2@latest;
-          go get sigs.k8s.io/kubetest2/kubetest2-gce@latest;
-          go get sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
-          kubetest2 gce -v 2 \;
-          --repo-root $REPO_ROOT \;
-          --legacy-mode \;
-          --build \;
-          --up \;
-          --down \;
-          --enable-cache-mutation-detector \;
-          --test=ginkgo \;
-          -- \;
-          --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]' \;
-          --parallel=30 \;
-          --use-built-binaries
+        - kubetest2
+        - gce
+        - -v=2
+        - --repo-root=$PWD
+        - --legacy-mode # indicate that we are using kubernetes/kubernetes as opposed to kubernetes/cloud-provider-gcp
+        - --build
+        - --up
+        - --down
+        - --enable-cache-mutation-detector # Panic if anything mutates a shared informer cache
+        - --test=ginkgo
+        - --
+        - --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
+        - --parallel=30
+        - --use-built-binaries # use the kubectl, e2e.test, and ginkgo binaries built during --build as opposed to from a GCS release tarball
 
 
   - name: pull-kubernetes-e2e-gce-canary


### PR DESCRIPTION
pick up https://github.com/kubernetes-sigs/kubetest2/issues/106

/cc @spiffxp @BenTheElder 