### PR TITLE
kubernetes-csi: do not use Bazel with Kubernetes >= 1.21

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
@@ -309,7 +309,7 @@ presubmits:
         - name: CSI_PROW_KUBERNETES_VERSION
           value: "1.21.0"
         - name: CSI_PROW_USE_BAZEL
-          value: "true"
+          value: "false"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
           value: "1.21"
         - name: CSI_PROW_DRIVER_VERSION
@@ -630,7 +630,7 @@ periodics:
       - name: CSI_PROW_KUBERNETES_VERSION
         value: "release-1.21"
       - name: CSI_PROW_USE_BAZEL
-        value: "true"
+        value: "false"
       - name: CSI_SNAPSHOTTER_VERSION
         value: "v4.0.0"
       - name: CSI_PROW_BUILD_JOB
@@ -818,7 +818,7 @@ periodics:
       - name: CSI_PROW_KUBERNETES_VERSION
         value: "release-1.21"
       - name: CSI_PROW_USE_BAZEL
-        value: "true"
+        value: "false"
       - name: CSI_SNAPSHOTTER_VERSION
         value: "v4.0.0"
       - name: CSI_PROW_BUILD_JOB
@@ -958,7 +958,7 @@ periodics:
       - name: CSI_PROW_KUBERNETES_VERSION
         value: "release-1.21"
       - name: CSI_PROW_USE_BAZEL
-        value: "true"
+        value: "false"
       - name: CSI_SNAPSHOTTER_VERSION
         value: "v4.0.0"
       - name: CSI_PROW_BUILD_JOB
@@ -1050,7 +1050,7 @@ periodics:
       - name: CSI_PROW_KUBERNETES_VERSION
         value: "release-1.21"
       - name: CSI_PROW_USE_BAZEL
-        value: "true"
+        value: "false"
       - name: CSI_SNAPSHOTTER_VERSION
         value: "v4.0.0"
       - name: CSI_PROW_BUILD_JOB

--- a/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
+++ b/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
@@ -309,7 +309,7 @@ presubmits:
         - name: CSI_PROW_KUBERNETES_VERSION
           value: "1.21.0"
         - name: CSI_PROW_USE_BAZEL
-          value: "true"
+          value: "false"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
           value: "1.21"
         - name: CSI_PROW_DRIVER_VERSION

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
@@ -309,7 +309,7 @@ presubmits:
         - name: CSI_PROW_KUBERNETES_VERSION
           value: "1.21.0"
         - name: CSI_PROW_USE_BAZEL
-          value: "true"
+          value: "false"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
           value: "1.21"
         - name: CSI_PROW_DRIVER_VERSION

--- a/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
+++ b/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
@@ -309,7 +309,7 @@ presubmits:
         - name: CSI_PROW_KUBERNETES_VERSION
           value: "1.21.0"
         - name: CSI_PROW_USE_BAZEL
-          value: "true"
+          value: "false"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
           value: "1.21"
         - name: CSI_PROW_DRIVER_VERSION

--- a/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
+++ b/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
@@ -309,7 +309,7 @@ presubmits:
         - name: CSI_PROW_KUBERNETES_VERSION
           value: "1.21.0"
         - name: CSI_PROW_USE_BAZEL
-          value: "true"
+          value: "false"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
           value: "1.21"
         - name: CSI_PROW_DRIVER_VERSION

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -283,7 +283,9 @@ pull_alwaysrun() {
 #
 #   where X,Y, and Z are any number.
 #
-# Partial versions (1.2, release-1.2) work as well.
+# Partial versions (1.2, release-1.2) work as well as long as both
+# arguments use the same format.
+#
 # The follow substrings are stripped before version comparison:
 #   - "v"
 #   - "release-"
@@ -302,6 +304,8 @@ function version_gt() {
     greaterVersion=${greaterVersion#"v"};
     test "$(printf '%s' "$versions" | sort -V | head -n 1)" != "$greaterVersion"
 }
+
+
 
 
 snapshotter_version() {
@@ -327,16 +331,19 @@ snapshotter_version() {
     fi
 }
 
-use_bazel() {
+use_bazel() (
     local kubernetes="$1"
 
+    # Strip z from x.y.z, version_gt does not handle it when comparing against 1.20.
+    kubernetes="$(echo "$kubernetes" | sed -e 's/^\([0-9]*\)\.\([0-9]*\)\.[0-9]*$/\1.\2/')"
+
     # Kubernetes 1.21 removed support for building with Bazel.
-    if version_gt "$kubernetes" "1.21"; then
+    if version_gt "$kubernetes" "1.20"; then
         echo "false"
     else
         echo "true"
     fi
-}
+)
 
 for repo in $hostpath_example_repos; do
     mkdir -p "$base/$repo"

--- a/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
+++ b/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
@@ -309,7 +309,7 @@ presubmits:
         - name: CSI_PROW_KUBERNETES_VERSION
           value: "1.21.0"
         - name: CSI_PROW_USE_BAZEL
-          value: "true"
+          value: "false"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
           value: "1.21"
         - name: CSI_PROW_DRIVER_VERSION

--- a/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
+++ b/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
@@ -309,7 +309,7 @@ presubmits:
         - name: CSI_PROW_KUBERNETES_VERSION
           value: "1.21.0"
         - name: CSI_PROW_USE_BAZEL
-          value: "true"
+          value: "false"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
           value: "1.21"
         - name: CSI_PROW_DRIVER_VERSION


### PR DESCRIPTION
The version check that was already added earlier did not work properly
for Kubernetes 1.21 (off-by-one, version_gt does not handle the `1.20.0 > 1.20` comparison).

/assign @msau42 