### PR TITLE
Update CAPG build image job

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
@@ -263,6 +263,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
+    preset-service-account: "true"
   decorate: true
   decoration_config:
     timeout: 3h

--- a/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
@@ -258,6 +258,12 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-image-pushes
     testgrid-tab-name: cluster-api-provider-openstack-push-images-nightly
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+
+##
+## This Job is a temporary solution that builds the machine images using image-builder repository
+## and packer. this is not the image for CAPG manager.
+## This should be replaced in the future with the work from https://github.com/kubernetes-sigs/image-builder/pull/445
+##
 - name: cluster-api-provider-gcp-build-image-nightly
   cluster: k8s-infra-prow-build-trusted
   labels:


### PR DESCRIPTION
from last job execution: 
```
/home/prow/go/src/sigs.k8s.io/cluster-api-provider-gcp/scripts/ci-e2e.sh: line 41: GOOGLE_APPLICATION_CREDENTIALS: Environment variable empty or not defined.
```
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/cluster-api-provider-gcp-build-image-nightly/1388388067756216320

and some clarification about the job
