### PR TITLE
Allow customisation of `do-not-merge/work-in-progress` label

### DIFF
--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -87,6 +87,7 @@ type Configuration struct {
 	Size                 Size                         `json:"size,omitempty"`
 	Triggers             []Trigger                    `json:"triggers,omitempty"`
 	Welcome              []Welcome                    `json:"welcome,omitempty"`
+	Wip                  []Wip                        `json:"wip,omitempty"`
 	Override             Override                     `json:"override,omitempty"`
 	Help                 Help                         `json:"help,omitempty"`
 }
@@ -603,6 +604,13 @@ type Welcome struct {
 	// MessageTemplate is the welcome message template to post on new-contributor PRs
 	// For the info struct see prow/plugins/welcome/welcome.go's PRInfo
 	MessageTemplate string `json:"message_template,omitempty"`
+}
+
+// Wip is config for the wip plugin.
+type Wip struct {
+	// Repos is either of the form org/repos or just org.
+	Repos []string `json:"repos,omitempty"`
+	Label string `json:"label"`
 }
 
 // Dco is config for the DCO (https://developercertificate.org/) checker plugin.

--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -610,7 +610,7 @@ type Welcome struct {
 type Wip struct {
 	// Repos is either of the form org/repos or just org.
 	Repos []string `json:"repos,omitempty"`
-	Label string `json:"label"`
+	Label string   `json:"label"`
 }
 
 // Dco is config for the DCO (https://developercertificate.org/) checker plugin.


### PR DESCRIPTION
Note: I have not fully evaluated how this will interact with `checkconfig`, so thoughts on that are welcome and I'd be happy to look into adjusting anything necessary.

This PR adds the ability to customise the label used for the `wip` plugin, falling back to the default `do-not-merge/work-in-progress` label, which would be useful for allowing more brief labels.

If this PR is okay I'll likely send one up in the near future for the `do-not-merge/hold` label also.