### PR TITLE
add image publishing job for gateway-api

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-gateway-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-gateway-api.yaml
@@ -1,0 +1,25 @@
+postsubmits:
+  kubernetes-sigs/gateway-api:
+    - name: post-gateway-api-push-images
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-network-gateway-api
+      decorate: true
+      branches:
+        - ^master$
+        # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20210302-aa40187
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR
+              # images are pushed to.
+              - --project=k8s-staging-gateway-api
+              # This is the same as above, but with -gcb appended.
+              - --scratch-bucket=gs://k8s-staging-gatewway-api-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - .


### PR DESCRIPTION
[Gateway API](https://github.com/kubernetes-sigs/gateway-api) (SIG Network initiative) is publishing a admission webhook server. This PR adds in prow configuration to build and publish images.

