### PR TITLE
E2E test images: Adds cuda-vector-add-old postsubmit job

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-e2e-test-images.sh
+++ b/config/jobs/image-pushing/k8s-staging-e2e-test-images.sh
@@ -21,6 +21,7 @@ readonly IMAGES=(
     apparmor-loader
     busybox
     cuda-vector-add
+    cuda-vector-add-old
     echoserver
     glusterdynamic-provisioner
     httpd

--- a/config/jobs/image-pushing/k8s-staging-e2e-test-images.yaml
+++ b/config/jobs/image-pushing/k8s-staging-e2e-test-images.yaml
@@ -158,6 +158,45 @@ postsubmits:
             # We override that with the cuda-vector-add image.
             - name: WHAT
               value: "cuda-vector-add"
+    - name: post-kubernetes-push-e2e-cuda-vector-add-old-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-testing-images
+      decorate: true
+      # we only need to run if the test images have been changed.
+      run_if_changed: '^test\/images\/cuda-vector-add-old\/'
+      branches:
+        - ^master$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20210302-aa40187
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR
+              # images are pushed to.
+              - --project=k8s-staging-e2e-test-images
+              # This is the same as above, but with -gcb appended.
+              - --scratch-bucket=gs://k8s-staging-e2e-test-images-gcb
+              - --env-passthrough=PULL_BASE_REF,WHAT
+              - --build-dir=.
+              - test/images
+            env:
+            # By default, the E2E test image's WHAT is all-conformance.
+            # We override that with the cuda-vector-add-old image.
+            - name: WHAT
+              value: "cuda-vector-add-old"
     - name: post-kubernetes-push-e2e-echoserver-test-images
       rerun_auth_config:
         github_team_slugs:


### PR DESCRIPTION
Currently, the only image left in ``gcr.io/kubernetes-e2e-test-images`` is the ``cuda-vector-add:1.0`` image. This adds a postsubmit job for it, so we can then promote it to the ``k8s.gcr.io/e2e-test-images`` registry.

Related: https://github.com/kubernetes/kubernetes/issues/96770
Related: https://github.com/kubernetes/kubernetes/pull/100887