### PR TITLE
drop handling of gcs/ job url prefix

### DIFF
--- a/config/prow/cluster/starter-gcs.yaml
+++ b/config/prow/cluster/starter-gcs.yaml
@@ -85,8 +85,7 @@ data:
 
     plank:
       job_url_prefix_config:
-        # TODO: Remove the gcs suffix once https://github.com/kubernetes/test-infra/pull/17779 is in
-        "*": https://prow.<< your-domain.com >>/view/gs
+        "*": https://prow.<< your-domain.com >>/view/
       report_templates:
         '*': >-
             [Full PR test history](https://prow.<< your-domain.com >>/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).

--- a/prow/cmd/checkconfig/testdata/combined.yaml
+++ b/prow/cmd/checkconfig/testdata/combined.yaml
@@ -31,7 +31,7 @@ deck:
       - artifacts/junit.*\.xml
 plank:
   job_url_prefix_config:
-    '*': "https://prow.maistra.io/view/gcs/"
+    '*': "https://prow.maistra.io/view/"
   default_decoration_configs:
     '*':
       timeout: 2h

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -640,19 +640,8 @@ func (p *Plank) FinalizeDefaultDecorationConfigs() error {
 }
 
 // GetJobURLPrefix gets the job url prefix from the config
-// for the given refs. As we're deprecating the "gcs/" suffix
-// (to allow using multiple storageProviders within a repo)
-// we always trim the suffix here. Thus, every caller can assume
-// the job url prefix does not have a storageProvider suffix.
+// for the given refs.
 func (p Plank) GetJobURLPrefix(pj *prowapi.ProwJob) string {
-	jobURLPrefix := p.getJobURLPrefix(pj)
-	if strings.HasSuffix(jobURLPrefix, "gcs/") {
-		return strings.TrimSuffix(jobURLPrefix, "gcs/")
-	}
-	return strings.TrimSuffix(jobURLPrefix, "gcs")
-}
-
-func (p Plank) getJobURLPrefix(pj *prowapi.ProwJob) string {
 	if pj.Spec.DecorationConfig != nil && pj.Spec.DecorationConfig.GCSConfiguration != nil && pj.Spec.DecorationConfig.GCSConfiguration.JobURLPrefix != "" {
 		return pj.Spec.DecorationConfig.GCSConfiguration.JobURLPrefix
 	}
@@ -1534,14 +1523,6 @@ func (c *Config) validateComponentConfig() error {
 	for k, v := range c.Plank.JobURLPrefixConfig {
 		if _, err := url.Parse(v); err != nil {
 			return fmt.Errorf(`Invalid value for Planks job_url_prefix_config["%s"]: %v`, k, err)
-		}
-		// TODO(@sbueringer): Remove in September 2020
-		if strings.HasSuffix(v, "gcs/") {
-			logrus.Warning(strings.Join([]string{
-				"configuring the 'gcs/' storage provider suffix in the job url prefix is now deprecated, ",
-				"please configure the job url prefix without the suffix as it's now appended automatically. Handling of the old ",
-				"configuration will be removed in September 2020",
-			}, ""))
 		}
 	}
 	if c.Gerrit.DeckURL != "" {

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -3160,11 +3160,6 @@ func TestPlankJobURLPrefix(t *testing.T) {
 			prowjob:              &prowjobv1.ProwJob{Spec: prowjobv1.ProwJobSpec{Refs: &prowapi.Refs{Org: "my-alternate-org", Repo: "my-second-repo"}}},
 			expectedJobURLPrefix: "https://my-prow",
 		},
-		{
-			name:                 "gcs/ suffix in JobURLPrefix will be automatically trimmed",
-			plank:                Plank{JobURLPrefixConfig: map[string]string{"*": "https://my-prow/view/gcs/"}},
-			expectedJobURLPrefix: "https://my-prow/view/",
-		},
 	}
 
 	for _, tc := range testCases {

--- a/prow/pjutil/pjutil_test.go
+++ b/prow/pjutil/pjutil_test.go
@@ -854,44 +854,6 @@ func TestJobURL(t *testing.T) {
 			expected: "https://gubernator.com/build/bucket/pr-logs/pull/org_repo/1",
 		},
 		{
-			name: "decorated job with prefix uses gcsupload and new bucket format with gcs (deprecated job url format)",
-			plank: config.Plank{
-				JobURLPrefixConfig: map[string]string{"*": "https://prow.k8s.io/view/gcs"},
-			},
-			pj: prowapi.ProwJob{Spec: prowapi.ProwJobSpec{
-				Type: prowapi.PresubmitJob,
-				Refs: &prowapi.Refs{
-					Org:   "org",
-					Repo:  "repo",
-					Pulls: []prowapi.Pull{{Number: 1}},
-				},
-				DecorationConfig: &prowapi.DecorationConfig{GCSConfiguration: &prowapi.GCSConfiguration{
-					Bucket:       "gs://bucket",
-					PathStrategy: prowapi.PathStrategyExplicit,
-				}},
-			}},
-			expected: "https://prow.k8s.io/view/gs/bucket/pr-logs/pull/org_repo/1",
-		},
-		{
-			name: "decorated job with prefix uses gcsupload and new bucket format with gcs (deprecated job url format with trailing slash)",
-			plank: config.Plank{
-				JobURLPrefixConfig: map[string]string{"*": "https://prow.k8s.io/view/gcs/"},
-			},
-			pj: prowapi.ProwJob{Spec: prowapi.ProwJobSpec{
-				Type: prowapi.PresubmitJob,
-				Refs: &prowapi.Refs{
-					Org:   "org",
-					Repo:  "repo",
-					Pulls: []prowapi.Pull{{Number: 1}},
-				},
-				DecorationConfig: &prowapi.DecorationConfig{GCSConfiguration: &prowapi.GCSConfiguration{
-					Bucket:       "gs://bucket",
-					PathStrategy: prowapi.PathStrategyExplicit,
-				}},
-			}},
-			expected: "https://prow.k8s.io/view/gs/bucket/pr-logs/pull/org_repo/1",
-		},
-		{
 			name: "decorated job with prefix uses gcsupload and new bucket format with gcs (new job url format)",
 			plank: config.Plank{
 				JobURLPrefixConfig: map[string]string{"*": "https://prow.k8s.io/view/"},

--- a/prow/spyglass/README.md
+++ b/prow/spyglass/README.md
@@ -21,7 +21,7 @@ To enable spyglass, just pass the `--spyglass` flag to your `deck` instance. Onc
 it will expose itself under `/view/` on your `deck` instance.
 
 In order to make Spyglass useful, you may want to set your job URLs to point at it. You can do so by
-setting `plank.job_url_prefix_config['*']` to `https://your.deck/view/gs/`, and possibly `plank.job_url_template`
+setting `plank.job_url_prefix_config['*']` to `https://your.deck/view/`, and possibly `plank.job_url_template`
 to reference something similar depending on your setup.
 
 If you are not using the images we provide, you may also need to provide `--spyglass-files-location`,

--- a/testgrid/cmd/configurator/prow_test.go
+++ b/testgrid/cmd/configurator/prow_test.go
@@ -664,15 +664,6 @@ func Test_applySingleProwjobAnnotations_OpenTestTemplate(t *testing.T) {
 			},
 		},
 		{
-			name: "job url prefix ends in /gcs, removed",
-			jobURLPrefixConfig: map[string]string{
-				"*": "https://config.go.k8s.io/gcs",
-			},
-			expectedOpenTestTemplate: &config.LinkTemplate{
-				Url: "https://config.go.k8s.io/gs/<gcs_prefix>/<changelist>",
-			},
-		},
-		{
 			name: "job url prefix for org is preferred over *",
 			jobURLPrefixConfig: map[string]string{
 				"*":    "https://some.other.url",


### PR DESCRIPTION
Was deprecated for quite a while

Fixes #21793

Hope I got everything