### PR TITLE
Use proper syntax for Bash subshell expression in Prow docs

### DIFF
--- a/prow/build_test_update.md
+++ b/prow/build_test_update.md
@@ -120,7 +120,7 @@ This command runs the ProwJob [`pull-test-infra-yamllint`](https://github.com/ku
 ```
 You may also need to set the `CONFIG_PATH` and `JOB_CONFIG_PATH` environmental variables:
 ```sh
-CONFIG_PATH=(realpath ../config/prow/config.yaml) JOB_CONFIG_PATH=(realpath ../config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml) ...
+CONFIG_PATH=$(realpath ../config/prow/config.yaml) JOB_CONFIG_PATH=$(realpath ../config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml) ...
 ```
 
 ##### Modifying pj-on-kind.sh for special scenarios


### PR DESCRIPTION
The docs here go over setting some environment variables, using `realpath` to get an absolute path from a relative one; this PR is just a slight adjustment so that the intended subshell expression works as expected and both `CONFIG_PATH` and `JOB_CONFIG_PATH` will be properly set if the line is copy-pasted.