### PR TITLE
Crier doesn't log error when the commit doesn't exist

### DIFF
--- a/prow/crier/reporters/github/reporter.go
+++ b/prow/crier/reporters/github/reporter.go
@@ -156,7 +156,7 @@ func (c *Client) Report(_ context.Context, log *logrus.Entry, pj *v1.ProwJob) ([
 			// This is completely unrecoverable, so just swallow the error to make sure we wont retry, even when crier gets restarted.
 			log.WithError(err).Debug("Encountered an error, skipping retries")
 			err = nil
-		} else if strings.Contains(err.Error(), "\"message\":\"Not Found\"") {
+		} else if strings.Contains(err.Error(), "\"message\":\"Not Found\"") || strings.Contains(err.Error(), "\"message\":\"No commit found for SHA:") {
 			// "message":"Not Found" error occurs when someone force push, which is not a crier error
 			log.WithError(err).Debug("Could not find PR commit, skipping retries")
 			err = nil

--- a/prow/crier/reporters/github/reporter_test.go
+++ b/prow/crier/reporters/github/reporter_test.go
@@ -186,11 +186,15 @@ func TestReport(t *testing.T) {
 		},
 		{
 			name:        "Maximum sha error gets swallowed",
-			githubError: errors.New("This SHA and context has reached the maximum number of statuses"),
+			githubError: errors.New(`This SHA and context has reached the maximum number of statuses`),
 		},
 		{
 			name:        "Error from user side gets swallowed",
-			githubError: errors.New("error setting status: status code 404 not one of [201], body: {\"message\":\"Not Found\",\"documentation_url\":\"https://docs.github.com/rest/reference/repos#create-a-commit-status\"}"),
+			githubError: errors.New(`error setting status: status code 404 not one of [201], body: {"message":"Not Found","documentation_url":"https://docs.github.com/rest/reference/repos#create-a-commit-status"}`),
+		},
+		{
+			name:        "Error from user side gets swallowed2",
+			githubError: errors.New(`failed to report job: error setting status: status code 422 not one of [201], body: {"message":"No commit found for SHA: 9d04799d1a22e9e604c50f6bbbec067aaccc1b32","documentation_url":"https://docs.github.com/rest/reference/repos#create-a-commit-status"}`),
 		},
 		{
 			name:          "Other error get returned",


### PR DESCRIPTION
Fixes https://github.com/kubernetes/test-infra/issues/21987