### PR TITLE
Enable gosimple linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,7 @@ linters:
   - misspell
   - ineffassign
   - staticcheck
+  - gosimple
   disable-all: true
 
 issues:

--- a/experiment/clustersecretbackup/main.go
+++ b/experiment/clustersecretbackup/main.go
@@ -114,8 +114,7 @@ func newClient(o options) (*client, error) {
 }
 
 func newKubeClients(clusterContext string) (ctrlruntimeclient.Client, error) {
-	var loader clientcmd.ClientConfigLoader
-	loader = clientcmd.NewDefaultClientConfigLoadingRules()
+	loader := clientcmd.NewDefaultClientConfigLoadingRules()
 
 	cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		loader, &clientcmd.ConfigOverrides{

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -682,7 +682,7 @@ func prepareGcp(o *options) error {
 				return fmt.Errorf("failed to get latest image from family %q in project %q: %s", o.gcpImageFamily, o.gcpImageProject, err)
 			}
 			latestImage := ""
-			latestImageRegexp := regexp.MustCompile("^name: *(\\S+)")
+			latestImageRegexp := regexp.MustCompile(`^name: *(\S+)`)
 			for _, line := range strings.Split(string(out), "\n") {
 				matches := latestImageRegexp.FindStringSubmatch(line)
 				if len(matches) == 2 {

--- a/label_sync/main.go
+++ b/label_sync/main.go
@@ -565,9 +565,7 @@ func syncLabels(config Configuration, org string, repos RepoLabels) (RepoUpdates
 			}
 		}
 
-		for _, a := range moveActions {
-			actions = append(actions, a)
-		}
+		actions = append(actions, moveActions...)
 	}
 
 	u := RepoUpdates{}

--- a/prow/cmd/deck/job_history.go
+++ b/prow/cmd/deck/job_history.go
@@ -53,7 +53,7 @@ const (
 )
 
 var (
-	linkRe = regexp.MustCompile("/([0-9]+)\\.txt$")
+	linkRe = regexp.MustCompile(`/([0-9]+)\.txt$`)
 )
 
 type buildData struct {

--- a/prow/cmd/generic-autobumper/bumper/bumper.go
+++ b/prow/cmd/generic-autobumper/bumper/bumper.go
@@ -886,9 +886,7 @@ func formatVariant(variant string) string {
 	if variant == "" {
 		return ""
 	}
-	if strings.HasPrefix(variant, "-") {
-		variant = variant[1:]
-	}
+	variant = strings.TrimPrefix(variant, "-")
 	return fmt.Sprintf("(%s)", variant)
 }
 

--- a/prow/cmd/horologium/main_test.go
+++ b/prow/cmd/horologium/main_test.go
@@ -50,11 +50,8 @@ func (fc *fakeCron) SyncConfig(cfg *config.Config) error {
 }
 
 func (fc *fakeCron) QueuedJobs() []string {
-	res := []string{}
-	for _, job := range fc.jobs {
-		res = append(res, job)
-	}
-	fc.jobs = []string{}
+	res := fc.jobs
+	fc.jobs = nil
 	return res
 }
 

--- a/prow/cmd/phaino/local.go
+++ b/prow/cmd/phaino/local.go
@@ -408,8 +408,7 @@ func (opts *options) resolveRefs(ctx context.Context, volumeMounts map[string]st
 	pj prowapi.ProwJob, container coreapi.Container) (string, error) {
 	var workingDir string
 
-	var readUserInput func(string, string) (string, error)
-	readUserInput = func(path, def string) (string, error) {
+	readUserInput := func(path, def string) (string, error) {
 		fmt.Fprintf(os.Stderr, "local /path/to/%s", path)
 		if def != "" {
 			fmt.Fprintf(os.Stderr, " [%s]", def)

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1303,8 +1303,7 @@ func yamlToConfig(path string, nc interface{}) error {
 		}
 	}
 
-	var fix func(*Periodic)
-	fix = func(job *Periodic) {
+	fix := func(job *Periodic) {
 		job.SourcePath = path
 	}
 	for i := range jc.Periodics {

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -551,9 +551,7 @@ func (c *JobConfig) AllStaticPostsubmits(repos []string) []Postsubmit {
 func (c *JobConfig) AllPeriodics() []Periodic {
 	listPeriodic := func(ps []Periodic) []Periodic {
 		var res []Periodic
-		for _, p := range ps {
-			res = append(res, p)
-		}
+		res = append(res, ps...)
 		return res
 	}
 

--- a/prow/gerrit/client/client.go
+++ b/prow/gerrit/client/client.go
@@ -263,9 +263,7 @@ func (c *Client) QueryChanges(lastState LastSyncState, rateLimit int) map[string
 			continue
 		}
 
-		for _, change := range changes {
-			result[h.instance] = append(result[h.instance], change)
-		}
+		result[h.instance] = append(result[h.instance], changes...)
 	}
 	return result
 }

--- a/prow/gerrit/client/client_test.go
+++ b/prow/gerrit/client/client_test.go
@@ -42,9 +42,7 @@ func (f *fgc) ListChangeComments(id string) (*map[string][]gerrit.CommentInfo, *
 	}
 
 	for path, retComments := range val {
-		for _, comment := range retComments {
-			comments[path] = append(comments[path], comment)
-		}
+		comments[path] = append(comments[path], retComments...)
 	}
 
 	return &comments, nil, nil
@@ -658,9 +656,7 @@ func TestQueryChange(t *testing.T) {
 			revisions[instance] = []string{}
 			for _, change := range changes {
 				revisions[instance] = append(revisions[instance], change.CurrentRevision)
-				for _, m := range change.Messages {
-					messages[change.ChangeID] = append(messages[change.ChangeID], m)
-				}
+				messages[change.ChangeID] = append(messages[change.ChangeID], change.Messages...)
 			}
 			sort.Strings(revisions[instance])
 		}

--- a/prow/plugins/assign/assign_test.go
+++ b/prow/plugins/assign/assign_test.go
@@ -48,9 +48,7 @@ func (c *fakeClient) AssignIssue(owner, repo string, number int, assignees []str
 	var missing github.MissingUsers
 	sort.Strings(assignees)
 	if len(assignees) > 10 {
-		for _, who := range assignees[10:] {
-			missing.Users = append(missing.Users, who)
-		}
+		missing.Users = append(missing.Users, assignees[10:]...)
 		for _, who := range assignees[:10] {
 			c.assigned[who]++
 		}

--- a/prow/plugins/golint/suggestion/golint_suggestion.go
+++ b/prow/plugins/golint/suggestion/golint_suggestion.go
@@ -29,8 +29,8 @@ var (
 	lintErrorfRegex          = regexp.MustCompile(`should replace errors\.New\(fmt\.Sprintf\(\.\.\.\)\) with fmt\.Errorf\(\.\.\.\)`)
 	lintNamesUnderscoreRegex = regexp.MustCompile("don't use underscores in Go names; (.*) should be (.*)")
 	lintNamesAllCapsRegex    = regexp.MustCompile("don't use ALL_CAPS in Go names; use CamelCase")
-	lintStutterRegex         = regexp.MustCompile("name will be used as [^.]+\\.(.*) by other packages, and that stutters; consider calling this (.*)")
-	lintRangesRegex          = regexp.MustCompile("should omit (?:2nd )?values? from range; this loop is equivalent to \\x60(for .*) ...\\x60")
+	lintStutterRegex         = regexp.MustCompile(`name will be used as [^.]+\.(.*) by other packages, and that stutters; consider calling this (.*)`)
+	lintRangesRegex          = regexp.MustCompile(`should omit (?:2nd )?values? from range; this loop is equivalent to \x60(for .*) ...\x60`)
 	lintVarDeclRegex         = regexp.MustCompile("should (?:omit type|drop) (.*) from declaration of (?:.*); (?:it will be inferred from the right-hand side|it is the zero value)")
 )
 

--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -391,9 +391,7 @@ func CloneRefs(pj prowapi.ProwJob, codeMount, logMount coreapi.VolumeMount) (*co
 	if pj.Spec.Refs != nil {
 		refs = append(refs, *pj.Spec.Refs)
 	}
-	for _, r := range pj.Spec.ExtraRefs {
-		refs = append(refs, r)
-	}
+	refs = append(refs, pj.Spec.ExtraRefs...)
 	if len(refs) == 0 { // nothing to clone
 		return nil, nil, nil, nil
 	}

--- a/prow/pod-utils/decorate/podspec_test.go
+++ b/prow/pod-utils/decorate/podspec_test.go
@@ -421,9 +421,7 @@ func TestCloneRefs(t *testing.T) {
 				if tc.pj.Spec.Refs != nil {
 					er = append(er, *tc.pj.Spec.Refs)
 				}
-				for _, r := range tc.pj.Spec.ExtraRefs {
-					er = append(er, r)
-				}
+				er = append(er, tc.pj.Spec.ExtraRefs...)
 				if !equality.Semantic.DeepEqual(refs, er) {
 					t.Errorf("unexpected refs:\n%s", diff.ObjectReflectDiff(er, refs))
 				}

--- a/prow/sidecar/run_test.go
+++ b/prow/sidecar/run_test.go
@@ -274,11 +274,9 @@ func TestWaitParallelContainers(t *testing.T) {
 
 			if tc.missing {
 				go func() {
-					select {
-					case <-time.After(missingMarkerTimeout):
-						cancel()
-						errCh <- nil
-					}
+					time.Sleep(missingMarkerTimeout)
+					cancel()
+					errCh <- nil
 				}()
 			}
 

--- a/prow/tide/status_test.go
+++ b/prow/tide/status_test.go
@@ -1053,9 +1053,7 @@ func TestIndexFuncPassingJobs(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			var results []string
-			for _, result := range indexFuncPassingJobs(tc.pj) {
-				results = append(results, result)
-			}
+			results = append(results, indexFuncPassingJobs(tc.pj)...)
 			if diff := deep.Equal(tc.expected, results); diff != nil {
 				t.Errorf("expected does not match result, diff: %v", diff)
 			}

--- a/releng/config-forker/main.go
+++ b/releng/config-forker/main.go
@@ -327,10 +327,8 @@ annotations:
 				v += ", " + "sig-release-job-config-errors"
 			}
 			didDashboards = true
-			break
 		case testgridTabNameAnnotation:
 			v = strings.ReplaceAll(v, "master", version)
-			break
 		case descriptionAnnotation:
 			continue annotations
 		}

--- a/velodrome/fetcher/client.go
+++ b/velodrome/fetcher/client.go
@@ -109,7 +109,7 @@ func (client *Client) limitsCheckAndWait() {
 			sleep = time.Minute
 		}
 		if limits != nil && limits.Core != nil && limits.Core.Remaining < tokenLimit {
-			sleep = limits.Core.Reset.Sub(time.Now())
+			sleep = time.Until(limits.Core.Reset.Time)
 			glog.Warning("RateLimits: reached. Sleeping for ", sleep)
 		}
 	}

--- a/velodrome/token-counter/token-counter.go
+++ b/velodrome/token-counter/token-counter.go
@@ -129,7 +129,7 @@ func (t TokenHandler) Process() {
 	}
 
 	for {
-		halfPeriod := lastRate.Reset.Time.Sub(time.Now()) / 2
+		halfPeriod := time.Until(lastRate.Reset.Time) / 2
 		time.Sleep(halfPeriod)
 		newRate, err := t.getCoreRate()
 		if err != nil {

--- a/velodrome/transform/plugins/events.go
+++ b/velodrome/transform/plugins/events.go
@@ -103,7 +103,7 @@ func (l LabelEvent) Match(eventName, label string) bool {
 
 // Opposite is unlabel
 func (l LabelEvent) Opposite() EventMatcher {
-	return UnlabelEvent{Label: l.Label}
+	return UnlabelEvent(l)
 }
 
 // UnlabelEvent is an "unlabeled" event
@@ -120,7 +120,7 @@ func (u UnlabelEvent) Match(eventName, label string) bool {
 
 // Opposite is label
 func (u UnlabelEvent) Opposite() EventMatcher {
-	return LabelEvent{Label: u.Label}
+	return LabelEvent(u)
 }
 
 // CloseEvent is a "closed" event


### PR DESCRIPTION
It requires to:
* Replace literal regex strings in `"` to use backticks instead so backslashes inside do not need double escaping
* Replacing loops that append from a slice to another slice to be replaced with `toAppendSlice = append(toAppendSlice, otherSlice...)`
* `time.TIme.Sub(time.Now())` to be replaced with `time.Until(time.Time)`
* Variable declarations that are immediately followed by variable assignments to use the short form of doing both (`a := val`)