### PR TITLE
gh: expose throttler parameters as options

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -3,6 +3,11 @@
 ## New features
 
 New features added to each component:
+  - *May 14th, 2021*: All components that interact with GitHub newly allow client-side throttling customization
+    via `--github-hourly-tokens` and `--github-allowed-burst` parameters. A notable exception to this is Tide which
+    has custom throttling logic and does not expose these two new options. Other existing custom options in branchprotector,
+    peribolos, status-reconciler and needs-rebase (`--tokens/--hourly-tokens` etc.) are deprecated and will be removed
+    in August 2021.
   - *April 12th, 2021* End of grace period for storage bucket validation, additional buckets have to be allowed
     by adding them to the `deck.additional_allowed_buckets` list.
   - *March 9th, 2021* Tide batchtesting will now continue to test a given batch even

--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -110,6 +110,7 @@ filegroup(
         "//prow/cmd/hook:all-srcs",
         "//prow/cmd/horologium:all-srcs",
         "//prow/cmd/initupload:all-srcs",
+        "//prow/cmd/invitations-accepter:all-srcs",
         "//prow/cmd/jenkins-operator:all-srcs",
         "//prow/cmd/mkpj:all-srcs",
         "//prow/cmd/mkpod:all-srcs",

--- a/prow/cmd/branchprotector/protect.go
+++ b/prow/cmd/branchprotector/protect.go
@@ -47,9 +47,12 @@ type options struct {
 	config             configflagutil.ConfigOptions
 	confirm            bool
 	verifyRestrictions bool
-	tokens             int
-	tokenBurst         int
-	github             flagutil.GitHubOptions
+
+	// TODO(petr-muller): Remove after August 2021, replaced by github.ThrottleHourlyTokens
+	tokens     int
+	tokenBurst int
+
+	github flagutil.GitHubOptions
 }
 
 func (o *options) Validate() error {
@@ -61,6 +64,21 @@ func (o *options) Validate() error {
 		return err
 	}
 
+	if o.tokens != defaultTokens {
+		if o.github.ThrottleHourlyTokens != defaultTokens {
+			return fmt.Errorf("--tokens cannot be specified together with --github-hourly-tokens: use just the latter")
+		}
+		logrus.Warn("--tokens is deprecated: use --github-hourly-tokens instead")
+		o.github.ThrottleHourlyTokens = o.tokens
+	}
+	if o.tokenBurst != defaultBurst {
+		if o.github.ThrottleAllowBurst != defaultBurst {
+			return fmt.Errorf("--token-burst cannot be specified together with --github-allowed-burst: use just the latter")
+		}
+		logrus.Warn("--token-burst is deprecated: use --github-allowed-burst instead")
+		o.github.ThrottleAllowBurst = o.tokenBurst
+	}
+
 	return nil
 }
 
@@ -69,10 +87,10 @@ func gatherOptions() options {
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	fs.BoolVar(&o.confirm, "confirm", false, "Mutate github if set")
 	fs.BoolVar(&o.verifyRestrictions, "verify-restrictions", false, "Verify the restrictions section of the request for authorized collaborators/teams")
-	fs.IntVar(&o.tokens, "tokens", defaultTokens, "Throttle hourly token consumption (0 to disable)")
-	fs.IntVar(&o.tokenBurst, "token-burst", defaultBurst, "Allow consuming a subset of hourly tokens in a short burst")
+	fs.IntVar(&o.tokens, "tokens", defaultTokens, "Throttle hourly token consumption (0 to disable) DEPRECATED: use --github-hourly-tokens")
+	fs.IntVar(&o.tokenBurst, "token-burst", defaultBurst, "Allow consuming a subset of hourly tokens in a short burst. DEPRECATED: use --github-allowed-burst")
 	o.config.AddFlags(fs)
-	o.github.AddFlags(fs)
+	o.github.AddCustomizedFlags(fs, flagutil.ThrottlerDefaults(defaultTokens, defaultBurst))
 	fs.Parse(os.Args[1:])
 	return o
 }
@@ -121,7 +139,6 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting GitHub client.")
 	}
-	githubClient.Throttle(o.tokens, o.tokenBurst)
 
 	p := protector{
 		client:             githubClient,

--- a/prow/cmd/branchprotector/protect_test.go
+++ b/prow/cmd/branchprotector/protect_test.go
@@ -46,14 +46,14 @@ func TestOptions_Validate(t *testing.T) {
 				config: configflagutil.ConfigOptions{
 					ConfigPath: "dummy",
 				},
-				github: flagutil.GitHubOptions{TokenPath: "fake"},
+				github: flagutil.GitHubOptions{TokenPath: "fake", ThrottleHourlyTokens: defaultTokens, ThrottleAllowBurst: defaultBurst},
 			},
 			expectedErr: false,
 		},
 		{
 			name: "no config",
 			opt: options{
-				github: flagutil.GitHubOptions{TokenPath: "fake"},
+				github: flagutil.GitHubOptions{TokenPath: "fake", ThrottleHourlyTokens: defaultTokens, ThrottleAllowBurst: defaultBurst},
 			},
 			expectedErr: true,
 		},
@@ -63,19 +63,33 @@ func TestOptions_Validate(t *testing.T) {
 				config: configflagutil.ConfigOptions{
 					ConfigPath: "dummy",
 				},
+				github: flagutil.GitHubOptions{ThrottleHourlyTokens: defaultTokens, ThrottleAllowBurst: defaultBurst},
 			},
 			expectedErr: false,
 		},
 		{
-			name: "override default tokens allowed",
+			name: "legacy override default tokens allowed only when new-style options are default)",
 			opt: options{
 				config: configflagutil.ConfigOptions{
 					ConfigPath: "dummy",
 				},
 				tokens:     5000,
 				tokenBurst: 200,
+				github:     flagutil.GitHubOptions{ThrottleHourlyTokens: defaultTokens, ThrottleAllowBurst: defaultBurst},
 			},
 			expectedErr: false,
+		},
+		{
+			name: "legacy override default tokens not allowed with new-style options",
+			opt: options{
+				config: configflagutil.ConfigOptions{
+					ConfigPath: "dummy",
+				},
+				tokens:     5000,
+				tokenBurst: 200,
+				github:     flagutil.GitHubOptions{ThrottleHourlyTokens: defaultTokens + 100, ThrottleAllowBurst: defaultBurst + 10},
+			},
+			expectedErr: true,
 		},
 	}
 

--- a/prow/cmd/checkconfig/main_test.go
+++ b/prow/cmd/checkconfig/main_test.go
@@ -1220,7 +1220,7 @@ func TestVerifyOwnersPresence(t *testing.T) {
 func TestOptions(t *testing.T) {
 
 	var defaultGitHubOptions flagutil.GitHubOptions
-	defaultGitHubOptions.AddFlags(flag.NewFlagSet("", flag.ContinueOnError))
+	defaultGitHubOptions.AddCustomizedFlags(flag.NewFlagSet("", flag.ContinueOnError), throttlerDefaults)
 	defaultGitHubOptions.AllowAnonymous = true
 
 	StringsFlag := func(vals []string) flagutil.Strings {

--- a/prow/cmd/invitations-accepter/main.go
+++ b/prow/cmd/invitations-accepter/main.go
@@ -30,6 +30,11 @@ import (
 	"k8s.io/test-infra/prow/github"
 )
 
+const (
+	defaultTokens = 300
+	defaultBurst  = 300
+)
+
 type options struct {
 	github flagutil.GitHubOptions
 
@@ -48,7 +53,7 @@ func gatherOptions() options {
 
 	fs.BoolVar(&o.dryRun, "dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
 
-	o.github.AddFlags(fs)
+	o.github.AddCustomizedFlags(fs, flagutil.ThrottlerDefaults(defaultTokens, defaultBurst))
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		logrus.WithError(err).Fatal("could not parse input")
 	}
@@ -71,7 +76,6 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting GitHub client.")
 	}
-	gc.Throttle(300, 300)
 
 	if err := acceptInvitations(gc, o.dryRun); err != nil {
 		logrus.WithError(err).Fatal("Errors occurred.")

--- a/prow/cmd/peribolos/README.md
+++ b/prow/cmd/peribolos/README.md
@@ -83,16 +83,9 @@ Peribolos can dump the current configuration to an org. For example you could du
 
 ```console
 $ bazel run //prow/cmd/peribolos -- --dump kubernetes-sigs --github-token-path ~/github-token | tee ~/current.yaml # --tokens=0 to disable throttling
-INFO: Analysed target //prow/cmd/peribolos:peribolos (0 packages loaded).
-INFO: Found 1 target...
-Target //prow/cmd/peribolos:peribolos up-to-date:
-  bazel-bin/prow/cmd/peribolos/darwin_amd64_pure_stripped/peribolos
-INFO: Elapsed time: 0.533s, Critical Path: 0.18s
-INFO: 0 processes.
+...
 INFO: Build completed successfully, 1 total action
-INFO: Running command line: bazel-bin/prow/cmd/peribolos/darwin_amd64_pure_stripped/peribolos --dump kubernetes-sigs
-INFO: Build completed successfully, 1 total action
-{"client":"github","component":"peribolos","level":"info","msg":"Throttle(300, 100)","time":"2018-09-28T13:17:42-07:00"}
+...
 {"client":"github","component":"peribolos","level":"info","msg":"GetOrg(kubernetes-sigs)","time":"2018-09-28T13:17:42-07:00"}
 {"client":"github","component":"peribolos","level":"info","msg":"ListOrgMembers(kubernetes-sigs, admin)","time":"2018-09-28T13:17:42-07:00"}
 {"client":"github","component":"peribolos","level":"info","msg":"ListOrgMembers(kubernetes-sigs, member)","time":"2018-09-28T13:17:43-07:00"}

--- a/prow/cmd/peribolos/main_test.go
+++ b/prow/cmd/peribolos/main_test.go
@@ -121,16 +121,15 @@ func TestOptions(t *testing.T) {
 			args: []string{"--config-path=foo", "--fix-team-members"},
 		},
 		{
-			name: "allow disabled throttle",
+			name: "allow legacy disabled throttle",
 			args: []string{"--config-path=foo", "--tokens=0"},
 			expected: &options{
-				config:        "foo",
-				minAdmins:     defaultMinAdmins,
-				requireSelf:   true,
-				maximumDelta:  defaultDelta,
-				tokensPerHour: 0,
-				tokenBurst:    defaultBurst,
-				logLevel:      "info",
+				config:       "foo",
+				minAdmins:    defaultMinAdmins,
+				requireSelf:  true,
+				maximumDelta: defaultDelta,
+				tokenBurst:   defaultBurst,
+				logLevel:     "info",
 			},
 		},
 		{
@@ -180,18 +179,20 @@ func TestOptions(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		flags := flag.NewFlagSet(tc.name, flag.ContinueOnError)
-		var actual options
-		err := actual.parseArgs(flags, tc.args)
-		actual.github = flagutil.GitHubOptions{}
-		switch {
-		case err == nil && tc.expected == nil:
-			t.Errorf("%s: failed to return an error", tc.name)
-		case err != nil && tc.expected != nil:
-			t.Errorf("%s: unexpected error: %v", tc.name, err)
-		case tc.expected != nil && !reflect.DeepEqual(*tc.expected, actual):
-			t.Errorf("%s: got incorrect options: %v", tc.name, cmp.Diff(actual, *tc.expected))
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			flags := flag.NewFlagSet(tc.name, flag.ContinueOnError)
+			var actual options
+			err := actual.parseArgs(flags, tc.args)
+			actual.github = flagutil.GitHubOptions{}
+			switch {
+			case err == nil && tc.expected == nil:
+				t.Errorf("%s: failed to return an error", tc.name)
+			case err != nil && tc.expected != nil:
+				t.Errorf("%s: unexpected error: %v", tc.name, err)
+			case tc.expected != nil && !reflect.DeepEqual(*tc.expected, actual):
+				t.Errorf("%s: got incorrect options: %v", tc.name, cmp.Diff(actual, *tc.expected, cmp.AllowUnexported(options{}, flagutil.Strings{}, flagutil.GitHubOptions{})))
+			}
+		})
 	}
 }
 

--- a/prow/cmd/status-reconciler/main.go
+++ b/prow/cmd/status-reconciler/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"fmt"
 	"os"
 	"time"
 
@@ -56,8 +57,10 @@ type options struct {
 	storage                   prowflagutil.StorageClientOptions
 	instrumentationOptions    prowflagutil.InstrumentationOptions
 
+	// TODO(petr-muller): Remove after August 2021, replaced by github.ThrottleHourlyTokens
 	tokenBurst    int
 	tokensPerHour int
+
 	// statusURI where Status-reconciler stores last known state, i.e. configuration.
 	// Can be /local/path, gs://path/to/object or s3://path/to/object.
 	// GCS writes will use the bucket's default acl for new objects. Ensure both that
@@ -77,9 +80,10 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	fs.Var(&o.addedPresubmitDenylistAll, "denylist-all", "Org or org/repo to ignore reconciling, set more than once to add more.")
 	fs.Var(&o.addedPresubmitBlacklist, "blacklist", "[Will be deprecated after May 2021] Org or org/repo to ignore new added presubmits for, set more than once to add more.")
 	fs.BoolVar(&o.dryRun, "dry-run", true, "Whether or not to make mutating API calls to GitHub.")
-	fs.IntVar(&o.tokensPerHour, "tokens", defaultTokens, "Throttle hourly token consumption (0 to disable)")
-	fs.IntVar(&o.tokenBurst, "token-burst", defaultBurst, "Allow consuming a subset of hourly tokens in a short burst")
-	for _, group := range []flagutil.OptionGroup{&o.kubernetes, &o.github, &o.storage, &o.instrumentationOptions, &o.config} {
+	fs.IntVar(&o.tokensPerHour, "tokens", defaultTokens, "Throttle hourly token consumption (0 to disable). DEPRECATED: use --github-hourly-tokens")
+	fs.IntVar(&o.tokenBurst, "token-burst", defaultBurst, "Allow consuming a subset of hourly tokens in a short burst. DEPRECATED: use --github-allowed-burst")
+	o.github.AddCustomizedFlags(fs, prowflagutil.ThrottlerDefaults(defaultTokens, defaultBurst))
+	for _, group := range []flagutil.OptionGroup{&o.kubernetes, &o.storage, &o.instrumentationOptions, &o.config} {
 		group.AddFlags(fs)
 	}
 	fs.Parse(args)
@@ -87,6 +91,21 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 }
 
 func (o *options) Validate() error {
+	if o.tokensPerHour != defaultTokens {
+		if o.github.ThrottleHourlyTokens != defaultTokens {
+			return fmt.Errorf("--tokens cannot be specified with together with --github-hourly-tokens: use just the latter")
+		}
+		logrus.Warn("--tokens is deprecated: use --github-hourly-tokens instead")
+		o.github.ThrottleHourlyTokens = o.tokensPerHour
+	}
+	if o.tokenBurst != defaultBurst {
+		if o.github.ThrottleAllowBurst != defaultBurst {
+			return fmt.Errorf("--token-burst cannot be specified with together with --github-allowed-burst: use just the latter")
+		}
+		logrus.Warn("--token-burst is deprecated: use --github-allowed-burst instead")
+		o.github.ThrottleAllowBurst = o.tokenBurst
+	}
+
 	for _, group := range []flagutil.OptionGroup{&o.kubernetes, &o.github, &o.storage, &o.config} {
 		if err := group.Validate(o.dryRun); err != nil {
 			return err
@@ -143,9 +162,6 @@ func main() {
 	githubClient, err := o.github.GitHubClient(secretAgent, o.dryRun)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting GitHub client.")
-	}
-	if o.tokensPerHour > 0 {
-		githubClient.Throttle(o.tokensPerHour, o.tokenBurst)
 	}
 
 	prowJobClient, err := o.kubernetes.ProwJobClient(configAgent.Config().ProwJobNamespace, o.dryRun)

--- a/prow/cmd/status-reconciler/main_test.go
+++ b/prow/cmd/status-reconciler/main_test.go
@@ -120,7 +120,7 @@ func TestGatherOptions(t *testing.T) {
 				instrumentationOptions: flagutil.DefaultInstrumentationOptions(),
 			}
 			expectedfs := flag.NewFlagSet("fake-flags", flag.PanicOnError)
-			expected.github.AddFlags(expectedfs)
+			expected.github.AddCustomizedFlags(expectedfs, flagutil.ThrottlerDefaults(300, 100))
 			if tc.expected != nil {
 				tc.expected(expected)
 			}

--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -84,7 +84,8 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	fs.IntVar(&o.port, "port", 8888, "Port to listen on.")
 	fs.BoolVar(&o.dryRun, "dry-run", true, "Whether to mutate any real-world state.")
 	fs.BoolVar(&o.runOnce, "run-once", false, "If true, run only once then quit.")
-	for _, group := range []flagutil.OptionGroup{&o.kubernetes, &o.github, &o.storage, &o.instrumentationOptions, &o.config} {
+	o.github.AddCustomizedFlags(fs, prowflagutil.DisableThrottlerOptions())
+	for _, group := range []flagutil.OptionGroup{&o.kubernetes, &o.storage, &o.instrumentationOptions, &o.config} {
 		group.AddFlags(fs)
 	}
 	fs.IntVar(&o.syncThrottle, "sync-hourly-tokens", 800, "The maximum number of tokens per hour to be used by the sync controller.")


### PR DESCRIPTION
Tools using the client may want to configure the behavior of their
throttling (these values are currently usually hardcoded). GH client
parameters are configured in a shared structure, but different tools
that use the client may want to specify different defaults depending on
their use case.

Add a new method that allows to build a flag parser using specified
defaults. I added a method using the functional options pattern so it is
extensible and quite easily usable from callsites.

The change makes all clients constructed from GH options call
`Throttle`, but the defaults are zeroes, which result in unthrottled
clients. The existing users of `Throttle` will not be broken, they will
just call `Throttle` twice, once with defaults, once with their values,
so their behavior should not change. The existing users can be ported to
defaults by removing their hardcoded `Throttle` calls and providing
custom defaults for options. I included such change for the
`needs-rebase` plugin and will port other callsites in test-infra if the
PR is accepted.

