### PR TITLE
azure: add additional regions

### DIFF
--- a/kubetest/aksengine.go
+++ b/kubetest/aksengine.go
@@ -291,10 +291,17 @@ func validateAzureStackCloudProfile() error {
 
 func randomAKSEngineLocation() string {
 	var AzureLocations = []string{
+		"canadacentral",
+		"centralus",
+		"eastus",
+		"eastus2",
+		"francecentral",
+		"northcentralus",
+		"northeurope",
+		"southcentralus",
+		"uksouth",
 		"westeurope",
 		"westus2",
-		"eastus2",
-		"southcentralus",
 	}
 
 	return AzureLocations[rand.Intn(len(AzureLocations))]


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

Attempts to fix https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-aks-engine-azure-master-windows-containerd/1387056891728760832. This PR adds additional Azure regions to minimize the chance of scheduling all jobs in a single region. I will open a follow-up PR to remove `--aksengine-location` flags so that jobs are scheduled to a random region.

/cc @jsturtevant 
/assign @feiskyer 