### PR TITLE
Needs-Rebase: Add github apps auth support

### DIFF
--- a/prow/external-plugins/needs-rebase/main.go
+++ b/prow/external-plugins/needs-rebase/main.go
@@ -124,7 +124,7 @@ func main() {
 
 	interrupts.TickLiteral(func() {
 		start := time.Now()
-		if err := plugin.HandleAll(log, githubClient, pa.Config()); err != nil {
+		if err := plugin.HandleAll(log, githubClient, pa.Config(), o.github.AppID != ""); err != nil {
 			log.WithError(err).Error("Error during periodic update of all PRs.")
 		}
 		log.WithField("duration", fmt.Sprintf("%v", time.Since(start))).Info("Periodic update complete.")

--- a/prow/external-plugins/needs-rebase/plugin/BUILD.bazel
+++ b/prow/external-plugins/needs-rebase/plugin/BUILD.bazel
@@ -25,6 +25,8 @@ go_test(
         "//prow/github:go_default_library",
         "//prow/labels:go_default_library",
         "//prow/plugins:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
+        "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
         "@com_github_shurcool_githubv4//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],


### PR DESCRIPTION
This change updates the needs-rebase plugin to shard it's graphql query
by org if GitHub apps auth is enabled. No changes are needed for the v3
api usage.

The motivation is that this plugin is a signifcant token consumer and we
have a lot more of them available when using apps auth.