### PR TITLE
csi-driver-nfs: add a new Job to test external e2e tests

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-nfs/csi-driver-nfs-unmanaged.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-nfs/csi-driver-nfs-unmanaged.yaml
@@ -121,3 +121,54 @@ presubmits:
       testgrid-tab-name: pull-csi-driver-nfs-e2e
       description: "Run E2E tests for NFS CSI driver."
       testgrid-num-columns-recent: '30'
+
+  - name: pull-csi-driver-nfs-external-e2e
+    decorate: true
+    always_run: true
+    path_alias: sigs.k8s.io/csi-driver-nfs
+    branches:
+    - master
+    labels:
+      preset-service-account: "true"
+      preset-azure-cred: "true"
+      preset-dind-enabled: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-master
+        command:
+        - runner.sh
+        - kubetest
+        args:
+        # Generic e2e test args
+        - --test
+        - --up
+        - --down
+        - --dump=$(ARTIFACTS)
+        # Azure-specific test args
+        - --provider=skeleton
+        - --deployment=aksengine
+        - --aksengine-admin-username=azureuser
+        - --aksengine-creds=$(AZURE_CREDENTIALS)
+        - --aksengine-orchestratorRelease=1.17
+        - --aksengine-location=eastus2
+        - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
+        - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-csi/csi-driver-smb/master/test/e2e/manifest/linux.json
+        - --aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz
+        # Specific test args
+        - --test-csi-driver-nfs
+        securityContext:
+          privileged: true
+        env:
+          - name: EXTERNAL_E2E_TEST
+            value: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-other
+      testgrid-tab-name: pull-csi-driver-nfs-external-e2e
+      description: "Run External E2E tests for NFS CSI driver."
+      testgrid-num-columns-recent: '30'


### PR DESCRIPTION
with this https://github.com/kubernetes-csi/csi-driver-nfs/pull/190 PR, csi-driver-nfs introduces kubernetes external e2e tests. To tests the external e2e tests, we will require a new job.

thanks,
Manohar.