### PR TITLE
Horologium: Use a cached prowjob client

### DIFF
--- a/config/prow-staging/cluster/horologium_rbac.yaml
+++ b/config/prow-staging/cluster/horologium_rbac.yaml
@@ -31,6 +31,7 @@ rules:
     verbs:
       - create
       - list
+      - watch
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/prow/cluster/horologium_rbac.yaml
+++ b/config/prow/cluster/horologium_rbac.yaml
@@ -17,6 +17,7 @@ rules:
     verbs:
       - create
       - list
+      - watch
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -138,6 +138,7 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *April 12th, 2021* Horologium now uses a cached client, which requires it to have watch permissions for Prowjobs on top of the already-required list and create.
  - *April 11th, 2021* The plank binary has been removed. Please use the [Prow Controller Manager](/prow/cmd/prow-controller-manager) instead, which provides a more modern implementation
    of the same functionality.
  - *April 1st, 2021* The `owners_dir_blacklist` field in prow config has been deprecated in favor of `owners_dir_denylist`. The support of `owners_dir_blacklist` will be stopped in October 2021.

--- a/prow/cmd/horologium/BUILD.bazel
+++ b/prow/cmd/horologium/BUILD.bazel
@@ -32,9 +32,9 @@ go_library(
         "//prow/metrics:go_default_library",
         "//prow/pjutil:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
-        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
-        "@io_k8s_apimachinery//pkg/labels:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/cluster:go_default_library",
     ],
 )
 
@@ -57,12 +57,12 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
-        "//prow/client/clientset/versioned/fake:go_default_library",
         "//prow/config:go_default_library",
         "//prow/flagutil:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
-        "@io_k8s_client_go//testing:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client/fake:go_default_library",
     ],
 )


### PR DESCRIPTION
This change makes Horologium use a cached prowjob client instead of
doing a List every minute against the API. This significantly
reduces the load both on the kube api and on horologium, because they
don't have to (de-) serialize a couple of hundred MB of json every
Minute.