### PR TITLE
ci-kubernetes-e2e-windows-containerd-gce* is not really testing containerd

### DIFF
--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -18,7 +18,7 @@ presets:
 - labels:
     preset-e2e-gce-windows-containerd: "true"
   env:
-  - name: KUBE_CONTAINER_RUNTIME
+  - name: KUBE_WINDOWS_CONTAINER_RUNTIME
     value: "containerd"
   - name: PREPULL_TIMEOUT
     value: "30m"


### PR DESCRIPTION
Looks like we never adjusted the job to really use `containerd` after https://github.com/kubernetes/kubernetes/pull/92063/files landed.

a quick look at logs confirms that the job is really using docker.
https://gcsweb.k8s.io/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-windows-containerd-gce/1379879151552434176/artifacts/

/cc @jingxu97 @marosset 

Signed-off-by: Davanum Srinivas <davanum@gmail.com>