### PR TITLE
Allow setting team/katacoda label

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -122,7 +122,8 @@ label:
     - tide/merge-method-merge
     - tide/merge-method-rebase
     - tide/merge-method-squash
-
+    # This label, for k/website, identifies issues relevant to https://katacoda.com/
+    - team/katacoda
 
 lgtm:
 - repos:


### PR DESCRIPTION
Follows on from https://github.com/kubernetes/test-infra/pull/21652

If this merges then I believe you can 
/label team/katacoda

for repos that have a Katacoda team label.

(Only the [k/website](https://github.com/kubernetes/website) repo actually has such a label)