### PR TITLE
Update azuredisk-csi-driver-config.yaml

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -276,6 +276,7 @@ presubmits:
         - --aksengine-admin-username=azureuser
         - --aksengine-creds=$(AZURE_CREDENTIALS)
         - --aksengine-orchestratorRelease=1.18
+        - --aksengine-location=eastus2
         - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
         - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/test/e2e/manifest/multi-az.json
         - --aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz
@@ -325,6 +326,7 @@ presubmits:
         - --aksengine-admin-username=azureuser
         - --aksengine-creds=$(AZURE_CREDENTIALS)
         - --aksengine-orchestratorRelease=1.20
+        - --aksengine-location=eastus2
         - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
         - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/test/e2e/manifest/multi-az.json
         - --aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz


### PR DESCRIPTION
availability zone support is only available in some regions, let's stick to `eastus2` region.

cc @chewong 

```
The template deployment failed with error: 'The resource with id: '/subscriptions/0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e/resourceGroups/kubetest-jmzhtna9/providers/Microsoft.Compute/virtualMachineScaleSets/k8s-agentpool-12564591-vmss' failed validation with message: 'The resource 'Microsoft.Compute/virtualMachineScaleSets/k8s-agentpool-12564591-vmss' does not support availability zones at location 'northcentralus'.'.'."},{"code":"InvalidTemplateDeployment","message":"The template deployment failed with error: 'The resource with id: '/subscriptions/0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e/resourceGroups/kubetest-jmzhtna9/providers/Microsoft.Compute/virtualMachineScaleSets/k8s-master-12564591-vmss' failed validation with message: 'The resource 'Microsoft.Compute/virtualMachineScaleSets/k8s-master-12564591-vmss' does not support availability zones at location 'northcentralus'.'.'."}]
```