### PR TITLE
Add missing cookie-secret in deck args

### DIFF
--- a/prow/cmd/deck/github_oauth_setup.md
+++ b/prow/cmd/deck/github_oauth_setup.md
@@ -69,6 +69,7 @@ The following steps will show you how to set up an OAuth app.
       ```yaml
       - --github-oauth-config-file=/etc/githuboauth/secret
       - --oauth-url=/github-login
+      - --cookie-secret=/etc/cookie/secret
       ```
       Note that the `--oauth-url` should eventually be changed to a boolean as described 
       in [#13804](https://github.com/kubernetes/test-infra/issues/13804).


### PR DESCRIPTION
This document explains how to use cookie store and pass the secrets via volume, but it misses to mention the required flag  `--cookie-secret` in the deck deployment. 

```
time="2021-05-01T22:16:24Z" level=info msg="Spyglass registered viewer podinfo with title Job Pod Info."
time="2021-05-01T22:16:24Z" level=info msg="Spyglass registered viewer restcoverage with title REST API coverage report."
{"component":"deck","error":"an OAuth URL was provided but required flag --cookie-secret was unset","file":"prow/cmd/deck/main.go:271","func":"main.main","level":"fatal","msg":"Invalid options","severity":"fatal","time":"2021-05-01T22:16:24Z"}
```
