### PR TITLE
Add Tide support for multiple TargetURLs.

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1943,6 +1943,17 @@ func parseProwConfig(c *Config) error {
 		return fmt.Errorf("tide has invalid max_goroutines (%d), it needs to be a positive number", c.Tide.MaxGoroutines)
 	}
 
+	if len(c.Tide.TargetURLs) > 0 && c.Tide.TargetURL != "" {
+		return fmt.Errorf("tide.target_url and tide.target_urls are mutually exclusive")
+	}
+
+	if c.Tide.TargetURLs == nil {
+		c.Tide.TargetURLs = map[string]string{}
+	}
+	if c.Tide.TargetURL != "" {
+		c.Tide.TargetURLs["*"] = c.Tide.TargetURL
+	}
+
 	if c.Tide.PRStatusBaseURLs == nil {
 		c.Tide.PRStatusBaseURLs = map[string]string{}
 	}

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -2448,6 +2448,65 @@ in_repo_config:
 				return nil
 			},
 		},
+		{
+			name: "tide global target_url respected",
+			prowConfig: `
+tide:
+  target_url: https://global.tide.com
+`,
+			verify: func(c *Config) error {
+				orgRepo := OrgRepo{Org: "org", Repo: "repo"}
+				if got, expected := c.Tide.GetTargetURL(orgRepo), "https://global.tide.com"; got != expected {
+					return fmt.Errorf("expected target URL for %q to be %q, but got %q", orgRepo.String(), expected, got)
+				}
+				return nil
+			},
+		},
+		{
+			name: "tide target_url and target_urls conflict",
+			prowConfig: `
+tide:
+  target_url: https://global.tide.com
+  target_urls:
+    "org": https://org.tide.com
+`,
+			expectError: true,
+		},
+		{
+			name: "tide specific target_urls respected",
+			prowConfig: `
+tide:
+  target_urls:
+    "*": https://star.tide.com
+    "org": https://org.tide.com
+    "org/repo": https://repo.tide.com
+`,
+			verify: func(c *Config) error {
+				orgRepo := OrgRepo{Org: "other-org", Repo: "other-repo"}
+				if got, expected := c.Tide.GetTargetURL(orgRepo), "https://star.tide.com"; got != expected {
+					return fmt.Errorf("expected target URL for %q to be %q, but got %q", orgRepo.String(), expected, got)
+				}
+				orgRepo = OrgRepo{Org: "org", Repo: "other-repo"}
+				if got, expected := c.Tide.GetTargetURL(orgRepo), "https://org.tide.com"; got != expected {
+					return fmt.Errorf("expected target URL for %q to be %q, but got %q", orgRepo.String(), expected, got)
+				}
+				orgRepo = OrgRepo{Org: "org", Repo: "repo"}
+				if got, expected := c.Tide.GetTargetURL(orgRepo), "https://repo.tide.com"; got != expected {
+					return fmt.Errorf("expected target URL for %q to be %q, but got %q", orgRepo.String(), expected, got)
+				}
+				return nil
+			},
+		},
+		{
+			name: "tide no target_url specified returns empty string",
+			verify: func(c *Config) error {
+				orgRepo := OrgRepo{Org: "org", Repo: "repo"}
+				if got, expected := c.Tide.GetTargetURL(orgRepo), ""; got != expected {
+					return fmt.Errorf("expected target URL for %q to be %q, but got %q", orgRepo.String(), expected, got)
+				}
+				return nil
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -1097,3 +1097,9 @@ tide:
     # We can consider allowing this to be set separately for separate repos, or
     # allowing it to be a template.
     target_url: ' '
+
+    # TargetURLs is a map from "*", <org>, or <org/repo> to the URL for the tide status contexts.
+    # The most specific key that matches will be used.
+    # This field is mutually exclusive with TargetURL.
+    target_urls:
+        "": ""

--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -103,6 +103,11 @@ type Tide struct {
 	// allowing it to be a template.
 	TargetURL string `json:"target_url,omitempty"`
 
+	// TargetURLs is a map from "*", <org>, or <org/repo> to the URL for the tide status contexts.
+	// The most specific key that matches will be used.
+	// This field is mutually exclusive with TargetURL.
+	TargetURLs map[string]string `json:"target_urls,omitempty"`
+
 	// PRStatusBaseURL is the base URL for the PR status page.
 	// This is used to link to a merge requirements overview
 	// in the tide status context.
@@ -217,11 +222,23 @@ func (t *Tide) MergeCommitTemplate(repo OrgRepo) TideMergeCommitTemplate {
 func (t *Tide) GetPRStatusBaseURL(repo OrgRepo) string {
 	if byOrgRepo, ok := t.PRStatusBaseURLs[repo.String()]; ok {
 		return byOrgRepo
-	} else if byOrg, ok := t.PRStatusBaseURLs[repo.Org]; ok {
+	}
+	if byOrg, ok := t.PRStatusBaseURLs[repo.Org]; ok {
 		return byOrg
 	}
 
 	return t.PRStatusBaseURLs["*"]
+}
+
+func (t *Tide) GetTargetURL(repo OrgRepo) string {
+	if byOrgRepo, ok := t.TargetURLs[repo.String()]; ok {
+		return byOrgRepo
+	}
+	if byOrg, ok := t.TargetURLs[repo.Org]; ok {
+		return byOrg
+	}
+
+	return t.TargetURLs["*"]
 }
 
 // TideQuery is turned into a GitHub search query. See the docs for details:

--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -328,9 +328,10 @@ func retestingStatus(retested []string) string {
 // the administrative Prow overview.
 func targetURL(c *config.Config, pr *PullRequest, log *logrus.Entry) string {
 	var link string
-	if tideURL := c.Tide.TargetURL; tideURL != "" {
+	orgRepo := config.OrgRepo{Org: string(pr.Repository.Owner.Login), Repo: string(pr.Repository.Name)}
+	if tideURL := c.Tide.GetTargetURL(orgRepo); tideURL != "" {
 		link = tideURL
-	} else if baseURL := c.Tide.GetPRStatusBaseURL(config.OrgRepo{Org: string(pr.Repository.Owner.Login), Repo: string(pr.Repository.Name)}); baseURL != "" {
+	} else if baseURL := c.Tide.GetPRStatusBaseURL(orgRepo); baseURL != "" {
 		parseURL, err := url.Parse(baseURL)
 		if err != nil {
 			log.WithError(err).Error("Failed to parse PR status base URL")

--- a/prow/tide/status_test.go
+++ b/prow/tide/status_test.go
@@ -892,13 +892,13 @@ func TestTargetUrl(t *testing.T) {
 		{
 			name:        "tide overview config",
 			pr:          &PullRequest{},
-			config:      config.Tide{TargetURL: "tide.com"},
+			config:      config.Tide{TargetURLs: map[string]string{"*": "tide.com"}},
 			expectedURL: "tide.com",
 		},
 		{
 			name:        "PR dashboard config and overview config",
 			pr:          &PullRequest{},
-			config:      config.Tide{TargetURL: "tide.com", PRStatusBaseURLs: map[string]string{"*": "pr.status.com"}},
+			config:      config.Tide{TargetURLs: map[string]string{"*": "tide.com"}, PRStatusBaseURLs: map[string]string{"*": "pr.status.com"}},
 			expectedURL: "tide.com",
 		},
 		{


### PR DESCRIPTION
Adds support for a `TargetURLs` map that is mutually exclusive with the existing `TargetURL` field. This will be used to make Tide status context links point to the correct domain when running a separate private deck instance.
This parallels the `PRStatusBaseURL` and `PRStatusBaseURLs` fields.

/assign @alvaroaleman @chaodaiG 