### PR TITLE
jobs: fix k8s.io deploy jobs

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
@@ -158,9 +158,14 @@ postsubmits:
         args:
         - -c
         - |
-          gcloud container clusters get-credentials prow-build --project=k8s-infra-prow-build --region=us-central1
-          kubectl --context=gke_k8s-infra-prow-build_us-central1_prow-build \
-            apply -f ./infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources
+          cd ./infra/gcp/clusters/projects/k8s-infra-prow-build
+          if [[ -x ./deploy.sh ]]; then
+            ./deploy.sh
+          else
+            gcloud container clusters get-credentials prow-build --project=k8s-infra-prow-build --region=us-central1
+            kubectl --context=gke_k8s-infra-prow-build_us-central1_prow-build \
+              apply -f ./prow-build/resources --recursive
+          fi
   - name: post-k8sio-deploy-prow-build-trusted-resources
     cluster: k8s-infra-prow-build-trusted
     decorate: true
@@ -182,6 +187,11 @@ postsubmits:
         args:
         - -c
         - |
-          gcloud container clusters get-credentials prow-build-trusted --project=k8s-infra-prow-build-trusted --region=us-central1
-          kubectl --context=gke_k8s-infra-prow-build-trusted_us-central1_prow-build-trusted \
-            apply -f ./infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources
+          cd ./infra/gcp/clusters/projects/k8s-infra-prow-build-trusted
+          if [[ -x ./deploy.sh ]]; then
+            ./deploy.sh
+          else
+            gcloud container clusters get-credentials prow-build-trusted --project=k8s-infra-prow-build-trusted --region=us-central1
+            kubectl --context=gke_k8s-infra-prow-build-trusted_us-central1_prow-build-trusted \
+              apply -f ./prow-build-trusted/resources --recursive
+          fi

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
@@ -22,29 +22,6 @@ periodics:
       args:
       - -c
       - "cd groups && make run -- --confirm"
-- name: ci-k8sio-groups-head
-  interval: 1h
-  cluster: k8s-infra-prow-build-trusted
-  decorate: true
-  max_concurrency: 1
-  annotations:
-    testgrid-dashboards: wg-k8s-infra-k8sio, sig-testing-canaries
-    testgrid-alert-email: k8s-infra-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: '1'
-  extra_refs:
-  - org: kubernetes
-    repo: k8s.io
-    base_ref: HEAD
-  spec:
-    serviceAccountName: gsuite-groups-manager
-    containers:
-    - name: groups
-      image: golang:1.13
-      command:
-      - bash
-      args:
-      - -c
-      - "cd groups && make run -- --confirm"
 - name: ci-k8sio-audit
   interval: 6h
   cluster: k8s-infra-prow-build-trusted

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
@@ -15,8 +15,7 @@ periodics:
   spec:
     serviceAccountName: gsuite-groups-manager
     containers:
-    - name: groups
-      image: golang:1.13
+    - image: golang:1.13
       command:
       - bash
       args:
@@ -44,8 +43,7 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-gcp-auditor
     containers:
-    - name: groups
-      image: gcr.io/k8s-staging-releng/releng-ci:latest
+    - image: gcr.io/k8s-staging-releng/releng-ci:latest
       command:
       - bash
       args:
@@ -112,8 +110,7 @@ postsubmits:
     spec:
       serviceAccountName: gsuite-groups-manager
       containers:
-      - name: groups
-        image: golang:1.13
+      - image: golang:1.13
         command:
         - bash
         args:

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
@@ -99,7 +99,7 @@ postsubmits:
     cluster: k8s-infra-prow-build-trusted
     decorate: true
     max_concurrency: 1
-    run_if_changed: '^groups/groups.yaml'
+    run_if_changed: '^groups/'
     branches:
     - ^main$
     annotations:
@@ -141,7 +141,7 @@ postsubmits:
     cluster: k8s-infra-prow-build-trusted
     decorate: true
     max_concurrency: 1
-    run_if_changed: "^infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/"
+    run_if_changed: "^infra/gcp/clusters/projects/k8s-infra-prow-build/"
     branches:
     - ^main$
     annotations:
@@ -165,7 +165,7 @@ postsubmits:
     cluster: k8s-infra-prow-build-trusted
     decorate: true
     max_concurrency: 1
-    run_if_changed: "^infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/"
+    run_if_changed: "^infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/"
     branches:
     - ^main$
     annotations:

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
@@ -1,6 +1,6 @@
 periodics:
 - name: ci-k8sio-groups
-  interval: 24h
+  interval: 6h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
   max_concurrency: 1


### PR DESCRIPTION
Main motivation was to fix the fact that the post-k8sio-groups job didn't trigger when a change to groups/committee-product-security/groups.yaml was merged (ref: https://github.com/kubernetes/k8s.io/pull/1973#issuecomment-827058843)

However I took care of a few other things while I was here:
- prep prow deploy jobs to use in-repo deploy scripts
- run the ci-k8sio-groups job 4x as frequently since postsubmits seem unreliable
- drop the perma-failing ci-k8sio-groups-head experiment job
- drop the "groups" container name copy-pasta from jobs