### PR TITLE
fix marker for 1.21 release branch

### DIFF
--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -373,7 +373,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/1.21
+      - --extract=ci/latest-1.21
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=8
       - --provider=gce


### PR DESCRIPTION
Whoops! correct url is https://storage.googleapis.com/kubernetes-release-dev/ci/latest-1.21.txt

Signed-off-by: Davanum Srinivas <davanum@gmail.com>