### PR TITLE
Adding Presubmit for sigs.k8s.io/cluster-api-provider-nested

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-nested/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-nested/OWNERS
@@ -1,0 +1,15 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+- christopherhein
+- cluster-api-admins
+- sig-cluster-lifecycle-leads
+- vincepri
+approvers:
+- christopherhein
+- cluster-api-admins
+- sig-cluster-lifecycle-leads
+- vincepri
+
+labels:
+- sig/cluster-lifecycle

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-nested/cluster-api-provider-nested-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-nested/cluster-api-provider-nested-presubmits.yaml
@@ -1,0 +1,72 @@
+presubmits:
+  kubernetes-sigs/cluster-api-provider-nested:
+  - name: pull-cluster-api-provider-nested-test
+    always_run: true
+    optional: false
+    decorate: true
+    path_alias: "sigs.k8s.io/cluster-api-provider-nested"
+    branches:
+    # The script this job runs is not in all branches.
+    - ^main$
+    - ^master$
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210428-a1a20d1-master
+        command:
+        - "./scripts/ci-test.sh"
+        resources:
+          requests:
+            memory: "6Gi"
+            cpu: "2"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-nested
+      testgrid-tab-name: pr-test
+  - name: pull-cluster-api-provider-nested-build
+    always_run: true
+    optional: false
+    decorate: true
+    path_alias: "sigs.k8s.io/cluster-api-provider-nested"
+    branches:
+    # The script this job runs is not in all branches.
+    - ^main$
+    - ^master$
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210428-a1a20d1-master
+        command:
+        - "./scripts/ci-build.sh"
+        resources:
+          requests:
+            memory: "6Gi"
+            cpu: "2"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-nested
+      testgrid-tab-name: pr-build
+  - name: pull-cluster-api-provider-nested-make
+    always_run: true
+    optional: false
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    path_alias: "sigs.k8s.io/cluster-api-provider-nested"
+    branches:
+    # The script this job runs is not in all branches.
+    - ^main$
+    - ^master$
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210428-a1a20d1-master
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        command:
+        - "runner.sh"
+        - "./scripts/ci-make.sh"
+        resources:
+          requests:
+            memory: "6Gi"
+            cpu: "2"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-nested
+      testgrid-tab-name: pr-make

--- a/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
+++ b/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
@@ -15,6 +15,7 @@ dashboard_groups:
     - sig-cluster-lifecycle-cluster-api-provider-openstack
     - sig-cluster-lifecycle-cluster-api-bootstrap-provider-kubeadm
     - sig-cluster-lifecycle-cluster-api-provider-docker
+    - sig-cluster-lifecycle-cluster-api-provider-nested
     - sig-cluster-lifecycle-kops
     - sig-cluster-lifecycle-etcdadm
     - sig-cluster-lifecycle-image-pushes
@@ -44,6 +45,7 @@ dashboards:
 - name: sig-cluster-lifecycle-cluster-api-provider-openstack
 - name: sig-cluster-lifecycle-cluster-api-bootstrap-provider-kubeadm
 - name: sig-cluster-lifecycle-cluster-api-provider-docker
+- name: sig-cluster-lifecycle-cluster-api-provider-nested
 - name: sig-cluster-lifecycle-kops
 - name: sig-cluster-lifecycle-etcdadm
 - name: sig-cluster-lifecycle-image-pushes


### PR DESCRIPTION
This adds a new project https://sigs.k8s.io/cluster-api-provider-nested. 

## Testing

**Generating Job:**

```bash
→ bazel run //prow/cmd/mkpj -- --config-path=/Users/chris/Code/src/k8s.io/test-infra/config/prow/config.yaml --job-config-path=/Users/chris/Code/src/k8s.io/test-infra/config/jobs/kubernetes-sigs/cluster-api-provider-nested/cluster-api-provider-nested-presubmits.yaml --job=pull-cluster-api-provider-nested-test > /tmp/foo
Loading:
Loading: 0 packages loaded
Analyzing: target //prow/cmd/mkpj:mkpj (0 packages loaded, 0 targets configured)
INFO: Analyzed target //prow/cmd/mkpj:mkpj (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
[0 / 2] [Prepa] BazelWorkspaceStatusAction stable-status.txt
Target //prow/cmd/mkpj:mkpj up-to-date:
  bazel-bin/prow/cmd/mkpj/mkpj_/mkpj
INFO: Elapsed time: 0.473s, Critical Path: 0.31s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/prow/cmd/mkpj/mkpj_/mkpj '--config-path=/Users/chris/Code/src/k8s.io/test-infra/config/prow/config.yaml' '--job-config-path=/Users/chris/Code/src/k8s.io/test-infra/config/jobs/kubernetes-sigs/cluster-api-provider-nested/cluster-api-provider-nested-presubmits.yaml' '--job=pull-cluster-api-provider-nested-test'
INFO: Build completed successfully, 1 total action
PR Number: 48
INFO[0003] GetPullRequest(kubernetes-sigs, cluster-api-provider-nested, 48)  client=github
DEBU[0004] GetPullRequest(kubernetes-sigs, cluster-api-provider-nested, 48) finished  client=github duration=479.900134ms
```

**Run Job**

```bash
→ bazel run //prow/cmd/phaino -- /tmp/foo --privileged
INFO: Analyzed target //prow/cmd/phaino:phaino (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //prow/cmd/phaino:phaino up-to-date:
  bazel-bin/prow/cmd/phaino/phaino_/phaino
INFO: Elapsed time: 0.474s, Critical Path: 0.31s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
INFO[0000] Reading...                                    path=/tmp/foo
INFO[0000] Converting job into docker run command...     job=pull-cluster-api-provider-nested-test
WARN[0000] Ignoring resource requirements                job=pull-cluster-api-provider-nested-test
fallback to GOPATH: /Users/chris/Code
: "docker" "run" "--rm=true" \
 "--name=phaino-34295-1" \
 "--entrypoint=./scripts/ci-test.sh" \
 "-w" \
 "/home/prow/go/src/sigs.k8s.io/cluster-api-provider-nested" \
 "-v" \
 "/Users/chris/Code/src/sigs.k8s.io/cluster-api-provider-nested:/home/prow/go/src/sigs.k8s.io/cluster-api-provider-nested" \
 "-e" \
 "GOPROXY=https://proxy.golang.org" \
 "--label=prow.k8s.io/refs.base_ref=master" \
 "--label=prow.k8s.io/refs.org=kubernetes-sigs" \
 "--label=prow.k8s.io/refs.pull=48" \
 "--label=prow.k8s.io/refs.repo=cluster-api-provider-nested" \
 "--label=prow.k8s.io/type=presubmit" \
 "--label=created-by-prow=true" \
 "--label=prow.k8s.io/context=pull-cluster-api-provider-nested-test" \
 "--label=prow.k8s.io/job=pull-cluster-api-provider-nested-test" \
 "--label=phaino=true" \
 "gcr.io/k8s-testimages/kubekins-e2e:v20210428-a1a20d1-master"
INFO[0000] Starting job...                               job=pull-cluster-api-provider-nested-test
INFO[0000] Waiting for job to finish...                  container=phaino-34295-1 job=pull-cluster-api-provider-nested-test
fetching tools
kubebuilder/
kubebuilder/bin/
kubebuilder/bin/etcd
kubebuilder/bin/kube-apiserver
kubebuilder/bin/kubectl
setting up env vars
fatal: No names found, cannot describe anything.
make generate-go
make[1]: Entering directory '/home/prow/go/src/sigs.k8s.io/cluster-api-provider-nested'
fatal: No names found, cannot describe anything.
go generate ./...
go: downloading k8s.io/client-go v0.19.4
go: downloading sigs.k8s.io/cluster-api v0.3.11-0.20201112165251-91b70900dbaf
go: downloading github.com/spf13/pflag v1.0.5
go: downloading k8s.io/apimachinery v0.19.4
go: downloading k8s.io/klog v1.0.0
go: downloading sigs.k8s.io/controller-runtime v0.7.0-alpha.5
go: downloading k8s.io/api v0.19.4
go: downloading sigs.k8s.io/kubebuilder-declarative-pattern v0.0.0-20210120001158-a905f3c7cf41
go: downloading github.com/go-logr/logr v0.3.0
go: downloading k8s.io/klog/v2 v2.2.0
go: downloading k8s.io/utils v0.0.0-20200912215256-4140de9c8800
go: downloading github.com/prometheus/client_golang v1.7.1
go: downloading golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
go: downloading github.com/evanphx/json-patch v4.9.0+incompatible
go: downloading k8s.io/component-base v0.19.2
go: downloading gomodules.xyz/jsonpatch/v2 v2.1.0
go: downloading github.com/gogo/protobuf v1.3.1
go: downloading sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06
go: downloading k8s.io/apiextensions-apiserver v0.19.2
go: downloading github.com/google/gofuzz v1.2.0
go: downloading sigs.k8s.io/structured-merge-diff/v4 v4.0.1
go: downloading github.com/google/uuid v1.1.2
go: downloading github.com/prometheus/client_model v0.2.0
go: downloading github.com/prometheus/common v0.10.0
go: downloading github.com/beorn7/perks v1.0.1
go: downloading github.com/cespare/xxhash v1.1.0
go: downloading github.com/golang/protobuf v1.4.2
go: downloading github.com/fsnotify/fsnotify v1.4.9
go: downloading gopkg.in/inf.v0 v0.9.1
go: downloading github.com/prometheus/procfs v0.1.3
go: downloading github.com/json-iterator/go v1.1.10
go: downloading github.com/modern-go/reflect2 v1.0.1
go: downloading sigs.k8s.io/yaml v1.2.0
go: downloading github.com/pkg/errors v0.9.1
go: downloading gopkg.in/yaml.v2 v2.3.0
go: downloading github.com/cespare/xxhash/v2 v2.1.1
go: downloading github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
go: downloading golang.org/x/net v0.0.0-20200707034311-ab3426394381
go: downloading github.com/googleapis/gnostic v0.5.1
go: downloading github.com/imdario/mergo v0.3.11
go: downloading golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
go: downloading github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
go: downloading golang.org/x/sys v0.0.0-20200814200057-3d37ad5750ed
go: downloading github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
go: downloading google.golang.org/protobuf v1.24.0
go: downloading github.com/blang/semver v3.5.1+incompatible
go: downloading github.com/gobuffalo/flect v0.2.2
go: downloading k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
go: downloading github.com/davecgh/go-spew v1.1.1
go: downloading github.com/google/go-cmp v0.5.2
go: downloading golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
go: downloading github.com/hashicorp/golang-lru v0.5.4
go: downloading github.com/docker/distribution v2.7.1+incompatible
go: downloading gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
go: downloading github.com/opencontainers/go-digest v1.0.0
go: downloading golang.org/x/text v0.3.3
/home/prow/go/src/sigs.k8s.io/cluster-api-provider-nested/hack/tools/bin/controller-gen \
        object:headerFile=./hack/boilerplate/boilerplate.generatego.txt \
        paths=./apis/...
make[1]: Leaving directory '/home/prow/go/src/sigs.k8s.io/cluster-api-provider-nested'
make generate-manifests
make[1]: Entering directory '/home/prow/go/src/sigs.k8s.io/cluster-api-provider-nested'
fatal: No names found, cannot describe anything.
/home/prow/go/src/sigs.k8s.io/cluster-api-provider-nested/hack/tools/bin/controller-gen \
        paths=./apis/... \
        paths=./controllers/... \
        crd:crdVersions=v1 \
        rbac:roleName=manager-role \
        output:crd:dir=./config/crd/bases \
        output:webhook:dir=./config/webhook \
        webhook
## Copy files in CI folders.
cp -f ./config/rbac/*.yaml ./config/ci/rbac/
cp -f ./config/manager/manager*.yaml ./config/ci/manager/
make[1]: Leaving directory '/home/prow/go/src/sigs.k8s.io/cluster-api-provider-nested'
/home/prow/go/src/sigs.k8s.io/cluster-api-provider-nested/hack/tools/bin/golangci-lint run -v
level=info msg="[config_reader] Config search paths: [./ /home/prow/go/src/sigs.k8s.io/cluster-api-provider-nested /home/prow/go/src/sigs.k8s.io /home/prow/go/src /home/prow/go /home/prow /home /]"
level=info msg="[config_reader] Used config file .golangci.yml"
level=info msg="[lintersdb] Active 28 linters: [asciicheck bodyclose deadcode depguard dogsled errcheck goconst gocritic gocyclo gofmt goimports golint gomodguard goprintffuncname gosimple govet ineffassign maligned misspell nolintlint prealloc rowserrcheck structcheck stylecheck testpackage typecheck unconvert varcheck]"
level=info msg="[loader] Go packages loading at mode 575 (files|name|types_sizes|compiled_files|deps|exports_file|imports) took 9.914101974s"
level=info msg="[runner/filename_unadjuster] Pre-built 0 adjustments in 7.573417ms"
level=info msg="[linters context/goanalysis] analyzers took 57.840740788s with top 10 stages: buildir: 45.275535984s, goimports: 6.210025267s, inspect: 2.206991306s, ctrlflow: 1.72961998s, printf: 1.563799761s, the_only_name: 271.080482ms, buildssa: 191.733088ms, misspell: 45.955931ms, golint: 40.451744ms, gofmt: 39.339422ms"
level=info msg="[runner] Issues before processing: 28, after processing: 0"
level=info msg="[runner] Processors filtering stat (out/in): filename_unadjuster: 28/28, autogenerated_exclude: 27/27, identifier_marker: 27/27, path_prettifier: 28/28, skip_files: 27/28, cgo: 28/28, skip_dirs: 27/27, exclude: 0/27"
level=info msg="[runner] processing took 10.290166ms with stages: autogenerated_exclude: 7.554146ms, path_prettifier: 1.139876ms, exclude: 792.212µs, identifier_marker: 636.371µs, skip_dirs: 87.83µs, skip_files: 70.224µs, cgo: 3.645µs, filename_unadjuster: 2.072µs, nolint: 1.142µs, max_same_issues: 753ns, uniq_by_line: 421ns, diff: 352ns, max_from_linter: 307ns, path_shortener: 247ns, exclude-rules: 234ns, source_code: 198ns, max_per_file_from_linter: 136ns"
level=info msg="[runner] linters took 14.572938447s with stages: goanalysis_metalinter: 14.562517634s"
level=info msg="File cache stats: 18 entries of total size 78.6KiB"
level=info msg="Memory: 245 samples, avg is 564.7MB, max is 1085.5MB"
level=info msg="Execution took 24.5026183s"
source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; go test -v ./...
fetching tools
kubebuilder/
kubebuilder/bin/
kubebuilder/bin/etcd
kubebuilder/bin/kube-apiserver
kubebuilder/bin/kubectl
setting up env vars
?       sigs.k8s.io/cluster-api-provider-nested [no test files]
?       sigs.k8s.io/cluster-api-provider-nested/apis/controlplane/v1alpha4      [no test files]
=== RUN   TestSubstituteTemplate
=== RUN   TestSubstituteTemplate/empty_template
=== PAUSE TestSubstituteTemplate/empty_template
=== RUN   TestSubstituteTemplate/normal_template
=== PAUSE TestSubstituteTemplate/normal_template
=== CONT  TestSubstituteTemplate/empty_template
    controller_util_test.go:59:         TestCase: empty template
=== CONT  TestSubstituteTemplate/normal_template
=== CONT  TestSubstituteTemplate/empty_template
    controller_util_test.go:68:         ✓       expect , get
=== CONT  TestSubstituteTemplate/normal_template
    controller_util_test.go:59:         TestCase: normal template
    controller_util_test.go:68:         ✓       expect name: test,
        age: 1, get name: test,
        age: 1
--- PASS: TestSubstituteTemplate (0.00s)
    --- PASS: TestSubstituteTemplate/empty_template (0.00s)
    --- PASS: TestSubstituteTemplate/normal_template (0.00s)
=== RUN   TestGetOwner
=== RUN   TestGetOwner/no_owner
=== PAUSE TestGetOwner/no_owner
=== RUN   TestGetOwner/owner_APIVersion_not_matched
=== PAUSE TestGetOwner/owner_APIVersion_not_matched
=== RUN   TestGetOwner/owner_kind_not_matched
=== PAUSE TestGetOwner/owner_kind_not_matched
=== RUN   TestGetOwner/owner_found
=== PAUSE TestGetOwner/owner_found
=== CONT  TestGetOwner/no_owner
    controller_util_test.go:154:        TestCase: no owner
=== CONT  TestGetOwner/owner_kind_not_matched
=== CONT  TestGetOwner/owner_APIVersion_not_matched
=== CONT  TestGetOwner/owner_found
=== CONT  TestGetOwner/owner_APIVersion_not_matched
    controller_util_test.go:154:        TestCase: owner APIVersion not matched
    controller_util_test.go:160:        ✓       expect {    <nil> <nil>}, get {    <nil> <nil>}
=== CONT  TestGetOwner/no_owner
    controller_util_test.go:160:        ✓       expect {    <nil> <nil>}, get {    <nil> <nil>}
=== CONT  TestGetOwner/owner_kind_not_matched
    controller_util_test.go:154:        TestCase: owner kind not matched
    controller_util_test.go:160:        ✓       expect {    <nil> <nil>}, get {    <nil> <nil>}
=== CONT  TestGetOwner/owner_found
    controller_util_test.go:154:        TestCase: owner found
    controller_util_test.go:160:        ✓       expect {controlplane.cluster.x-k8s.io/v1alpha4 NestedControlPlane test-name xxxxx-xxxxx-xxxxx-xxxxx <nil> <nil>}, get {controlplane.cluster.x-k8s.io/v1alpha4 NestedControlPlane test-name xxxxx-xxxxx-xxxxx-xxxxx <nil> <nil>}
--- PASS: TestGetOwner (0.00s)
    --- PASS: TestGetOwner/owner_APIVersion_not_matched (0.00s)
    --- PASS: TestGetOwner/no_owner (0.00s)
    --- PASS: TestGetOwner/owner_kind_not_matched (0.00s)
    --- PASS: TestGetOwner/owner_found (0.00s)
=== RUN   TestGenInitialClusterArgs
=== RUN   TestGenInitialClusterArgs/1_replicas
=== PAUSE TestGenInitialClusterArgs/1_replicas
=== RUN   TestGenInitialClusterArgs/2_replicas
=== PAUSE TestGenInitialClusterArgs/2_replicas
=== CONT  TestGenInitialClusterArgs/1_replicas
    controller_util_test.go:195:        TestCase: 1 replicas
    controller_util_test.go:201:        ✓       expect netcdSts-0=https://netcdSts-0.netcdSvc:2380, get netcdSts-0=https://netcdSts-0.netcdSvc:2380
=== CONT  TestGenInitialClusterArgs/2_replicas
    controller_util_test.go:195:        TestCase: 2 replicas
    controller_util_test.go:201:        ✓       expect netcdSts-0=https://netcdSts-0.netcdSvc:2380,netcdSts-1=https://netcdSts-1.netcdSvc:2380, get netcdSts-0=https://netcdSts-0.netcdSvc:2380,netcdSts-1=https://netcdSts-1.netcdSvc:2380
--- PASS: TestGenInitialClusterArgs (0.00s)
    --- PASS: TestGenInitialClusterArgs/1_replicas (0.00s)
    --- PASS: TestGenInitialClusterArgs/2_replicas (0.00s)
=== RUN   TestAPIs
Running Suite: Controller Suite
===============================
Random Seed: 1620262314
Will run 0 of 0 specs



Ran 0 of 0 Specs in 5.449 seconds
SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestAPIs (5.45s)
PASS
ok      sigs.k8s.io/cluster-api-provider-nested/controllers/controlplane        5.479s
?       sigs.k8s.io/cluster-api-provider-nested/hack/boilerplate/test   [no test files]
INFO[0052] PASS: b60c0cb4-ae04-11eb-9881-d0817ad4a2e0    duration=52.959435596s job=pull-cluster-api-provider-nested-test
INFO[0052] SUCCESS
INFO[0052] Press Ctrl + c to exit.
^CINFO[0057] Received signal.                              signal=interrupt
INFO[0057] Interrupt received.
INFO[0057] All workers gracefully terminated, exiting.
```

## Related

* https://github.com/kubernetes-sigs/cluster-api-provider-nested/issues/46

Signed-off-by: Chris Hein <me@chrishein.com>