### PR TITLE
pr-creator: add ability to attach labels to created pr

### DIFF
--- a/robots/pr-creator/BUILD.bazel
+++ b/robots/pr-creator/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("//prow:def.bzl", "prow_image", "prow_push")
 
 go_library(
@@ -10,7 +10,7 @@ go_library(
         "//prow/config/secret:go_default_library",
         "//prow/flagutil:go_default_library",
         "//robots/pr-creator/updater:go_default_library",
-        "@com_github_sirupsen_logrus//:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )
 
@@ -44,4 +44,11 @@ filegroup(
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["main_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//prow/flagutil:go_default_library"],
 )

--- a/robots/pr-creator/BUILD.bazel
+++ b/robots/pr-creator/BUILD.bazel
@@ -10,7 +10,7 @@ go_library(
         "//prow/config/secret:go_default_library",
         "//prow/flagutil:go_default_library",
         "//robots/pr-creator/updater:go_default_library",
-        "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )
 

--- a/robots/pr-creator/main.go
+++ b/robots/pr-creator/main.go
@@ -45,6 +45,7 @@ type options struct {
 	headBranch string
 	matchTitle string
 	body       string
+	labels     string
 }
 
 func (o options) validate() error {
@@ -66,6 +67,13 @@ func (o options) validate() error {
 	return nil
 }
 
+func (o options) getLabels() []string {
+	if o.labels != "" {
+		return strings.Split(o.labels, ",")
+	}
+	return []string{}
+}
+
 func optionsFromFlags() options {
 	var o options
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
@@ -82,6 +90,7 @@ func optionsFromFlags() options {
 	fs.StringVar(&o.headBranch, "head-branch", "", "Reuse any self-authored open PR from this branch. This takes priority over match-title")
 	fs.StringVar(&o.matchTitle, "match-title", "", "Reuse any self-autohred open PR that matches this title. If both this and head-branch are set, this will be overwritten by head-branch")
 	fs.StringVar(&o.body, "body", "", "Body of PR")
+	fs.StringVar(&o.labels, "labels", "", "labels to attach to PR")
 	fs.Parse(os.Args[1:])
 	return o
 }
@@ -109,7 +118,7 @@ func main() {
 	} else {
 		queryTokensString = "in:title " + o.matchTitle
 	}
-	n, err := updater.EnsurePRWithQueryTokens(o.org, o.repo, o.title, o.body, o.source, o.branch, queryTokensString, o.allowMods, gc)
+	n, err := updater.EnsurePRWithQueryTokensAndLabels(o.org, o.repo, o.title, o.body, o.source, o.branch, queryTokensString, o.allowMods, o.getLabels(), gc)
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to ensure PR exists.")
 	}

--- a/robots/pr-creator/main.go
+++ b/robots/pr-creator/main.go
@@ -71,7 +71,7 @@ func (o options) getLabels() []string {
 	if o.labels != "" {
 		return strings.Split(o.labels, ",")
 	}
-	return []string{}
+	return nil
 }
 
 func optionsFromFlags() options {

--- a/robots/pr-creator/main_test.go
+++ b/robots/pr-creator/main_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (
@@ -44,7 +60,7 @@ func Test_options_getLabels(t *testing.T) {
 				body:       "",
 				labels:     "",
 			},
-			want: []string{},
+			want: nil,
 		},
 		{
 			name: "one label",

--- a/robots/pr-creator/main_test.go
+++ b/robots/pr-creator/main_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"k8s.io/test-infra/prow/flagutil"
+	"reflect"
+	"testing"
+)
+
+func Test_options_getLabels(t *testing.T) {
+	type fields struct {
+		github     flagutil.GitHubOptions
+		branch     string
+		allowMods  bool
+		confirm    bool
+		local      bool
+		org        string
+		repo       string
+		source     string
+		title      string
+		headBranch string
+		matchTitle string
+		body       string
+		labels     string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   []string
+	}{
+		{
+			name: "empty labels",
+			fields: fields{
+				github:     flagutil.GitHubOptions{},
+				branch:     "",
+				allowMods:  false,
+				confirm:    false,
+				local:      false,
+				org:        "",
+				repo:       "",
+				source:     "",
+				title:      "",
+				headBranch: "",
+				matchTitle: "",
+				body:       "",
+				labels:     "",
+			},
+			want: []string{},
+		},
+		{
+			name: "one label",
+			fields: fields{
+				github:     flagutil.GitHubOptions{},
+				branch:     "",
+				allowMods:  false,
+				confirm:    false,
+				local:      false,
+				org:        "",
+				repo:       "",
+				source:     "",
+				title:      "",
+				headBranch: "",
+				matchTitle: "",
+				body:       "",
+				labels:     "lgtm",
+			},
+			want: []string{
+				"lgtm",
+			},
+		},
+		{
+			name: "two labels",
+			fields: fields{
+				github:     flagutil.GitHubOptions{},
+				branch:     "",
+				allowMods:  false,
+				confirm:    false,
+				local:      false,
+				org:        "",
+				repo:       "",
+				source:     "",
+				title:      "",
+				headBranch: "",
+				matchTitle: "",
+				body:       "",
+				labels:     "lgtm,approve",
+			},
+			want: []string{
+				"lgtm",
+				"approve",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := options{
+				github:     tt.fields.github,
+				branch:     tt.fields.branch,
+				allowMods:  tt.fields.allowMods,
+				confirm:    tt.fields.confirm,
+				local:      tt.fields.local,
+				org:        tt.fields.org,
+				repo:       tt.fields.repo,
+				source:     tt.fields.source,
+				title:      tt.fields.title,
+				headBranch: tt.fields.headBranch,
+				matchTitle: tt.fields.matchTitle,
+				body:       tt.fields.body,
+				labels:     tt.fields.labels,
+			}
+			if got := o.getLabels(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getLabels() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+}

--- a/robots/pr-creator/updater/BUILD.bazel
+++ b/robots/pr-creator/updater/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//prow/github:go_default_library",
-        "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )
 
@@ -32,6 +32,6 @@ go_test(
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
     ],
 )

--- a/robots/pr-creator/updater/BUILD.bazel
+++ b/robots/pr-creator/updater/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//prow/github:go_default_library",
-        "@com_github_sirupsen_logrus//:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )
 
@@ -32,6 +32,6 @@ go_test(
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",
-        "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )

--- a/robots/pr-creator/updater/updater.go
+++ b/robots/pr-creator/updater/updater.go
@@ -94,7 +94,11 @@ func updatePRWithQueryTokens(org, repo, title, body, queryTokensString string, g
 }
 
 func EnsurePRWithLabels(org, repo, title, body, source, baseBranch, headBranch string, allowMods bool, gc ensureClient, labels []string) (*int, error) {
-	n, err := EnsurePRWithQueryTokens(org, repo, title, body, source, baseBranch, "head:"+headBranch, allowMods, gc)
+	return EnsurePRWithQueryTokensAndLabels(org, repo, title, body, source, baseBranch, "head:"+headBranch, allowMods, labels, gc)
+}
+
+func EnsurePRWithQueryTokensAndLabels(org, repo, title, body, source, baseBranch, queryTokensString string, allowMods bool, labels []string, gc ensureClient) (*int, error) {
+	n, err := EnsurePRWithQueryTokens(org, repo, title, body, source, baseBranch, queryTokensString, allowMods, gc)
 	if err != nil {
 		return n, err
 	}


### PR DESCRIPTION
Adds the `--labels` option to `pr-creator` to be able to attach one or more labels to the PR.