### PR TITLE
Abort batch jobs that are invalid because of PR head changed or left pool

### DIFF
--- a/config/prow/cluster/starter-gcs.yaml
+++ b/config/prow/cluster/starter-gcs.yaml
@@ -902,6 +902,7 @@ rules:
       - list
       - get
       - watch
+      - patch
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/prow/cluster/starter-s3.yaml
+++ b/config/prow/cluster/starter-s3.yaml
@@ -900,6 +900,7 @@ rules:
       - list
       - get
       - watch
+      - patch
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/prow/cluster/tide_rbac.yaml
+++ b/config/prow/cluster/tide_rbac.yaml
@@ -21,6 +21,7 @@ rules:
       - list
       - get
       - watch
+      - patch
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -867,18 +867,23 @@ func (c *Controller) accumulateBatch(sp subpool) (successBatch []PullRequest, pe
 					state.prs = append(state.prs, pr)
 				} else if !ok {
 					state.validPulls = false
-					sp.log.WithField("batch", ref).WithFields(pr.logFields()).Debug("batch job invalid, PR left pool")
+					sp.log.WithField("batch", ref).WithFields(pr.logFields()).Debug("batch job invalid, PR left pool, aborting any pending presubmits")
 					break
 				} else {
 					state.validPulls = false
-					sp.log.WithField("batch", ref).WithFields(pr.logFields()).Debug("batch job invalid, PR HEAD changed")
+					sp.log.WithField("batch", ref).WithFields(pr.logFields()).Debug("batch job invalid, PR HEAD changed, aborting any pending presubmits")
 					break
 				}
 			}
 			states[ref] = state
 		}
 		if !states[ref].validPulls {
-			// The batch contains a PR ref that has changed. Skip it.
+			// The batch contains a PR ref that has changed. Skip it and set state to abort.
+			prevPJ := pj.DeepCopy()
+			pj.Status.State = prowapi.AbortedState
+			if err := c.prowJobClient.Patch(c.ctx, pj.DeepCopy(), ctrlruntimeclient.MergeFrom(prevPJ)); err != nil {
+				sp.log.WithError(err).Error("patching prowjob with Aborted State")
+			}
 			continue
 		}
 


### PR DESCRIPTION
Any reason to keep running presubmit jobs for invalid batch jobs?, I couldn't figure out the logic here, let me know if there is something obvious I'm missing