### PR TITLE
Allow kubekins image to build images in trusted cluster

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
@@ -287,7 +287,7 @@ periodics:
   spec:
     serviceAccountName: gcb-builder
     containers:
-      - image: gcr.io/k8s-testimages/image-builder:v20210302-aa40187
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210426-51fd28e-master
         env:
           # TODO(dims): reuse this project for now to test this job.
           # need to create a separate project.

--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -354,10 +354,13 @@ func TestK8sInfraTrusted(t *testing.T) {
 
 func validateImagePushingImage(spec *coreapi.PodSpec) error {
 	const imagePushingImage = "gcr.io/k8s-testimages/image-builder"
+	const kubekinsImage = "gcr.io/k8s-testimages/kubekins-e2e"
 
 	for _, c := range spec.Containers {
-		if !strings.HasPrefix(c.Image, imagePushingImage+":") {
-			return fmt.Errorf("must use a pinned version of %s", imagePushingImage)
+		if !strings.HasPrefix(c.Image, imagePushingImage+":") &&
+			!strings.HasPrefix(c.Image, kubekinsImage+":") {
+			return fmt.Errorf("must use a pinned version of %s or %s",
+				imagePushingImage, kubekinsImage)
 		}
 	}
 


### PR DESCRIPTION
Trying to get a CAPG node image working. The image-builder image does
not have all the things needed, so let's allow kubekins as well.
kubekins works fine in existing CAPG jobs where this node image is being
built.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>