### PR TITLE
Remove deprecated hyperkube image building jobs

### DIFF
--- a/config/jobs/image-pushing/releng/k8s-staging-build-image.yaml
+++ b/config/jobs/image-pushing/releng/k8s-staging-build-image.yaml
@@ -29,41 +29,6 @@ postsubmits:
       rerun_auth_config:
         github_team_ids:
           - 2241179 # release-managers
-    # TODO(releng): While hyperkube is deprecated in 1.19, we still need to
-    #               maintain its base image to support publishing it for the
-    #               1.18, 1.17, and 1.16 releases.
-    #               DO NOT REMOVE THIS UNTIL AFTER KUBERNETES 1.21 IS RELEASED
-    #               AND YOU'VE CONFIRMED WITH RELEASE MANAGERS THAT IT'S OKAY
-    #               TO DO SO.
-    - name: post-release-push-image-debian-hyperkube-base
-      cluster: k8s-infra-prow-build-trusted
-      annotations:
-        testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes
-        testgrid-alert-email: release-managers+alerts@kubernetes.io
-      decorate: true
-      run_if_changed: '^images\/build\/debian-hyperkube-base\/'
-      branches:
-        - ^master$
-      spec:
-        serviceAccountName: gcb-builder
-        containers:
-          - image: gcr.io/k8s-testimages/image-builder:v20210302-aa40187
-            command:
-              - /run.sh
-            args:
-              - --project=k8s-staging-build-image
-              - --scratch-bucket=gs://k8s-staging-build-image-gcb
-              - --env-passthrough=REGISTRY
-              - --build-dir=.
-              - images/build/debian-hyperkube-base
-            env:
-              - name: LOG_TO_STDOUT
-                value: "y"
-              - name: REGISTRY
-                value: "gcr.io/k8s-staging-build-image"
-      rerun_auth_config:
-        github_team_ids:
-          - 2241179 # release-managers
     - name: post-release-push-image-debian-iptables
       cluster: k8s-infra-prow-build-trusted
       annotations:

--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -193,41 +193,6 @@ presubmits:
       testgrid-num-failures-to-alert: '10'
       testgrid-alert-email: release-managers+alerts@kubernetes.io
       testgrid-num-columns-recent: '30'
-  - name: pull-release-image-debian-hyperkube-base
-    cluster: k8s-infra-prow-build
-    decorate: true
-    run_if_changed: '^images\/build\/debian-hyperkube-base\/'
-    path_alias: k8s.io/release
-    spec:
-      serviceAccountName: gcb-builder-releng-test
-      containers:
-        - image: gcr.io/k8s-testimages/image-builder:v20210302-aa40187
-          command:
-            - /run.sh
-          args:
-            - --project=k8s-staging-releng-test
-            - --scratch-bucket=gs://k8s-staging-releng-test
-            - --build-dir=.
-            - --env-passthrough=REGISTRY
-            - images/build/debian-hyperkube-base
-          env:
-            - name: LOG_TO_STDOUT
-              value: "y"
-            - name: REGISTRY
-              value: "gcr.io/k8s-staging-releng-test"
-          resources:
-            requests:
-              cpu: 1000m
-              memory: 1Gi
-            limits:
-              cpu: 1000m
-              memory: 1Gi
-    annotations:
-      testgrid-dashboards: sig-release-releng-presubmits
-      testgrid-tab-name: release-image-debian-hyperkube-base
-      testgrid-num-failures-to-alert: '10'
-      testgrid-alert-email: release-managers+alerts@kubernetes.io
-      testgrid-num-columns-recent: '30'
   - name: pull-release-image-debian-iptables
     cluster: k8s-infra-prow-build
     decorate: true

--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -339,9 +339,9 @@ larger set of contributors to apply/remove them.
 | <a id="area/conformance" href="#area/conformance">`area/conformance`</a> | Issues or PRs related to kubernetes conformance tests| label | |
 | <a id="area/deflake" href="#area/deflake">`area/deflake`</a> | Issues or PRs related to deflaking kubernetes tests| label | |
 | <a id="area/e2e-test-framework" href="#area/e2e-test-framework">`area/e2e-test-framework`</a> | Issues or PRs related to refactoring the kubernetes e2e test framework| label | |
-| <a id="area/hyperkube" href="#area/hyperkube">`area/hyperkube`</a> | Issues or PRs related to the hyperkube subproject| label | |
 | <a id="area/network-policy" href="#area/network-policy">`area/network-policy`</a> | Issues or PRs related to Network Policy subproject| label | |
 | <a id="area/release-eng" href="#area/release-eng">`area/release-eng`</a> | Issues or PRs related to the Release Engineering subproject <br><br> This was previously `area/release-infra`, | label | |
+| <a id="deprecated/hyperkube" href="#deprecated/hyperkube">`deprecated/hyperkube`</a> | Issues or PRs related to the hyperkube subproject <br><br> This was previously `area/hyperkube`, | label | |
 
 ## Labels that apply to kubernetes/kubernetes, only for issues
 

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -997,11 +997,13 @@ repos:
         name: area/e2e-test-framework
         target: both
         addedBy: label
-      - color: 0052cc
+      - color: e11d21
         description: Issues or PRs related to the hyperkube subproject
-        name: area/hyperkube
+        name: deprecated/hyperkube
         target: both
         addedBy: label
+        previously:
+          - name: area/hyperkube
       - color: 0052cc
         description: Issues or PRs related to Network Policy subproject
         name: area/network-policy


### PR DESCRIPTION
- Remove deprecated hyperkube image building jobs
- Rename area/hyperkube label to deprecated/hyperkube

Tracking issue: https://github.com/kubernetes/release/issues/2017

/hold until [v1.18 and hyperkube is EOL (on 5/12/21)](https://github.com/kubernetes/sig-release/blob/master/releases/patch-releases.md#118)
cc: @kubernetes/release-engineering 