### PR TITLE
python client repos: require kind label and release notes in pull requests

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -654,6 +654,16 @@ require_matching_label:
   issues: true
   prs: true
   regexp: ^priority/
+- missing_label: needs-kind
+  org: kubernetes-client
+  repo: python
+  prs: true
+  regexp: ^kind/
+- missing_label: needs-kind
+  org: kubernetes-client
+  repo: python-base
+  prs: true
+  regexp: ^kind/
 
 retitle:
   allow_closed_issues: true
@@ -859,6 +869,16 @@ plugins:
     - welcome
     - wip
     - yuks
+
+  kubernetes-client/python:
+    plugins:
+    - release-note
+    - require-matching-label
+
+  kubernetes-client/python-base:
+    plugins:
+    - release-note
+    - require-matching-label
 
   kubernetes-csi:
     plugins:


### PR DESCRIPTION
Enable `release-note` and `require-matching-label` plugins in 
- https://github.com/kubernetes-client/python
- https://github.com/kubernetes-client/python-base

to help us automatically collect and categorize release notes: https://github.com/kubernetes-client/python/pull/1419

fyi @yliaog 