### PR TITLE
[phaino] format env vars properly for docker

### DIFF
--- a/prow/cmd/phaino/local.go
+++ b/prow/cmd/phaino/local.go
@@ -280,7 +280,7 @@ func (opts *options) convertToLocal(ctx context.Context, log *logrus.Entry, pj p
 	}
 	// Add args for env vars.
 	for envKey, envVal := range envs {
-		localArgs = append(localArgs, "-e", envKey+":"+envVal)
+		localArgs = append(localArgs, "-e", envKey+"="+envVal)
 	}
 	// Add args for labels.
 	for k, v := range pj.Labels {


### PR DESCRIPTION
Env variables passed to docker should be formated like

```
-e ENV1=val1 -e ENV2=val2
```

instead of

```
-e ENV1:val1 -e ENV2:val2
```

This  fixes an issue where env variables defined on the containers were not passed through.

Signed-off-by: Roman Mohr <rmohr@redhat.com>