### PR TITLE
Network Performance tc's: changes for fetching worker pod logs

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -949,6 +949,7 @@ periodics:
       - --gcp-nodes=102
       - --provider=gce
       - --test=false
+      - --env=LOG_DUMP_EXTRA_FILES=containers/worker*
       - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
       - --test-cmd-args=cluster-loader2
       - --test-cmd-args=--nodes=100


### PR DESCRIPTION
Currently the worker pod logs are not extracted by logexporter, this change is for fetching the worker pods log as well along with other logs.