### PR TITLE
Add missing dry-run=false to sinker args

### DIFF
--- a/config/prow/cluster/starter-gcs.yaml
+++ b/config/prow/cluster/starter-gcs.yaml
@@ -326,6 +326,7 @@ spec:
         image: gcr.io/k8s-prow/sinker:v20210415-ecffc9c27e
         args:
         - --config-path=/etc/config/config.yaml
+        - --dry-run=false
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/config/prow/cluster/starter-s3.yaml
+++ b/config/prow/cluster/starter-s3.yaml
@@ -325,6 +325,7 @@ spec:
         image: gcr.io/k8s-prow/sinker:v20210415-ecffc9c27e
         args:
         - --config-path=/etc/config/config.yaml
+        - --dry-run=false
         volumeMounts:
         - name: config
           mountPath: /etc/config


### PR DESCRIPTION
Add missing `--dry-run=false` to sinker args in starter manifests. Currently, sinker deployment is missing dry-run arg, and this is resulting in pod failure.

```
$ kubectl logs -n prow  sinker-5ddf7cdbc5-tz2jp
{"component":"sinker","error":"a dry-run was requested but required flag -deck-url was unset","file":"prow/cmd/sinker/main.go:102","func":"main.main","level":"fatal","msg":"Invalid options","severity":"fatal","time":"2021-04-18T01:30:14Z"}
```
I can also see that in other sinker deployments like [here](https://github.com/kubernetes/test-infra/blob/f7e21a3c18f4f4bbc7ee170675ed53e4544a0632/prow/test/integration/prow/cluster/sinker.yaml#L134), dry-run is added, while not in starters.
