### PR TITLE
azurefile-csi-driver: add new prow job to test external e2e tests

### DIFF
--- a/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
@@ -424,3 +424,53 @@ presubmits:
       testgrid-tab-name: pr-azurefile-csi-driver-e2e-migration-windows
       description: "Run E2E tests on a cluster for Azure File CSI driver with CSI migration feature enabled on Windows nodes."
       testgrid-num-columns-recent: '30'
+  - name: pull-azurefile-csi-driver-external-e2e
+    decorate: true
+    always_run: true
+    path_alias: sigs.k8s.io/azurefile-csi-driver
+    branches:
+    - master
+    labels:
+      preset-service-account: "true"
+      preset-azure-cred: "true"
+      preset-dind-enabled: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210426-51fd28e-master
+        command:
+        - runner.sh
+        - kubetest
+        args:
+        # Generic e2e test args
+        - --test
+        - --up
+        - --down
+        - --dump=$(ARTIFACTS)
+        # Azure-specific test args
+        - --provider=skeleton
+        - --deployment=aksengine
+        - --aksengine-admin-username=azureuser
+        - --aksengine-creds=$(AZURE_CREDENTIALS)
+        - --aksengine-orchestratorRelease=1.17
+        - --aksengine-location=eastus2
+        - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
+        - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/azurefile-csi-driver/master/test/e2e/manifest/linux.json
+        - --aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz
+        # Specific test args
+        - --test-azure-file-csi-driver
+        securityContext:
+          privileged: true
+        env:
+          - name: EXTERNAL_E2E_TEST
+            value: "true"
+    annotations:
+      testgrid-dashboards: provider-azure-azurefile-csi-driver
+      testgrid-tab-name: pr-azurefile-csi-driver-external-e2e
+      description: "Run External E2E tests for Azure File CSI driver."
+      testgrid-num-columns-recent: '30'


### PR DESCRIPTION
with this https://github.com/kubernetes-sigs/azurefile-csi-driver/pull/637  PR, `azurefile-csi-driver` introduces kubernetes external e2e tests. To tests the external e2e tests, we will require a new job.

thanks,
Manohar.