### PR TITLE
Fix CAPI upgrade tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
@@ -10,6 +10,10 @@ periodics:
     repo: cluster-api
     base_ref: master
     path_alias: sigs.k8s.io/cluster-api
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20210403-e49d2c6-go-canary
@@ -50,6 +54,10 @@ periodics:
     repo: cluster-api
     base_ref: master
     path_alias: sigs.k8s.io/cluster-api
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20210403-e49d2c6-go-canary
@@ -90,6 +98,10 @@ periodics:
     repo: cluster-api
     base_ref: master
     path_alias: sigs.k8s.io/cluster-api
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20210403-e49d2c6-go-canary
@@ -130,6 +142,10 @@ periodics:
     repo: cluster-api
     base_ref: master
     path_alias: sigs.k8s.io/cluster-api
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20210403-e49d2c6-go-canary
@@ -137,12 +153,10 @@ periodics:
         - runner.sh
         - "./scripts/ci-e2e.sh"
       env:
-        - name: BUILD_NODE_IMAGE_TAG
-          value: "ci/latest"
         - name: KUBERNETES_VERSION_UPGRADE_FROM
           value: "stable-1.20"
         - name: KUBERNETES_VERSION_UPGRADE_TO
-          value: "ci/latest"
+          value: "ci/latest-1.21"
         - name: ETCD_VERSION_UPGRADE_TO
           value: "3.4.13-0"
         - name: COREDNS_VERSION_UPGRADE_TO

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -192,14 +192,10 @@ presubmits:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
-          - name: BUILD_NODE_IMAGE_TAG
-            value: "ci/latest"
-          - name: KUBERNETES_VERSION
-            value: "ci/latest"
           - name: KUBERNETES_VERSION_UPGRADE_FROM
             value: "v1.20.0"
           - name: KUBERNETES_VERSION_UPGRADE_TO
-            value: "ci/latest"
+            value: "ci/latest-1.21"
           - name: ETCD_VERSION_UPGRADE_TO
             value: "3.4.13-0"
           - name: COREDNS_VERSION_UPGRADE_TO


### PR DESCRIPTION
This PR updates CAPI upgrade jobs to the changes introduced by https://github.com/kubernetes-sigs/cluster-api/pull/4397 and more specifically
- all the jobs are pulling Kubernetes, so we can build kinder images if those are not published yer
- remove the unnecessary BUILD_NODE_IMAGE_TAG variable

We are also handing the fact that in kubernetes CI there is already the v1.22 release even if 1.21 is not published yet

/assign @vincepri 
@srm09 