### PR TITLE
[invitations-accepter] Add a new tool that accepts all pending repository invitations

### DIFF
--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -28,6 +28,7 @@ prow_push(
             "hmac",
             "horologium",
             "initupload",
+            "invitations-accepter",
             "jenkins-operator",
             "mkpj",
             "mkpod",

--- a/prow/cmd/invitations-accepter/BUILD.bazel
+++ b/prow/cmd/invitations-accepter/BUILD.bazel
@@ -1,0 +1,58 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("//prow:def.bzl", "prow_image")
+
+NAME = "invitations-accepter"
+
+prow_image(
+    name = "image",
+    base = "@alpine-base//image",
+    component = NAME,
+    directory = "/",
+    files = [":invitations-accepter"],
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/experiment/invitations-accepter",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//prow/config/secret:go_default_library",
+        "//prow/flagutil:go_default_library",
+        "//prow/github:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/errors:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "invitations-accepter",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["main_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/github/fakegithub:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/cmd/invitations-accepter/README.md
+++ b/prow/cmd/invitations-accepter/README.md
@@ -1,0 +1,17 @@
+# Invitations Accepter
+
+The `invitations-accepter` tool approves all pending repository invitations. 
+
+## Usage
+
+*example*:
+```sh
+invitations-accepter --dry-run=false --github-token-path=/etc/github/oauth
+```
+
+using with GitHub Apps
+
+```sh
+invitations-accepter --dry-run=false --github-app-id=12345 --github-app-private-key-path=/etc/github/cert
+
+```

--- a/prow/cmd/invitations-accepter/main.go
+++ b/prow/cmd/invitations-accepter/main.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	"k8s.io/test-infra/prow/config/secret"
+	"k8s.io/test-infra/prow/flagutil"
+	"k8s.io/test-infra/prow/github"
+)
+
+type options struct {
+	github flagutil.GitHubOptions
+
+	dryRun bool
+}
+
+type githubClient interface {
+	ListCurrentUserRepoInvitations() ([]github.UserRepoInvitation, error)
+	AcceptUserRepoInvitation(invitationID int) error
+	BotUser() (*github.UserData, error)
+}
+
+func gatherOptions() options {
+	o := options{}
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+	fs.BoolVar(&o.dryRun, "dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
+
+	o.github.AddFlags(fs)
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		logrus.WithError(err).Fatal("could not parse input")
+	}
+	return o
+}
+
+func (o *options) Validate() error {
+	return o.github.Validate(o.dryRun)
+}
+
+func main() {
+	o := gatherOptions()
+
+	sa := &secret.Agent{}
+	if err := sa.Start(nil); err != nil {
+		logrus.WithError(err).Fatal("Error starting secrets agent.")
+	}
+
+	gc, err := o.github.GitHubClient(sa, o.dryRun)
+	if err != nil {
+		logrus.WithError(err).Fatal("Error getting GitHub client.")
+	}
+	gc.Throttle(300, 300)
+
+	if err := acceptInvitations(gc, o.dryRun); err != nil {
+		logrus.WithError(err).Fatal("Errors occurred.")
+	}
+}
+
+func acceptInvitations(gc githubClient, dryRun bool) error {
+	var errs []error
+
+	botUser, err := gc.BotUser()
+	if err != nil {
+		return fmt.Errorf("couldn't get bot's user name: %v", err)
+	}
+	repoInvitations, err := gc.ListCurrentUserRepoInvitations()
+	if err != nil {
+		return fmt.Errorf("couldn't get repo invitations for the authenticated user: %v", err)
+	}
+
+	for _, inv := range repoInvitations {
+		logger := logrus.WithFields(logrus.Fields{"bot-user": botUser.Login, "invitation-id": inv.InvitationID, "repo": inv.Repository.FullName})
+		if dryRun {
+			logger.Info("(dry-run) Accepting invitation.")
+		} else {
+			logger.Info("Accepting invitation.")
+			errs = append(errs, gc.AcceptUserRepoInvitation(inv.InvitationID))
+		}
+	}
+
+	return utilerrors.NewAggregate(errs)
+}

--- a/prow/cmd/invitations-accepter/main_test.go
+++ b/prow/cmd/invitations-accepter/main_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/github/fakegithub"
+)
+
+func TestAcceptInvitations(t *testing.T) {
+
+	testCases := []struct {
+		id          string
+		invitations map[int]github.UserRepoInvitation
+	}{
+		{
+			id: "no invitations to accept",
+		},
+		{
+			id: "one invitation to accept",
+			invitations: map[int]github.UserRepoInvitation{
+				1: {InvitationID: 1, Repository: &github.Repo{FullName: "foo/bar"}},
+			},
+		},
+		{
+			id: "multiple invitations per client to accept",
+			invitations: map[int]github.UserRepoInvitation{
+				1: {InvitationID: 1, Repository: &github.Repo{FullName: "foo/bar"}},
+				2: {InvitationID: 2, Repository: &github.Repo{FullName: "james/bond"}},
+				3: {InvitationID: 3, Repository: &github.Repo{FullName: "captain/hook"}},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.id, func(t *testing.T) {
+			fgh := &fakegithub.FakeClient{UserRepoInvitations: tc.invitations}
+
+			if err := acceptInvitations(fgh, false); err != nil {
+				t.Fatalf("error wasn't expected: %v", err)
+			}
+
+			actualInvitations, err := fgh.ListCurrentUserRepoInvitations()
+			if err != nil {
+				t.Fatalf("error not expected: %v", err)
+			}
+
+			var expected []github.UserRepoInvitation
+			if diff := cmp.Diff(actualInvitations, expected); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}

--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 
@@ -999,6 +1000,10 @@ func (f *FakeClient) ListCurrentUserRepoInvitations() ([]github.UserRepoInvitati
 	for _, inv := range f.UserRepoInvitations {
 		ret = append(ret, inv)
 	}
+
+	sort.Slice(ret, func(p, q int) bool {
+		return ret[p].InvitationID < ret[q].InvitationID
+	})
 
 	return ret, nil
 }


### PR DESCRIPTION
This tool accepts all pending repository invitations for a given GitHub account.

/cc @stevekuznetsov @alvaroaleman 


Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>


