### PR TITLE
Upload config through config merger

### DIFF
--- a/testgrid/config-upload.sh
+++ b/testgrid/config-upload.sh
@@ -19,7 +19,7 @@ set -o pipefail
 
 TESTINFRA_ROOT=$(git rev-parse --show-toplevel)
 
-for output in gs://k8s-testgrid-canary/config gs://k8s-testgrid-canary/configs/k8s/config gs://k8s-testgrid/config gs://k8s-testgrid/configs/k8s/config; do
+for output in gs://k8s-testgrid-canary/configs/k8s/config gs://k8s-testgrid/configs/k8s/config; do
   dir="$(dirname "${BASH_SOURCE}")"
   (
     set -o xtrace


### PR DESCRIPTION
Causes configurator to write to its config location, instead of writing there and also overwriting the results of the config_merger.

Do not merge until https://github.com/GoogleCloudPlatform/testgrid/pull/424 has been deployed in Canary and Prod.
/hold