### PR TITLE
capz: add presubmit conformance job to k/k

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
@@ -214,6 +214,41 @@ presubmits:
       testgrid-tab-name: pull-kubernetes-e2e-aks-engine-azure-file
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       testgrid-num-columns-recent: '30'
+  - name: pull-kubernetes-e2e-capz-conformance
+    decorate: true
+    always_run: false
+    optional: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+    extra_refs:
+    - org: chewong # TODO(chewong): change it to 'kubernetes-sigs'
+      repo: cluster-api-provider-azure
+      base_ref: upload-build-to-azure # TODO(chewong): change it to 'master'
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-master
+        command:
+        - runner.sh
+        - ./scripts/ci-conformance.sh
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1
+            memory: "4Gi"
+        env:
+        - name: KUBETEST_CONF_PATH
+          value: /home/prow/go/src/sigs.k8s.io/cluster-api-provider-azure/test/e2e/data/kubetest/conformance-fast.yaml
+    annotations:
+      testgrid-dashboards: provider-azure-presubmit
+      testgrid-tab-name: pull-kubernetes-e2e-capz-conformance
+      testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+      testgrid-num-columns-recent: '30'
 periodics:
 - interval: 24h
   name: aks-engine-conformance-master


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

Adding `pull-kubernetes-e2e-capz-conformance` to test https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1264.

/assign @CecileRobertMichon 