### PR TITLE
Azure: Set LOCAL_ONLY as part of anonymous pull preset

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-release-0-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-release-0-4.yaml
@@ -90,8 +90,6 @@ periodics:
       env:
         - name: GINKGO_FOCUS
           value: "Cluster API E2E tests"
-        - name: LOCAL_ONLY
-          value: "false"
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
@@ -125,8 +123,6 @@ periodics:
           value: "Workload cluster creation"
         - name: GINKGO_SKIP
           value: ""
-        - name: LOCAL_ONLY
-          value: "false"
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
@@ -90,8 +90,6 @@ periodics:
       env:
         - name: GINKGO_FOCUS
           value: "Cluster API E2E tests"
-        - name: LOCAL_ONLY
-          value: "false"
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
@@ -160,8 +158,6 @@ periodics:
           value: "Workload cluster creation"
         - name: GINKGO_SKIP
           value: ""
-        - name: LOCAL_ONLY
-          value: "false"
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-postsubmits-release-0-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-postsubmits-release-0-4.yaml
@@ -23,8 +23,6 @@ postsubmits:
             value: "Workload cluster creation"
           - name: GINKGO_SKIP
             value: ""
-          - name: LOCAL_ONLY
-            value: "false"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-postsubmits.yaml
@@ -23,8 +23,6 @@ postsubmits:
             value: "Workload cluster creation"
           - name: GINKGO_SKIP
             value: ""
-          - name: LOCAL_ONLY
-            value: "false"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-0-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-0-4.yaml
@@ -60,8 +60,6 @@ presubmits:
             value: "Workload cluster creation"
           - name: GINKGO_SKIP
             value: "Creating a GPU-enabled cluster|.*Windows.*"
-          - name: LOCAL_ONLY
-            value: "false"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -94,8 +92,6 @@ presubmits:
             value: "Workload cluster creation"
           - name: GINKGO_SKIP
             value: ""
-          - name: LOCAL_ONLY
-            value: "false"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -129,8 +125,6 @@ presubmits:
             value: ".*Windows.*"
           - name: GINKGO_SKIP
             value: ""
-          - name: LOCAL_ONLY
-            value: "false"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -163,8 +157,6 @@ presubmits:
         env:
           - name: GINKGO_FOCUS
             value: "Cluster API E2E tests"
-          - name: LOCAL_ONLY
-            value: "false"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -60,8 +60,6 @@ presubmits:
             value: "Workload cluster creation"
           - name: GINKGO_SKIP
             value: "Creating a GPU-enabled cluster|.*Windows.*|Creating a cluster that uses the external cloud provider"
-          - name: LOCAL_ONLY
-            value: "false"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -94,8 +92,6 @@ presubmits:
             value: "Workload cluster creation"
           - name: GINKGO_SKIP
             value: ""
-          - name: LOCAL_ONLY
-            value: "false"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -129,8 +125,6 @@ presubmits:
             value: ".*Windows.*"
           - name: GINKGO_SKIP
             value: ""
-          - name: LOCAL_ONLY
-            value: "false"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -163,8 +157,6 @@ presubmits:
         env:
           - name: GINKGO_FOCUS
             value: "Cluster API E2E tests"
-          - name: LOCAL_ONLY
-            value: "false"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -723,6 +723,8 @@ presets:
   env:
     - name: REGISTRY
       value: capzci.azurecr.io
+    - name: LOCAL_ONLY
+      value: "false"
 - labels:
     preset-azure-cred-only: "true"
   env:


### PR DESCRIPTION
When using the `preset-azure-anonymous-pull` preset which sets `REGISTRY` to "capzci.azurecr.io", we should always set `LOCAL_ONLY` to false. This PR adds it to the preset so we don't have to add it to every single job that uses the preset.

/assign @chewong @devigned 