### PR TITLE
Add minikube build in prow

### DIFF
--- a/config/jobs/kubernetes/minikube/OWNERS
+++ b/config/jobs/kubernetes/minikube/OWNERS
@@ -1,0 +1,18 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - tstromberg
+  - afbjorklund
+  - sharifelgamal
+  - RA489
+  - medyagh
+  - blueelvis
+  - prasadkatti
+  - ilya-zuyev
+  - prezha	
+approvers:
+  - tstromberg
+  - afbjorklund
+  - sharifelgamal
+  - medyagh
+  - ilya-zuyev

--- a/config/jobs/kubernetes/minikube/OWNERS
+++ b/config/jobs/kubernetes/minikube/OWNERS
@@ -1,6 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
+  - sig-cluster-lifecycle-leads
   - tstromberg
   - afbjorklund
   - sharifelgamal
@@ -11,8 +12,11 @@ reviewers:
   - ilya-zuyev
   - prezha	
 approvers:
+  - sig-cluster-lifecycle-leads
   - tstromberg
   - afbjorklund
   - sharifelgamal
   - medyagh
   - ilya-zuyev
+labels:
+- sig/cluster-lifecycle

--- a/config/jobs/kubernetes/minikube/minikube.yaml
+++ b/config/jobs/kubernetes/minikube/minikube.yaml
@@ -23,7 +23,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: docker.io/azhao155/prow-test:1.7
+      - image: gcr.io/k8s-minikube/prow-test:v0.0.1
         command:
         - wrapper.sh
         - bash

--- a/config/jobs/kubernetes/minikube/minikube.yaml
+++ b/config/jobs/kubernetes/minikube/minikube.yaml
@@ -15,6 +15,23 @@ presets:
 
 presubmits:
   kubernetes/minikube:
+  - name: pull-minikube-build
+    decorate: true
+    path_alias: "k8s.io/minikube"
+    always_run: true
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: docker.io/azhao155/prow-test:1.7
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        - make && ./out/minikube start --force && kubectl get pods -A
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
   - name: pull-minikube-platform-tests
     labels:
         preset-minikube-e2e-creds: "true"


### PR DESCRIPTION
Tested with

Build job
```
zyanshu@zyanshu-ubuntu:~/test-infra$ bazel run //prow/cmd/mkpj -- --config-path=/home/zyanshu/test-infra/config/prow/config.yaml --job-config-path=/home/zyanshu/test-infra/config/
jobs/kubernetes/minikube/minikube.yaml --job=pull-minikube-build > /tmp/foo
Starting local Bazel server and connecting to it...
Loading:
Loading: 0 packages loaded
Loading: 0 packages loaded
Loading: 0 packages loaded
    currently loading: prow/cmd/mkpj
Analyzing: target //prow/cmd/mkpj:mkpj (1 packages loaded, 0 targets configured)
Analyzing: target //prow/cmd/mkpj:mkpj (9 packages loaded, 6 targets configured)
Analyzing: target //prow/cmd/mkpj:mkpj (13 packages loaded, 6 targets configured)
Analyzing: target //prow/cmd/mkpj:mkpj (25 packages loaded, 5425 targets configured)
Analyzing: target //prow/cmd/mkpj:mkpj (36 packages loaded, 7036 targets configured)
Analyzing: target //prow/cmd/mkpj:mkpj (38 packages loaded, 7142 targets configured)
Analyzing: target //prow/cmd/mkpj:mkpj (111 packages loaded, 7613 targets configured)
Analyzing: target //prow/cmd/mkpj:mkpj (196 packages loaded, 7770 targets configured)
Analyzing: target //prow/cmd/mkpj:mkpj (305 packages loaded, 8605 targets configured)
Analyzing: target //prow/cmd/mkpj:mkpj (502 packages loaded, 10505 targets configured)
Analyzing: target //prow/cmd/mkpj:mkpj (614 packages loaded, 11319 targets configured)
INFO: Analyzed target //prow/cmd/mkpj:mkpj (755 packages loaded, 12075 targets configured).
INFO: Found 1 target...
[2 / 4] [Prepa] BazelWorkspaceStatusAction stable-status.txt
[793 / 1,156] checking cached actions
Target //prow/cmd/mkpj:mkpj up-to-date:
  bazel-bin/prow/cmd/mkpj/mkpj_/mkpj
INFO: Elapsed time: 60.595s, Critical Path: 6.23s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/prow/cmd/mkpj/mkpj_/mkpj '--config-path=/home/zyanshu/test-infra/config/prow/config.yaml' '--job-config-path=/home/zyanshu/test-infra/config/
jobs/kubernetes/minikube/minikube.yaml' '--job=pull-minikube-build'
INFO: Build completed successfully, 1 total action
WARN[0000] empty -github-token-path, will use anonymous github client
PR Number: 11176
INFO[0007] GetPullRequest(kubernetes, minikube, 11176)   client=github
DEBU[0008] GetPullRequest(kubernetes, minikube, 11176) finished  client=github duration=507.615796ms
```

Run
```
zyanshu@zyanshu-ubuntu:~/test-infra$ bazel run //prow/cmd/phaino -- /tmp/foo --privileged                                                                               [563/15690]
INFO: Analyzed target //prow/cmd/phaino:phaino (1 packages loaded, 5 targets configured).
INFO: Found 1 target...
Target //prow/cmd/phaino:phaino up-to-date:
  bazel-bin/prow/cmd/phaino/phaino_/phaino
INFO: Elapsed time: 1.553s, Critical Path: 0.70s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
INFO[0000] Reading...                                    path=/tmp/foo
INFO[0000] Converting job into docker run command...     job=pull-minikube-build
WARN[0000] WARNING: running privileged job "pull-minikube-build" can allow nearly all access to the host, please be careful with it
fallback to GOPATH: /home/zyanshu/go
: "docker" "run" "--rm=true" \
 "--name=phaino-593522-1" \
 "--entrypoint=wrapper.sh" \
 "--privileged" \
 "-w" \
 "/go/src/k8s.io/minikube" \
 "-v" \
 "/home/zyanshu/minikube:/go/src/k8s.io/minikube" \
 "-v" \
 ":/docker-graph" \
 "-v" \
 ":/var/lib/docker" \
 "-e" \
 "GOPROXY:https://proxy.golang.org" \
 "-e" \
 "DOCKER_IN_DOCKER_ENABLED:true" \
 "--label=prow.k8s.io/type=presubmit" \
 "--label=created-by-prow=true" \
 "--label=preset-dind-enabled=true" \
 "--label=prow.k8s.io/job=pull-minikube-build" \
 "--label=prow.k8s.io/refs.org=kubernetes" \
 "--label=prow.k8s.io/refs.pull=11176" \
 "--label=prow.k8s.io/refs.repo=minikube" \
 "--label=phaino=true" \
 "docker.io/azhao155/prow-test:1.7" \
 "bash" \
 "-c" \
 "make && ./out/minikube start --force && kubectl get pods -A"
INFO[0000] Starting job...                               job=pull-minikube-build
INFO[0000] Waiting for job to finish...                  container=phaino-593522-1 job=pull-minikube-build
wrapper.sh] [INFO] Wrapping Test Command: `bash -c make && ./out/minikube start --force && kubectl get pods -A`
================================================================================
wrapper.sh] [SETUP] Performing pre-test setup ...
wrapper.sh] [SETUP] Docker in Docker enabled, initializing ...
Starting Docker: docker.
wrapper.sh] [SETUP] Waiting for Docker to be ready, sleeping for 1 seconds ...
wrapper.sh] [SETUP] Done setting up Docker in Docker.
================================================================================
wrapper.sh] [TEST] Running Test Command: `bash -c make && ./out/minikube start --force && kubectl get pods -A` ...
...
* Creating docker container (CPUs=2, Memory=2200MB) ...
* Preparing Kubernetes v1.20.2 on Docker 20.10.6 ...
  - Generating certificates and keys ...
  - Booting up control plane ...
  - Configuring RBAC rules ...
* Verifying Kubernetes components...
  - Using image gcr.io/k8s-minikube/storage-provisioner:v5
* Enabled addons: storage-provisioner, default-storageclass
* Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE
kube-system   etcd-minikube                      0/1     Pending   0          2s
kube-system   kube-apiserver-minikube            0/1     Running   0          2s
kube-system   kube-controller-manager-minikube   0/1     Running   0          2s
kube-system   kube-scheduler-minikube            0/1     Running   0          2s
kube-system   storage-provisioner                0/1     Pending   0          1s
wrapper.sh] [TEST] Test Command exit code: 0
wrapper.sh] [CLEANUP] Cleaning up after Docker in Docker ...
66ceba696a64
Stopping Docker: docker.
wrapper.sh] [CLEANUP] Done cleaning up after Docker in Docker.
================================================================================
wrapper.sh] Exiting 0
INFO[0450] PASS: deccc97c-ab70-11eb-83eb-42010a800002    duration=7m30.636192668s job=pull-minikube-build
INFO[0450] SUCCESS
INFO[0450] Press Ctrl + c to exit.
^CINFO[0533] Received signal.                              signal=interrupt
INFO[0533] Interrupt received.
INFO[0533] All workers gracefully terminated, exiting.
```

