### PR TITLE
Temporarily disable KUBEMARK_NODE_OBJECT_SIZE_BYTES feature for kubemark-5k

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -467,6 +467,8 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
+      # TODO(mm4tt): Remove after 2021-04-15
+      - --env=KUBEMARK_NODE_OBJECT_SIZE_BYTES=
       - --cluster=kubemark-5000
       - --extract=ci/latest
       - --gcp-node-image=gci


### PR DESCRIPTION
Kubemark 5k jobs are continuously failing. 
At a cursory glance, there are performance issues for node related api calls. I wanted to see how it would work without this extra node annotation.