### PR TITLE
Reference CI scripts in new location

### DIFF
--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
@@ -14,7 +14,7 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210403-e49d2c6-master
         args:
           - runner.sh
-          - "./images/capi/packer/azure/scripts/ci-azure-e2e.sh"
+          - "./images/capi/scripts/ci-azure-e2e.sh"
         resources:
           requests:
             cpu: 1000m
@@ -36,7 +36,7 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210403-e49d2c6-master
         args:
           - runner.sh
-          - "./images/capi/packer/azure/scripts/ci-azure-e2e.sh"
+          - "./images/capi/scripts/ci-azure-e2e.sh"
         env:
           - name: AZURE_BUILD_FORMAT
             value: "sig"
@@ -58,7 +58,7 @@ presubmits:
         - image: gcr.io/k8s-testimages/kubekins-e2e:v20210403-e49d2c6-master
           args:
             - runner.sh
-            - "./images/capi/hack/ci-json-sort.sh"
+            - "./images/capi/scripts/ci-json-sort.sh"
           resources:
             requests:
               cpu: 1000m
@@ -96,7 +96,7 @@ presubmits:
         - image: gcr.io/k8s-testimages/kubekins-e2e:v20210403-e49d2c6-master
           args:
             - runner.sh
-            - "./images/capi/packer/gce/scripts/ci-gce.sh"
+            - "./images/capi/scripts/ci-gce.sh"
           env:
             - name: BOSKOS_HOST
               value: "boskos.test-pods.svc.cluster.local"


### PR DESCRIPTION
All image-builder CI scripts are now in images/capi/scripts.

/hold
^ Hold for https://github.com/kubernetes-sigs/image-builder/pull/586