### PR TITLE
Set disable_prowjob_analysis via ProwJob annotation

### DIFF
--- a/testgrid/cmd/configurator/prow.go
+++ b/testgrid/cmd/configurator/prow.go
@@ -43,6 +43,7 @@ const testgridAlertStaleResultsHoursAnnotation = "testgrid-alert-stale-results-h
 const testgridNumFailuresToAlertAnnotation = "testgrid-num-failures-to-alert"
 const testgridDaysOfResultsAnnotation = "testgrid-days-of-results"
 const testgridInCellMetric = "testgrid-in-cell-metric"
+const testGridDisableProwJobAnalysis = "testgrid-disable-prowjob-analysis"
 const descriptionAnnotation = "description"
 const minPresubmitNumColumnsRecent = 20
 
@@ -166,6 +167,14 @@ func (pac *prowAwareConfigurator) applySingleProwjobAnnotations(c *configpb.Conf
 
 	if stm, ok := j.Annotations[testgridInCellMetric]; ok {
 		testGroup.ShortTextMetric = stm
+	}
+
+	if dpa, ok := j.Annotations[testGridDisableProwJobAnalysis]; ok {
+		dpaBool, err := strconv.ParseBool(dpa)
+		if err != nil {
+			return fmt.Errorf("%s value %q in not a valid boolean", testGridDisableProwJobAnalysis, dpa)
+		}
+		testGroup.DisableProwjobAnalysis = dpaBool
 	}
 
 	if tn, ok := j.Annotations[testgridTabNameAnnotation]; ok {

--- a/testgrid/cmd/configurator/prow_test.go
+++ b/testgrid/cmd/configurator/prow_test.go
@@ -339,6 +339,7 @@ func Test_applySingleProwjobAnnotations(t *testing.T) {
 				"testgrid-alert-stale-results-hours": "24",
 				"testgrid-days-of-results":           "30",
 				"testgrid-in-cell-metric":            "haunted-house",
+				"testgrid-disable-prowjob-analysis":  "true",
 			},
 			expectedConfig: config.Configuration{
 				TestGroups: []*config.TestGroup{
@@ -350,6 +351,7 @@ func Test_applySingleProwjobAnnotations(t *testing.T) {
 						AlertStaleResultsHours: 24,
 						DaysOfResults:          30,
 						ShortTextMetric:        "haunted-house",
+						DisableProwjobAnalysis: true,
 					},
 				},
 				Dashboards: []*config.Dashboard{


### PR DESCRIPTION
This PR makes it possible to configure [the new `disable_prowjob_analysis` field](https://github.com/GoogleCloudPlatform/testgrid/pull/396) on TestGrid's test group via an annotation to ProwJob in the same way how it is done for other test group fields [here](https://github.com/kubernetes/test-infra/blob/master/testgrid/cmd/configurator/prow.go#L133-L173).

This would make it easier to configure this field for cases where the TestGrid config is generated using [transfigure](https://github.com/kubernetes/test-infra/tree/master/testgrid/cmd/transfigure) and [configurator](https://github.com/kubernetes/test-infra/tree/master/testgrid/cmd/configurator).

I have added a test for the new annotation to one of the exisiting test cases and have also tested manually that if `testgrid-disable-prowjob-analysis: 'true'` annotation is added to a ProwJob it will appear on the corresponding test group in a TestGrid config generated by [configurator](https://github.com/kubernetes/test-infra/tree/master/testgrid/cmd/configurator).

Fixes #21841 

Signed-off-by: irbekrm <irbekrm@gmail.com>