### PR TITLE
gh: handle 403 when x-accepted-oauth-scopes is empty

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -896,7 +896,7 @@ func (c *client) requestRetry(method, path, accept, org string, body interface{}
 
 					want := sets.NewString(strings.Split(acceptedScopes, ",")...)
 					got := strings.Split(authorizedScopes, ",")
-					if !want.HasAny(got...) {
+					if len(want) > 0 && !want.HasAny(got...) {
 						err = fmt.Errorf("the account is using %s oauth scopes, please make sure you are using at least one of the following oauth scopes: %s", authorizedScopes, acceptedScopes)
 					} else {
 						body, _ := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
Bona-fide 403s can have empty `x-accepted-oauth-scopes` headers, making
calls emit a misleading error log message and eat the useful error
message (note the empty "following oauth scopes"):

```
the account is using notifications, read:org, read:user, repo, please make sure you are using at least one of the following oauth scopes:
````

Reproducer (use a repo where `user` does not have any permissions):

```console
$ curl -u user:$token -X GET https:/api.github.com/repos/org/repo/collaborators -v
...
< x-oauth-scopes: notifications, read:org, read:user, repo, workflow
< x-accepted-oauth-scopes: 
...
{
  "message": "Must have push access to view repository collaborators.",
  "documentation_url": "https://docs.github.com/rest/reference/repos#list-repository-collaborators"
}
```