### PR TITLE
needs-rebase: fix gh api gotcha that skipped all PRs

### DIFF
--- a/prow/external-plugins/needs-rebase/plugin/plugin.go
+++ b/prow/external-plugins/needs-rebase/plugin/plugin.go
@@ -92,7 +92,7 @@ func HandleIssueCommentEvent(log *logrus.Entry, ghc githubClient, ice *github.Is
 // label needs to be added or removed. It depends on GitHub mergeability check
 // to decide the need for a rebase.
 func handle(log *logrus.Entry, ghc githubClient, pr *github.PullRequest) error {
-	if pr.State != string(githubql.PullRequestStateOpen) {
+	if pr.State != github.PullRequestStateOpen {
 		return nil
 	}
 	// Before checking mergeability wait a few seconds to give github a chance to calculate it.

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -243,6 +243,11 @@ type PullRequestEvent struct {
 	GUID string
 }
 
+const (
+	PullRequestStateOpen   = "open"
+	PullRequestStateClosed = "closed"
+)
+
 // PullRequest contains information about a PullRequest.
 type PullRequest struct {
 	ID                 int               `json:"id"`


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/21900/ added the following check to `handle()`:

```go
func handle(log *logrus.Entry, ghc githubClient, pr *github.PullRequest) error {
    if pr.State != string(githubql.PullRequestStateOpen) {
            return nil
    }
...
```

`github.PullRequest` comes from v3 API (from `GetPullRequest()` call) where `state` is either `open` or `closed` (https://docs.github.com/en/rest/reference/pulls#update-a-pull-request).

Comparing it to v4 enums that are upper-case and have an additional `MERGED` state does not make sense and made `handle()` skip all events, so needs-rebase only did its thing on the `HandleAll()` opportunity which is just called periodically, uses v4 API and overall a separate code path.
