### PR TITLE
Leftpad GitHub status description before adding basesha

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -2546,6 +2546,16 @@ func ContextDescriptionWithBaseSha(humanReadable, baseSHA string) string {
 	var suffix string
 	if baseSHA != "" {
 		suffix = contextDescriptionBaseSHADelimiter + baseSHA
+		// Leftpad the baseSHA suffix so its shown at a stable position on the right side in the GitHub UI.
+		// The GitHub UI will also trim it on the right side and replace some part of it with '...'. The
+		// API always returns the full string.
+		if len(humanReadable+suffix) < contextDescriptionMaxLen {
+			for i := 0; i < contextDescriptionMaxLen-len(humanReadable+suffix); i++ {
+				// This looks like a standard space but is U+2001, because GitHub seems to deduplicate normal
+				// spaces in their frontend.
+				suffix = " " + suffix
+			}
+		}
 	}
 	return truncate(humanReadable, contextDescriptionMaxLen-len(suffix)) + suffix
 }


### PR DESCRIPTION
This leftpads the Github status description before the basesha which
makes the thing look a lot nicer. Roundtripping works for both unpadded
and padded descriptions.

Now:
<img width="628" alt="basesha_padded" src="https://user-images.githubusercontent.com/6496100/113943944-b07eef80-97d1-11eb-9a10-3eebf1d56ca0.png">

vs before:

<img width="607" alt="basesha_unpadded" src="https://user-images.githubusercontent.com/6496100/113944013-d4423580-97d1-11eb-8480-ffd7ab245618.png">
