### PR TITLE
remove ubuntu sctp job

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -566,44 +566,6 @@ periodics:
       - --timeout=500m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-master
 
-- interval: 12h
-  name: ci-kubernetes-e2e-ubuntu-gce-basic-sctp
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=70
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --env=KUBE_FEATURE_GATES=SCTPSupport=true
-      - --env=ALLOW_PRIVILEGED=true
-      - --env=NET_PLUGIN=kubenet
-      - --env=KUBE_CONTAINER_RUNTIME=containerd
-      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.0-rc.0
-      - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc93
-      - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
-      - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
-      - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
-      - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-2004-focal-v20200423
-      - --env=KUBE_GCE_MASTER_PROJECT=ubuntu-os-cloud
-      - --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu
-      - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2004-focal-v20200423
-      - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
-      - --extract=ci/latest
-      - --gcp-master-image=ubuntu
-      - --gcp-node-image=ubuntu
-      - --gcp-nodes=4
-      - --gcp-zone=us-west1-b
-      - --provider=gce
-      # SCTPConnectivity hangs on GCE when trying to access the NodePort service, but works for ClusterIP
-      - --test_args=--ginkgo.focus=\[Feature:SCTP\] --ginkgo.skip=\[Feature:NetworkPolicy\]
-      - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-master
-
 - interval: 4h
   name: ci-kubernetes-e2e-ubuntu-gce-network-policies
   labels:

--- a/config/testgrids/kubernetes/sig-network/config.yaml
+++ b/config/testgrids/kubernetes/sig-network/config.yaml
@@ -97,11 +97,6 @@ dashboards:
       description: network gci-gce alpha features e2e tests for master branch
       alert_options:
         alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
-    - name: ubuntu-gce-basic-sctp
-      test_group_name: ci-kubernetes-e2e-ubuntu-gce-basic-sctp
-      description: network ubuntu-gce SCTP support basic e2e tests for master branch
-      alert_options:
-        alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
 
 - name: sig-network-ingress-gce-e2e
 - name: sig-network-ingress-nginx


### PR DESCRIPTION
SCTP has been graduated and the tests are running in another jobs.

Current job fails because the feature gate no longer exist:

E0423 04:45:52.278716   10374 server.go:216] "Failed to set feature gates from initial flags-based config" err="unrecognized feature gate: SCTPSupport"

xref https://testgrid.k8s.io/sig-network-gce#ubuntu-gce-basic-sctp