### PR TITLE
cluster-api: fix tag of coredns 1.8.0 image in upgrade tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
@@ -117,7 +117,7 @@ periodics:
         - name: ETCD_VERSION_UPGRADE_TO
           value: "3.4.13-0"
         - name: COREDNS_VERSION_UPGRADE_TO
-          value: "1.8.0"
+          value: "v1.8.0"
         - name: GINKGO_FOCUS
           value: "\\[K8s-Upgrade\\]"
       # we need privileged mode in order to do docker in docker
@@ -161,7 +161,7 @@ periodics:
         - name: ETCD_VERSION_UPGRADE_TO
           value: "3.4.13-0"
         - name: COREDNS_VERSION_UPGRADE_TO
-          value: "1.8.0"
+          value: "v1.8.0"
         - name: GINKGO_FOCUS
           value: "\\[K8s-Upgrade\\]"
       # we need privileged mode in order to do docker in docker

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -199,7 +199,7 @@ presubmits:
           - name: ETCD_VERSION_UPGRADE_TO
             value: "3.4.13-0"
           - name: COREDNS_VERSION_UPGRADE_TO
-            value: "1.8.0"
+            value: "v1.8.0"
           - name: GINKGO_FOCUS
             value: "\\[K8s-Upgrade\\]"
         # we need privileged mode in order to do docker in docker


### PR DESCRIPTION
coredns image name has changed. So we have to adjust the COREDNS_VERSION:
* k8s.gcr.io/coredns:1.7.0
* k8s.gcr.io/coredns/coredns:v1.7.0
* k8s.gcr.io/coredns/coredns:v1.8.0

In theory we could also handle the `v` prefix in the e2e test, I personally prefer to avoid this, as it's less "magic" specifying the tag here correctly.

Part of a fix for:
* https://github.com/kubernetes-sigs/cluster-api/issues/4462
* https://github.com/kubernetes-sigs/cluster-api/issues/4463

We only have to adjust the tag, kubeadm will handle the rest.