### PR TITLE
Add repository to capz acr REGISTRY variable in preset

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -722,7 +722,7 @@ presets:
     preset-azure-anonymous-pull: "true"
   env:
     - name: REGISTRY
-      value: capzci.azurecr.io
+      value: capzci.azurecr.io/prow
 - labels:
     preset-azure-cred-only: "true"
   env:


### PR DESCRIPTION
This will facilitate running a purge task on the ACR registry (see [here](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-auto-purge). The preset is currently only used by cluster-api-provider-azure jobs.

/assign @devigned @chewong 