### PR TITLE
Update milestone applier for k/website dev-1.22 release branch

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -381,7 +381,7 @@ milestone_applier:
     release-0.6: v0.6.x
     release-0.5: v0.5.x
   kubernetes/website:
-    dev-1.21: 1.21
+    dev-1.22: 1.22
 
 repo_milestone:
   # Default maintainer


### PR DESCRIPTION
Update the k/website milestone applier for the `dev-1.22` branch to automatically apply the 1.22 milestone for PRs created against the `dev-1.22` branch

/hold for review from @kubernetes/sig-docs-leads
