### PR TITLE
Update CAPI jobs for Kubernetes 1.21

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
@@ -1,47 +1,4 @@
 periodics:
-- name: periodic-cluster-api-e2e-workload-upgrade-1-17-1-18-main
-  interval: 24h
-  decorate: true
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: cluster-api
-    base_ref: master
-    path_alias: sigs.k8s.io/cluster-api
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210403-e49d2c6-go-canary
-      args:
-        - runner.sh
-        - "./scripts/ci-e2e.sh"
-      env:
-        - name: KUBERNETES_VERSION_UPGRADE_FROM
-          value: "stable-1.17"
-        - name: KUBERNETES_VERSION_UPGRADE_TO
-          value: "stable-1.18"
-        - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.4.3-0"
-        - name: COREDNS_VERSION_UPGRADE_TO
-          value: "1.6.7"
-        - name: GINKGO_FOCUS
-          value: "\\[K8s-Upgrade\\]"
-      # we need privileged mode in order to do docker in docker
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          cpu: 7300m
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-    testgrid-tab-name: capi-e2e-main-1-17-1-18
-    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-18-1-19-main
   interval: 24h
@@ -131,7 +88,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 
-- name: periodic-cluster-api-e2e-workload-upgrade-1-20-latest-main
+- name: periodic-cluster-api-e2e-workload-upgrade-1-20-1-21-main
   interval: 24h
   decorate: true
   labels:
@@ -156,7 +113,7 @@ periodics:
         - name: KUBERNETES_VERSION_UPGRADE_FROM
           value: "stable-1.20"
         - name: KUBERNETES_VERSION_UPGRADE_TO
-          value: "ci/latest-1.21"
+          value: "stable-1.21"
         - name: ETCD_VERSION_UPGRADE_TO
           value: "3.4.13-0"
         - name: COREDNS_VERSION_UPGRADE_TO
@@ -171,6 +128,50 @@ periodics:
           cpu: 7300m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-    testgrid-tab-name: capi-e2e-main-1-20-latest
+    testgrid-tab-name: capi-e2e-main-1-20-1-21
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "2"
+
+- name: periodic-cluster-api-e2e-workload-upgrade-1-21-latest-main
+  interval: 24h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api
+    base_ref: master
+    path_alias: sigs.k8s.io/cluster-api
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210403-e49d2c6-go-canary
+      args:
+        - runner.sh
+        - "./scripts/ci-e2e.sh"
+      env:
+        - name: KUBERNETES_VERSION_UPGRADE_FROM
+          value: "stable-1.21"
+        - name: KUBERNETES_VERSION_UPGRADE_TO
+          value: "ci/latest-1.22"
+        - name: ETCD_VERSION_UPGRADE_TO
+          value: "3.4.13-0"
+        - name: COREDNS_VERSION_UPGRADE_TO
+          value: "1.8.0"
+        - name: GINKGO_FOCUS
+          value: "\\[K8s-Upgrade\\]"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+    testgrid-tab-name: capi-e2e-main-1-21-latest
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -169,7 +169,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-e2e-full-main
-  - name: pull-cluster-api-e2e-workload-upgrade-1-20-latest-main
+  - name: pull-cluster-api-e2e-workload-upgrade-1-21-latest-main
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -193,9 +193,9 @@ presubmits:
           - "./scripts/ci-e2e.sh"
         env:
           - name: KUBERNETES_VERSION_UPGRADE_FROM
-            value: "stable-1.20"
+            value: "stable-1.21"
           - name: KUBERNETES_VERSION_UPGRADE_TO
-            value: "ci/latest-1.21"
+            value: "ci/latest-1.22"
           - name: ETCD_VERSION_UPGRADE_TO
             value: "3.4.13-0"
           - name: COREDNS_VERSION_UPGRADE_TO
@@ -210,4 +210,4 @@ presubmits:
             cpu: 7300m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-      testgrid-tab-name: capi-pr-e2e-main-1-20-latest
+      testgrid-tab-name: capi-pr-e2e-main-1-21-latest


### PR DESCRIPTION
This PR updates CAPI jobs for Kubernetes 1.21, more specifically
- workload-upgrade-1-17-1-18 is dropped
- workload-upgrade-1-20-master is now workload-upgrade-1-20-1.21
- workload-upgrade-1-21-master was added

/assign @vincepri 
@sbueringer 