### PR TITLE
releng: Use branch variant images for kubernetes build jobs

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -333,7 +333,6 @@ presubmits:
       testgrid-alert-email: release-managers+alerts@kubernetes.io
       testgrid-num-columns-recent: '30'
   - name: pull-release-image-k8s-ci-builder
-    optional: true
     cluster: k8s-infra-prow-build
     decorate: true
     run_if_changed: '^images\/releng\/k8s-ci-builder\/'

--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -80,7 +80,8 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-releng/k8s-ci-builder:v20201128-v0.6.0-6-g6313f696-default
+    - image: gcr.io/k8s-staging-releng/k8s-ci-builder:latest-default
+      imagePullPolicy: Always
       command:
       - wrapper.sh
       - /krel
@@ -105,7 +106,7 @@ periodics:
       - 2241179 # release-managers
   annotations:
     fork-per-release: "true"
-    fork-per-release-replacements: "k8s-master -> k8s-beta"
+    fork-per-release-replacements: "k8s-master -> k8s-beta, latest-default -> latest-{{.Version}}"
     testgrid-dashboards: sig-release-master-blocking, sig-release-releng-blocking
     testgrid-tab-name: build-master
     testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -224,7 +224,8 @@ periodics:
       - --bucket=k8s-release-dev
       - --registry=gcr.io/k8s-staging-ci-images
       - --extra-version-markers=k8s-stable3
-      image: gcr.io/k8s-staging-releng/k8s-ci-builder:v20201128-v0.6.0-6-g6313f696-default
+      image: gcr.io/k8s-staging-releng/k8s-ci-builder:latest-1.18
+      imagePullPolicy: Always
       name: ""
       resources:
         limits:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -182,7 +182,8 @@ periodics:
       - --bucket=k8s-release-dev
       - --registry=gcr.io/k8s-staging-ci-images
       - --extra-version-markers=k8s-stable2
-      image: gcr.io/k8s-staging-releng/k8s-ci-builder:v20201128-v0.6.0-6-g6313f696-default
+      image: gcr.io/k8s-staging-releng/k8s-ci-builder:latest-1.19
+      imagePullPolicy: Always
       name: ""
       resources:
         limits:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
@@ -181,7 +181,8 @@ periodics:
       - --bucket=k8s-release-dev
       - --registry=gcr.io/k8s-staging-ci-images
       - --extra-version-markers=k8s-stable1
-      image: gcr.io/k8s-staging-releng/k8s-ci-builder:v20201128-v0.6.0-6-g6313f696-default
+      image: gcr.io/k8s-staging-releng/k8s-ci-builder:latest-1.20
+      imagePullPolicy: Always
       name: ""
       resources:
         limits:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.21.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.21.yaml
@@ -259,7 +259,8 @@ periodics:
       - --bucket=k8s-release-dev
       - --registry=gcr.io/k8s-staging-ci-images
       - --extra-version-markers=k8s-master
-      image: gcr.io/k8s-staging-releng/k8s-ci-builder:v20201128-v0.6.0-6-g6313f696-default
+      image: gcr.io/k8s-staging-releng/k8s-ci-builder:latest-1.21
+      imagePullPolicy: Always
       name: ""
       resources:
         limits:


### PR DESCRIPTION
Noticed this image has been frozen in time for a while now while working on https://github.com/kubernetes/release/pull/2003.
We should be using per-branch variant images for the build jobs.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/priority critical-urgent
/assign @hasheddan @puerco @cpanato 
/hold for https://github.com/kubernetes/release/pull/2004 AND for k8s-ci-builder postsubmit to create the `latest-1.21` tag