### PR TITLE
Spyglass: Add a lens to display html from the artifacts

### DIFF
--- a/prow/cmd/deck/BUILD.bazel
+++ b/prow/cmd/deck/BUILD.bazel
@@ -157,6 +157,7 @@ go_library(
         "//prow/spyglass/lenses/buildlog:go_default_library",
         "//prow/spyglass/lenses/common:go_default_library",
         "//prow/spyglass/lenses/coverage:go_default_library",
+        "//prow/spyglass/lenses/html:go_default_library",
         "//prow/spyglass/lenses/junit:go_default_library",
         "//prow/spyglass/lenses/links:go_default_library",
         "//prow/spyglass/lenses/metadata:go_default_library",

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -80,6 +80,7 @@ import (
 	"k8s.io/test-infra/prow/spyglass/lenses"
 	_ "k8s.io/test-infra/prow/spyglass/lenses/buildlog"
 	_ "k8s.io/test-infra/prow/spyglass/lenses/coverage"
+	_ "k8s.io/test-infra/prow/spyglass/lenses/html"
 	_ "k8s.io/test-infra/prow/spyglass/lenses/junit"
 	_ "k8s.io/test-infra/prow/spyglass/lenses/links"
 	_ "k8s.io/test-infra/prow/spyglass/lenses/metadata"

--- a/prow/spyglass/lenses/BUILD.bazel
+++ b/prow/spyglass/lenses/BUILD.bazel
@@ -8,6 +8,7 @@ filegroup(
     srcs = [
         "//prow/spyglass/lenses/buildlog:template",
         "//prow/spyglass/lenses/coverage:template",
+        "//prow/spyglass/lenses/html:template",
         "//prow/spyglass/lenses/junit:template",
         "//prow/spyglass/lenses/links:template",
         "//prow/spyglass/lenses/metadata:template",
@@ -21,6 +22,7 @@ filegroup(
     srcs = [
         "//prow/spyglass/lenses/buildlog:resources",
         "//prow/spyglass/lenses/coverage:resources",
+        "//prow/spyglass/lenses/html:resources",
         "//prow/spyglass/lenses/junit:resources",
         "//prow/spyglass/lenses/links:resources",
         "//prow/spyglass/lenses/metadata:resources",
@@ -60,6 +62,7 @@ filegroup(
         "//prow/spyglass/lenses/buildlog:all-srcs",
         "//prow/spyglass/lenses/common:all-srcs",
         "//prow/spyglass/lenses/coverage:all-srcs",
+        "//prow/spyglass/lenses/html:all-srcs",
         "//prow/spyglass/lenses/junit:all-srcs",
         "//prow/spyglass/lenses/links:all-srcs",
         "//prow/spyglass/lenses/metadata:all-srcs",

--- a/prow/spyglass/lenses/html/BUILD.bazel
+++ b/prow/spyglass/lenses/html/BUILD.bazel
@@ -1,0 +1,77 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//def:ts.bzl", "rollup_bundle", "ts_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["html.go"],
+    importpath = "k8s.io/test-infra/prow/spyglass/lenses/html",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/config:go_default_library",
+        "//prow/spyglass/api:go_default_library",
+        "//prow/spyglass/lenses:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+    ],
+)
+
+ts_library(
+    name = "script",
+    srcs = [
+        "html.ts",
+    ],
+    deps = [
+        "//prow/spyglass/lenses:lens_api",
+    ],
+)
+
+rollup_bundle(
+    name = "script_bundle",
+    entry_point = ":html.ts",
+    deps = [
+        ":script",
+    ],
+)
+
+filegroup(
+    name = "resources",
+    srcs = [
+        "html.css",
+        ":script_bundle.min",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "template",
+    srcs = ["template.html"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["html_test.go"],
+    data = glob([
+        "testdata/**",
+        "template.html",
+    ]),
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/config:go_default_library",
+        "//prow/spyglass/api:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
+    ],
+)

--- a/prow/spyglass/lenses/html/html.css
+++ b/prow/spyglass/lenses/html/html.css
@@ -1,0 +1,24 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+body {
+  overflow: hidden;
+}
+
+.hidden-data {
+  visibility: collapse;
+  display: none;
+}

--- a/prow/spyglass/lenses/html/html.go
+++ b/prow/spyglass/lenses/html/html.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package html
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"text/template"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/spyglass/api"
+	"k8s.io/test-infra/prow/spyglass/lenses"
+)
+
+func init() {
+	lenses.RegisterLens(Lens{})
+}
+
+type Lens struct{}
+
+// Config returns the lens's configuration.
+func (lens Lens) Config() lenses.LensConfig {
+	return lenses.LensConfig{
+		Name:      "html",
+		Title:     "HTML",
+		Priority:  21,
+		HideTitle: true,
+	}
+}
+
+// Header renders the content of <head> from template.html.
+func (lens Lens) Header(artifacts []api.Artifact, resourceDir string, config json.RawMessage, spyglassConfig config.Spyglass) string {
+	t, err := template.ParseFiles(filepath.Join(resourceDir, "template.html"))
+	if err != nil {
+		return fmt.Sprintf("<!-- FAILED LOADING HEADER: %v -->", err)
+	}
+	var buf bytes.Buffer
+	if err := t.ExecuteTemplate(&buf, "header", nil); err != nil {
+		return fmt.Sprintf("<!-- FAILED EXECUTING HEADER TEMPLATE: %v -->", err)
+	}
+	return buf.String()
+}
+
+// Callback does nothing.
+func (lens Lens) Callback(artifacts []api.Artifact, resourceDir string, data string, config json.RawMessage, spyglassConfig config.Spyglass) string {
+	return ""
+}
+
+// Body renders the <body>
+func (lens Lens) Body(artifacts []api.Artifact, resourceDir string, data string, config json.RawMessage, spyglassConfig config.Spyglass) string {
+	if len(artifacts) == 0 {
+		logrus.Error("html Body() called with no artifacts, which should never happen.")
+		return "Why am I here? There is no html file"
+	}
+
+	documents := map[string]string{}
+	for _, artifact := range artifacts {
+		content, err := artifact.ReadAll()
+		if err != nil {
+			logrus.WithError(err).WithField("artifact_url", artifact.CanonicalLink()).Warn("failed to read content")
+			continue
+		}
+		name := filepath.Base(artifact.CanonicalLink())
+
+		content = injectHeightNotifier(content, name)
+
+		// Escape double quotes as we are going to put this into an iframes srcdoc attribute. We can not reference the
+		// src directly because we have to inject the height notifier.
+		// Ref: https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-srcdoc
+		content = bytes.ReplaceAll(content, []byte(`"`), []byte(`&quot;`))
+		documents[name] = string(content)
+	}
+
+	template, err := template.ParseFiles(filepath.Join(resourceDir, "template.html"))
+	if err != nil {
+		logrus.WithError(err).Error("Error executing template.")
+		return fmt.Sprintf("Failed to load template file: %v", err)
+	}
+
+	buf := &bytes.Buffer{}
+	if err := template.ExecuteTemplate(buf, "body", documents); err != nil {
+		return fmt.Sprintf("failed to execute template: %v", err)
+	}
+	return buf.String()
+}
+
+// injectHeightNotifier injects a small javascript snippet that will tell the iframe container about the height
+// of the iframe. Iframe height can only be set as an absolute value and CORS doesn't allow the container to
+// query the iframe.
+func injectHeightNotifier(content []byte, name string) []byte {
+	content = append([]byte(`<div id="wrapper">`), content...)
+	// From https://stackoverflow.com/a/44547866 and extended to also pass
+	// back the element id, as we can have multiple pages.
+	return append(content, []byte(fmt.Sprintf(`</div><script type="text/javascript">
+window.addEventListener("load", function(){
+    if(window.self === window.top) return; // if w.self === w.top, we are not in an iframe
+    send_height_to_parent_function = function(){
+        var height = document.getElementById("wrapper").offsetHeight;
+        parent.postMessage({"height" : height , "id": "%s"}, "*");
+    }
+    send_height_to_parent_function(); //whenever the page is loaded
+    window.addEventListener("resize", send_height_to_parent_function); // whenever the page is resized
+    var observer = new MutationObserver(send_height_to_parent_function);           // whenever DOM changes PT1
+    var config = { attributes: true, childList: true, characterData: true, subtree:true}; // PT2
+    observer.observe(window.document, config);                                            // PT3
+});
+</script>`, name))...)
+}

--- a/prow/spyglass/lenses/html/html.ts
+++ b/prow/spyglass/lenses/html/html.ts
@@ -1,0 +1,49 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+function addSectionExpanders(): void {
+  const expanders = document.querySelectorAll<HTMLTableRowElement>('tr.section-expander');
+  for (const expander of Array.from(expanders)) {
+    expander.onclick = () => {
+      const nextRow = expander.nextElementSibling!;
+      const icon = expander.querySelector('i')!;
+      if (nextRow.classList.contains('hidden-data')) {
+        nextRow.classList.remove('hidden-data');
+        icon.innerText = 'expand_less';
+      } else {
+        nextRow.classList.add('hidden-data');
+        icon.innerText = 'expand_more';
+      }
+      spyglass.contentUpdated();
+    };
+  }
+}
+
+function resizeIframe(e: MessageEvent): void {
+    const iFrame = document.getElementById(e.data.id) as HTMLIFrameElement;
+    if (!iFrame) {
+        return;
+    }
+    if (iFrame.contentWindow === e.source) {
+        const height = e.data.height + "px";
+        iFrame.height = height;
+        iFrame.style.height = height;
+        spyglass.contentUpdated();
+    }
+}
+
+window.addEventListener('DOMContentLoaded', addSectionExpanders);
+window.addEventListener('message', resizeIframe );

--- a/prow/spyglass/lenses/html/html_test.go
+++ b/prow/spyglass/lenses/html/html_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package html
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/spyglass/api"
+)
+
+type FakeArtifact struct {
+	path      string
+	content   []byte
+	sizeLimit int64
+}
+
+func (fa *FakeArtifact) JobPath() string {
+	return fa.path
+}
+
+func (fa *FakeArtifact) Size() (int64, error) {
+	return int64(len(fa.content)), nil
+}
+
+func (fa *FakeArtifact) CanonicalLink() string {
+	return fa.path
+}
+
+func (fa *FakeArtifact) ReadAt(b []byte, off int64) (int, error) {
+	r := bytes.NewReader(fa.content)
+	return r.ReadAt(b, off)
+}
+
+func (fa *FakeArtifact) ReadAll() ([]byte, error) {
+	return fa.content, nil
+}
+
+func (fa *FakeArtifact) ReadTail(n int64) ([]byte, error) {
+	return nil, nil
+}
+
+func (fa *FakeArtifact) UseContext(ctx context.Context) error {
+	return nil
+}
+
+func (fa *FakeArtifact) ReadAtMost(n int64) ([]byte, error) {
+	return nil, nil
+}
+
+func TestRenderBody(t *testing.T) {
+	testCases := []struct {
+		name     string
+		artifact FakeArtifact
+	}{
+		{
+			name: "Simple",
+			artifact: FakeArtifact{
+				path:    "https://s3.internal/bucket/file.html",
+				content: []byte(`<body>Hello world!</body>`),
+			},
+		},
+		{
+			name: "With quotes",
+			artifact: FakeArtifact{
+				path:    "https://s3.internal/bucket/file.html",
+				content: []byte(`<body>"Hello world!"</body>`),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := (Lens{}).Body([]api.Artifact{&tc.artifact}, ".", "", nil, config.Spyglass{})
+			fixtureName := filepath.Join("testdata", fmt.Sprintf("%s.yaml", strings.ReplaceAll(t.Name(), "/", "_")))
+			if os.Getenv("UPDATE") != "" {
+				if err := ioutil.WriteFile(fixtureName, []byte(body), 0644); err != nil {
+					t.Errorf("failed to update fixture: %v", err)
+				}
+			}
+			expectedRaw, err := ioutil.ReadFile(fixtureName)
+			if err != nil {
+				t.Fatalf("failed to read fixture: %v", err)
+			}
+			expected := string(expectedRaw)
+			if diff := cmp.Diff(expected, body); diff != "" {
+				t.Errorf("expected doesn't match actual: \n%s\nIf this is expected, re-run the tests with the UPDATE env var set to update the fixture:\n\tUPDATE=true go test ./prow/spyglass/lenses/html/... -run TestRenderBody", diff)
+			}
+		})
+	}
+}

--- a/prow/spyglass/lenses/html/template.html
+++ b/prow/spyglass/lenses/html/template.html
@@ -1,0 +1,21 @@
+{{define "header"}}
+  <link rel="stylesheet" type="text/css" href="html.css">
+  <script type="text/javascript" src="script_bundle.min.js"></script>
+{{end}}
+
+{{define "body"}}
+  <table class="mdl-data-table mdl-js-data-table mdl-shadow--2dp">
+    {{ range $title, $content:= . }}
+    <tr class="header section-expander">
+      <td class="mdl-data-table__cell--non-numeric expander failed" colspan="1"><h6>{{$title}}</h6></td>
+      <td class="mdl-data-table__cell--non-numeric expander"><i class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
+    </tr>
+    {{/* Do _not_ hide this by default, that will break inner javascript that dynamically resizes. Hiding post-render is ok */}}
+    <tr class="">
+      <td colspan="2" style="border: 0px; padding: 0px;">
+        <iframe srcdoc="{{$content}}" title="{{$title}}" sandbox="allow-scripts" id="{{$title}}" width="100%" scrolling="no"></iframe>
+      </td>
+    </tr>
+    {{end}}
+  </table>
+{{end}}

--- a/prow/spyglass/lenses/html/testdata/TestRenderBody_Simple.yaml
+++ b/prow/spyglass/lenses/html/testdata/TestRenderBody_Simple.yaml
@@ -1,0 +1,28 @@
+
+  <table class="mdl-data-table mdl-js-data-table mdl-shadow--2dp">
+    
+    <tr class="header section-expander">
+      <td class="mdl-data-table__cell--non-numeric expander failed" colspan="1"><h6>file.html</h6></td>
+      <td class="mdl-data-table__cell--non-numeric expander"><i class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
+    </tr>
+    
+    <tr class="">
+      <td colspan="2" style="border: 0px; padding: 0px;">
+        <iframe srcdoc="<div id=&quot;wrapper&quot;><body>Hello world!</body></div><script type=&quot;text/javascript&quot;>
+window.addEventListener(&quot;load&quot;, function(){
+    if(window.self === window.top) return; // if w.self === w.top, we are not in an iframe
+    send_height_to_parent_function = function(){
+        var height = document.getElementById(&quot;wrapper&quot;).offsetHeight;
+        parent.postMessage({&quot;height&quot; : height , &quot;id&quot;: &quot;file.html&quot;}, &quot;*&quot;);
+    }
+    send_height_to_parent_function(); //whenever the page is loaded
+    window.addEventListener(&quot;resize&quot;, send_height_to_parent_function); // whenever the page is resized
+    var observer = new MutationObserver(send_height_to_parent_function);           // whenever DOM changes PT1
+    var config = { attributes: true, childList: true, characterData: true, subtree:true}; // PT2
+    observer.observe(window.document, config);                                            // PT3
+});
+</script>" title="file.html" sandbox="allow-scripts" id="file.html" width="100%" scrolling="no"></iframe>
+      </td>
+    </tr>
+    
+  </table>

--- a/prow/spyglass/lenses/html/testdata/TestRenderBody_With_quotes.yaml
+++ b/prow/spyglass/lenses/html/testdata/TestRenderBody_With_quotes.yaml
@@ -1,0 +1,28 @@
+
+  <table class="mdl-data-table mdl-js-data-table mdl-shadow--2dp">
+    
+    <tr class="header section-expander">
+      <td class="mdl-data-table__cell--non-numeric expander failed" colspan="1"><h6>file.html</h6></td>
+      <td class="mdl-data-table__cell--non-numeric expander"><i class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
+    </tr>
+    
+    <tr class="">
+      <td colspan="2" style="border: 0px; padding: 0px;">
+        <iframe srcdoc="<div id=&quot;wrapper&quot;><body>&quot;Hello world!&quot;</body></div><script type=&quot;text/javascript&quot;>
+window.addEventListener(&quot;load&quot;, function(){
+    if(window.self === window.top) return; // if w.self === w.top, we are not in an iframe
+    send_height_to_parent_function = function(){
+        var height = document.getElementById(&quot;wrapper&quot;).offsetHeight;
+        parent.postMessage({&quot;height&quot; : height , &quot;id&quot;: &quot;file.html&quot;}, &quot;*&quot;);
+    }
+    send_height_to_parent_function(); //whenever the page is loaded
+    window.addEventListener(&quot;resize&quot;, send_height_to_parent_function); // whenever the page is resized
+    var observer = new MutationObserver(send_height_to_parent_function);           // whenever DOM changes PT1
+    var config = { attributes: true, childList: true, characterData: true, subtree:true}; // PT2
+    observer.observe(window.document, config);                                            // PT3
+});
+</script>" title="file.html" sandbox="allow-scripts" id="file.html" width="100%" scrolling="no"></iframe>
+      </td>
+    </tr>
+    
+  </table>


### PR DESCRIPTION
This change adds a lens to spyglass that if setup will display html
files from the artifacts dir. This makes it very easy for job owners to
extend the view with custom output of their own.

Sample view when including [this](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-aws-ovn-upgrade/1382306626584711168/artifacts/e2e-aws-ovn-upgrade/openshift-e2e-test/artifacts/e2e-intervals_20210414-125331.html) (Cut off on the screenshot because its too large, but its displayed properly until the end):

<img width="1895" alt="expanded" src="https://user-images.githubusercontent.com/6496100/115079385-19035600-9ecf-11eb-8289-8da5769307b3.png">

Collapsed:

<img width="1909" alt="collapsed" src="https://user-images.githubusercontent.com/6496100/115079397-1dc80a00-9ecf-11eb-9064-b34bcc4b9786.png">

