### PR TITLE
Needs rebase: Make hourly tokens configurable

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -395,7 +395,13 @@ type throttlerDelegate struct {
 }
 
 func (t *throttler) Wait() {
+	start := time.Now()
 	log := logrus.WithFields(logrus.Fields{"client": "github", "throttled": true})
+	defer func() {
+		if waitTime := time.Since(start); waitTime > time.Minute {
+			log.WithField("throttle-duration", waitTime.String()).Warn("Throttled clientside for more than a minute")
+		}
+	}()
 	t.lock.RLock()
 	defer t.lock.RUnlock()
 	var more bool


### PR DESCRIPTION
We had occurences where the clientside throttling took more than 2h. This PR also adds a warning if throttling takes more than a minute, because it took some time until @petr-muller realized that a 2h long api request is caused by the clientside throttling.

Related: https://github.com/kubernetes/test-infra/issues/21691

I will probably make another PR to add github apps support, because we have a lot more tokens there. Right now it won't work due to the v4 usage.