### PR TITLE
update gpu node image to new cos-89

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -3,7 +3,7 @@ presets:
     preset-ci-gce-device-plugin-gpu: "true"
   env:
   - name: KUBE_GCE_NODE_IMAGE
-    value: gke-1134-gke-rc5-cos-69-10895-138-0-v190320-pre-nvda-gpu
+    value: cos-stable-89-16108-403-22
   - name: KUBE_GCE_NODE_PROJECT
     value: gke-node-images
   - name: NODE_ACCELERATORS


### PR DESCRIPTION
cos-stable-89-16108-403-22

Fixes https://github.com/kubernetes/kubernetes/issues/101558

- [x] gke-1-8-4-gke-1-cos-stable-63-10032-71-0-p-v171208-pre-nvda-gpu
- [x] gke-1134-gke-rc5-cos-69-10895-138-0-v190320-pre-nvda-gpu
- [ ] gke-1202-gke-1-cos-89-16108-403-22-v201003-pre-nvda-gpu  ?? Can not find it and just use the general image to test.

cos-89-16108-403-22 ?
```
Date:           Apr 22, 2021
Kernel:         COS-5.4.104
Kubernetes:     v1.20.2
Docker:         v20.10.3
Containerd:     v1.4.3
Changelog (vs 89-16108-403-15):
    * Fixed an out-of-bounds write issue in the Linux kernel.
``` 