### PR TITLE
Spyglass html lense: Hide documents by default

### DIFF
--- a/prow/spyglass/lenses/html/html.go
+++ b/prow/spyglass/lenses/html/html.go
@@ -41,7 +41,7 @@ func (lens Lens) Config() lenses.LensConfig {
 	return lenses.LensConfig{
 		Name:      "html",
 		Title:     "HTML",
-		Priority:  21,
+		Priority:  3,
 		HideTitle: true,
 	}
 }

--- a/prow/spyglass/lenses/html/html.ts
+++ b/prow/spyglass/lenses/html/html.ts
@@ -37,12 +37,19 @@ function resizeIframe(e: MessageEvent): void {
     if (!iFrame) {
         return;
     }
-    if (iFrame.contentWindow === e.source) {
-        const height = e.data.height + "px";
-        iFrame.height = height;
-        iFrame.style.height = height;
-        spyglass.contentUpdated();
+    if (iFrame.contentWindow !== e.source) {
+        return;
     }
+    const height = e.data.height + "px";
+    iFrame.height = height;
+    iFrame.style.height = height;
+
+    const row = document.getElementById(e.data.id + '-tr') as HTMLTableRowElement;
+    if (row && row.classList.contains("initial")) {
+      row.classList.remove("initial");
+      row.classList.add("hidden-data");
+    }
+    spyglass.contentUpdated();
 }
 
 window.addEventListener('DOMContentLoaded', addSectionExpanders);

--- a/prow/spyglass/lenses/html/template.html
+++ b/prow/spyglass/lenses/html/template.html
@@ -10,8 +10,8 @@
       <td class="mdl-data-table__cell--non-numeric expander failed" colspan="1"><h6>{{$title}}</h6></td>
       <td class="mdl-data-table__cell--non-numeric expander"><i class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
     </tr>
-    {{/* Do _not_ hide this by default, that will break inner javascript that dynamically resizes. Hiding post-render is ok */}}
-    <tr class="">
+    {{/* Do _not_ hide this by default, that will break inner javascript that dynamically resizes. Hiding post-render is ok, so we hide on first resize request */}}
+    <tr class="initial" id="{{$title}}-tr">
       <td colspan="2" style="border: 0px; padding: 0px;">
         <iframe srcdoc="{{$content}}" title="{{$title}}" sandbox="allow-scripts" id="{{$title}}" width="100%" scrolling="no"></iframe>
       </td>

--- a/prow/spyglass/lenses/html/testdata/TestRenderBody_Simple.yaml
+++ b/prow/spyglass/lenses/html/testdata/TestRenderBody_Simple.yaml
@@ -6,7 +6,7 @@
       <td class="mdl-data-table__cell--non-numeric expander"><i class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
     </tr>
     
-    <tr class="">
+    <tr class="initial" id="file.html-tr">
       <td colspan="2" style="border: 0px; padding: 0px;">
         <iframe srcdoc="<div id=&quot;wrapper&quot;><body>Hello world!</body></div><script type=&quot;text/javascript&quot;>
 window.addEventListener(&quot;load&quot;, function(){

--- a/prow/spyglass/lenses/html/testdata/TestRenderBody_With_quotes.yaml
+++ b/prow/spyglass/lenses/html/testdata/TestRenderBody_With_quotes.yaml
@@ -6,7 +6,7 @@
       <td class="mdl-data-table__cell--non-numeric expander"><i class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
     </tr>
     
-    <tr class="">
+    <tr class="initial" id="file.html-tr">
       <td colspan="2" style="border: 0px; padding: 0px;">
         <iframe srcdoc="<div id=&quot;wrapper&quot;><body>&quot;Hello world!&quot;</body></div><script type=&quot;text/javascript&quot;>
 window.addEventListener(&quot;load&quot;, function(){


### PR DESCRIPTION
This allows us to both not show documents by default and not break their
rendering if they fail expect a non-zero size.