### PR TITLE
Update Cluster API Provider AWS jobs for v1alpha4 and rename default branch to main

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-0-6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-0-6.yaml
@@ -1,5 +1,5 @@
 periodics:
-- name: periodic-cluster-api-provider-aws-e2e
+- name: periodic-cluster-api-provider-aws-e2e-v1alpha3
   decorate: true
   decoration_config:
     timeout: 5h
@@ -13,7 +13,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-aws
-    base_ref: main
+    base_ref: release-0.6
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
@@ -36,10 +36,10 @@ periodics:
           memory: "4Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
-    testgrid-tab-name: periodic-e2e
+    testgrid-tab-name: periodic-e2e-v1alpha3
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
-- name: periodic-cluster-api-provider-aws-capi-e2e
+- name: periodic-cluster-api-provider-aws-capi-e2e-v1alpha3
   decorate: true
   decoration_config:
     timeout: 5h
@@ -53,7 +53,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-aws
-      base_ref: main
+      base_ref: release-0.6
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
@@ -78,10 +78,10 @@ periodics:
             memory: "4Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
-    testgrid-tab-name: periodic-capi-e2e
+    testgrid-tab-name: periodic-capi-e2e-v1alpha3
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
-- name: periodic-cluster-api-provider-aws-e2e-conformance
+- name: periodic-cluster-api-provider-aws-e2e-conformance-v1alpha3
   decorate: true
   decoration_config:
     timeout: 5h
@@ -95,7 +95,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-aws
-      base_ref: main
+      base_ref: release-0.6
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
@@ -116,10 +116,10 @@ periodics:
             memory: "4Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
-    testgrid-tab-name: periodic-e2e-conformance
+    testgrid-tab-name: periodic-e2e-conformance-v1alpha3
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
-- name: periodic-cluster-api-provider-aws-e2e-conformance-with-k8s-ci-artifacts
+- name: periodic-cluster-api-provider-aws-e2e-conformance-v1alpha3-with-k8s-ci-artifacts
   max_concurrency: 1
   labels:
     preset-dind-enabled: "true"
@@ -136,7 +136,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-aws
-      base_ref: main
+      base_ref: release-0.6
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     - org: kubernetes-sigs
       repo: image-builder
@@ -171,6 +171,6 @@ periodics:
             cpu: 2000m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws, sig-release-master-informing
-    testgrid-tab-name: capa-conformance-k8s-main
+    testgrid-tab-name: capa-conformance-v1alpha3-k8s-master
     testgrid-num-columns-recent: '20'
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io, release-team@kubernetes.io


### PR DESCRIPTION
Rename default branch to main as part of the process
Deletes v1alpha2 and adds v1alpha3 jobs

Part of https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/1782

/hold

For actual branch rename

/assign @richardcase 