### PR TITLE
Phaino: add a new flag code-mount-path replacing gopath arg

### DIFF
--- a/prow/cmd/phaino/README.md
+++ b/prow/cmd/phaino/README.md
@@ -33,7 +33,7 @@ volumes that the Prow Job may require.
 * `--print` the command that runs each job without running it
 * `--privileged` jobs are allowed to run instead of rejected
 * `--timeout=10m` controls how long to allow jobs to run before interrupting them
-* `--gopath=/go` provides the GOPATH that is used in the container
+* `--code-mount-path=/go` changes the path where code is mounted in the container
 * `--skip-volume-mounts=volume1,volume2` includes the unwanted volume mounts that are defined in the job spec
 * `--extra-volume-mounts=/go/src/k8s.io/test-infra=/Users/xyz/k8s-test-infra` includes the extra volume mounts needed for the container. Key is the mount path and value is the local path
 * `--skip-envs=env1,env2` includes the unwanted env vars that are defined in the job spec
@@ -48,7 +48,7 @@ it's desired to save the prompts, use the following tricks instead:
 
 - If the repo needs to be cloned under GOPATH, use:
   ```
-  --gopath=/whatever/go/src # Controls where source code is cloned in container
+  --code-mount-path==/whatever/go/src # Controls where source code is mounted in container
   --extra-volume-mounts=/whatever/go/src/k8s.io/test-infra=/Users/xyz/k8s-test-infra
   ```
 - If job requires mounting kubeconfig, assume the mount is named `kubeconfig`,use:

--- a/prow/cmd/phaino/local.go
+++ b/prow/cmd/phaino/local.go
@@ -45,9 +45,9 @@ const (
 	kubeconfigEnvKey = "KUBECONFIG"
 	// The path to mount the kubectl default config files to the container.
 	kubectlDefaultConfigMountPath = "/root/.kube"
-	// The default GOPATH in the container.
+	// The default code mount path in the container.
 	// To be consistent with https://github.com/kubernetes/test-infra/blob/19829768bb8ff2a9bb8de76e4dbcc1e520aaeb18/prow/pod-utils/decorate/podspec.go#L52
-	defaultGOPATH = "/home/prow/go"
+	defaultCodeMountpath = "/home/prow/go/src"
 )
 
 var baseArgs = []string{"docker", "run", "--rm=true"}
@@ -418,7 +418,6 @@ func (opts *options) resolveRefs(ctx context.Context, volumeMounts map[string]st
 		return scanln(ctx)
 	}
 
-	goSrcPath := filepath.Join(opts.gopath, "src")
 	var refs []prowapi.Refs
 	if pj.Spec.Refs != nil {
 		refs = append(refs, *pj.Spec.Refs)
@@ -426,7 +425,7 @@ func (opts *options) resolveRefs(ctx context.Context, volumeMounts map[string]st
 	refs = append(refs, pj.Spec.ExtraRefs...)
 	for _, ref := range refs {
 		repoPath := pathAlias(ref)
-		dest := filepath.Join(goSrcPath, repoPath)
+		dest := filepath.Join(opts.codeMountPath, repoPath)
 		// The repo hasn't been mounted.
 		if _, ok := opts.extraVolumesMounts[dest]; !ok {
 			repo, err := readRepo(repoPath, readUserInput)


### PR DESCRIPTION
The use of gopath can lead to the confusion of something related to golang, which is not very friendly with repos that don't primarily use golang