### PR TITLE
Adding fixing job timeouts for 1.21 gce-windows-* prow jobs

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.21.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.21.yaml
@@ -534,6 +534,8 @@ periodics:
     testgrid-dashboards: google-windows, sig-windows-gce, sig-release-1.21-informing, sig-windows-signal
     testgrid-tab-name: gce-windows-2019-1.21
   decorate: true
+  decoration_config:
+    timeout: 3h
   extra_refs:
   - base_ref: master
     org: kubernetes-sigs
@@ -580,6 +582,8 @@ periodics:
     testgrid-dashboards: google-windows, sig-windows-gce, sig-release-1.21-informing, sig-windows-signal, sig-windows-master-release
     testgrid-tab-name: gce-windows-20h2-1.21
   decorate: true
+  decoration_config:
+    timeout: 3h
   extra_refs:
   - base_ref: master
     org: kubernetes-sigs
@@ -626,6 +630,8 @@ periodics:
     testgrid-dashboards: google-windows, sig-windows-gce, sig-release-1.21-informing, sig-windows-master-release
     testgrid-tab-name: gce-windows-2004-1.21
   decorate: true
+  decoration_config:
+    timeout: 3h
   extra_refs:
   - base_ref: master
     org: kubernetes-sigs


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

Applying the same decoration_config\timeout settings that were applied to gce Windows master jobs with https://github.com/kubernetes/test-infra/pull/21584 to extend job timeout to 3 hours.