### PR TITLE
add tam7t as reviewer for secrets-store-csi-driver test config

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/OWNERS
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/OWNERS
@@ -3,6 +3,7 @@
 reviewers:
 - aramase
 - ritazh
+- tam7t
 approvers:
 - aramase
 - ritazh


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

@tam7t is already a reviewer for the Secrets Store CSI Driver sig-auth subproject. Adding Tommy as reviewer to the test config as well.

Membership request for kubernetes org is complete: https://github.com/kubernetes/org/issues/2638

/assign @ritazh 
/cc @tam7t 