### PR TITLE
kubekins/krte: Build go1.16.3 variants

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.16.1
+    GO_VERSION: 1.16.3
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
@@ -9,7 +9,7 @@ variants:
     UPGRADE_DOCKER: 'true'
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.16.1
+    GO_VERSION: 1.16.3
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
@@ -22,13 +22,13 @@ variants:
     KIND_VERSION: 0.10.0
   master:
     CONFIG: master
-    GO_VERSION: 1.16.1
+    GO_VERSION: 1.16.3
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.21':
     CONFIG: '1.21'
-    GO_VERSION: 1.16.1
+    GO_VERSION: 1.16.3
     K8S_RELEASE: latest-1.21
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
Tracking issue: https://github.com/kubernetes/release/issues/2005

/hold for https://github.com/kubernetes/kubernetes/pull/101206
/assign @hasheddan @puerco @cpanato 
cc: @kubernetes/release-engineering 

Signed-off-by: Stephen Augustus <foo@auggie.dev>