### PR TITLE
gateway-api: fix a typo in bucket name

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-gateway-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-gateway-api.yaml
@@ -20,6 +20,6 @@ postsubmits:
               # images are pushed to.
               - --project=k8s-staging-gateway-api
               # This is the same as above, but with -gcb appended.
-              - --scratch-bucket=gs://k8s-staging-gatewway-api-gcb
+              - --scratch-bucket=gs://k8s-staging-gateway-api-gcb
               - --env-passthrough=PULL_BASE_REF
               - .


### PR DESCRIPTION
This was a typo that was introduced in https://github.com/kubernetes/test-infra/pull/21881 and was detected in https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-gateway-api-push-images/1387533807061569536