### PR TITLE
releng: Correct k8s-cloud-builder registry name

### DIFF
--- a/config/jobs/image-pushing/releng/k8s-staging-releng.yaml
+++ b/config/jobs/image-pushing/releng/k8s-staging-releng.yaml
@@ -124,7 +124,7 @@ postsubmits:
               - name: LOG_TO_STDOUT
                 value: "y"
               - name: REGISTRY
-                value: "gcr.io/k8s-staging-build-image"
+                value: "gcr.io/k8s-staging-releng"
       rerun_auth_config:
         github_team_ids:
           - 2241179 # release-managers


### PR DESCRIPTION
Recently we introduced a `$REGISTRY` variable to control the registry where we push some of our images.
During the change, the registry for the `k8s-cloud-builder` image was specified incorrectly. This PR fixes the registry name.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>