### PR TITLE
Make pull-kubernetes-node-e2e-containerd as presubmit job

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1,15 +1,13 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-node-e2e
-    skip_branches:
-    - release-\d+\.\d+  # per-release image
+    branches:
+      - master
     annotations:
-      fork-per-release: "true"
-      testgrid-alert-stale-results-hours: "24"
       testgrid-create-test-group: "true"
-      testgrid-num-failures-to-alert: "10"
-    always_run: true
-    cluster: k8s-infra-prow-build
+    always_run: false
+    optional: true
+    skip_report: false
     max_concurrency: 12
     labels:
       preset-service-account: "true"
@@ -27,6 +25,7 @@ presubmits:
         - --scenario=kubernetes_e2e
         - -- # end bootstrap args, scenario args below
         - --deployment=node
+        - --gcp-project-type=node-e2e-project
         - --gcp-zone=us-west1-b
         - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
         - --node-tests=true
@@ -130,11 +129,16 @@ presubmits:
         securityContext:
           privileged: true
   - name: pull-kubernetes-node-e2e-containerd
-    branches:
-    - master
+    skip_branches:
+      - release-\d+\.\d+  # per-release image
+    annotations:
+      fork-per-release: "true"
+      testgrid-alert-stale-results-hours: "24"
+      testgrid-create-test-group: "true"
+      testgrid-num-failures-to-alert: "10"
     always_run: false
-    optional: true
-    skip_report: false
+    optional: false
+    cluster: k8s-infra-prow-build
     max_concurrency: 12
     labels:
       preset-service-account: "true"
@@ -152,7 +156,6 @@ presubmits:
         - --scenario=kubernetes_e2e
         - --
         - --deployment=node
-        - --gcp-project-type=node-e2e-project
         - --gcp-zone=us-west1-b
         - '--node-test-args=--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
         - --node-tests=true
@@ -161,10 +164,12 @@ presubmits:
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/image-config.yaml
         resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
           requests:
-            memory: "6Gi"
-    annotations:
-      testgrid-create-test-group: 'true'
+            cpu: 4
+            memory: 6Gi
   - name: pull-kubernetes-node-e2e-alpha
     branches:
     - master


### PR DESCRIPTION
`pull-kubernetes-node-e2e` is docker-only. Since docker is getting
deprecated, let's switch over to the containerd one as the main CI job
that runs the node e2e conformance tests.

Fix for #22086 

Signed-off-by: Davanum Srinivas <davanum@gmail.com>