### PR TITLE
cluster-api-provider-openstack: send stale test alerts after 48h

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics.yaml
@@ -44,6 +44,7 @@ periodics:
     testgrid-tab-name: periodic-e2e-test-main
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
+    testgrid-alert-stale-results-hours: "48"
 - name: periodic-cluster-api-provider-openstack-conformance-test-main-with-k8s-ci-artifacts
   labels:
     preset-service-account: "true"
@@ -96,3 +97,4 @@ periodics:
     testgrid-tab-name: periodic-conformance-test-main
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
+    testgrid-alert-stale-results-hours: "48"


### PR DESCRIPTION
After we added the alerts yesterday there where already alerts today. Problem is that we run the tests every 12h hours and we get the first alert after 12h without new results.

xref: https://kubernetes.slack.com/archives/C8TSNPY4T/p1617911492444300