### PR TITLE
Deck: Re-include spyglass config defaulting

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -273,7 +273,7 @@ func main() {
 	pjutil.ServePProf(o.instrumentation.PProfPort)
 
 	// setup config agent, pod log clients etc.
-	configAgent, err := o.config.ConfigAgent()
+	configAgent, err := o.config.ConfigAgentWithAdditionals(&config.Agent{}, []func(*config.Config) error{spglassConfigDefaulting})
 	if err != nil {
 		logrus.WithError(err).Fatal("Error starting config agent.")
 	}

--- a/prow/flagutil/config/config.go
+++ b/prow/flagutil/config/config.go
@@ -78,5 +78,9 @@ func (o *ConfigOptions) ConfigAgent(reuse ...*config.Agent) (*config.Agent, erro
 	} else {
 		ca = &config.Agent{}
 	}
-	return ca, ca.Start(o.ConfigPath, o.JobConfigPath, o.SupplementalProwConfigDirs.Strings(), o.SupplementalProwConfigsFileName)
+	return o.ConfigAgentWithAdditionals(ca, nil)
+}
+
+func (o *ConfigOptions) ConfigAgentWithAdditionals(ca *config.Agent, additionals []func(*config.Config) error) (*config.Agent, error) {
+	return ca, ca.Start(o.ConfigPath, o.JobConfigPath, o.SupplementalProwConfigDirs.Strings(), o.SupplementalProwConfigsFileName, additionals...)
 }


### PR DESCRIPTION
This got lost in e2eee43381f0dfcfa55a55a53df48aef06928d96