### PR TITLE
Revert "Revert "Block conformance changes on release branches in k/k""

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -163,6 +163,12 @@ blockades:
   - ^pkg/util/[^/]+\.go$
   explanation: "Utility code must be added to a subpackage like pkg/util/flag, not pkg/util directly. See: #49923"
 - repos:
+  - kubernetes/kubernetes
+  blockregexps:
+  - ^test/conformance/testdata/conformance.yaml$
+  branchregexp: "^release-*"
+  explanation: "`test/conformance/testdata/conformance.yaml` cannot be updated on release branches."
+- repos:
   - kubernetes/community
   blockregexps:
   - ^events/2016


### PR DESCRIPTION
This reverts commit 354567c63fbd557b8325222ecfc2107eda23b02b.

Related PRs:
- #21021 introduced the ability to configure blockades per branch
-  #21082 added the relvant config change to the blockade plugin - to block conformance changes on release branches in k/k
- Identified NPE after #21082 merged, config change reverted - https://github.com/kubernetes/test-infra/pull/21092
- NPE fixed in blockade in https://github.com/kubernetes/test-infra/pull/21093
- #21410 made hook recover from any panics in plugins


Given that the NPE was fixed and proper panic handling was introduced to hook, it should be safe to introduce this config change again.

cc @Riaankl @hh @dims @spiffxp 

/assign @dims 