### PR TITLE
Kops - also ignore failing KMS test on CI k8s version markers

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -386,7 +386,7 @@ def build_test(cloud='aws',
 
     # TODO(rifelpet): Remove once k8s tags has been created that include
     #  https://github.com/kubernetes/kubernetes/pull/101443
-    if cloud == 'aws' and k8s_version in ('latest', 'stable', '1.21', '1.22') and skip_regex:
+    if cloud == 'aws' and k8s_version in ('ci', 'latest', 'stable', '1.21', '1.22') and skip_regex:
         skip_regex += r'|Invalid.AWS.KMS.key'
 
     suffix = ""
@@ -500,7 +500,7 @@ def presubmit_test(cloud='aws',
         kops_ssh_key_path = '/etc/aws-ssh/aws-ssh-private'
     # TODO(rifelpet): Remove once k8s tags has been created that include
     #  https://github.com/kubernetes/kubernetes/pull/101443
-        if k8s_version in ('latest', 'stable', '1.21', '1.22'):
+        if k8s_version in ('ci', 'latest', 'stable', '1.21', '1.22'):
             skip_override += r'|Invalid.AWS.KMS.key'
 
     elif cloud == 'gce':

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -436,7 +436,7 @@ periodics:
           --test-package-dir=ci \
           --test-package-marker=latest.txt \
           --parallel=25 \
-          --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler"
+          --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|Invalid.AWS.KMS.key"
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
@@ -504,7 +504,7 @@ periodics:
           --test-package-marker=latest.txt \
           --parallel=25 \
           --focus-regex="\[Conformance\]|\[NodeConformance\]" \
-          --skip-regex="\[Slow\]|\[Serial\]|\[Flaky\]"
+          --skip-regex="\[Slow\]|\[Serial\]|\[Flaky\]|Invalid.AWS.KMS.key"
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
@@ -572,7 +572,7 @@ periodics:
           --test-package-marker=latest.txt \
           --parallel=25 \
           --focus-regex="\[Conformance\]|\[NodeConformance\]" \
-          --skip-regex="\[Slow\]|\[Serial\]|\[Flaky\]"
+          --skip-regex="\[Slow\]|\[Serial\]|\[Flaky\]|Invalid.AWS.KMS.key"
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private

--- a/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
@@ -43,7 +43,7 @@ periodics:
           --test-package-dir=ci \
           --test-package-marker=latest.txt \
           --parallel=25 \
-          --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler"
+          --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|Invalid.AWS.KMS.key"
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private


### PR DESCRIPTION
followup to https://github.com/kubernetes/test-infra/pull/21968

jobs like this one are failing because this test isnt being ignored: https://testgrid.k8s.io/kops-versions#kops-aws-k8s-latest

once the fix is merged we can immediately revert this PR