### PR TITLE
Branchprotection: Add a new unmanaged setting

### DIFF
--- a/prow/cmd/branchprotector/BUILD.bazel
+++ b/prow/cmd/branchprotector/BUILD.bazel
@@ -57,6 +57,7 @@ go_test(
         "//prow/flagutil:go_default_library",
         "//prow/flagutil/config:go_default_library",
         "//prow/github:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
         "@io_k8s_apimachinery//pkg/util/diff:go_default_library",
         "@io_k8s_sigs_yaml//:go_default_library",
     ],

--- a/prow/config/branch_protection.go
+++ b/prow/config/branch_protection.go
@@ -30,6 +30,10 @@ import (
 // Policy for the config/org/repo/branch.
 // When merging policies, a nil value results in inheriting the parent policy.
 type Policy struct {
+	// Unmanaged makes us not manage the branchprotection.
+	// Careful: Contrary to all other settings, this can _not_ be overridden
+	// on a lower level and is always inherited.
+	Unmanaged *bool `json:"unmanaged,omitempty"`
 	// Protect overrides whether branch protection is enabled if set.
 	Protect *bool `json:"protect,omitempty"`
 	// RequiredStatusChecks configures github contexts
@@ -160,6 +164,7 @@ func mergeRestrictions(parent, child *Restrictions) *Restrictions {
 // Apply returns a policy that merges the child into the parent
 func (p Policy) Apply(child Policy) Policy {
 	return Policy{
+		Unmanaged:                  selectBool(p.Unmanaged, child.Unmanaged),
 		Protect:                    selectBool(p.Protect, child.Protect),
 		RequiredStatusChecks:       mergeContextPolicy(p.RequiredStatusChecks, child.RequiredStatusChecks),
 		Admins:                     selectBool(p.Admins, child.Admins),

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -103,6 +103,11 @@ branch-protection:
                                 users:
                                   - ""
 
+                            # Unmanaged makes us not manage the branchprotection.
+                            # Careful: Contrary to all other settings, this can _not_ be overridden
+                            # on a lower level and is always inherited.
+                            unmanaged: false
+
                     # Admins overrides whether protections apply to admins if set.
                     enforce_admins: false
 
@@ -151,6 +156,11 @@ branch-protection:
                         users:
                           - ""
 
+                    # Unmanaged makes us not manage the branchprotection.
+                    # Careful: Contrary to all other settings, this can _not_ be overridden
+                    # on a lower level and is always inherited.
+                    unmanaged: false
+
             # RequiredLinearHistory enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch.
             required_linear_history: false
 
@@ -187,6 +197,11 @@ branch-protection:
                   - ""
                 users:
                   - ""
+
+            # Unmanaged makes us not manage the branchprotection.
+            # Careful: Contrary to all other settings, this can _not_ be overridden
+            # on a lower level and is always inherited.
+            unmanaged: false
 
     # Protect overrides whether branch protection is enabled if set.
     protect: false
@@ -232,6 +247,11 @@ branch-protection:
           - ""
         users:
           - ""
+
+    # Unmanaged makes us not manage the branchprotection.
+    # Careful: Contrary to all other settings, this can _not_ be overridden
+    # on a lower level and is always inherited.
+    unmanaged: false
 
 
 # The git sha from which this config was generated


### PR DESCRIPTION
This is helpful for two reasons:
* protect: false changes its meaning depending on if we have a mandatory
  prowjob or not: If we do, it means "Do not touch bp settings", if we
  don't it means "Remove all Branchprotection config". This is extremely
  confusing
* The new setting avoids doing any api calls for unmanaged config

Contrary to all other branchprotection settings, this one can not be
overriden on a lower level, which is why a new checkconfig check was
added.

/cc @petr-muller 