### PR TITLE
Checkconfig: Fix validate-supplemental-prow-config-hirarchy

### DIFF
--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -124,6 +124,7 @@ var defaultWarnings = []string{
 	validateURLsWarning,
 	unknownFieldsWarning,
 	validateClusterFieldWarning,
+	validateSupplementalProwConfigOrgRepoHirarchy,
 }
 
 var expensiveWarnings = []string{
@@ -367,7 +368,7 @@ func validate(o options) error {
 
 	if o.warningEnabled(validateSupplementalProwConfigOrgRepoHirarchy) {
 		for _, supplementalProwConfigDir := range o.config.SupplementalProwConfigDirs.Strings() {
-			errs = append(errs, validateAdditionalProwConfigIsInOrgRepoDirectoryStructure(filepath.Dir(supplementalProwConfigDir), os.DirFS("/")))
+			errs = append(errs, validateAdditionalProwConfigIsInOrgRepoDirectoryStructure(supplementalProwConfigDir, os.DirFS("./")))
 		}
 	}
 


### PR DESCRIPTION
* It didn't register the check, making it inaccessible
* It incorrectly used the dir of the supplemental-prow-config dir
* It incorrectly gave an afero subfs at / instead of ./

I've verified with a sample config that this now correctly fails when it
should and doesn't when it shouldn't.