### PR TITLE
Azure: Enable CAPZ CCM e2e by default

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -265,7 +265,7 @@ presubmits:
       description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
       testgrid-num-columns-recent: '30'
   - name: pull-cloud-provider-azure-e2e-ccm-capz
-    always_run: false
+    always_run: true
     optional: true
     decorate: true
     decoration_config:
@@ -279,9 +279,9 @@ presubmits:
       preset-azure-cred-only: "true"
       preset-azure-anonymous-pull: "true"
     extra_refs:
-      - org: CecileRobertMichon # TODO(CecileRobertMichon): change it to 'kubernetes-sigs'
+      - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: ccm-presubmit-tests # TODO(CecileRobertMichon): change it to 'master'
+        base_ref: master
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
     spec:

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -131,8 +131,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: K8S_AZURE_LOADBALANCE_SKU
-          value: "basic"
         - name: AZURE_LOADBALANCER_SKU
           value: "basic"
     annotations:
@@ -193,8 +191,6 @@ presubmits:
           securityContext:
             privileged: true
           env:
-            - name: K8S_AZURE_LOADBALANCE_SKU
-              value: "standard"
             - name: AZURE_LOADBALANCER_SKU
               value: "standard"
     annotations:
@@ -255,8 +251,6 @@ presubmits:
           securityContext:
             privileged: true
           env:
-            - name: K8S_AZURE_LOADBALANCE_SKU
-              value: "standard"
             - name: AZURE_LOADBALANCER_SKU
               value: "standard"
     annotations:
@@ -301,8 +295,6 @@ presubmits:
           env:
             - name: TEST_CCM
               value: "true"
-            - name: K8S_AZURE_LOADBALANCE_SKU
-              value: "standard"
             - name: AZURE_LOADBALANCER_SKU
               value: "standard"
     annotations:
@@ -383,8 +375,6 @@ periodics:
       - --test-ccm
       - --ginkgo-parallel=30
       env:
-      - name: K8S_AZURE_LOADBALANCE_SKU
-        value: "standard"
       - name: AZURE_LOADBALANCER_SKU
         value: "standard"
       securityContext:
@@ -449,8 +439,6 @@ periodics:
       env:
       - name: CCM_E2E_ARGS
         value: "-ginkgo.focus=autoscaler"
-      - name: K8S_AZURE_LOADBALANCE_SKU
-        value: "standard"
       - name: AZURE_LOADBALANCER_SKU
         value: "standard"
   annotations:
@@ -513,8 +501,6 @@ periodics:
       env:
       - name: CCM_E2E_ARGS
         value: "-ginkgo.focus=autoscaler"
-      - name: K8S_AZURE_LOADBALANCE_SKU
-        value: "standard"
       - name: AZURE_LOADBALANCER_SKU
         value: "standard"
   annotations:
@@ -697,8 +683,6 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private # Requires preset-k8s-ssh label
       - name: KUBE_SSH_USER
         value: azureuser
-      - name: K8S_AZURE_LOADBALANCE_SKU
-        value: "basic"
       - name: AZURE_LOADBALANCER_SKU
         value: "standard"
   annotations:
@@ -757,8 +741,6 @@ periodics:
       - --test-ccm
       - --ginkgo-parallel=30
       env:
-      - name: K8S_AZURE_LOADBALANCE_SKU
-        value: "standard"
       - name: AZURE_LOADBALANCER_SKU
         value: "standard"
       securityContext:

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-0.7.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-0.7.yaml
@@ -131,8 +131,6 @@ presubmits:
             securityContext:
               privileged: true
             env:
-              - name: K8S_AZURE_LOADBALANCE_SKU
-                value: "basic"
               - name: AZURE_LOADBALANCER_SKU
                 value: "basic"
       annotations:
@@ -193,8 +191,6 @@ presubmits:
             securityContext:
               privileged: true
             env:
-              - name: K8S_AZURE_LOADBALANCE_SKU
-                value: "standard"
               - name: AZURE_LOADBALANCER_SKU
                 value: "standard"
       annotations:
@@ -255,8 +251,6 @@ presubmits:
             securityContext:
               privileged: true
             env:
-              - name: K8S_AZURE_LOADBALANCE_SKU
-                value: "standard"
               - name: AZURE_LOADBALANCER_SKU
                 value: "standard"
       annotations:


### PR DESCRIPTION
/hold until https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1330 merges

Enabled the job to run by default, still optional for now.

Removed `K8S_AZURE_LOADBALANCE_SKU` variable since https://github.com/kubernetes-sigs/cloud-provider-azure/pull/599 has merged.

/assign @feiskyer @chewong 