### PR TITLE
Update Prow configuration for cluster-api-provider-aws and prep main branch rename for CAP* repos

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -334,11 +334,13 @@ milestone_applier:
     release-1.17: v1.17
     release-1.16: v1.16
   kubernetes-sigs/cluster-api:
+    main: v0.4
     master: v0.4
     release-0.4: v0.4
     operator-0.4: v0.4 # Remove this when it gets merged back.
     release-0.3: v0.3
   kubernetes-sigs/cluster-api-provider-azure:
+    main: v0.5.0
     master: v0.5.0
     release-0.4: v0.4.15
   kubernetes-sigs/cluster-api-provider-digitalocean:

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -305,6 +305,12 @@ slack:
     - kops-dev
     exempt_users:
     - k8s-ci-robot
+  - repos:
+    - kubernetes/cluster-api-provider-aws
+    channels:
+    - cluster-api-aws
+    exempt_users:
+    - k8s-ci-robot
 
 milestone_applier:
   kubernetes/enhancements:
@@ -339,6 +345,9 @@ milestone_applier:
     release-0.4: v0.4
     operator-0.4: v0.4 # Remove this when it gets merged back.
     release-0.3: v0.3
+  kubernetes-sigs/cluster-api-provider-aws:
+    main: v0.7.0
+    release-0.6: v0.6.x
   kubernetes-sigs/cluster-api-provider-azure:
     main: v0.5.0
     master: v0.5.0
@@ -676,6 +685,12 @@ require_matching_label:
     SIG CLI takes a lead on issue triage for this repo, but any Kubernetes member can accept issues by applying the `triage/accepted` label.
 
     The `triage/accepted` label can be added by org members by writing `/triage accepted` in a comment.
+- missing_label: needs-priority
+  org: kubernetes-sigs
+  repo: cluster-api-provider-aws
+  issues: true
+  prs: true
+  regexp: ^priority/
 
 retitle:
   allow_closed_issues: true
@@ -994,9 +1009,13 @@ plugins:
 
   kubernetes-sigs/cluster-api-provider-aws:
     plugins:
+    - golint
+    - mergecommitblocker
     - milestone
+    - milestonestatus
     - override
     - release-note
+    - require-matching-label
 
   kubernetes-sigs/cluster-api-provider-azure:
     plugins:


### PR DESCRIPTION
Updates the milestone appliers to support main branch renaming for CAP* repos
Updates Prow configuration for Cluster API Provider AWS