### PR TITLE
jenkins-operator: Configure jenkins operator to retrigger aborted jo…

### DIFF
--- a/prow/cmd/jenkins-operator/main.go
+++ b/prow/cmd/jenkins-operator/main.go
@@ -57,6 +57,7 @@ type options struct {
 	caCertFile             string
 	csrfProtect            bool
 	skipReport             bool
+	retryAbortedJobs       bool
 
 	dryRun                 bool
 	kubernetes             prowflagutil.KubernetesOptions
@@ -113,6 +114,7 @@ func gatherOptions() options {
 	fs.BoolVar(&o.csrfProtect, "csrf-protect", false, "Request a CSRF protection token from Jenkins that will be used in all subsequent requests to Jenkins.")
 
 	fs.BoolVar(&o.skipReport, "skip-report", false, "Whether or not to ignore report with githubClient")
+	fs.BoolVar(&o.retryAbortedJobs, "retry-aborted-jobs", false, "Whether or not to retrigger aborted jobs that where the abortion was not initiated by prow")
 	fs.BoolVar(&o.dryRun, "dry-run", true, "Whether or not to make mutating API calls to GitHub/Kubernetes/Jenkins.")
 	for _, group := range []flagutil.OptionGroup{&o.kubernetes, &o.github, &o.instrumentationOptions, &o.config} {
 		group.AddFlags(fs)
@@ -198,7 +200,7 @@ func main() {
 		logrus.WithError(err).Fatal("Error getting GitHub client.")
 	}
 
-	c, err := jenkins.NewController(prowJobClient, jc, githubClient, nil, cfg, o.totURL, o.selector, o.skipReport)
+	c, err := jenkins.NewController(prowJobClient, jc, githubClient, nil, cfg, o.totURL, o.selector, o.skipReport, o.retryAbortedJobs)
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to instantiate Jenkins controller.")
 	}

--- a/prow/jenkins/controller_test.go
+++ b/prow/jenkins/controller_test.go
@@ -526,6 +526,50 @@ func TestSyncPendingJobs(t *testing.T) {
 			expectedComplete: true,
 			expectedReport:   true,
 		},
+		{
+			name: "aborted outside of prow",
+			pj: prowapi.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "needtoretry",
+					Namespace: "prowjobs",
+				},
+				Spec: prowapi.ProwJobSpec{
+					Job: "test-job",
+				},
+				Status: prowapi.ProwJobStatus{
+					State: prowapi.PendingState,
+				},
+			},
+			builds: map[string]Build{
+				"needtoretry": {Result: pState(aborted), Number: 13},
+			},
+			expectedState:    prowapi.PendingState,
+			expectedEnqueued: true,
+			expectedBuild:    true,
+			expectedReport:   true,
+		},
+		{
+			name: "aborted from prow",
+			pj: prowapi.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dontretry",
+					Namespace: "prowjobs",
+				},
+				Spec: prowapi.ProwJobSpec{
+					Job: "test-job",
+				},
+				Status: prowapi.ProwJobStatus{
+					State: prowapi.AbortedState,
+				},
+			},
+			builds: map[string]Build{
+				"dontretry": {Result: pState(aborted), Number: 14},
+			},
+			expectedURL:      "dontretry/aborted",
+			expectedState:    prowapi.AbortedState,
+			expectedComplete: true,
+			expectedReport:   true,
+		},
 	}
 	for _, tc := range testcases {
 		t.Logf("scenario %q", tc.name)
@@ -539,14 +583,15 @@ func TestSyncPendingJobs(t *testing.T) {
 		fakeProwJobClient := fake.NewSimpleClientset(&tc.pj)
 
 		c := Controller{
-			prowJobClient: fakeProwJobClient.ProwV1().ProwJobs("prowjobs"),
-			jc:            fjc,
-			log:           logrus.NewEntry(logrus.StandardLogger()),
-			cfg:           newFakeConfigAgent(t, 0, nil).Config,
-			totURL:        totServ.URL,
-			lock:          sync.RWMutex{},
-			pendingJobs:   make(map[string]int),
-			clock:         clock.RealClock{},
+			prowJobClient:    fakeProwJobClient.ProwV1().ProwJobs("prowjobs"),
+			jc:               fjc,
+			log:              logrus.NewEntry(logrus.StandardLogger()),
+			cfg:              newFakeConfigAgent(t, 0, nil).Config,
+			totURL:           totServ.URL,
+			lock:             sync.RWMutex{},
+			pendingJobs:      make(map[string]int),
+			retryAbortedJobs: true,
+			clock:            clock.RealClock{},
 		}
 
 		reports := make(chan prowapi.ProwJob, 100)

--- a/prow/jenkins/jenkins.go
+++ b/prow/jenkins/jenkins.go
@@ -663,7 +663,9 @@ func (c *Client) ListBuilds(jobs []BuildQueryParams) (map[string]Build, error) {
 
 	for builds := range buildChan {
 		for id, build := range builds {
-			jenkinsBuilds[id] = build
+			if _, ok := jenkinsBuilds[id]; !ok {
+				jenkinsBuilds[id] = build
+			}
 		}
 	}
 
@@ -736,7 +738,9 @@ func (c *Client) GetBuilds(job string) (map[string]Build, error) {
 		if prowJobID == "" {
 			continue
 		}
-		jenkinsBuilds[prowJobID] = jb
+		if _, ok := jenkinsBuilds[prowJobID]; !ok {
+			jenkinsBuilds[prowJobID] = jb
+		}
 	}
 	return jenkinsBuilds, nil
 }


### PR DESCRIPTION
…bs not initiated by prow

Introduce jenkins operator config `retryAbortedJobs`, where the behavior from this bool setting will be:
- If prow does not initiate the abortion of a job and we get an aborted state from jenkins, retrigger the job and update the URL/jenkins job that the prowjob links to.
- If prow initiates the abort, don't retrigger
- If setting is not set, setting is not in effect

This setting is specially useful for cases where you don't control when workers terminate, such as when using EC2 spot instances.