### PR TITLE
prow: kubernetes secret alert set to critical

### DIFF
--- a/config/prow/cluster/monitoring/mixins/prometheus/external_secret_alerts.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/external_secret_alerts.libsonnet
@@ -13,7 +13,7 @@
               increase(kubernetes_external_secrets_sync_calls_count{job="kubernetes-external-secrets",status!="success"}[1m]) > 1.5
             |||,
             labels: {
-              severity: 'user-warning',
+              severity: 'critical',
             },
             annotations: {
               message: 'ExternalSecret {{ $labels.namespace }}/{{ $labels.name }} failed to be synced. does %s have `roles/secretmanager.viewer` and `roles/secretmanager.secretAccessor` permissions on the google secret manager secret used for this cluster secret?' % $._config.kubernetesExternalSecretServiceAccount,


### PR DESCRIPTION
It currently set as 'user-warning', which doesn't alert anywhere, change it to critical as oncall relies on this alert for onboarding new build cluster