### PR TITLE
gh: reduce warn log spam on throttling

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -398,8 +398,12 @@ func (t *throttler) Wait() {
 	start := time.Now()
 	log := logrus.WithFields(logrus.Fields{"client": "github", "throttled": true})
 	defer func() {
-		if waitTime := time.Since(start); waitTime > time.Minute {
-			log.WithField("throttle-duration", waitTime.String()).Warn("Throttled clientside for more than a minute")
+		waitTime := time.Since(start)
+		switch {
+		case waitTime > 15*time.Minute:
+			log.WithField("throttle-duration", waitTime.String()).Warn("Throttled clientside for more than 15 minutes")
+		case waitTime > time.Minute:
+			log.WithField("throttle-duration", waitTime.String()).Debug("Throttled clientside for more than a minute")
 		}
 	}()
 	t.lock.RLock()


### PR DESCRIPTION
We recently added a log warning on >1m throttled calls. We found out
that such throttling is sometimes really desirable to smoothen the load
during peak hours, and not all usage is sensitive to short delays. Hence,
downgrade the >1m log to `Debug` and warn on >15m. Of course these
limits are still quite arbitrary :)

Ideally these thresholds could be configurable (use cases tolerate
throttling differently). I'm planning to make it so, but I'd like to
reduce the spam we're seeing as a band-aid.