### PR TITLE
[Kettle] Encode error string to avoid Unicode failure

### DIFF
--- a/kettle/cloudbuild.yaml
+++ b/kettle/cloudbuild.yaml
@@ -2,7 +2,7 @@ steps:
   - name: gcr.io/cloud-builders/docker
     args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/kettle:$_GIT_TAG', '.' ]
     dir: kettle/
-    timeout: 1200s
+    timeout: 2000s
   - name: gcr.io/cloud-builders/docker
     args: [ 'tag', 'gcr.io/$PROJECT_ID/kettle:$_GIT_TAG', 'gcr.io/$PROJECT_ID/kettle:latest']
 substitutions:
@@ -10,4 +10,4 @@ substitutions:
 images:
   - 'gcr.io/$PROJECT_ID/kettle:$_GIT_TAG'
   - 'gcr.io/$PROJECT_ID/kettle:latest'
-timeout: 1260s
+timeout: 2000s

--- a/kettle/stream.py
+++ b/kettle/stream.py
@@ -112,7 +112,7 @@ def retry(func, *args, **kwargs):
             args_size = sys.getsizeof(args)
             kwargs_str = ','.join('{}={}'.format(k, v) for k, v in kwargs.items())
             print(f"Error running {func.__name__} \
-                   ([bytes in args]{args_size} with {kwargs_str}) : {err}")
+                   ([bytes in args]{args_size} with {kwargs_str}) : {str(err).encode('utf8')}")
             return None # Skip
     return func(*args, **kwargs)  # one last attempt
 


### PR DESCRIPTION
#21674 
also extend build time as it periodically timeout

/area kettle
Tested in staging. The failing bytes are odd however:
```
Error running insert_rows                    ([bytes in args]64 with skip_invalid_rows=True) : b'400 POST https://bigquery.googleapis.com/bigquery/v2/projects/k8s-gubernator/datasets/build/tables/staging/insertAll?prettyPrint=false: <!DOCTYPE html>\n<html lang=en>\n  <meta charset=utf-8>\n  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">\n  <title>Error 400 (Bad Request)!!1</title>\n  <style>\n    *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}\n  </style>\n  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>\n  <p><b>400.</b> <ins>That\xe2\x80\x99s an error.</ins>\n  <p>Your client has issued a malformed or illegal request.  <ins>That\xe2\x80\x99s all we know.</ins>\n'
```
/cc @amwat 