### PR TITLE
Kops - fix digitalocean presubmit job

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -73,20 +73,26 @@ presubmits:
         command:
         - runner.sh
         args:
-        - --provider=digitalocean \
-        - --cluster-name=e2e-test-do.k8s.local \
-        - --up --down \
-        - --env S3_ENDPOINT=sfo3.digitaloceanspaces.com \
-        - --env JOB_NAME=pull-kops-e2e-kubernetes-do-kubetest2 \
-        - --create-args "--networking=calico --api-loadbalancer-type=public --node-count=2 --master-count=3" \
-        - --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.20/latest-ci.txt \
-        - --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
-        - --test=kops \
-        - -- \
-        - --ginkgo-args="--debug" \
-        - --test-package-marker=stable-1.20.txt \
-        - --parallel 25 \
-        - --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*NodePort.*listening.*same.*port|TCP.CLOSE_WAIT|should.*run.*through.*the.*lifecycle.*of.*Pods.*and.*PodStatus"
+        - bash
+        - -c
+        - |
+            make test-e2e-install
+            kubetest2 kops \
+            -v 2 \
+            --up --build --down \
+            --cloud-provider=digitalocean \
+            --cluster-name=e2e-test-do.k8s.local \
+            --env S3_ENDPOINT=sfo3.digitaloceanspaces.com \
+            --env JOB_NAME=pull-kops-e2e-kubernetes-do-kubetest2 \
+            --create-args "--networking=calico --api-loadbalancer-type=public --node-count=2 --master-count=3" \
+            --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.20/latest-ci.txt \
+            --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
+            --test=kops \
+            -- \
+            --ginkgo-args="--debug" \
+            --test-package-marker=stable-1.20.txt \
+            --parallel 25 \
+            --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*NodePort.*listening.*same.*port|TCP.CLOSE_WAIT|should.*run.*through.*the.*lifecycle.*of.*Pods.*and.*PodStatus"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
Updating the job args to match the [build_jobs.py template](https://github.com/kubernetes/test-infra/blob/f4e301ff04a7a272ec78ed214273526ea53f4d75/config/jobs/kubernetes/kops/build_jobs.py#L97)

xref: https://github.com/kubernetes/kops/pull/10963#issuecomment-830802892

https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kops/10963/pull-kops-e2e-kubernetes-do-kubetest2/1388834428083507200