### PR TITLE
cluster-api-provider-aws: Upgrade kubekins images

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
@@ -17,7 +17,7 @@ periodics:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-1.19
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-go-canary
       command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -57,7 +57,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-1.19
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-go-canary
         command:
           - "runner.sh"
           - "./scripts/ci-e2e.sh"
@@ -99,7 +99,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-1.19
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-go-canary
         command:
           - "runner.sh"
           - "./scripts/ci-conformance.sh"
@@ -148,7 +148,7 @@ periodics:
       path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-1.19
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-go-canary
         env:
           - name: BOSKOS_HOST
             value: "boskos.test-pods.svc.cluster.local"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
@@ -14,7 +14,7 @@ postsubmits:
         preset-aws-credential: "true"
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-1.19
+          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-go-canary
             command:
               - "runner.sh"
               - "./scripts/ci-e2e.sh"
@@ -50,7 +50,7 @@ postsubmits:
         preset-aws-credential: "true"
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-1.19
+          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-go-canary
             command:
               - "runner.sh"
               - "./scripts/ci-conformance.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-1.19
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-go-canary
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -20,7 +20,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-1.19
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-go-canary
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -33,7 +33,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-1.19
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-go-canary
         command:
         - "make"
         - "verify"
@@ -68,7 +68,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-1.19
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-go-canary
           command:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"
@@ -108,7 +108,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-1.19
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-go-canary
           command:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"
@@ -145,7 +145,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-1.19
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-go-canary
           command:
             - "runner.sh"
             - "./scripts/ci-e2e.sh"
@@ -182,7 +182,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-1.19
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-go-canary
           command:
             - "runner.sh"
             - "./scripts/ci-e2e-eks.sh"


### PR DESCRIPTION
This PR upgrades kubekins images to canary for postsubmit and presubmit jobs.

assign @randomvariable 