### PR TITLE
Switch to runner.sh for capg-build-image job

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
@@ -296,8 +296,8 @@ periodics:
           - name: "SKIP_CLEANUP"
             value: "true"
         command:
-          - /home/prow/go/src/sigs.k8s.io/cluster-api-provider-gcp/scripts/ci-e2e.sh
-        args:
+          - "runner.sh"
+          - "scripts/ci-e2e.sh"
           - "--verbose"
           - "--build-image-only"
         # we need privileged mode in order to do docker in docker


### PR DESCRIPTION
Was trying other ways ... didn't work out :)

In the end, this should like like `capg-conformance-v1alpha4-k8s-master` except for the additional `serviceAccountName: gcb-builder` and the changes to the parameters

Signed-off-by: Davanum Srinivas <davanum@gmail.com>