### PR TITLE
Updating the prowjob CRD to v1

### DIFF
--- a/config/prow-staging/cluster/prowjob_customresourcedefinition.yaml
+++ b/config/prow-staging/cluster/prowjob_customresourcedefinition.yaml
@@ -35,6 +35,7 @@ spec:
         properties:
           spec:
             type: object
+            x-kubernetes-preserve-unknown-fields: true
             properties:
               max_concurrency:
                 type: integer

--- a/config/prow-staging/cluster/prowjob_customresourcedefinition.yaml
+++ b/config/prow-staging/cluster/prowjob_customresourcedefinition.yaml
@@ -48,6 +48,7 @@ spec:
                 - "batch"
           status:
             type: object
+            x-kubernetes-preserve-unknown-fields: true
             properties:
               state:
                 type: string

--- a/config/prow-staging/cluster/prowjob_customresourcedefinition.yaml
+++ b/config/prow-staging/cluster/prowjob_customresourcedefinition.yaml
@@ -12,89 +12,96 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: prowjobs.prow.k8s.io
+  annotations:
+    "api-approved.kubernetes.io": "https://github.com/kubernetes/test-infra/pull/8669"
 spec:
   group: prow.k8s.io
-  version: v1
   names:
     kind: ProwJob
     singular: prowjob
     plural: prowjobs
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            max_concurrency:
-              type: integer
-              minimum: 0
-            type:
-              type: string
-              enum:
-              - "presubmit"
-              - "postsubmit"
-              - "periodic"
-              - "batch"
-        status:
-          properties:
-            state:
-              type: string
-              enum:
-              - "triggered"
-              - "pending"
-              - "success"
-              - "failure"
-              - "aborted"
-              - "error"
-          anyOf:
-          - not:
-              properties:
-                state:
-                  type: string
-                  enum:
-                  - "success"
-                  - "failure"
-                  - "error"
-          - required:
-            - completionTime
-  additionalPrinterColumns:
-  - name: Job
-    type: string
-    description: The name of the job being run.
-    JSONPath: .spec.job
-  - name: BuildId
-    type: string
-    description: The ID of the job being run.
-    JSONPath: .status.build_id
-  - name: Type
-    type: string
-    description: The type of job being run.
-    JSONPath: .spec.type
-  - name: Org
-    type: string
-    description: The org for which the job is running.
-    JSONPath: .spec.refs.org
-  - name: Repo
-    type: string
-    description: The repo for which the job is running.
-    JSONPath: .spec.refs.repo
-  - name: Pulls
-    type: string
-    description: The pulls for which the job is running.
-    JSONPath: ".spec.refs.pulls[*].number"
-  - name: StartTime
-    type: date
-    description: When the job started running.
-    JSONPath: .status.startTime
-  - name: CompletionTime
-    type: date
-    description: When the job finished running.
-    JSONPath: .status.completionTime
-  - name: State
-    description: The state of the job.
-    type: string
-    JSONPath: .status.state
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              max_concurrency:
+                type: integer
+                minimum: 0
+              type:
+                type: string
+                enum:
+                - "presubmit"
+                - "postsubmit"
+                - "periodic"
+                - "batch"
+          status:
+            type: object
+            properties:
+              state:
+                type: string
+                enum:
+                - "triggered"
+                - "pending"
+                - "success"
+                - "failure"
+                - "aborted"
+                - "error"
+            anyOf:
+            - not:
+                properties:
+                  state:
+                    enum:
+                    - "success"
+                    - "failure"
+                    - "error"
+            - required:
+              - completionTime
+    additionalPrinterColumns:
+    - name: Job
+      type: string
+      description: The name of the job being run.
+      jsonPath: .spec.job
+    - name: BuildId
+      type: string
+      description: The ID of the job being run.
+      jsonPath: .status.build_id
+    - name: Type
+      type: string
+      description: The type of job being run.
+      jsonPath: .spec.type
+    - name: Org
+      type: string
+      description: The org for which the job is running.
+      jsonPath: .spec.refs.org
+    - name: Repo
+      type: string
+      description: The repo for which the job is running.
+      jsonPath: .spec.refs.repo
+    - name: Pulls
+      type: string
+      description: The pulls for which the job is running.
+      jsonPath: ".spec.refs.pulls[*].number"
+    - name: StartTime
+      type: date
+      description: When the job started running.
+      jsonPath: .status.startTime
+    - name: CompletionTime
+      type: date
+      description: When the job finished running.
+      jsonPath: .status.completionTime
+    - name: State
+      description: The state of the job.
+      type: string
+      jsonPath: .status.state

--- a/config/prow/cluster/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob_customresourcedefinition.yaml
@@ -21,6 +21,7 @@ spec:
         properties:
           spec:
             type: object
+            x-kubernetes-preserve-unknown-fields: true
             properties:
               max_concurrency:
                 type: integer

--- a/config/prow/cluster/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob_customresourcedefinition.yaml
@@ -1,86 +1,93 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: prowjobs.prow.k8s.io
+  annotations:
+    "api-approved.kubernetes.io": "https://github.com/kubernetes/test-infra/pull/8669"
 spec:
   group: prow.k8s.io
-  version: v1
   names:
     kind: ProwJob
     singular: prowjob
     plural: prowjobs
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            max_concurrency:
-              type: integer
-              minimum: 0
-            type:
-              type: string
-              enum:
-              - "presubmit"
-              - "postsubmit"
-              - "periodic"
-              - "batch"
-        status:
-          properties:
-            state:
-              type: string
-              enum:
-              - "triggered"
-              - "pending"
-              - "success"
-              - "failure"
-              - "aborted"
-              - "error"
-          anyOf:
-          - not:
-              properties:
-                state:
-                  type: string
-                  enum:
-                  - "success"
-                  - "failure"
-                  - "error"
-          - required:
-            - completionTime
-  additionalPrinterColumns:
-  - name: Job
-    type: string
-    description: The name of the job being run.
-    JSONPath: .spec.job
-  - name: BuildId
-    type: string
-    description: The ID of the job being run.
-    JSONPath: .status.build_id
-  - name: Type
-    type: string
-    description: The type of job being run.
-    JSONPath: .spec.type
-  - name: Org
-    type: string
-    description: The org for which the job is running.
-    JSONPath: .spec.refs.org
-  - name: Repo
-    type: string
-    description: The repo for which the job is running.
-    JSONPath: .spec.refs.repo
-  - name: Pulls
-    type: string
-    description: The pulls for which the job is running.
-    JSONPath: ".spec.refs.pulls[*].number"
-  - name: StartTime
-    type: date
-    description: When the job started running.
-    JSONPath: .status.startTime
-  - name: CompletionTime
-    type: date
-    description: When the job finished running.
-    JSONPath: .status.completionTime
-  - name: State
-    description: The state of the job.
-    type: string
-    JSONPath: .status.state
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              max_concurrency:
+                type: integer
+                minimum: 0
+              type:
+                type: string
+                enum:
+                - "presubmit"
+                - "postsubmit"
+                - "periodic"
+                - "batch"
+          status:
+            type: object
+            properties:
+              state:
+                type: string
+                enum:
+                - "triggered"
+                - "pending"
+                - "success"
+                - "failure"
+                - "aborted"
+                - "error"
+            anyOf:
+            - not:
+                properties:
+                  state:
+                    enum:
+                    - "success"
+                    - "failure"
+                    - "error"
+            - required:
+              - completionTime
+    additionalPrinterColumns:
+    - name: Job
+      type: string
+      description: The name of the job being run.
+      jsonPath: .spec.job
+    - name: BuildId
+      type: string
+      description: The ID of the job being run.
+      jsonPath: .status.build_id
+    - name: Type
+      type: string
+      description: The type of job being run.
+      jsonPath: .spec.type
+    - name: Org
+      type: string
+      description: The org for which the job is running.
+      jsonPath: .spec.refs.org
+    - name: Repo
+      type: string
+      description: The repo for which the job is running.
+      jsonPath: .spec.refs.repo
+    - name: Pulls
+      type: string
+      description: The pulls for which the job is running.
+      jsonPath: ".spec.refs.pulls[*].number"
+    - name: StartTime
+      type: date
+      description: When the job started running.
+      jsonPath: .status.startTime
+    - name: CompletionTime
+      type: date
+      description: When the job finished running.
+      jsonPath: .status.completionTime
+    - name: State
+      description: The state of the job.
+      type: string
+      jsonPath: .status.state

--- a/config/prow/cluster/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob_customresourcedefinition.yaml
@@ -34,6 +34,7 @@ spec:
                 - "batch"
           status:
             type: object
+            x-kubernetes-preserve-unknown-fields: true
             properties:
               state:
                 type: string

--- a/config/prow/cluster/starter-gcs.yaml
+++ b/config/prow/cluster/starter-gcs.yaml
@@ -127,92 +127,99 @@ data:
         - image: alpine
           command: ["/bin/date"]
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: prowjobs.prow.k8s.io
+  annotations:
+    "api-approved.kubernetes.io": "https://github.com/kubernetes/test-infra/pull/8669"
 spec:
   group: prow.k8s.io
-  version: v1
   names:
     kind: ProwJob
     singular: prowjob
     plural: prowjobs
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            max_concurrency:
-              type: integer
-              minimum: 0
-            type:
-              type: string
-              enum:
-              - "presubmit"
-              - "postsubmit"
-              - "periodic"
-              - "batch"
-        status:
-          properties:
-            state:
-              type: string
-              enum:
-              - "triggered"
-              - "pending"
-              - "success"
-              - "failure"
-              - "aborted"
-              - "error"
-          anyOf:
-          - not:
-              properties:
-                state:
-                  type: string
-                  enum:
-                  - "success"
-                  - "failure"
-                  - "error"
-          - required:
-            - completionTime
-  additionalPrinterColumns:
-  - name: Job
-    type: string
-    description: The name of the job being run.
-    JSONPath: .spec.job
-  - name: BuildId
-    type: string
-    description: The ID of the job being run.
-    JSONPath: .status.build_id
-  - name: Type
-    type: string
-    description: The type of job being run.
-    JSONPath: .spec.type
-  - name: Org
-    type: string
-    description: The org for which the job is running.
-    JSONPath: .spec.refs.org
-  - name: Repo
-    type: string
-    description: The repo for which the job is running.
-    JSONPath: .spec.refs.repo
-  - name: Pulls
-    type: string
-    description: The pulls for which the job is running.
-    JSONPath: ".spec.refs.pulls[*].number"
-  - name: StartTime
-    type: date
-    description: When the job started running.
-    JSONPath: .status.startTime
-  - name: CompletionTime
-    type: date
-    description: When the job finished running.
-    JSONPath: .status.completionTime
-  - name: State
-    description: The state of the job.
-    type: string
-    JSONPath: .status.state
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              max_concurrency:
+                type: integer
+                minimum: 0
+              type:
+                type: string
+                enum:
+                - "presubmit"
+                - "postsubmit"
+                - "periodic"
+                - "batch"
+          status:
+            type: object
+            properties:
+              state:
+                type: string
+                enum:
+                - "triggered"
+                - "pending"
+                - "success"
+                - "failure"
+                - "aborted"
+                - "error"
+            anyOf:
+            - not:
+                properties:
+                  state:
+                    enum:
+                    - "success"
+                    - "failure"
+                    - "error"
+            - required:
+              - completionTime
+    additionalPrinterColumns:
+    - name: Job
+      type: string
+      description: The name of the job being run.
+      jsonPath: .spec.job
+    - name: BuildId
+      type: string
+      description: The ID of the job being run.
+      jsonPath: .status.build_id
+    - name: Type
+      type: string
+      description: The type of job being run.
+      jsonPath: .spec.type
+    - name: Org
+      type: string
+      description: The org for which the job is running.
+      jsonPath: .spec.refs.org
+    - name: Repo
+      type: string
+      description: The repo for which the job is running.
+      jsonPath: .spec.refs.repo
+    - name: Pulls
+      type: string
+      description: The pulls for which the job is running.
+      jsonPath: ".spec.refs.pulls[*].number"
+    - name: StartTime
+      type: date
+      description: When the job started running.
+      jsonPath: .status.startTime
+    - name: CompletionTime
+      type: date
+      description: When the job finished running.
+      jsonPath: .status.completionTime
+    - name: State
+      description: The state of the job.
+      type: string
+      jsonPath: .status.state
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/config/prow/cluster/starter-gcs.yaml
+++ b/config/prow/cluster/starter-gcs.yaml
@@ -163,6 +163,7 @@ spec:
                 - "batch"
           status:
             type: object
+            x-kubernetes-preserve-unknown-fields: true
             properties:
               state:
                 type: string

--- a/config/prow/cluster/starter-gcs.yaml
+++ b/config/prow/cluster/starter-gcs.yaml
@@ -150,6 +150,7 @@ spec:
         properties:
           spec:
             type: object
+            x-kubernetes-preserve-unknown-fields: true
             properties:
               max_concurrency:
                 type: integer

--- a/config/prow/cluster/starter-s3.yaml
+++ b/config/prow/cluster/starter-s3.yaml
@@ -127,92 +127,99 @@ data:
         - image: alpine
           command: ["/bin/date"]
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: prowjobs.prow.k8s.io
+  annotations:
+    "api-approved.kubernetes.io": "https://github.com/kubernetes/test-infra/pull/8669"
 spec:
   group: prow.k8s.io
-  version: v1
   names:
     kind: ProwJob
     singular: prowjob
     plural: prowjobs
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            max_concurrency:
-              type: integer
-              minimum: 0
-            type:
-              type: string
-              enum:
-              - "presubmit"
-              - "postsubmit"
-              - "periodic"
-              - "batch"
-        status:
-          properties:
-            state:
-              type: string
-              enum:
-              - "triggered"
-              - "pending"
-              - "success"
-              - "failure"
-              - "aborted"
-              - "error"
-          anyOf:
-          - not:
-              properties:
-                state:
-                  type: string
-                  enum:
-                  - "success"
-                  - "failure"
-                  - "error"
-          - required:
-            - completionTime
-  additionalPrinterColumns:
-  - name: Job
-    type: string
-    description: The name of the job being run.
-    JSONPath: .spec.job
-  - name: BuildId
-    type: string
-    description: The ID of the job being run.
-    JSONPath: .status.build_id
-  - name: Type
-    type: string
-    description: The type of job being run.
-    JSONPath: .spec.type
-  - name: Org
-    type: string
-    description: The org for which the job is running.
-    JSONPath: .spec.refs.org
-  - name: Repo
-    type: string
-    description: The repo for which the job is running.
-    JSONPath: .spec.refs.repo
-  - name: Pulls
-    type: string
-    description: The pulls for which the job is running.
-    JSONPath: ".spec.refs.pulls[*].number"
-  - name: StartTime
-    type: date
-    description: When the job started running.
-    JSONPath: .status.startTime
-  - name: CompletionTime
-    type: date
-    description: When the job finished running.
-    JSONPath: .status.completionTime
-  - name: State
-    description: The state of the job.
-    type: string
-    JSONPath: .status.state
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              max_concurrency:
+                type: integer
+                minimum: 0
+              type:
+                type: string
+                enum:
+                - "presubmit"
+                - "postsubmit"
+                - "periodic"
+                - "batch"
+          status:
+            type: object
+            properties:
+              state:
+                type: string
+                enum:
+                - "triggered"
+                - "pending"
+                - "success"
+                - "failure"
+                - "aborted"
+                - "error"
+            anyOf:
+            - not:
+                properties:
+                  state:
+                    enum:
+                    - "success"
+                    - "failure"
+                    - "error"
+            - required:
+              - completionTime
+    additionalPrinterColumns:
+    - name: Job
+      type: string
+      description: The name of the job being run.
+      jsonPath: .spec.job
+    - name: BuildId
+      type: string
+      description: The ID of the job being run.
+      jsonPath: .status.build_id
+    - name: Type
+      type: string
+      description: The type of job being run.
+      jsonPath: .spec.type
+    - name: Org
+      type: string
+      description: The org for which the job is running.
+      jsonPath: .spec.refs.org
+    - name: Repo
+      type: string
+      description: The repo for which the job is running.
+      jsonPath: .spec.refs.repo
+    - name: Pulls
+      type: string
+      description: The pulls for which the job is running.
+      jsonPath: ".spec.refs.pulls[*].number"
+    - name: StartTime
+      type: date
+      description: When the job started running.
+      jsonPath: .status.startTime
+    - name: CompletionTime
+      type: date
+      description: When the job finished running.
+      jsonPath: .status.completionTime
+    - name: State
+      description: The state of the job.
+      type: string
+      jsonPath: .status.state
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/config/prow/cluster/starter-s3.yaml
+++ b/config/prow/cluster/starter-s3.yaml
@@ -163,6 +163,7 @@ spec:
                 - "batch"
           status:
             type: object
+            x-kubernetes-preserve-unknown-fields: true
             properties:
               state:
                 type: string

--- a/config/prow/cluster/starter-s3.yaml
+++ b/config/prow/cluster/starter-s3.yaml
@@ -150,6 +150,7 @@ spec:
         properties:
           spec:
             type: object
+            x-kubernetes-preserve-unknown-fields: true
             properties:
               max_concurrency:
                 type: integer

--- a/prow/test/integration/prow/cluster/100_starter.yaml
+++ b/prow/test/integration/prow/cluster/100_starter.yaml
@@ -55,6 +55,7 @@ spec:
                 - "batch"
           status:
             type: object
+            x-kubernetes-preserve-unknown-fields: true
             properties:
               state:
                 type: string

--- a/prow/test/integration/prow/cluster/100_starter.yaml
+++ b/prow/test/integration/prow/cluster/100_starter.yaml
@@ -42,6 +42,7 @@ spec:
         properties:
           spec:
             type: object
+            x-kubernetes-preserve-unknown-fields: true
             properties:
               max_concurrency:
                 type: integer

--- a/prow/test/integration/prow/cluster/100_starter.yaml
+++ b/prow/test/integration/prow/cluster/100_starter.yaml
@@ -19,89 +19,96 @@ metadata:
 stringData:
   config: ""
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: prowjobs.prow.k8s.io
+  annotations:
+    "api-approved.kubernetes.io": "https://github.com/kubernetes/test-infra/pull/8669"
 spec:
   group: prow.k8s.io
-  version: v1
   names:
     kind: ProwJob
     singular: prowjob
     plural: prowjobs
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            max_concurrency:
-              type: integer
-              minimum: 0
-            type:
-              type: string
-              enum:
-              - "presubmit"
-              - "postsubmit"
-              - "periodic"
-              - "batch"
-        status:
-          properties:
-            state:
-              type: string
-              enum:
-              - "triggered"
-              - "pending"
-              - "success"
-              - "failure"
-              - "aborted"
-              - "error"
-          anyOf:
-          - not:
-              properties:
-                state:
-                  type: string
-                  enum:
-                  - "success"
-                  - "failure"
-                  - "error"
-          - required:
-            - completionTime
-  additionalPrinterColumns:
-  - name: Job
-    type: string
-    description: The name of the job being run.
-    JSONPath: .spec.job
-  - name: BuildId
-    type: string
-    description: The ID of the job being run.
-    JSONPath: .status.build_id
-  - name: Type
-    type: string
-    description: The type of job being run.
-    JSONPath: .spec.type
-  - name: Org
-    type: string
-    description: The org for which the job is running.
-    JSONPath: .spec.refs.org
-  - name: Repo
-    type: string
-    description: The repo for which the job is running.
-    JSONPath: .spec.refs.repo
-  - name: Pulls
-    type: string
-    description: The pulls for which the job is running.
-    JSONPath: ".spec.refs.pulls[*].number"
-  - name: StartTime
-    type: date
-    description: When the job started running.
-    JSONPath: .status.startTime
-  - name: CompletionTime
-    type: date
-    description: When the job finished running.
-    JSONPath: .status.completionTime
-  - name: State
-    description: The state of the job.
-    type: string
-    JSONPath: .status.state
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              max_concurrency:
+                type: integer
+                minimum: 0
+              type:
+                type: string
+                enum:
+                - "presubmit"
+                - "postsubmit"
+                - "periodic"
+                - "batch"
+          status:
+            type: object
+            properties:
+              state:
+                type: string
+                enum:
+                - "triggered"
+                - "pending"
+                - "success"
+                - "failure"
+                - "aborted"
+                - "error"
+            anyOf:
+            - not:
+                properties:
+                  state:
+                    enum:
+                    - "success"
+                    - "failure"
+                    - "error"
+            - required:
+              - completionTime
+    additionalPrinterColumns:
+    - name: Job
+      type: string
+      description: The name of the job being run.
+      jsonPath: .spec.job
+    - name: BuildId
+      type: string
+      description: The ID of the job being run.
+      jsonPath: .status.build_id
+    - name: Type
+      type: string
+      description: The type of job being run.
+      jsonPath: .spec.type
+    - name: Org
+      type: string
+      description: The org for which the job is running.
+      jsonPath: .spec.refs.org
+    - name: Repo
+      type: string
+      description: The repo for which the job is running.
+      jsonPath: .spec.refs.repo
+    - name: Pulls
+      type: string
+      description: The pulls for which the job is running.
+      jsonPath: ".spec.refs.pulls[*].number"
+    - name: StartTime
+      type: date
+      description: When the job started running.
+      jsonPath: .status.startTime
+    - name: CompletionTime
+      type: date
+      description: When the job finished running.
+      jsonPath: .status.completionTime
+    - name: State
+      description: The state of the job.
+      type: string
+      jsonPath: .status.state


### PR DESCRIPTION
The prowjob api has been available at `v1` for quite some time.  This PR bumps the existing CRDs from `v1beta1` to `v1`.