### PR TITLE
Soak time for containerd 1.5.0 using release candidate rc.0

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -298,8 +298,8 @@ presubmits:
             - --build=quick
             - --cluster=
             - --env=KUBE_CONTAINER_RUNTIME=containerd
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.4.3
-            - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc92
+            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.0-rc.0
+            - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc93
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=ENABLE_POD_SECURITY_POLICY=true
             - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -359,8 +359,8 @@ presubmits:
             - --build=quick
             - --cluster=
             - --env=KUBE_CONTAINER_RUNTIME=containerd
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.4.3
-            - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc92
+            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.0-rc.0
+            - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc93
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=ENABLE_POD_SECURITY_POLICY=true
             - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -537,8 +537,8 @@ periodics:
           - --
           - --check-leaked-resources
           - --env=KUBE_CONTAINER_RUNTIME=containerd
-          - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.4.3
-          - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc92
+          - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.0-rc.0
+          - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc93
           - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
           - --env=ENABLE_POD_SECURITY_POLICY=true
           - --env=CONTAINER_RUNTIME_TEST_HANDLER=true

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -33,8 +33,8 @@ presubmits:
         - --env=ALLOW_PRIVILEGED=true
         - --env=NETWORK_POLICY_PROVIDER=calico
         - --env=KUBE_CONTAINER_RUNTIME=containerd
-        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.4.0
-        - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc92
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.0-rc.0
+        - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc93
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
         - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
@@ -583,8 +583,8 @@ periodics:
       - --env=ALLOW_PRIVILEGED=true
       - --env=NET_PLUGIN=kubenet
       - --env=KUBE_CONTAINER_RUNTIME=containerd
-      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.4.3
-      - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc92
+      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.0-rc.0
+      - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc93
       - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
       - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
       - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
@@ -620,8 +620,8 @@ periodics:
       - --env=ALLOW_PRIVILEGED=true
       - --env=NETWORK_POLICY_PROVIDER=calico
       - --env=KUBE_CONTAINER_RUNTIME=containerd
-      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.4.0
-      - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc92
+      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.0-rc.0
+      - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc93
       - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
       - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
       - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu


### PR DESCRIPTION
Note that the matching runc version is now documented in a file here:
https://github.com/containerd/containerd/blob/v1.5.0-rc.0/script/setup/runc-version

Signed-off-by: Davanum Srinivas <davanum@gmail.com>