### PR TITLE
Switch all kubeconfig consumer deployments to use KUBECONFIG envvar

### DIFF
--- a/config/prow/cluster/crier_deployment.yaml
+++ b/config/prow/cluster/crier_deployment.yaml
@@ -42,10 +42,13 @@ spec:
         - --github-token-path=/etc/github/oauth
         - --github-workers=5
         - --job-config-path=/etc/job-config
-        - --kubeconfig=/etc/kubeconfig/config
         - --kubernetes-blob-storage-workers=1
         - --slack-token-file=/etc/slack/token
         - --slack-workers=1
+        env:
+        # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
+        - name: KUBECONFIG
+          value: "/etc/kubeconfig/config"
         volumeMounts:
         - mountPath: /etc/kubeconfig
           name: kubeconfig

--- a/config/prow/cluster/deck_deployment.yaml
+++ b/config/prow/cluster/deck_deployment.yaml
@@ -44,7 +44,6 @@ spec:
           - name: http
             containerPort: 8080
         args:
-        - --kubeconfig=/etc/kubeconfig/config
         - --tide-url=http://tide/
         - --hook-url=http://hook:8888/plugin-help
         - --redirect-http-to=prow.k8s.io
@@ -59,6 +58,10 @@ spec:
         - --github-oauth-config-file=/etc/githuboauth/secret
         - --cookie-secret=/etc/cookie/secret
         - --plugin-config=/etc/plugins/plugins.yaml
+        env:
+        # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
+        - name: KUBECONFIG
+          value: "/etc/kubeconfig/config"
         volumeMounts:
         - name: oauth-config
           mountPath: /etc/githuboauth

--- a/config/prow/cluster/hook_deployment.yaml
+++ b/config/prow/cluster/hook_deployment.yaml
@@ -48,7 +48,10 @@ spec:
         - --github-token-path=/etc/github/oauth
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
-        - --kubeconfig=/etc/kubeconfig/config
+        env:
+        # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
+        - name: KUBECONFIG
+          value: "/etc/kubeconfig/config"
         ports:
           - name: http
             containerPort: 8888

--- a/config/prow/cluster/pipeline_deployment.yaml
+++ b/config/prow/cluster/pipeline_deployment.yaml
@@ -22,7 +22,10 @@ spec:
         args:
         - --all-contexts
         - --config=/etc/prow-config/config.yaml
-        - --kubeconfig=/etc/kubeconfig/config
+        env:
+        # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
+        - name: KUBECONFIG
+          value: "/etc/kubeconfig/config"
         volumeMounts:
         - mountPath: /etc/kubeconfig
           name: kubeconfig

--- a/config/prow/cluster/prow_controller_manager_deployment.yaml
+++ b/config/prow/cluster/prow_controller_manager_deployment.yaml
@@ -40,7 +40,10 @@ spec:
         - --dry-run=false
         - --enable-controller=plank
         - --job-config-path=/etc/job-config
-        - --kubeconfig=/etc/kubeconfig/config
+        env:
+        # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
+        - name: KUBECONFIG
+          value: "/etc/kubeconfig/config"
         volumeMounts:
         - mountPath: /etc/kubeconfig
           name: kubeconfig

--- a/config/prow/cluster/sinker_deployment.yaml
+++ b/config/prow/cluster/sinker_deployment.yaml
@@ -19,11 +19,14 @@ spec:
       containers:
       - name: sinker
         args:
-        - --kubeconfig=/etc/kubeconfig/config
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
         image: gcr.io/k8s-prow/sinker:v20210409-985ef5e721
+        env:
+        # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
+        - name: KUBECONFIG
+          value: "/etc/kubeconfig/config"
         volumeMounts:
         - mountPath: /etc/kubeconfig
           name: kubeconfig


### PR DESCRIPTION
So that the build cluster onboarding process doesn't require manipulating/merging kubeconfig secret. The onboading process will be updated soon after this PR