### PR TITLE
Add the missing labels to ingress-nginx

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -664,6 +664,31 @@ require_matching_label:
   repo: python-base
   prs: true
   regexp: ^kind/
+- missing_label: needs-triage
+  org: kubernetes
+  repo: ingress-nginx
+  issues: true
+  prs: true
+  regexp: ^triage/accepted$
+  missing_comment: |
+    This issue is currently awaiting triage.
+
+    If Ingress contributors determines this is a relevant issue, they will accept it by applying the `triage/accepted` label and provide further guidance.
+
+    The `triage/accepted` label can be added by org members by writing `/triage accepted` in a comment.
+- missing_label: needs-kind
+  org: kubernetes
+  repo: ingress-nginx
+  issues: true
+  prs: true
+  regexp: ^kind/
+- missing_label: needs-priority
+  org: kubernetes
+  repo: ingress-nginx
+  issues: true
+  prs: true
+  regexp: ^priority/
+
 
 retitle:
   allow_closed_issues: true


### PR DESCRIPTION
Signed-off-by: Ricardo Pchevuzinske Katz <ricardo.katz@gmail.com>

Let's start adding some 'needs-triage', 'needs-priority' and 'needs-kind' to ingress-nginx PRs and issues :D