### PR TITLE
capz: allow 4h timeout for capz HA control plane test

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
@@ -254,6 +254,8 @@ presubmits:
       testgrid-num-columns-recent: '30'
   - name: pull-kubernetes-e2e-capz-ha-control-plane
     decorate: true
+    decoration_config:
+      timeout: 4h
     always_run: false
     optional: true
     path_alias: k8s.io/kubernetes


### PR DESCRIPTION
This PR adds an explicit 4 hour timeout configuration for the capz HA control plane test to permit enough time for the serial test to complete.