### PR TITLE
Revert "Replace owners_dir_blacklist with owners_dir_denylist"

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -135,7 +135,6 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
- - *April 1st, 2021* The `owners_dir_blacklist` field in prow config has been deprecated in favor of `owners_dir_denylist`. The support of `owners_dir_blacklist` will be stopped in October 2021.
  - *April 1st, 2021* The `labels_blacklist` field in verify-owners plugin config
    is deprecated in favor of `labels_denylist`. The support for `labels_blacklist` shall be stopped in
    *October 2021*.

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -204,23 +204,13 @@ func main() {
 	skipCollaborators := func(org, repo string) bool {
 		return pluginAgent.Config().SkipCollaborators(org, repo)
 	}
-	ownersDirDenylist := func() *config.OwnersDirDenylist {
-		deprecated := configAgent.Config().OwnersDirBlacklist
-		l := configAgent.Config().OwnersDirDenylist
-		if deprecated != nil {
-			logrus.Warn("owners_dir_blacklist will be deprecated after October 2021, use owners_dir_denylist instead")
-			if l != nil {
-				logrus.Warn("Both owners_dir_blacklist and owners_dir_denylist are provided, owners_dir_blacklist is discarded")
-			} else {
-				l = deprecated
-			}
-		}
-		return l
+	ownersDirBlacklist := func() config.OwnersDirBlacklist {
+		return configAgent.Config().OwnersDirBlacklist
 	}
 	resolver := func(org, repo string) ownersconfig.Filenames {
 		return pluginAgent.Config().OwnersFilenames(org, repo)
 	}
-	ownersClient := repoowners.NewClient(git.ClientFactoryFrom(gitClient), githubClient, mdYAMLEnabled, skipCollaborators, ownersDirDenylist, resolver)
+	ownersClient := repoowners.NewClient(git.ClientFactoryFrom(gitClient), githubClient, mdYAMLEnabled, skipCollaborators, ownersDirBlacklist, resolver)
 
 	clientAgent := &plugins.ClientAgent{
 		GitHubClient:              githubClient,

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -5974,6 +5974,7 @@ log_level: info
 managed_webhooks:
   auto_accept_invitation: false
   respect_legacy_global_token: false
+owners_dir_blacklist: {}
 plank:
   max_goroutines: 20
   pod_pending_timeout: 10m0s

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -481,22 +481,9 @@ managed_webhooks:
     respect_legacy_global_token: false
 
 
-# OwnersDirBlacklist is deprecated, use OwnersDirDenylist instead
-owners_dir_blacklist:
-    # Default configures a default blacklist for all repos (or orgs).
-    # Some directories like ".git", "_output" and "vendor/.*/OWNERS"
-    # are already preconfigured to be blacklisted, and need not be included here.
-    default:
-      - ""
-
-    # Repos configures a directory blacklist per repo (or org)
-    repos:
-        "": null
-
-
-# OwnersDirDenylist is used to configure regular expressions matching directories
+# OwnersDirBlacklist is used to configure regular expressions matching directories
 # to ignore when searching for OWNERS{,_ALIAS} files in a repo.
-owners_dir_denylist:
+owners_dir_blacklist:
     # Default configures a default blacklist for all repos (or orgs).
     # Some directories like ".git", "_output" and "vendor/.*/OWNERS"
     # are already preconfigured to be blacklisted, and need not be included here.

--- a/prow/hook/hook_test.go
+++ b/prow/hook/hook_test.go
@@ -108,7 +108,7 @@ func TestHook(t *testing.T) {
 	ca := &config.Agent{}
 	clientAgent := &plugins.ClientAgent{
 		GitHubClient:   github.NewFakeClient(),
-		OwnersClient:   repoowners.NewClient(nil, nil, func(org, repo string) bool { return false }, func(org, repo string) bool { return false }, func() *config.OwnersDirDenylist { return &config.OwnersDirDenylist{} }, ownersconfig.FakeResolver),
+		OwnersClient:   repoowners.NewClient(nil, nil, func(org, repo string) bool { return false }, func(org, repo string) bool { return false }, func() config.OwnersDirBlacklist { return config.OwnersDirBlacklist{} }, ownersconfig.FakeResolver),
 		BugzillaClient: &bugzilla.Fake{},
 	}
 	metrics := githubeventserver.NewMetrics()

--- a/prow/repoowners/repoowners.go
+++ b/prow/repoowners/repoowners.go
@@ -163,10 +163,10 @@ type Client struct {
 type delegate struct {
 	git git.ClientFactory
 
-	mdYAMLEnabled     func(org, repo string) bool
-	skipCollaborators func(org, repo string) bool
-	ownersDirDenylist func() *prowConf.OwnersDirDenylist
-	filenames         ownersconfig.Resolver
+	mdYAMLEnabled      func(org, repo string) bool
+	skipCollaborators  func(org, repo string) bool
+	ownersDirBlacklist func() prowConf.OwnersDirBlacklist
+	filenames          ownersconfig.Resolver
 
 	cache *cache
 }
@@ -196,7 +196,7 @@ func NewClient(
 	ghc github.Client,
 	mdYAMLEnabled func(org, repo string) bool,
 	skipCollaborators func(org, repo string) bool,
-	ownersDirDenylist func() *prowConf.OwnersDirDenylist,
+	ownersDirBlacklist func() prowConf.OwnersDirBlacklist,
 	filenames ownersconfig.Resolver,
 ) *Client {
 	return &Client{
@@ -206,10 +206,10 @@ func NewClient(
 			git:   gc,
 			cache: newCache(),
 
-			mdYAMLEnabled:     mdYAMLEnabled,
-			skipCollaborators: skipCollaborators,
-			ownersDirDenylist: ownersDirDenylist,
-			filenames:         filenames,
+			mdYAMLEnabled:      mdYAMLEnabled,
+			skipCollaborators:  skipCollaborators,
+			ownersDirBlacklist: ownersDirBlacklist,
+			filenames:          filenames,
 		},
 	}
 }
@@ -394,7 +394,7 @@ func (c *Client) cacheEntryFor(org, repo, base, cloneRef, fullName, sha string, 
 			log.WithField("duration", time.Since(start).String()).Debugf("Completed loadAliasesFrom(%s, log)", gitRepo.Directory())
 
 			start = time.Now()
-			ignoreDirPatterns := c.ownersDirDenylist().ListIgnoredDirs(org, repo)
+			ignoreDirPatterns := c.ownersDirBlacklist().ListIgnoredDirs(org, repo)
 			var dirIgnorelist []*regexp.Regexp
 			for _, pattern := range ignoreDirPatterns {
 				re, err := regexp.Compile(pattern)

--- a/prow/repoowners/repoowners_test.go
+++ b/prow/repoowners/repoowners_test.go
@@ -149,8 +149,8 @@ func getTestClient(
 	skipCollab,
 	includeAliases bool,
 	ignorePreconfiguredDefaults bool,
-	ownersDirDenylistDefault []string,
-	ownersDirDenylistByRepo map[string][]string,
+	ownersDirBlacklistDefault []string,
+	ownersDirBlacklistByRepo map[string][]string,
 	extraBranchesAndFiles map[string]map[string][]byte,
 	cacheOptions *cacheOptions,
 	clients localgit.Clients,
@@ -276,10 +276,10 @@ labels:
 				skipCollaborators: func(org, repo string) bool {
 					return skipCollab
 				},
-				ownersDirDenylist: func() *prowConf.OwnersDirDenylist {
-					return &prowConf.OwnersDirDenylist{
-						Repos:                       ownersDirDenylistByRepo,
-						Default:                     ownersDirDenylistDefault,
+				ownersDirBlacklist: func() prowConf.OwnersDirBlacklist {
+					return prowConf.OwnersDirBlacklist{
+						Repos:                       ownersDirBlacklistByRepo,
+						Default:                     ownersDirBlacklistDefault,
 						IgnorePreconfiguredDefaults: ignorePreconfiguredDefaults,
 					}
 				},
@@ -294,16 +294,16 @@ labels:
 		nil
 }
 
-func TestOwnersDirDenylist(t *testing.T) {
-	testOwnersDirDenylist(localgit.New, t)
+func TestOwnersDirBlacklist(t *testing.T) {
+	testOwnersDirBlacklist(localgit.New, t)
 }
 
-func TestOwnersDirDenylistV2(t *testing.T) {
-	testOwnersDirDenylist(localgit.NewV2, t)
+func TestOwnersDirBlacklistV2(t *testing.T) {
+	testOwnersDirBlacklist(localgit.NewV2, t)
 }
 
-func testOwnersDirDenylist(clients localgit.Clients, t *testing.T) {
-	getRepoOwnersWithDenylist := func(t *testing.T, defaults []string, byRepo map[string][]string, ignorePreconfiguredDefaults bool) *RepoOwners {
+func testOwnersDirBlacklist(clients localgit.Clients, t *testing.T) {
+	getRepoOwnersWithBlacklist := func(t *testing.T, defaults []string, byRepo map[string][]string, ignorePreconfiguredDefaults bool) *RepoOwners {
 		client, cleanup, err := getTestClient(testFiles, true, false, true, ignorePreconfiguredDefaults, defaults, byRepo, nil, nil, clients)
 		if err != nil {
 			t.Fatalf("Error creating test client: %v.", err)
@@ -392,7 +392,7 @@ func testOwnersDirDenylist(clients localgit.Clients, t *testing.T) {
 
 	for name, conf := range tests {
 		t.Run(name, func(t *testing.T) {
-			ro := getRepoOwnersWithDenylist(t, conf.blacklistDefault, conf.blacklistByRepo, conf.ignorePreconfiguredDefaults)
+			ro := getRepoOwnersWithBlacklist(t, conf.blacklistDefault, conf.blacklistByRepo, conf.ignorePreconfiguredDefaults)
 
 			includeDirs := sets.NewString(conf.includeDirs...)
 			excludeDirs := sets.NewString(conf.excludeDirs...)


### PR DESCRIPTION
This reverts commit 7b13a11779d1029ce201ddf441fda8f730410047.

I think this is the root cause of https://kubernetes.slack.com/archives/C7J9RP96G/p1617765164034100, reverting for now