### PR TITLE
test-infra: add (no-op) golangci-lint job

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -17,13 +17,41 @@ presubmits:
         - test
         - --config=ci
         - --nobuild_tests_only
+        - --
         - //...
+        - -//hack:verify-golangci-lint
         env:
         - name: BAZEL_FETCH_PLEASE
           value: //...
     annotations:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: bazel
+
+  - name: pull-test-infra-golangci-lint
+    branches:
+    - master
+    always_run: false
+    optional: true
+    decorate: true
+    labels:
+      preset-service-account: "true"
+      preset-bazel-scratch-dir: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:v20210204-b06ec78-test-infra
+        command:
+        - hack/bazel.sh
+        args:
+        - test
+        - --config=ci
+        - --nobuild_tests_only
+        - //hack:verify-golangci-lint
+        env:
+        - name: BAZEL_FETCH_PLEASE
+          value: //...
+    annotations:
+      testgrid-dashboards: presubmits-test-infra
+      testgrid-tab-name: golangci-lint
 
   - name: pull-test-infra-gubernator
     branches:

--- a/hack/BUILD.bazel
+++ b/hack/BUILD.bazel
@@ -223,6 +223,11 @@ test_suite(
 )
 
 test_suite(
+    name = "verify-golangci-lint",
+    tests = [],
+)
+
+test_suite(
     name = "verify-linters",
     tags = ["lint"],  # picks up all non-manual targets with this tag
 )


### PR DESCRIPTION
xref: https://github.com/kubernetes/test-infra/pull/21719#discussion_r609993039

As discussed. I would change it to `always_run` true in the 2nd PR.

I tested it locally by executing:
```
./hack/bazel.sh test --nobuild_tests_only -- //... -//hack:verify-golangci-lint
./hack/bazel.sh test --nobuild_tests_only //hack:verify-golangci-lint
```