### PR TITLE
Change autobumper PR body to use prefix rather than name

### DIFF
--- a/prow/cmd/generic-autobumper/bumper/bumper.go
+++ b/prow/cmd/generic-autobumper/bumper/bumper.go
@@ -925,11 +925,11 @@ func generateSummary(name, repo, prefix string, summarise bool, images map[strin
 
 	switch {
 	case len(versions) == 0:
-		return fmt.Sprintf("No %s changes.", name)
+		return fmt.Sprintf("No %s changes.", prefix)
 	case len(versions) == 1 && summarise:
 		for k, v := range versions {
 			s := strings.Split(k, ":")
-			return fmt.Sprintf("%s changes: %s/compare/%s...%s (%s → %s)", name, repo, s[0], s[1], formatTagDate(v[0].oldDate), formatTagDate(v[0].newDate))
+			return fmt.Sprintf("%s changes: %s/compare/%s...%s (%s → %s)", prefix, repo, s[0], s[1], formatTagDate(v[0].oldDate), formatTagDate(v[0].newDate))
 		}
 	default:
 		changes := make([]string, 0, len(versions))
@@ -944,7 +944,7 @@ func generateSummary(name, repo, prefix string, summarise bool, images map[strin
 				repo, s[0], s[1], formatTagDate(v[0].oldDate), formatTagDate(v[0].newDate), strings.Join(names, ", ")))
 		}
 		sort.Slice(changes, func(i, j int) bool { return strings.Split(changes[i], "|")[1] < strings.Split(changes[j], "|")[1] })
-		return fmt.Sprintf("Multiple distinct %s changes:\n\nCommits | Dates | Images\n--- | --- | ---\n%s\n", name, strings.Join(changes, "\n"))
+		return fmt.Sprintf("Multiple distinct %s changes:\n\nCommits | Dates | Images\n--- | --- | ---\n%s\n", prefix, strings.Join(changes, "\n"))
 	}
 	panic("unreachable!")
 }

--- a/prow/cmd/generic-autobumper/bumper/bumper_test.go
+++ b/prow/cmd/generic-autobumper/bumper/bumper_test.go
@@ -1151,7 +1151,7 @@ func TestGenerateSummary(t *testing.T) {
 	afterCommit2 := "4f1234567"
 	beforeDate2 := "20210125"
 	afterDate2 := "20210126"
-	unsummarizedOutHeader := `Multiple distinct Test changes:
+	unsummarizedOutHeader := `Multiple distinct %s changes:
 
 Commits | Dates | Images
 --- | --- | ---`
@@ -1181,7 +1181,7 @@ Commits | Dates | Images
 			prefix:    "gcr.io/none",
 			summarize: true,
 			images:    sampleImages,
-			expected:  "No Test changes.",
+			expected:  "No gcr.io/none changes.",
 		},
 		{
 			testName:  "Image not bumped summarized",
@@ -1190,7 +1190,7 @@ Commits | Dates | Images
 			prefix:    "gcr.io/none",
 			summarize: true,
 			images:    sampleImages,
-			expected:  "No Test changes.",
+			expected:  "No gcr.io/none changes.",
 		},
 		{
 			testName:  "Image bumped: summarized",
@@ -1199,7 +1199,7 @@ Commits | Dates | Images
 			prefix:    "gcr.io/bumped",
 			summarize: true,
 			images:    sampleImages,
-			expected:  fmt.Sprintf("Test changes: github.com/test/repo/compare/%s...%s (%s → %s)", beforeCommit, afterCommit, formatTagDate(beforeDate), formatTagDate(afterDate)),
+			expected:  fmt.Sprintf("gcr.io/bumped changes: github.com/test/repo/compare/%s...%s (%s → %s)", beforeCommit, afterCommit, formatTagDate(beforeDate), formatTagDate(afterDate)),
 		},
 		{
 			testName:  "Image bumped: not summarized",
@@ -1208,7 +1208,7 @@ Commits | Dates | Images
 			prefix:    "gcr.io/bumped",
 			summarize: false,
 			images:    sampleImages,
-			expected:  fmt.Sprintf("%s\n%s\n", unsummarizedOutHeader, fmt.Sprintf(unsummarizedOutLine, beforeCommit, afterCommit, formatTagDate(beforeDate), formatTagDate(afterDate), "bumpName")),
+			expected:  fmt.Sprintf("%s\n%s\n", fmt.Sprintf(unsummarizedOutHeader, "gcr.io/bumped"), fmt.Sprintf(unsummarizedOutLine, beforeCommit, afterCommit, formatTagDate(beforeDate), formatTagDate(afterDate), "bumpName")),
 		},
 		{
 			testName:  "Image bumped: not summarized",
@@ -1217,7 +1217,7 @@ Commits | Dates | Images
 			prefix:    "gcr.io/variant",
 			summarize: false,
 			images:    sampleImages,
-			expected:  fmt.Sprintf("%s\n%s\n", unsummarizedOutHeader, fmt.Sprintf(unsummarizedOutLine, beforeCommit, afterCommit, formatTagDate(beforeDate), formatTagDate(afterDate), "name(first), name(second)")),
+			expected:  fmt.Sprintf("%s\n%s\n", fmt.Sprintf(unsummarizedOutHeader, "gcr.io/variant"), fmt.Sprintf(unsummarizedOutLine, beforeCommit, afterCommit, formatTagDate(beforeDate), formatTagDate(afterDate), "name(first), name(second)")),
 		},
 		{
 			testName:  "Image bumped, inconsistent: not summarized",
@@ -1226,7 +1226,7 @@ Commits | Dates | Images
 			prefix:    "gcr.io/inconsistent",
 			summarize: false,
 			images:    sampleImages,
-			expected:  fmt.Sprintf("%s\n%s\n%s\n", unsummarizedOutHeader, fmt.Sprintf(unsummarizedOutLine, beforeCommit2, afterCommit2, formatTagDate(beforeDate2), formatTagDate(afterDate2), "first"), fmt.Sprintf(unsummarizedOutLine, beforeCommit, afterCommit, formatTagDate(beforeDate), formatTagDate(afterDate), "second")),
+			expected:  fmt.Sprintf("%s\n%s\n%s\n", fmt.Sprintf(unsummarizedOutHeader, "gcr.io/inconsistent"), fmt.Sprintf(unsummarizedOutLine, beforeCommit2, afterCommit2, formatTagDate(beforeDate2), formatTagDate(afterDate2), "first"), fmt.Sprintf(unsummarizedOutLine, beforeCommit, afterCommit, formatTagDate(beforeDate), formatTagDate(afterDate), "second")),
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
The current PR body is not always clear given that the Prefix name is configurable and not always easy to understand. We would rather this always have the exact prefix being bumped (ex. gcr.io/k8s-prow) 