### PR TITLE
Bugzilla: Handle multiple whitespace characters between Bug and number

### DIFF
--- a/prow/plugins/bugzilla/bugzilla.go
+++ b/prow/plugins/bugzilla/bugzilla.go
@@ -39,7 +39,7 @@ import (
 )
 
 var (
-	titleMatch           = regexp.MustCompile(`(?i)Bug ([0-9]+):`)
+	titleMatch           = regexp.MustCompile(`(?i)Bug\s+([0-9]+):`)
 	refreshCommandMatch  = regexp.MustCompile(`(?mi)^/bugzilla refresh\s*$`)
 	qaAssignCommandMatch = regexp.MustCompile(`(?mi)^/bugzilla assign-qa\s*$`)
 	qaReviewCommandMatch = regexp.MustCompile(`(?mi)^/bugzilla cc-qa\s*$`)

--- a/prow/plugins/bugzilla/bugzilla_test.go
+++ b/prow/plugins/bugzilla/bugzilla_test.go
@@ -1837,6 +1837,10 @@ func TestBugIDFromTitle(t *testing.T) {
 			title:       "Bug 34: Revert: \"Bug 12: Revert default\"",
 			expectedNum: 34,
 		},
+		{
+			title:       "Bug  34: A title with multiple whitespaces between Bug and number",
+			expectedNum: 34,
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.title, func(t *testing.T) {


### PR DESCRIPTION
This is super confusing for users, because redundant whitespaces isn't
rendered by the frontend in either the title nor markdown comments.