### PR TITLE
Bumper: Use https to push to github

### DIFF
--- a/prow/cmd/generic-autobumper/bumper/bumper.go
+++ b/prow/cmd/generic-autobumper/bumper/bumper.go
@@ -355,7 +355,7 @@ func Run(o *Options) error {
 			}
 		}
 
-		if err := MakeGitCommit(fmt.Sprintf("git@github.com:%s/%s.git", o.GitHubLogin, o.RemoteName), o.HeadBranchName, o.GitName, o.GitEmail, o.Prefixes, stdout, stderr, versions); err != nil {
+		if err := MakeGitCommit(fmt.Sprintf("https://%s:%s@github.com/%s/%s.git", o.GitHubLogin, string(sa.GetTokenGenerator(o.GitHubToken)()), o.GitHubLogin, o.RemoteName), o.HeadBranchName, o.GitName, o.GitEmail, o.Prefixes, stdout, stderr, versions); err != nil {
 			return fmt.Errorf("failed to push changes to the remote branch: %w", err)
 		}
 


### PR DESCRIPTION
The bumper currently both requires a github token with write access
(because it checks if a fork exists and creates one if that is not the
case) _and_ a ssh key which is used for pushing. This is needlessly
complicated, this change makes us use the the token and push via https
instead.

/assign @chaodaiG 