### PR TITLE
image-build/capg: add periodic job to build gce images

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/image-builder/OWNERS
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/image-builder/OWNERS
@@ -1,0 +1,11 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - akutz
+  - CecileRobertMichon
+  - codenrhoden
+  - figo
+  - justinsb
+  - luxas
+  - moshloop
+  - timothysc

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/image-builder/image-builder-periodics.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/image-builder/image-builder-periodics.yaml
@@ -1,0 +1,33 @@
+periodics:
+- name: periodic-image-builder-gcp-all-nightly
+  cluster: k8s-infra-prow-build-trusted
+  interval: 24h
+  decorate: true
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: image-builder
+    base_ref: master
+    path_alias: "sigs.k8s.io/image-builder"
+  labels:
+    preset-service-account: "true"
+  spec:
+    serviceAccountName: gcb-builder-cluster-api-gcp
+    containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210426-51fd28e-master
+        args:
+          - runner.sh
+          - "./images/capi/scripts/ci-gce-nightly.sh"
+        env:
+          - name: GCP_PROJECT
+            value: "k8s-staging-cluster-api-gcp"
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "4Gi"
+            cpu: 2000m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-image-builder
+    testgrid-tab-name: periodic-image-builder-gcp-all-nightly
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "2"


### PR DESCRIPTION
- remove the temporary job created
- add a periodic job to build the gce images

/hold for https://github.com/kubernetes-sigs/image-builder/pull/445

/assign @CecileRobertMichon @dims @codenrhoden


TODO:
- create a GCP project to have the images published
- change this periodic to use the project and publish nightly builds