### PR TITLE
capz: update presubmit test target branches

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
@@ -225,9 +225,9 @@ presubmits:
       preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
     extra_refs:
-    - org: chewong # TODO(chewong): change it to 'kubernetes-sigs'
+    - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: upload-build-to-azure # TODO(chewong): change it to 'master'
+      base_ref: master
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
     spec:
@@ -263,9 +263,9 @@ presubmits:
       preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
     extra_refs:
-    - org: chewong # TODO(chewong): change it to 'kubernetes-sigs'
+    - org: jackfrancis #TODO change back to kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: upload-build-to-azure # TODO(chewong): change it to 'master'
+      base_ref: capz-ha-control-plane-tests #TODO change back to master
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
     spec:


### PR DESCRIPTION
In expectation of this PR being merged soon:

https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1264

... this PR updates the `pull-kubernetes-e2e-capz-ha-control-plane` and `pull-kubernetes-e2e-capz-conformance` test specs so that they derive the capz-specific bits from the master branch.