### PR TITLE
Make Cluster API make-main target optional

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -22,7 +22,8 @@ presubmits:
   - name: pull-cluster-api-make-main
     decorate: true
     path_alias: sigs.k8s.io/cluster-api
-    always_run: true
+    always_run: false
+    optional: true
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"


### PR DESCRIPTION
After moving golangci-lint to github actions, which have an internal cache and can run in parallel, we can move this target to optional and then removing it a bit later.

Re-apply https://github.com/kubernetes/test-infra/pull/21524 now that the github action is running on every PR.

/assign @vincepri 