### PR TITLE
Clonerefs pipes stdin in exec

### DIFF
--- a/prow/pod-utils/clone/clone.go
+++ b/prow/pod-utils/clone/clone.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/url"
+	"os"
 	"os/exec"
 	"path"
 	"strconv"
@@ -344,6 +345,7 @@ func (c cloneCommand) run() (string, string, error) {
 	cmd := exec.Command(c.command, c.args...)
 	cmd.Dir = c.dir
 	cmd.Env = append(cmd.Env, c.env...)
+	cmd.Stdin = os.Stdin
 	cmd.Stdout = &output
 	cmd.Stderr = &output
 	err := cmd.Run()


### PR DESCRIPTION
Majority of times this will not be used, since clonerefs has been working. Lately I have observed that  hangs in prow job for several hours. Local test suggests:

- In a repo where http cookiefile is required,  prompts for username when cookiefile expired
- Doing the same thing in GKE pod with plain bash, and it fail right away, suggests tty detected

So the suspicion is that shelling out to  in Go stuck around this, https://groups.google.com/g/golang-nuts/c/pJe7TVb-68w suggests stdin might be related