### PR TITLE
Add pull-aws-ebs-csi-driver-external-test-latest-eks presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-periodics.yaml
@@ -1,5 +1,5 @@
 periodics:
-- name: ci-aws-ebs-csi-driver-migration-test-latest
+- name: ci-aws-ebs-csi-driver-migration-test
   decorate: true
   decoration_config:
     timeout: 1h20m
@@ -24,8 +24,8 @@ periodics:
         privileged: true
   annotations:
     testgrid-dashboards: provider-aws-ebs-csi-driver
-    testgrid-tab-name: ci-migration-test-latest
-    description: aws ebs csi driver migration test on latest kubernetes, continuous
+    testgrid-tab-name: ci-migration-test
+    description: aws ebs csi driver migration test, continuous
     testgrid-num-columns-recent: '30'
 - name: ci-aws-ebs-csi-driver-unit-test
   decorate: true
@@ -111,7 +111,7 @@ periodics:
     testgrid-tab-name: ci-e2e-test-multi-az
     description: aws ebs csi driver e2e test on mutiple AZs, continuous
     testgrid-num-columns-recent: '30'
-- name: ci-aws-ebs-csi-driver-external-test-latest
+- name: ci-aws-ebs-csi-driver-external-test
   decorate: true
   decoration_config:
     timeout: 1h20m
@@ -136,6 +136,6 @@ periodics:
         privileged: true
   annotations:
     testgrid-dashboards: provider-aws-ebs-csi-driver
-    testgrid-tab-name: ci-external-test-latest
-    description: kubernetes/kubernetes external test on latest kubernetes, continuous
+    testgrid-tab-name: ci-external-test
+    description: kubernetes/kubernetes external test, continuous
     testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -88,7 +88,7 @@ presubmits:
       testgrid-tab-name: pull-e2e-test-multi-az
       description: aws ebs csi driver e2e test on mutiple AZs on pull request
       testgrid-num-columns-recent: '30'
-  - name: pull-aws-ebs-csi-driver-migration-test-latest
+  - name: pull-aws-ebs-csi-driver-migration-test
     always_run: true
     decorate: true
     skip_branches:
@@ -109,10 +109,10 @@ presubmits:
             privileged: true
     annotations:
       testgrid-dashboards: provider-aws-ebs-csi-driver
-      testgrid-tab-name: pull-migration-test-latest
-      description: aws ebs csi driver migration test on latest kubernetes on pull request
+      testgrid-tab-name: pull-migration-test
+      description: aws ebs csi driver migration test on pull request
       testgrid-num-columns-recent: '30'
-  - name: pull-aws-ebs-csi-driver-external-test-latest
+  - name: pull-aws-ebs-csi-driver-external-test
     always_run: true
     decorate: true
     skip_branches:
@@ -133,6 +133,6 @@ presubmits:
             privileged: true
     annotations:
       testgrid-dashboards: provider-aws-ebs-csi-driver
-      testgrid-tab-name: pull-external-test-latest
-      description: kubernetes/kubernetes external test on latest kubernetes on pull request
+      testgrid-tab-name: pull-external-test
+      description: kubernetes/kubernetes external test on pull request
       testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -136,3 +136,27 @@ presubmits:
       testgrid-tab-name: pull-external-test
       description: kubernetes/kubernetes external test on pull request
       testgrid-num-columns-recent: '30'
+  - name: pull-aws-ebs-csi-driver-external-test-eks
+    always_run: false
+    decorate: true
+    skip_branches:
+      - gh-pages
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-aws-credential-aws-oss-testing: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-master
+          command:
+            - runner.sh
+          args:
+            - make
+            - test-e2e-external-eks
+          securityContext:
+            privileged: true
+    annotations:
+      testgrid-dashboards: provider-aws-ebs-csi-driver
+      testgrid-tab-name: pull-external-test-eks
+      description: kubernetes/kubernetes external test on pull request on eks
+      testgrid-num-columns-recent: '30'


### PR DESCRIPTION
Working on getting EKS variant jobs of every existing kops job working, starting with `pull-aws-ebs-csi-driver-external-test-latest`. Hence I'm appending the suffix -eks, `pull-aws-ebs-csi-driver-external-test-latest-eks`. Currently there is no such make rule as `test-e2e-external-eks` but I will add it in https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/852 or a future PR.

Once I get it working, I will come back here and mark the job always_required.

I'm also thinking of renaming all the tests*. The `-latest` suffix will be more confusing since the version of EKS being tested won't necessarily be the same as KOPS. For example, we are running kops 1.20 tests but the newest available EKS version is 1.19 so latest kops != latest eks. Anyway, I'm not sure it's useful to include k8s version information in the job name since we have been updating the test k8s version on a best-effort basis, and we only run tests against 1 version at a time.
