### PR TITLE
nginx-ingress: update pull-ingress-nginx-test to use make test instead of cover

### DIFF
--- a/config/jobs/kubernetes/sig-network/ingress-nginx.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-nginx.yaml
@@ -143,22 +143,8 @@ presubmits:
       containers:
       - image: k8s.gcr.io/ingress-nginx/e2e-test-runner:v20210104-g81a8d5cd8@sha256:bfd55f589ea998f961825a9d09158d766cf621d1b8fc5d8c905aba07d9794e08
         command:
-        - /bin/bash
-        - -c
-        - "GIT_COMMIT=${PULL_PULL_SHA} make cover"
-        env:
-        - name: CODECOV_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: ingress-nginx-codecov-token
-              key: ingress-nginx-codecov-token
-    volumes:
-    - name: ingress-nginx-codecov-token
-      secret:
-        secretName: ingress-nginx-codecov-token
-        items:
-        - key: ingress-nginx-codecov-token
-          path: ingress-nginx-codecov-token
+        - make
+        - test
     annotations:
       testgrid-dashboards: sig-network-ingress-nginx
       testgrid-tab-name: test


### PR DESCRIPTION
the cover rule was removed here: https://github.com/kubernetes/ingress-nginx/commit/a1c662a9a85a4b314b3c0d1835e2e11e6147b532#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52

so updating the job to run the unit tests without the cover for now.

/assign @rikatz @ElvinEfendi @strongjz