### PR TITLE
gh: fix handling of empty OAuth scopes

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -906,7 +906,7 @@ func (c *client) requestRetry(method, path, accept, org string, body interface{}
 
 					want := sets.NewString(strings.Split(acceptedScopes, ",")...)
 					got := strings.Split(authorizedScopes, ",")
-					if len(want) > 0 && !want.HasAny(got...) {
+					if acceptedScopes != "" && !want.HasAny(got...) {
 						err = fmt.Errorf("the account is using %s oauth scopes, please make sure you are using at least one of the following oauth scopes: %s", authorizedScopes, acceptedScopes)
 					} else {
 						body, _ := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
> If s does not contain sep and sep is not empty, Split returns a slice
> of length 1 whose only element is s.

@petr-muller