### PR TITLE
azure: add 1.21 signal dashboard

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -343,7 +343,7 @@ periodics:
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
     testgrid-tab-name: cloud-provider-azure-master
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
     description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
 - interval: 24h
   # cloud-provider-azure-autoscaling runs node autoscaling tests periodically.
@@ -406,7 +406,7 @@ periodics:
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
     testgrid-tab-name: cloud-provider-azure-autoscaling
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
     description: "Runs node autoscaling tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
 - interval: 24h
   # cloud-provider-azure-autoscaling-multipool runs node autoscaling tests with multiple nodepools periodically.
@@ -469,7 +469,7 @@ periodics:
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
     testgrid-tab-name: cloud-provider-azure-autoscaling-multipool
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
     description: "Runs node multiple nodepools autoscaling tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
 - interval: 24h
   # cloud-provider-azure-conformance runs Kubernetes conformance tests periodically.
@@ -527,7 +527,7 @@ periodics:
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
     testgrid-tab-name: cloud-provider-azure-conformance
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
     description: "Runs Kubernetes conformance tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
 - interval: 24h
   # cloud-provider-azure-slow runs Kubernetes slow tests periodically.
@@ -585,7 +585,7 @@ periodics:
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
     testgrid-tab-name: cloud-provider-azure-slow
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
     description: "Runs Kubernetes slow tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
 - interval: 24h
   # cloud-provider-azure-serial runs Kubernetes serial tests periodically.
@@ -655,7 +655,7 @@ periodics:
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
     testgrid-tab-name: cloud-provider-azure-serial
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
     description: "Runs Kubernetes serial tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
 - interval: 24h
   # cloud-provider-azure-master-vmss runs Azure specific tests periodically on VMSS.
@@ -716,7 +716,7 @@ periodics:
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
     testgrid-tab-name: cloud-provider-azure-master-vmss
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
     description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on VMSS."
 - interval: 24h
   # cloud-provider-azure-conformance-vmss runs Kubernetes conformance tests periodically on VMSS.
@@ -774,7 +774,7 @@ periodics:
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
     testgrid-tab-name: cloud-provider-azure-conformance-vmss
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
     description: "Runs Kubernetes conformance tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on VMSS."
 - interval: 24h
   # cloud-provider-azure-slow-vmss runs Kubernetes slow tests periodically on VMSS.
@@ -832,7 +832,7 @@ periodics:
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
     testgrid-tab-name: cloud-provider-azure-slow-vmss
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
     description: "Runs Kubernetes slow tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on VMSS."
 - interval: 24h
   # cloud-provider-azure-multiple-zones runs Kubernetes multiple availability zones tests periodically.
@@ -891,7 +891,7 @@ periodics:
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
     testgrid-tab-name: cloud-provider-azure-multiple-zones
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
     description: "Runs Kubernetes multiple availability zones tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on VMSS."
 
 # conformance test against kubernetes master branch with `azure` ipv6
@@ -945,7 +945,7 @@ periodics:
     testgrid-dashboards: provider-azure-cloud-provider-azure
     testgrid-tab-name: ci-kubernetes-azure-conformance-ipv6
     description: Runs conformance tests using kubetest against latest kubernetes master with an IPv6 azure cluster
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
     testgrid-num-columns-recent: '3'
 
 # scalability tests

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/OWNERS
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/OWNERS
@@ -3,6 +3,7 @@
 reviewers:
 - andyzhangx
 - brendandburns
+- CecileRobertMichon
 - chewong
 - feiskyer
 - justaugustus

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/generate.sh
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/generate.sh
@@ -252,9 +252,11 @@ $(generate_presubmit_annotations ${branch} pull-kubernetes-e2e-aks-engine-azure-
           value: kubernetes.io/azure-file # In-tree Azure file storage class
 $(generate_presubmit_annotations ${branch} pull-kubernetes-e2e-aks-engine-azure-file)
 periodics:
-- interval: 24h
+- interval: 3h
   name: aks-engine-conformance-${release/./-}
   decorate: true
+  decoration_config:
+    timeout: 3h
   labels:
     preset-service-account: "true"
     preset-azure-cred: "true"
@@ -466,7 +468,7 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     testgrid-num-columns-recent: '30'
 
-- interval: 24h
+- interval: 3h
   name: capz-conformance-${release/./-}
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.18.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.18.yaml
@@ -199,9 +199,11 @@ presubmits:
           value: kubernetes.io/azure-file # In-tree Azure file storage class
 
 periodics:
-- interval: 24h
+- interval: 3h
   name: aks-engine-conformance-1-18
   decorate: true
+  decoration_config:
+    timeout: 3h
   labels:
     preset-service-account: "true"
     preset-azure-cred: "true"
@@ -413,7 +415,7 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     testgrid-num-columns-recent: '30'
 
-- interval: 24h
+- interval: 3h
   name: capz-conformance-1-18
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.19.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.19.yaml
@@ -199,9 +199,11 @@ presubmits:
           value: kubernetes.io/azure-file # In-tree Azure file storage class
 
 periodics:
-- interval: 24h
+- interval: 3h
   name: aks-engine-conformance-1-19
   decorate: true
+  decoration_config:
+    timeout: 3h
   labels:
     preset-service-account: "true"
     preset-azure-cred: "true"
@@ -413,7 +415,7 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     testgrid-num-columns-recent: '30'
 
-- interval: 24h
+- interval: 3h
   name: capz-conformance-1-19
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.21.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.21.yaml
@@ -8,14 +8,14 @@ presubmits:
     run_if_changed: 'azure.*\.go'
     path_alias: k8s.io/kubernetes
     branches:
-    - release-1.20
+    - release-1.21
     labels:
       preset-service-account: "true"
       preset-azure-cred: "true"
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210412-176e4b6-1.20
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210412-176e4b6-1.21
         command:
         - runner.sh
         - kubetest
@@ -32,7 +32,7 @@ presubmits:
         - --aksengine-agentpoolcount=2
         - --aksengine-admin-username=azureuser
         - --aksengine-creds=$(AZURE_CREDENTIALS)
-        - --aksengine-orchestratorRelease=1.20
+        - --aksengine-orchestratorRelease=1.21
         - --aksengine-mastervmsize=Standard_DS2_v2
         - --aksengine-agentvmsize=Standard_DS2_v2
         - --aksengine-deploy-custom-k8s
@@ -53,7 +53,7 @@ presubmits:
     run_if_changed: 'azure.*\.go'
     path_alias: k8s.io/kubernetes
     branches:
-    - release-1.20
+    - release-1.21
     labels:
       preset-service-account: "true"
       preset-azure-cred: "true"
@@ -65,7 +65,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210412-176e4b6-1.20
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210412-176e4b6-1.21
         command:
         - runner.sh
         - kubetest
@@ -81,7 +81,7 @@ presubmits:
         - --deployment=aksengine
         - --aksengine-admin-username=azureuser
         - --aksengine-creds=$(AZURE_CREDENTIALS)
-        - --aksengine-orchestratorRelease=1.20
+        - --aksengine-orchestratorRelease=1.21
         - --aksengine-deploy-custom-k8s
         - --aksengine-location=westus2
         - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
@@ -102,7 +102,7 @@ presubmits:
     run_if_changed: 'azure.*\.go'
     path_alias: k8s.io/kubernetes
     branches:
-    - release-1.20
+    - release-1.21
     labels:
       preset-service-account: "true"
       preset-azure-cred: "true"
@@ -114,7 +114,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210412-176e4b6-1.20
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210412-176e4b6-1.21
         command:
         - runner.sh
         - kubetest
@@ -130,7 +130,7 @@ presubmits:
         - --deployment=aksengine
         - --aksengine-admin-username=azureuser
         - --aksengine-creds=$(AZURE_CREDENTIALS)
-        - --aksengine-orchestratorRelease=1.20
+        - --aksengine-orchestratorRelease=1.21
         - --aksengine-deploy-custom-k8s
         - --aksengine-location=westus2
         - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
@@ -153,7 +153,7 @@ presubmits:
     run_if_changed: 'azure.*\.go'
     path_alias: k8s.io/kubernetes
     branches:
-    - release-1.20
+    - release-1.21
     labels:
       preset-service-account: "true"
       preset-azure-cred: "true"
@@ -165,7 +165,7 @@ presubmits:
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210412-176e4b6-1.20
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210412-176e4b6-1.21
         command:
         - runner.sh
         - kubetest
@@ -182,7 +182,7 @@ presubmits:
         - --aksengine-agentpoolcount=2
         - --aksengine-admin-username=azureuser
         - --aksengine-creds=$(AZURE_CREDENTIALS)
-        - --aksengine-orchestratorRelease=1.20
+        - --aksengine-orchestratorRelease=1.21
         - --aksengine-mastervmsize=Standard_DS2_v2
         - --aksengine-agentvmsize=Standard_DS2_v2
         - --aksengine-deploy-custom-k8s
@@ -200,7 +200,7 @@ presubmits:
 
 periodics:
 - interval: 3h
-  name: aks-engine-conformance-1-20
+  name: aks-engine-conformance-1-21
   decorate: true
   decoration_config:
     timeout: 3h
@@ -211,11 +211,11 @@ periodics:
   extra_refs:
   - org: kubernetes
     repo: kubernetes
-    base_ref: release-1.20
+    base_ref: release-1.21
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210412-176e4b6-1.20
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210412-176e4b6-1.21
       command:
       - runner.sh
       - kubetest
@@ -232,7 +232,7 @@ periodics:
       - --aksengine-agentpoolcount=2
       - --aksengine-admin-username=azureuser
       - --aksengine-creds=$(AZURE_CREDENTIALS)
-      - --aksengine-orchestratorRelease=1.20
+      - --aksengine-orchestratorRelease=1.21
       - --aksengine-mastervmsize=Standard_DS2_v2
       - --aksengine-agentvmsize=Standard_DS2_v2
       - --aksengine-deploy-custom-k8s
@@ -246,13 +246,13 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: provider-azure-1.20-signal
+    testgrid-dashboards: provider-azure-1.21-signal
     testgrid-tab-name: aks-engine-conformance
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     testgrid-num-columns-recent: '30'
 
 - interval: 24h
-  name: aks-engine-azure-disk-vmas-1-20
+  name: aks-engine-azure-disk-vmas-1-21
   decorate: true
   labels:
     preset-service-account: "true"
@@ -261,7 +261,7 @@ periodics:
   extra_refs:
   - org: kubernetes
     repo: kubernetes
-    base_ref: release-1.20
+    base_ref: release-1.21
     path_alias: k8s.io/kubernetes
   - org: kubernetes-sigs
     repo: azuredisk-csi-driver
@@ -269,7 +269,7 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210412-176e4b6-1.20
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210412-176e4b6-1.21
       command:
       - runner.sh
       - kubetest
@@ -285,7 +285,7 @@ periodics:
       - --deployment=aksengine
       - --aksengine-admin-username=azureuser
       - --aksengine-creds=$(AZURE_CREDENTIALS)
-      - --aksengine-orchestratorRelease=1.20
+      - --aksengine-orchestratorRelease=1.21
       - --aksengine-deploy-custom-k8s
       - --aksengine-location=westus2
       - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
@@ -299,13 +299,13 @@ periodics:
       - name: AZURE_STORAGE_DRIVER
         value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
   annotations:
-    testgrid-dashboards: provider-azure-1.20-signal
+    testgrid-dashboards: provider-azure-1.21-signal
     testgrid-tab-name: aks-engine-azure-disk-vmas
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     testgrid-num-columns-recent: '30'
 
 - interval: 24h
-  name: aks-engine-azure-disk-vmss-1-20
+  name: aks-engine-azure-disk-vmss-1-21
   decorate: true
   labels:
     preset-service-account: "true"
@@ -314,7 +314,7 @@ periodics:
   extra_refs:
   - org: kubernetes
     repo: kubernetes
-    base_ref: release-1.20
+    base_ref: release-1.21
     path_alias: k8s.io/kubernetes
   - org: kubernetes-sigs
     repo: azuredisk-csi-driver
@@ -322,7 +322,7 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210412-176e4b6-1.20
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210412-176e4b6-1.21
       command:
       - runner.sh
       - kubetest
@@ -338,7 +338,7 @@ periodics:
       - --deployment=aksengine
       - --aksengine-admin-username=azureuser
       - --aksengine-creds=$(AZURE_CREDENTIALS)
-      - --aksengine-orchestratorRelease=1.20
+      - --aksengine-orchestratorRelease=1.21
       - --aksengine-deploy-custom-k8s
       - --aksengine-location=westus2
       - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
@@ -354,13 +354,13 @@ periodics:
       - name: ENABLE_TOPOLOGY
         value: "true"
   annotations:
-    testgrid-dashboards: provider-azure-1.20-signal
+    testgrid-dashboards: provider-azure-1.21-signal
     testgrid-tab-name: aks-engine-azure-disk-vmss
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     testgrid-num-columns-recent: '30'
 
 - interval: 24h
-  name: aks-engine-azure-file-1-20
+  name: aks-engine-azure-file-1-21
   decorate: true
   labels:
     preset-service-account: "true"
@@ -369,7 +369,7 @@ periodics:
   extra_refs:
   - org: kubernetes
     repo: kubernetes
-    base_ref: release-1.20
+    base_ref: release-1.21
     path_alias: k8s.io/kubernetes
   - org: kubernetes-sigs
     repo: azurefile-csi-driver
@@ -377,7 +377,7 @@ periodics:
     path_alias: sigs.k8s.io/azurefile-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210412-176e4b6-1.20
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210412-176e4b6-1.21
       command:
       - runner.sh
       - kubetest
@@ -394,7 +394,7 @@ periodics:
       - --aksengine-agentpoolcount=2
       - --aksengine-admin-username=azureuser
       - --aksengine-creds=$(AZURE_CREDENTIALS)
-      - --aksengine-orchestratorRelease=1.20
+      - --aksengine-orchestratorRelease=1.21
       - --aksengine-mastervmsize=Standard_DS2_v2
       - --aksengine-agentvmsize=Standard_DS2_v2
       - --aksengine-deploy-custom-k8s
@@ -410,13 +410,13 @@ periodics:
       - name: AZURE_STORAGE_DRIVER
         value: kubernetes.io/azure-file # In-tree Azure file storage class
   annotations:
-    testgrid-dashboards: provider-azure-1.20-signal
+    testgrid-dashboards: provider-azure-1.21-signal
     testgrid-tab-name: aks-engine-azure-file
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     testgrid-num-columns-recent: '30'
 
 - interval: 3h
-  name: capz-conformance-1-20
+  name: capz-conformance-1-21
   decorate: true
   decoration_config:
     timeout: 3h
@@ -439,7 +439,7 @@ periodics:
       - name: E2E_ARGS
         value: "-kubetest.use-ci-artifacts"
       - name: KUBERNETES_VERSION
-        value: "latest-1.20"
+        value: "latest-1.21"
       - name: CONFORMANCE_WORKER_MACHINE_COUNT
         value: "2"
       securityContext:
@@ -449,13 +449,13 @@ periodics:
           cpu: 1
           memory: "4Gi"
   annotations:
-    testgrid-dashboards: provider-azure-1.20-signal
+    testgrid-dashboards: provider-azure-1.21-signal
     testgrid-tab-name: capz-conformance
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     testgrid-num-columns-recent: '30'
 
 - interval: 24h
-  name: capz-azure-file-1-20
+  name: capz-azure-file-1-21
   decorate: true
   decoration_config:
     timeout: 3h
@@ -474,7 +474,7 @@ periodics:
     path_alias: sigs.k8s.io/azurefile-csi-driver
   - org: kubernetes
     repo: kubernetes
-    base_ref: release-1.20
+    base_ref: release-1.21
     path_alias: k8s.io/kubernetes
   spec:
     containers:
@@ -501,13 +501,13 @@ periodics:
           cpu: 1
           memory: "4Gi"
   annotations:
-    testgrid-dashboards: provider-azure-1.20-signal
+    testgrid-dashboards: provider-azure-1.21-signal
     testgrid-tab-name: capz-azure-file
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     testgrid-num-columns-recent: '30'
 
 - interval: 24h
-  name: capz-azure-file-machinepool-1-20
+  name: capz-azure-file-machinepool-1-21
   decorate: true
   decoration_config:
     timeout: 3h
@@ -526,7 +526,7 @@ periodics:
     path_alias: sigs.k8s.io/azurefile-csi-driver
   - org: kubernetes
     repo: kubernetes
-    base_ref: release-1.20
+    base_ref: release-1.21
     path_alias: k8s.io/kubernetes
   spec:
     containers:
@@ -555,13 +555,13 @@ periodics:
           cpu: 1
           memory: "4Gi"
   annotations:
-    testgrid-dashboards: provider-azure-1.20-signal
+    testgrid-dashboards: provider-azure-1.21-signal
     testgrid-tab-name: capz-azure-file-machinepool
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     testgrid-num-columns-recent: '30'
 
 - interval: 24h
-  name: capz-azure-disk-1-20
+  name: capz-azure-disk-1-21
   decorate: true
   decoration_config:
     timeout: 3h
@@ -580,7 +580,7 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   - org: kubernetes
     repo: kubernetes
-    base_ref: release-1.20
+    base_ref: release-1.21
     path_alias: k8s.io/kubernetes
   spec:
     containers:
@@ -606,13 +606,13 @@ periodics:
           cpu: 1
           memory: "4Gi"
   annotations:
-    testgrid-dashboards: provider-azure-1.20-signal
+    testgrid-dashboards: provider-azure-1.21-signal
     testgrid-tab-name: capz-azure-disk
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     testgrid-num-columns-recent: '30'
 
 - interval: 24h
-  name: capz-azure-disk-machinepool-1-20
+  name: capz-azure-disk-machinepool-1-21
   decorate: true
   decoration_config:
     timeout: 3h
@@ -631,7 +631,7 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   - org: kubernetes
     repo: kubernetes
-    base_ref: release-1.20
+    base_ref: release-1.21
     path_alias: k8s.io/kubernetes
   spec:
     containers:
@@ -659,7 +659,7 @@ periodics:
           cpu: 1
           memory: "4Gi"
   annotations:
-    testgrid-dashboards: provider-azure-1.20-signal
+    testgrid-dashboards: provider-azure-1.21-signal
     testgrid-tab-name: capz-azure-disk-machinepool
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
@@ -215,9 +215,11 @@ presubmits:
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       testgrid-num-columns-recent: '30'
 periodics:
-- interval: 24h
+- interval: 3h
   name: aks-engine-conformance-master
   decorate: true
+  decoration_config:
+    timeout: 3h
   labels:
     preset-service-account: "true"
     preset-azure-cred: "true"
@@ -429,7 +431,7 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     testgrid-num-columns-recent: '30'
 
-- interval: 24h
+- interval: 3h
   name: capz-conformance-master
   decorate: true
   decoration_config:

--- a/config/testgrids/kubernetes/sig-cloud-provider/azure/OWNERS
+++ b/config/testgrids/kubernetes/sig-cloud-provider/azure/OWNERS
@@ -3,6 +3,7 @@
 reviewers:
 - andyzhangx
 - brendandburns
+- CecileRobertMichon
 - chewong
 - feiskyer
 - justaugustus

--- a/config/testgrids/kubernetes/sig-cloud-provider/azure/config.yaml
+++ b/config/testgrids/kubernetes/sig-cloud-provider/azure/config.yaml
@@ -20,6 +20,7 @@ dashboard_groups:
     - provider-azure-scalability
     - provider-azure-presubmit
     - provider-azure-master-signal
+    - provider-azure-1.21-signal
     - provider-azure-1.20-signal
     - provider-azure-1.19-signal
     - provider-azure-1.18-signal
@@ -34,6 +35,7 @@ dashboards:
 - name: provider-azure-scalability
 - name: provider-azure-presubmit
 - name: provider-azure-master-signal
+- name: provider-azure-1.21-signal
 - name: provider-azure-1.20-signal
 - name: provider-azure-1.19-signal
 - name: provider-azure-1.18-signal


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

- added provider-azure-1.21-signal dashboard
- increased https://testgrid.k8s.io/provider-azure-master-signal#aks-engine-conformance timeout to 3h
- increased the period of conformance jobs from 24h to 3h to get more frequent test signals
- pointed `testgrid-alert-email` to https://groups.google.com/g/kubernetes-provider-azure-oot for out-of-tree components

/assign @CecileRobertMichon @feiskyer 