### PR TITLE
Reduce oncall top-level reviewers.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,7 +4,10 @@ reviewers:
 - BenTheElder # lead
 - spiffxp # lead
 - stevekuznetsov # lead
-- test-infra-oncall # oncall
+- chaodaiG # oncall
+- cjwagner # oncall
+- mpherman2 # oncall
+- fejta # oncall
 approvers:
 - BenTheElder # lead
 - spiffxp # lead


### PR DESCRIPTION
Oncall has people with different amounts of involvement in test-infra.
It is useful to have oncall be able to approve these PRs when necessary,
but we should try to direct reviews to the people actively involved in
this repo. So reduce to that subset.

For feedback:
/assign @BenTheElder @spiffxp @stevekuznetsov 


Do you three want to get these kinds of reviews?
/cc @chaodaiG @cjwagner @mpherman2

ref https://github.com/kubernetes/test-infra/issues/22099
/hold
