### PR TITLE
test-infra: add golangci-lint Job

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,8 @@
+run:
+  deadline: 10m
+
+linters:
+  disable-all: true
+  enable:
+  - gofmt
+  - misspell

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -17,13 +17,41 @@ presubmits:
         - test
         - --config=ci
         - --nobuild_tests_only
+        - --
         - //...
+        - -//hack:verify-golangci-lint
         env:
         - name: BAZEL_FETCH_PLEASE
           value: //...
     annotations:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: bazel
+
+  - name: pull-test-infra-golangci-lint
+    branches:
+    - master
+    always_run: true
+    optional: true
+    decorate: true
+    labels:
+      preset-service-account: "true"
+      preset-bazel-scratch-dir: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:v20210204-b06ec78-test-infra
+        command:
+        - hack/bazel.sh
+        args:
+        - test
+        - --config=ci
+        - --nobuild_tests_only
+        - //hack:verify-golangci-lint
+        env:
+        - name: BAZEL_FETCH_PLEASE
+          value: //...
+    annotations:
+      testgrid-dashboards: presubmits-test-infra
+      testgrid-tab-name: golangci-lint
 
   - name: pull-test-infra-gubernator
     branches:

--- a/hack/BUILD.bazel
+++ b/hack/BUILD.bazel
@@ -223,6 +223,13 @@ test_suite(
 )
 
 test_suite(
+    name = "verify-golangci-lint",
+    tests = [
+        "@io_k8s_repo_infra//hack:verify-golangci-lint",
+    ],
+)
+
+test_suite(
     name = "verify-linters",
     tags = ["lint"],  # picks up all non-manual targets with this tag
 )

--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if ! command -v bazel &> /dev/null; then
+  echo "Install bazel at https://bazel.build" >&2
+  exit 1
+fi
+
+set -o xtrace
+bazel test --test_output=streamed @io_k8s_repo_infra//hack:verify-golangci-lint

--- a/prow/version/doc_test.go
+++ b/prow/version/doc_test.go
@@ -33,7 +33,7 @@ func TestVersionTimestamp(t *testing.T) {
 			false,
 		},
 		{
-			"invlid version",
+			"invalid version",
 			"v20200102a-a1b2c3",
 			0,
 			true,


### PR DESCRIPTION
Bazel-based implementation of golangci-lint

Hope this helps to resolve the deadlock from: https://github.com/kubernetes/test-infra/pull/19589#discussion_r507889662

xref: 
* https://github.com/kubernetes/test-infra/pull/19589
* https://github.com/kubernetes/test-infra/issues/19588

Notes:
* idea is to start with an additional optional job for now and make it mandatory and add additional linter over time
* do we want to use the same golangci-lint version as in repo infra:
  * let's use the same version for now. 1.34.1 is reasonable up-to-date and we can always move away from repo-infra in case we really have to 
* do we want to run golangci-lint in a separate job
  * I tested to run it with the regular bazel job and I always hit a 10m timeout. Even if we adjust the timeout the bazel Job would get significantly slower


I'm not sure how to get the tests green as we basically first need the changes to the `pull-test-infra-bazel ` job. Should I open a PR to exclude the golangci-linter first so this PR get's green before merge, wdyt?