### PR TITLE
re-enable workspace root importfor coverage lense

### DIFF
--- a/prow/spyglass/lenses/coverage/BUILD.bazel
+++ b/prow/spyglass/lenses/coverage/BUILD.bazel
@@ -31,6 +31,7 @@ ts_library(
 rollup_bundle(
     name = "script_bundle",
     entry_point = ":coverage.ts",
+    link_workspace_root = True,
     deps = [
         ":script",
         "//gopherage/cmd/html/static:parser",


### PR DESCRIPTION
see: https://github.com/kubernetes/test-infra/issues/21563, https://github.com/bazelbuild/rules_nodejs/wiki#no-longer-link-the-workspace-root