### PR TITLE
Print debug message for http cookiefile used during git clone

### DIFF
--- a/prow/clonerefs/run.go
+++ b/prow/clonerefs/run.go
@@ -17,6 +17,7 @@ limitations under the License.
 package clonerefs
 
 import (
+	"crypto/md5"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -83,6 +84,16 @@ func (o *Options) createRecords() []clone.Record {
 		oauthToken = token
 	}
 
+	// Print md5 sum of cookiefile for debugging purpose
+	if len(o.CookiePath) > 0 {
+		l := logrus.WithField("http-cookiefile", o.CookiePath)
+		f, err := ioutil.ReadFile(o.CookiePath)
+		if err != nil {
+			l.WithError(err).Warn("Cannot read http cookiefile")
+		} else {
+			l.WithField("md5sum", fmt.Sprintf("%x", md5.Sum(f))).Debug("Http cookiefile md5 sum")
+		}
+	}
 	if p := needsGlobalCookiePath(o.CookiePath, o.GitRefs...); p != "" {
 		cmd, err := configureGlobalCookiefile(p)
 		rec.Commands = append(rec.Commands, cmd)


### PR DESCRIPTION
We use http cookiefile for authenticating during cloning with http protocol, the cookiefile is rotated by either https://github.com/kubernetes/test-infra/blob/master/prow/cmd/grandmatriarch or https://github.com/istio/test-infra/tree/master/authentikos. When the cloning failed for any reason, half of the time the suspect tured to be staled cookiefile being used, but there is no immediate easy way for us to figure this out. Adding this debug line would help greatly in this scenario as grandmatriarch already prints md5sum.