### PR TITLE
Update cloud-provider-azure variable names for consistency

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -135,6 +135,8 @@ presubmits:
         env:
         - name: K8S_AZURE_LOADBALANCE_SKU
           value: "basic"
+        - name: AZURE_LOADBALANCER_SKU
+          value: "basic"
     annotations:
       testgrid-dashboards: provider-azure-cloud-provider-azure
       testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-basic-lb
@@ -196,6 +198,8 @@ presubmits:
           env:
             - name: K8S_AZURE_LOADBALANCE_SKU
               value: "standard"
+            - name: AZURE_LOADBALANCER_SKU
+              value: "standard"
     annotations:
       testgrid-dashboards: provider-azure-cloud-provider-azure
       testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm
@@ -256,6 +260,8 @@ presubmits:
             privileged: true
           env:
             - name: K8S_AZURE_LOADBALANCE_SKU
+              value: "standard"
+            - name: AZURE_LOADBALANCER_SKU
               value: "standard"
     annotations:
       testgrid-dashboards: provider-azure-cloud-provider-azure
@@ -338,6 +344,8 @@ periodics:
       env:
       - name: K8S_AZURE_LOADBALANCE_SKU
         value: "standard"
+      - name: AZURE_LOADBALANCER_SKU
+        value: "standard"
       securityContext:
         privileged: true
   annotations:
@@ -403,6 +411,8 @@ periodics:
         value: "-ginkgo.focus=autoscaler"
       - name: K8S_AZURE_LOADBALANCE_SKU
         value: "standard"
+      - name: AZURE_LOADBALANCER_SKU
+        value: "standard"
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
     testgrid-tab-name: cloud-provider-azure-autoscaling
@@ -465,6 +475,8 @@ periodics:
       - name: CCM_E2E_ARGS
         value: "-ginkgo.focus=autoscaler"
       - name: K8S_AZURE_LOADBALANCE_SKU
+        value: "standard"
+      - name: AZURE_LOADBALANCER_SKU
         value: "standard"
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
@@ -651,7 +663,8 @@ periodics:
         value: azureuser
       - name: K8S_AZURE_LOADBALANCE_SKU
         value: "basic"
-
+      - name: AZURE_LOADBALANCER_SKU
+        value: "standard"
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
     testgrid-tab-name: cloud-provider-azure-serial
@@ -710,6 +723,8 @@ periodics:
       - --ginkgo-parallel=30
       env:
       - name: K8S_AZURE_LOADBALANCE_SKU
+        value: "standard"
+      - name: AZURE_LOADBALANCER_SKU
         value: "standard"
       securityContext:
         privileged: true

--- a/kubetest/aksengine.go
+++ b/kubetest/aksengine.go
@@ -1201,6 +1201,7 @@ func (c *aksEngineDeployer) GetClusterCreated(clusterName string) (time.Time, er
 }
 
 func (c *aksEngineDeployer) setCred() error {
+	// TODO (cecile): remove old variables once the cloud provider e2e test variables are updated.
 	if err := os.Setenv("K8S_AZURE_TENANTID", c.credentials.TenantID); err != nil {
 		return err
 	}
@@ -1217,6 +1218,21 @@ func (c *aksEngineDeployer) setCred() error {
 		return err
 	}
 
+	if err := os.Setenv("AZURE_TENANT_ID", c.credentials.TenantID); err != nil {
+		return err
+	}
+	if err := os.Setenv("AZURE_SUBSCRIPTION_ID", c.credentials.SubscriptionID); err != nil {
+		return err
+	}
+	if err := os.Setenv("AZURE_CLIENT_ID", c.credentials.ClientID); err != nil {
+		return err
+	}
+	if err := os.Setenv("AZURE_CLIENT_SECRET", c.credentials.ClientSecret); err != nil {
+		return err
+	}
+	if err := os.Setenv("AZURE_LOCATION", c.location); err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
Following up on https://github.com/kubernetes-sigs/azurefile-csi-driver/issues/459. 

cloud-provider-azure e2e uses different environment variable names than everything else (https://github.com/kubernetes-sigs/cloud-provider-azure/blob/83ec139e2224561e12e896c483b31cb08ad351a2/site/content/en/development/e2e/e2e-tests-azure.md). Updating kubetest to set the same environment variables for consistency. The new names are also slightly better syntactically IMO.

This change will have no effect on current tests. Kept the old variables for now. The plan is to update the actual vars once this is merged and then remove the old vars.

/assign @chewong @feiskyer @nilo19 