### PR TITLE
kubeadm: fix dash/dot issue in kinder-kubelet-x-on-y.yaml

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kubelet-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kubelet-x-on-y.yaml
@@ -73,7 +73,7 @@ periodics:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
       args:
-      - "skew-kubelet-1.20-on-1-21"
+      - "skew-kubelet-1.20-on-1.21"
       securityContext:
         privileged: true
       resources:


### PR DESCRIPTION
Replace dash with dot:
https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-kinder-kubelet-1-20-on-1-21/1379641470570467328/build-log.txt

> Error: invalid workflow file: /home/prow/go/src/k8s.io/kubeadm/kinder/ci/workflows/skew-kubelet-1.20-on-1-21.yaml does not exist

/sig cluster-lifecycle
/kind bug
/assign @RA489 
