### PR TITLE
Security contacts validation

### DIFF
--- a/prow/plugins/verify-owners/verify-owners_test.go
+++ b/prow/plugins/verify-owners/verify-owners_test.go
@@ -88,6 +88,52 @@ reviewers:
 labels:
 - lgtm
 `),
+	"slackDisplayNameInSecContacts": []byte(`approvers:
+- jdoe
+reviewers:
+- alice
+- bob
+security_contacts:
+  alice:
+    email: foo@bar.com
+    slack_id: alice
+`),
+	"slackIDInSecContacts": []byte(`approvers:
+- jdoe
+reviewers:
+- alice
+- bob
+security_contacts:
+  alice:
+    email: foo@bar.com
+    slack_id: U123ABC
+`),
+	"EmailOnlyInSecContacts": []byte(`approvers:
+- jdoe
+reviewers:
+- alice
+- bob
+security_contacts:
+  alice:
+    email: foo@bar.com
+`),
+	"slackIDOnlyInSecContacts": []byte(`approvers:
+- jdoe
+reviewers:
+- alice
+- bob
+security_contacts:
+  alice:
+    slack_id: U123ABC
+`),
+	"EmptyEntryInSecContacts": []byte(`approvers:
+- jdoe
+reviewers:
+- alice
+- bob
+security_contacts:
+  alice: {}
+`),
 	"invalidLabelsFilters": []byte(`filters:
   ".*":
     approvers:
@@ -442,6 +488,36 @@ func testHandle(clients localgit.Clients, t *testing.T) {
 			filesChangedAfterPR: []string{"OWNERS_ALIASES"},
 			addedContent:        "toBeAddedAlias",
 			shouldLabel:         false,
+		},
+		{
+			name:         "security_contacts includes slack display name instead of id",
+			filesChanged: []string{"OWNERS"},
+			ownersFile:   "slackDisplayNameInSecContacts",
+			shouldLabel:  true,
+		},
+		{
+			name:         "security_contacts includes slack id",
+			filesChanged: []string{"OWNERS"},
+			ownersFile:   "slackIDInSecContacts",
+			shouldLabel:  false,
+		},
+		{
+			name:         "security_contacts includes email only",
+			filesChanged: []string{"OWNERS"},
+			ownersFile:   "EmailOnlyInSecContacts",
+			shouldLabel:  false,
+		},
+		{
+			name:         "security_contacts includes Slack ID only",
+			filesChanged: []string{"OWNERS"},
+			ownersFile:   "slackIDOnlyInSecContacts",
+			shouldLabel:  false,
+		},
+		{
+			name:         "security_contacts has empty contact info",
+			filesChanged: []string{"OWNERS"},
+			ownersFile:   "EmptyEntryInSecContacts",
+			shouldLabel:  true,
 		},
 	}
 	lg, c, err := clients()

--- a/prow/repoowners/repoowners_test.go
+++ b/prow/repoowners/repoowners_test.go
@@ -48,6 +48,10 @@ reviewers:
 - bob
 required_reviewers:
 - chris
+security_contacts:
+  bob:
+    email: bob@bob.com
+    slack_id: U123ABC
 labels:
 - EVERYTHING`),
 		"src/OWNERS": []byte(`approvers:
@@ -114,6 +118,11 @@ func regexpAll(values ...string) map[*regexp.Regexp]sets.String {
 func patternAll(values ...string) map[string]sets.String {
 	// use "" to represent nil and distinguish it from a ".*" regexp (which shouldn't exist).
 	return map[string]sets.String{"": sets.NewString(values...)}
+}
+
+// contactInfoAll is used to construct a default {regexp string -> values} mapping for ".*"
+func contactInfoAll(values map[string]ContactInfo) map[*regexp.Regexp]map[string]ContactInfo {
+	return map[*regexp.Regexp]map[string]ContactInfo{nil: values}
 }
 
 type cacheOptions struct {
@@ -467,6 +476,7 @@ func TestLoadRepoOwnersV2(t *testing.T) {
 
 func testLoadRepoOwners(clients localgit.Clients, t *testing.T) {
 	t.Parallel()
+	expectedContactInfo := contactInfoAll(map[string]ContactInfo{"bob": ContactInfo{Email: "bob@bob.com", SlackID: "U123ABC"}})
 	tests := []struct {
 		name              string
 		mdEnabled         bool
@@ -477,6 +487,8 @@ func testLoadRepoOwners(clients localgit.Clients, t *testing.T) {
 		extraBranchesAndFiles map[string]map[string][]byte
 
 		expectedApprovers, expectedReviewers, expectedRequiredReviewers, expectedLabels map[string]map[string]sets.String
+
+		expectedSecurityContacts map[string]map[*regexp.Regexp]map[string]ContactInfo
 
 		expectedOptions  map[string]dirOptions
 		cacheOptions     *cacheOptions
@@ -500,6 +512,9 @@ func testLoadRepoOwners(clients localgit.Clients, t *testing.T) {
 			expectedRequiredReviewers: map[string]map[string]sets.String{
 				"":        patternAll("chris"),
 				"src/dir": patternAll("ben"),
+			},
+			expectedSecurityContacts: map[string]map[*regexp.Regexp]map[string]ContactInfo{
+				"":             expectedContactInfo,
 			},
 			expectedLabels: map[string]map[string]sets.String{
 				"":        patternAll("EVERYTHING"),
@@ -531,6 +546,9 @@ func testLoadRepoOwners(clients localgit.Clients, t *testing.T) {
 			expectedRequiredReviewers: map[string]map[string]sets.String{
 				"":        patternAll("chris"),
 				"src/dir": patternAll("ben"),
+			},
+			expectedSecurityContacts: map[string]map[*regexp.Regexp]map[string]ContactInfo{
+				"":             expectedContactInfo,
 			},
 			expectedLabels: map[string]map[string]sets.String{
 				"":        patternAll("EVERYTHING"),
@@ -564,6 +582,9 @@ func testLoadRepoOwners(clients localgit.Clients, t *testing.T) {
 			expectedRequiredReviewers: map[string]map[string]sets.String{
 				"":        patternAll("chris"),
 				"src/dir": patternAll("ben"),
+			},
+			expectedSecurityContacts: map[string]map[*regexp.Regexp]map[string]ContactInfo{
+				"":             expectedContactInfo,
 			},
 			expectedLabels: map[string]map[string]sets.String{
 				"":             patternAll("EVERYTHING"),
@@ -603,6 +624,9 @@ func testLoadRepoOwners(clients localgit.Clients, t *testing.T) {
 				"":        patternAll("chris"),
 				"src/dir": patternAll("ben"),
 			},
+			expectedSecurityContacts: map[string]map[*regexp.Regexp]map[string]ContactInfo{
+				"":             expectedContactInfo,
+			},
 			expectedLabels: map[string]map[string]sets.String{
 				"":        patternAll("EVERYTHING"),
 				"src/dir": patternAll("src-code"),
@@ -639,6 +663,9 @@ func testLoadRepoOwners(clients localgit.Clients, t *testing.T) {
 				"":        patternAll("chris"),
 				"src/dir": patternAll("ben"),
 			},
+			expectedSecurityContacts: map[string]map[*regexp.Regexp]map[string]ContactInfo{
+				"":             expectedContactInfo,
+			},
 			expectedLabels: map[string]map[string]sets.String{
 				"":        patternAll("EVERYTHING"),
 				"src/dir": patternAll("src-code"),
@@ -669,6 +696,9 @@ func testLoadRepoOwners(clients localgit.Clients, t *testing.T) {
 			expectedRequiredReviewers: map[string]map[string]sets.String{
 				"":        patternAll("chris"),
 				"src/dir": patternAll("ben"),
+			},
+			expectedSecurityContacts: map[string]map[*regexp.Regexp]map[string]ContactInfo{
+				"":             expectedContactInfo,
 			},
 			expectedLabels: map[string]map[string]sets.String{
 				"":        patternAll("EVERYTHING"),
@@ -720,6 +750,9 @@ func testLoadRepoOwners(clients localgit.Clients, t *testing.T) {
 				"":        patternAll("chris"),
 				"src/dir": patternAll("ben"),
 			},
+			expectedSecurityContacts: map[string]map[*regexp.Regexp]map[string]ContactInfo{
+				"":             expectedContactInfo,
+			},
 			expectedLabels: map[string]map[string]sets.String{
 				"":             patternAll("EVERYTHING"),
 				"src/dir":      patternAll("src-code"),
@@ -754,6 +787,9 @@ func testLoadRepoOwners(clients localgit.Clients, t *testing.T) {
 			expectedRequiredReviewers: map[string]map[string]sets.String{
 				"":        patternAll("chris"),
 				"src/dir": patternAll("ben"),
+			},
+			expectedSecurityContacts: map[string]map[*regexp.Regexp]map[string]ContactInfo{
+				"":             expectedContactInfo,
 			},
 			expectedLabels: map[string]map[string]sets.String{
 				"":             patternAll("EVERYTHING"),
@@ -790,6 +826,9 @@ func testLoadRepoOwners(clients localgit.Clients, t *testing.T) {
 				"":        patternAll("chris"),
 				"src/dir": patternAll("ben"),
 			},
+			expectedSecurityContacts: map[string]map[*regexp.Regexp]map[string]ContactInfo{
+				"":             expectedContactInfo,
+			},
 			expectedLabels: map[string]map[string]sets.String{
 				"":        patternAll("EVERYTHING"),
 				"src/dir": patternAll("src-code"),
@@ -824,6 +863,9 @@ func testLoadRepoOwners(clients localgit.Clients, t *testing.T) {
 			expectedRequiredReviewers: map[string]map[string]sets.String{
 				"":        patternAll("chris"),
 				"src/dir": patternAll("ben"),
+			},
+			expectedSecurityContacts: map[string]map[*regexp.Regexp]map[string]ContactInfo{
+				"":             expectedContactInfo,
 			},
 			expectedLabels: map[string]map[string]sets.String{
 				"":        patternAll("EVERYTHING"),
@@ -870,6 +912,9 @@ func testLoadRepoOwners(clients localgit.Clients, t *testing.T) {
 			expectedRequiredReviewers: map[string]map[string]sets.String{
 				"":        patternAll("chris"),
 				"src/dir": patternAll("ben"),
+			},
+			expectedSecurityContacts: map[string]map[*regexp.Regexp]map[string]ContactInfo{
+				"":             expectedContactInfo,
 			},
 			expectedLabels: map[string]map[string]sets.String{
 				"":             patternAll("EVERYTHING"),
@@ -951,6 +996,11 @@ func testLoadRepoOwners(clients localgit.Clients, t *testing.T) {
 			check("reviewers", test.expectedReviewers, ro.reviewers)
 			check("required_reviewers", test.expectedRequiredReviewers, ro.requiredReviewers)
 			check("labels", test.expectedLabels, ro.labels)
+
+			if !reflect.DeepEqual(test.expectedSecurityContacts, ro.securityContacts) {
+				t.Errorf("Expected security_contacts to be:\n%#v\ngot:\n%#v.", test.expectedSecurityContacts, ro.securityContacts)
+			}
+
 			if !reflect.DeepEqual(test.expectedOptions, ro.options) {
 				t.Errorf("Expected options to be:\n%#v\ngot:\n%#v.", test.expectedOptions, ro.options)
 			}


### PR DESCRIPTION
To support proposed change in https://github.com/kubernetes/security/issues/56

Marked this PR as a draft, as first the spec change to OWNERS/SECURITY_CONTACTS should be agreed upon and merged:

https://github.com/kubernetes/community/pull/5398