### PR TITLE
Fix bumper to add github token

### DIFF
--- a/prow/cmd/generic-autobumper/bumper/bumper.go
+++ b/prow/cmd/generic-autobumper/bumper/bumper.go
@@ -314,7 +314,7 @@ func Run(o *Options) error {
 	if o.SkipPullRequest {
 		logrus.Debugf("--skip-pull-request is set to true, won't create a pull request.")
 	} else if o.Gerrit == nil {
-		if err := sa.Start(nil); err != nil {
+		if err := sa.Start([]string{o.GitHubToken}); err != nil {
 			return fmt.Errorf("failed to start secrets agent: %w", err)
 		}
 


### PR DESCRIPTION
I broke this in 85035a9c4adfdf02013056bf66fab1ef2a187f35 because for some reason the autobumper deosn't use the standard flagutil and instead re-implements a small subset of what the flagutil does but gets the config for that from a file.

/assign @chaodaiG 