### PR TITLE
cluster-api migrate to new capi alert group

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
@@ -225,7 +225,7 @@ periodics:
     # this is the name of some testgrid dashboard to report to.
     testgrid-dashboards: sig-cluster-lifecycle-image-pushes
     testgrid-tab-name: cluster-api-push-images-nightly
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
 - name: cluster-api-provider-openstack-push-images-nightly
   cluster: k8s-infra-prow-build-trusted
   decorate: true
@@ -257,4 +257,4 @@ periodics:
     # this is the name of some testgrid dashboard to report to.
     testgrid-dashboards: sig-cluster-lifecycle-image-pushes
     testgrid-tab-name: cluster-api-provider-openstack-push-images-nightly
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
@@ -37,7 +37,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
     testgrid-tab-name: periodic-e2e-v1alpha3
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-provider-aws-capi-e2e-v1alpha3
   decorate: true
@@ -79,7 +79,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
     testgrid-tab-name: periodic-capi-e2e-v1alpha3
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-provider-aws-e2e-v1alpha2
   decorate: true
@@ -117,7 +117,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
     testgrid-tab-name: periodic-e2e-v1alpha2
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-provider-aws-e2e-conformance-v1alpha3
   decorate: true
@@ -155,7 +155,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
     testgrid-tab-name: periodic-e2e-conformance-v1alpha3
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-provider-aws-e2e-conformance-v1alpha2
   decorate: true
@@ -193,7 +193,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
     testgrid-tab-name: periodic-e2e-conformance-v1alpha2
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-provider-aws-e2e-conformance-v1alpha2-with-k8s-ci-artifacts
   max_concurrency: 1
@@ -250,7 +250,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
     testgrid-tab-name: capa-conformance-v1alpha2-k8s-master
     testgrid-num-columns-recent: '20'
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
 - name: periodic-cluster-api-provider-aws-e2e-conformance-v1alpha3-with-k8s-ci-artifacts
   max_concurrency: 1
   labels:
@@ -305,4 +305,4 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws, sig-release-master-informing
     testgrid-tab-name: capa-conformance-v1alpha3-k8s-master
     testgrid-num-columns-recent: '20'
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com, release-team@kubernetes.io
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io, release-team@kubernetes.io

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
@@ -35,7 +35,7 @@ postsubmits:
         testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
         testgrid-tab-name: ci-e2e
         testgrid-num-columns-recent: '20'
-        testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+        testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     - name: ci-cluster-api-provider-aws-e2e-conformance
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
       decorate: true
@@ -69,4 +69,4 @@ postsubmits:
         testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
         testgrid-tab-name: ci-e2e-conformance
         testgrid-num-columns-recent: '20'
-        testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+        testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics-janitor.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics-janitor.yaml
@@ -24,4 +24,4 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
     testgrid-tab-name: capdo-periodic-janitor
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics-release-0-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics-release-0-4.yaml
@@ -28,4 +28,4 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
     testgrid-tab-name: capdo-periodic-conformance-release-0-4
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics.yaml
@@ -28,4 +28,4 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
     testgrid-tab-name: capdo-periodic-conformance
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-release-0-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-release-0-3.yaml
@@ -45,7 +45,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
     testgrid-tab-name: capg-conformance-v1alpha3-release-0-3
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-provider-gcp-make-conformance-v1alpha3-k8s-ci-artifacts
   labels:
@@ -94,5 +94,5 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
     testgrid-tab-name: capg-conformance-v1alpha3-release-0-3-ci-artifacts
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics.yaml
@@ -87,7 +87,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
     testgrid-tab-name: capg-conformance-v1alpha4
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-provider-gcp-make-conformance-v1alpha4-k8s-ci-artifacts
   labels:
@@ -136,5 +136,5 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp, sig-release-master-informing
     testgrid-tab-name: capg-conformance-v1alpha4-k8s-master
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com, release-team@kubernetes.io
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io, release-team@kubernetes.io
     testgrid-num-failures-to-alert: "2"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics.yaml
@@ -1,5 +1,5 @@
 periodics:
-- name: periodic-cluster-api-provider-openstack-e2e-test-master
+- name: periodic-cluster-api-provider-openstack-e2e-test-main
   labels:
     preset-service-account: "true"
     preset-bazel-scratch-dir: "true"
@@ -41,8 +41,10 @@ periodics:
           cpu: 2000m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
-    testgrid-tab-name: periodic-e2e-test-master
-- name: periodic-cluster-api-provider-openstack-conformance-test-master-with-k8s-ci-artifacts
+    testgrid-tab-name: periodic-e2e-test-main
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "2"
+- name: periodic-cluster-api-provider-openstack-conformance-test-main-with-k8s-ci-artifacts
   labels:
     preset-service-account: "true"
     preset-bazel-scratch-dir: "true"
@@ -91,4 +93,6 @@ periodics:
           cpu: 2000m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
-    testgrid-tab-name: periodic-conformance-test-master
+    testgrid-tab-name: periodic-conformance-test-main
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "2"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
@@ -40,7 +40,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi-e2e-main-1-17-1-18
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-18-1-19-main
@@ -84,7 +84,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi-e2e-main-1-18-1-19
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-19-1-20-main
@@ -128,7 +128,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi-e2e-main-1-19-1-20
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-20-latest-main
@@ -172,5 +172,5 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi-e2e-main-1-20-latest
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -20,7 +20,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi-test-main
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-e2e-main
   interval: 1h
@@ -51,7 +51,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi-e2e-main
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-verify-book-links-main
   interval: 6h

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-3.yaml
@@ -20,7 +20,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.3
     testgrid-tab-name: capi-test-release-0-3
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-e2e-release-0-3
   interval: 1h
@@ -48,7 +48,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.3
     testgrid-tab-name: capi-e2e-release-0-3
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-verify-book-links-release-0-3
   interval: 6h


### PR DESCRIPTION
Notes:
* migrates to the new alert mailing list
* adds alerts for CAPO periodic jobs

xref:
* https://github.com/kubernetes/k8s.io/pull/1884
* https://github.com/kubernetes/k8s.io/issues/1863