### PR TITLE
Needs rebase: Don't always require github token

### DIFF
--- a/prow/external-plugins/needs-rebase/main.go
+++ b/prow/external-plugins/needs-rebase/main.go
@@ -99,7 +99,11 @@ func main() {
 	log := logrus.StandardLogger().WithField("plugin", labels.NeedsRebase)
 
 	secretAgent := &secret.Agent{}
-	if err := secretAgent.Start([]string{o.github.TokenPath, o.webhookSecretFile}); err != nil {
+	secrets := []string{o.webhookSecretFile}
+	if o.github.TokenPath != "" {
+		secrets = append(secrets, o.github.TokenPath)
+	}
+	if err := secretAgent.Start(secrets); err != nil {
 		logrus.WithError(err).Fatal("Error starting secrets agent.")
 	}
 

--- a/prow/flagutil/github.go
+++ b/prow/flagutil/github.go
@@ -134,7 +134,7 @@ func (o *GitHubOptions) githubClient(secretAgent *secret.Agent, dryRun bool) (gi
 			return nil, fmt.Errorf("cannot store token from %q without a secret agent", o.AppPrivateKeyPath)
 		}
 		if err := secretAgent.Add(o.AppPrivateKeyPath); err != nil {
-			return nil, fmt.Errorf("failed to add the the key from --app-private-key-path to scret agent: %w", err)
+			return nil, fmt.Errorf("failed to add the the key from --app-private-key-path to secret agent: %w", err)
 		}
 		appsGenerator = func() *rsa.PrivateKey {
 			raw := secretAgent.GetTokenGenerator(o.AppPrivateKeyPath)()


### PR DESCRIPTION
When using apps auth, the token isn't needed.

I've manually deployed this with apps auth to check if it works now, which it does.