### PR TITLE
Create verify install packages periodic job

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -483,3 +483,26 @@ periodics:
   rerun_auth_config:
     github_team_ids:
       - 2241179 # release-managers
+- name: periodic-release-verify-install-packages
+  interval: 6h
+  annotations:
+    testgrid-alert-email: release-managers+alerts@kubernetes.io
+    testgrid-dashboards: sig-release-releng-informing
+    testgrid-tab-name: verify-install-packages
+  decorate: true
+  extra_refs:
+  - org: kubernetes
+    repo: release
+    base_ref: master
+    path_alias: k8s.io/release
+  spec:
+    containers:
+    - image: quay.io/k8s/release-tools-centos:latest
+      imagePullPolicy: Always
+      command:
+      - make
+      - verify-installed-debs
+  rerun_auth_config:
+    github_team_ids:
+      - 2241179 # release-managers
+


### PR DESCRIPTION
**Why this PR?** 

This PR adds a periodic job to testgrid that verifies the installed debian packages. 
This corresponds to the script added here https://github.com/kubernetes/release/pull/1997 and originally references this issue https://github.com/kubernetes/release/issues/821