### PR TITLE
Return error when `--github-token-path` is missed

### DIFF
--- a/prow/flagutil/github.go
+++ b/prow/flagutil/github.go
@@ -84,9 +84,7 @@ func (o *GitHubOptions) Validate(bool) error {
 	}
 
 	if o.TokenPath == "" && o.AppID == "" && !o.AllowAnonymous {
-		// TODO(fejta): just return error after May 2020
-		logrus.Warnf("missing required flag: please set to --github-token-path=%s before June 2020", DefaultGitHubTokenPath)
-		o.TokenPath = DefaultGitHubTokenPath
+		return fmt.Errorf("missing required flag: please set to --github-token-path=%s", DefaultGitHubTokenPath)
 	}
 
 	if o.TokenPath != "" && len(endpoints) == 1 && endpoints[0] == github.DefaultAPIEndpoint && !o.AllowDirectAccess {


### PR DESCRIPTION
Hi,
I've found the `TODO` comment below, and fixed it.

https://github.com/kubernetes/test-infra/blob/0f3eef4736c0519f009e1e71e06b13e91af09b2b/prow/flagutil/github.go#L86-L90