### PR TITLE
Add additional buckets for Windows tests to deck

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -94,6 +94,9 @@ deck:
       github_team_ids:
       - 2009231 # test-infra-admins
       - 2460384 # milestone-maintainers
+  additional_allowed_buckets:
+    - k8s-ovn
+    - containerd-integration
 
 prowjob_namespace: default
 pod_namespace: test-pods


### PR DESCRIPTION
Add additional_allowed_buckets to Deck in prow config in order to allow external Windows Networking and containerD integration tests to be published to testgrid.