### PR TITLE
prow/config/tide: Order TideQuery properties by stability

### DIFF
--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -206,21 +206,21 @@ func (t *Tide) GetPRStatusBaseURL(repo OrgRepo) string {
 // TideQuery is turned into a GitHub search query. See the docs for details:
 // https://help.github.com/articles/searching-issues-and-pull-requests/
 type TideQuery struct {
-	Orgs          []string `json:"orgs,omitempty"`
-	Repos         []string `json:"repos,omitempty"`
-	ExcludedRepos []string `json:"excludedRepos,omitempty"`
-
 	Author string `json:"author,omitempty"`
-
-	ExcludedBranches []string `json:"excludedBranches,omitempty"`
-	IncludedBranches []string `json:"includedBranches,omitempty"`
 
 	Labels        []string `json:"labels,omitempty"`
 	MissingLabels []string `json:"missingLabels,omitempty"`
 
+	ExcludedBranches []string `json:"excludedBranches,omitempty"`
+	IncludedBranches []string `json:"includedBranches,omitempty"`
+
 	Milestone string `json:"milestone,omitempty"`
 
 	ReviewApprovedRequired bool `json:"reviewApprovedRequired,omitempty"`
+
+	Orgs          []string `json:"orgs,omitempty"`
+	Repos         []string `json:"repos,omitempty"`
+	ExcludedRepos []string `json:"excludedRepos,omitempty"`
 }
 
 // constructQuery returns a map[org][]orgSpecificQueryParts (org, repo, -repo), remainingQueryString


### PR DESCRIPTION
Some tools [use Go's stdlib JSON serializer to order `TideQuery` entries when normalizing the Prow config][1].  Go's stdlib JSON serializer renders properties in the order in which they are defined in the struct.  With this commit, I'm keeping things which are likely to be stable identifiers of "handling like this" early in the struct, while moving things which are likely to be unstable "repos which want this handling" later in the struct.  That should reduce churn for folks who have a slowly-evolving set of handling strategies and a more-quickly evolving set of members within each strategy.  In a pinch, folks can use 8d921acfb9 (#16039)'s `Author` property to enforce ordering, although it would also be possible to add a `Description` string or similar, if folks wanted something separate from `Author` as the lead property.

[1]: https://github.com/openshift/ci-tools/blob/4f2b89656b7aa14f1ee892c20e717b3dfdeb6034/cmd/determinize-prow-config/main.go#L113-L128