### PR TITLE
Update image in gce-device-plugin-gpu job

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -2,10 +2,12 @@ presets:
 - labels:
     preset-ci-gce-device-plugin-gpu: "true"
   env:
+  # Note: The GCE Node image used may have a dependency on the nvidia-driver-installer image defined in https://github.com/kubernetes/kubernetes/blob/master/test/e2e/testing-manifests/scheduling/nvidia-driver-installer.yaml
+  # If updating the image defined here, the cos-gpu-installer image may need to updated to support the corresponding COS image.
   - name: KUBE_GCE_NODE_IMAGE
-    value: gke-1134-gke-rc5-cos-69-10895-138-0-v190320-pre-nvda-gpu
+    value: cos-85-13310-1041-9
   - name: KUBE_GCE_NODE_PROJECT
-    value: gke-node-images
+    value: cos-cloud
   - name: NODE_ACCELERATORS
     value: type=nvidia-tesla-k80,count=2
 


### PR DESCRIPTION
xref: https://github.com/kubernetes/kubernetes/issues/101558

Update image from deprecated cos-69 to cos-85 which is currently the  [default GCI version](https://github.com/kubernetes/kubernetes/blob/50e319767cc4aad5c6ff56a8d002c406cdcc3e0e/cluster/gce/config-default.sh#L89).

Updating to cos-85 requires also updating the cos-gpu-installer. That change is made in k/k in  https://github.com/kubernetes/kubernetes/pull/101595

Tested in https://github.com/kubernetes/kubernetes/pull/101595#issuecomment-828838584