### PR TITLE
Kops - increase validation time on Flatcar jobs

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -60,6 +60,9 @@ periodic_template = """
           {%- if terraform_version %}
           --terraform-version={{terraform_version}} \\
           {%- endif %}
+          {%- if validation_wait %}
+          --validation-wait={{validation_wait}} \\
+          {%- endif %}
           --test=kops \\
           -- \\
           --ginkgo-args="--debug" \\
@@ -354,6 +357,7 @@ def build_test(cloud='aws',
 
     kops_image = distro_images[distro]
     kops_ssh_user = distros_ssh_user[distro]
+    validation_wait = '20m' if distro == 'flatcar' else None
 
     marker, k8s_deploy_url, test_package_bucket, test_package_dir = k8s_version_info(k8s_version)
     args = create_args(kops_channel, networking, container_runtime, extra_flags, kops_image)
@@ -407,6 +411,7 @@ def build_test(cloud='aws',
         test_package_dir=test_package_dir,
         focus_regex=focus_regex,
         publish_version_marker=publish_version_marker,
+        validation_wait=validation_wait,
     )
 
     spec = {

--- a/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
@@ -610,6 +610,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -1570,6 +1570,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -1634,6 +1635,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -1698,6 +1700,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.20/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -1762,6 +1765,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -1826,6 +1830,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -1890,6 +1895,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.20/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -1954,6 +1960,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -2018,6 +2025,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.20/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -5666,6 +5674,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -5730,6 +5739,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -5794,6 +5804,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.20/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -5858,6 +5869,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -5922,6 +5934,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -5986,6 +5999,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.20/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -6050,6 +6064,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -6114,6 +6129,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.20/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -11298,6 +11314,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -11362,6 +11379,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -11426,6 +11444,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.20/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -11490,6 +11509,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -11554,6 +11574,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -11618,6 +11639,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.20/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -11682,6 +11704,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -11746,6 +11769,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.20/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -15394,6 +15418,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -15458,6 +15483,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -15522,6 +15548,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.20/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -15586,6 +15613,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -15650,6 +15678,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -15714,6 +15743,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.20/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -15778,6 +15808,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -15842,6 +15873,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.20/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -19490,6 +19522,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -19554,6 +19587,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -19618,6 +19652,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.20/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -19682,6 +19717,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -19746,6 +19782,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -19810,6 +19847,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.20/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -19874,6 +19912,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -19938,6 +19977,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.20/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -23586,6 +23626,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -23650,6 +23691,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -23714,6 +23756,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.20/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -23778,6 +23821,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -23842,6 +23886,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -23906,6 +23951,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.20/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -23970,6 +24016,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -24034,6 +24081,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.20/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -29218,6 +29266,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -29282,6 +29331,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -29346,6 +29396,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.20/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -29410,6 +29461,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -29474,6 +29526,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -29538,6 +29591,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.20/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -29602,6 +29656,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -29666,6 +29721,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.20/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -33314,6 +33370,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -33378,6 +33435,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -33442,6 +33500,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.20/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -33506,6 +33565,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -33570,6 +33630,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.19/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -33634,6 +33695,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.20/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -33698,6 +33760,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
@@ -33762,6 +33825,7 @@ periodics:
           --create-args="--image='075585003325/Flatcar-stable-2765.2.2-hvm' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.20/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --ginkgo-args="--debug" \


### PR DESCRIPTION
Flatcar runs package updates and a reboot on instance launch, even when using the latest flatcar AMI.
This causes cluster validation to timeout because pods are still coming back up post-reboot.

This increases the validation timeout from 15m to 20m for flatcar jobs.

Depends on https://github.com/kubernetes/kops/pull/11178