### PR TITLE
Add a package for replicating improvements made in k8s prow monitoring stack

### DIFF
--- a/experiment/bumpmonitoring/BUILD.bazel
+++ b/experiment/bumpmonitoring/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/experiment/bumpmonitoring",
+    visibility = ["//visibility:private"],
+    deps = ["@com_github_sirupsen_logrus//:go_default_library"],
+)
+
+go_binary(
+    name = "bumpmonitoring",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["main_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "@com_github_google_go_cmp//cmp:go_default_library",
+        "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
+    ],
+)

--- a/experiment/bumpmonitoring/README.md
+++ b/experiment/bumpmonitoring/README.md
@@ -1,0 +1,26 @@
+# bumpmonitoring
+
+This package is used for copying changes from k8s prow monitoring stacks, more
+specifically mixins to other prow monitoring stacks.
+
+This is based on the assumption that:
+
+- Configs under
+  [`mixins/prometheus`](./config/prow/cluster/monitoring/mixins/prometheus)
+  are general enough that doesn't contain any k8s prow specific information
+- Prow specific values are configured in
+  [`mixins/lib`](./config/prow/cluster/monitoring/mixins/lib)
+- Downstream prow monitoring stacks maintain the same directory layout under
+  `mixins` as k8s prow
+
+This tool will:
+
+- Copy files(Except for `prometheus.libsonnet`, explained below) from
+  [`mixins/prometheus`](./config/prow/cluster/monitoring/mixins/prometheus) to
+  other prow instances, skip the files that don't exist in downstream prow
+  (Downstream prow will need to manually add the new file, which will be bumped
+  by this tool afterwards)
+- For `mixins/prometheus/prometheus.libsonnet`, it's essentially a file
+  explicitly importing other files under this directory, no change should be
+  expected in this file as the tool doesn't add/remove files
+- Create PR

--- a/experiment/bumpmonitoring/main.go
+++ b/experiment/bumpmonitoring/main.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	srcPath = "../../config/prow/cluster/monitoring"
+)
+
+var (
+	configPathsToUpdate = map[string]*regexp.Regexp{
+		"mixins/grafana_dashboards": regexp.MustCompile(`.*\.jsonnet$`),
+		"mixins/prometheus":         regexp.MustCompile(`.*\.libsonnet$`),
+	}
+	configPathExcluded = []*regexp.Regexp{
+		regexp.MustCompile(`mixins/prometheus/prometheus\.libsonnet`),
+	}
+	configPathProwSpecific = []string{
+		"mixins/lib/config_util.libsonnet",
+	}
+)
+
+type options struct {
+	srcPath string
+	dstPath string
+}
+
+type client struct {
+	srcPath string
+	dstPath string
+	paths   []string
+}
+
+func (c *client) findConfigToUpdate() error {
+	for subPath, re := range configPathsToUpdate {
+		fullPath := path.Join(c.dstPath, subPath)
+
+		if _, err := os.Stat(fullPath); err != nil {
+			if !os.IsNotExist(err) {
+				return fmt.Errorf("failed to get the file info for %q: %v", fullPath, err)
+			}
+			logrus.Infof("Skipping %s as it doesn't exist from dst", fullPath)
+		}
+
+		// No error is expected
+		filepath.Walk(fullPath, func(leafPath string, info os.FileInfo, err error) error {
+			if !re.MatchString(leafPath) {
+				return nil
+			}
+			for _, reExcluded := range configPathExcluded {
+				if reExcluded.MatchString(leafPath) {
+					return nil
+				}
+			}
+			relPath, _ := filepath.Rel(c.dstPath, leafPath)
+			c.paths = append(c.paths, relPath)
+			return nil
+		})
+	}
+
+	return nil
+}
+
+func (c *client) copyFiles() error {
+	for _, subPath := range c.paths {
+		srcPath := path.Join(c.srcPath, subPath)
+		dstPath := path.Join(c.dstPath, subPath)
+		content, err := ioutil.ReadFile(srcPath)
+		if err != nil {
+			return fmt.Errorf("failed reading file %q: %w", srcPath, err)
+		}
+		if err := ioutil.WriteFile(dstPath, content, 0755); err != nil {
+			return fmt.Errorf("failed writing file %q: %w", dstPath, err)
+		}
+	}
+	return nil
+}
+
+func (c *client) generateMsg() string {
+	return fmt.Sprintf(`Update monitoring stack
+
+For code reviewers:
+- breaking changes are only introduced in %s/mixins/lib/config.libsonnet
+- presubmit test is expected to fail if there is any breaking change
+- push to this change with fix if it's the case`, c.dstPath)
+}
+
+func main() {
+	o := options{}
+	flag.StringVar(&o.srcPath, "src", "", "Src dir of monitoring")
+	flag.StringVar(&o.dstPath, "dst", "", "Dst dir of monitoring")
+	flag.Parse()
+
+	c := client{
+		srcPath: o.srcPath,
+		dstPath: o.dstPath,
+		paths:   make([]string, 0),
+	}
+
+	if err := c.findConfigToUpdate(); err != nil {
+		logrus.Fatal(err)
+	}
+
+	if err := c.copyFiles(); err != nil {
+		logrus.Fatal(err)
+	}
+}

--- a/experiment/bumpmonitoring/main_test.go
+++ b/experiment/bumpmonitoring/main_test.go
@@ -1,0 +1,247 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestFindConfigToUpdate(t *testing.T) {
+	tests := []struct {
+		name     string
+		desc     string
+		srcNodes []node
+		dstNodes []node
+		want     []string
+		wantErr  bool
+	}{
+		{
+			name: "base",
+			dstNodes: []node{
+				{Path: "mixins/grafana_dashboards/a.jsonnet"},
+				{Path: "mixins/prometheus/a.libsonnet"},
+			},
+			want: []string{
+				"mixins/grafana_dashboards/a.jsonnet",
+				"mixins/prometheus/a.libsonnet",
+			},
+			wantErr: false,
+		},
+		{
+			name: "multiple-files",
+			dstNodes: []node{
+				{Path: "mixins/grafana_dashboards/a.jsonnet"},
+				{Path: "mixins/grafana_dashboards/b.jsonnet"},
+			},
+			want: []string{
+				"mixins/grafana_dashboards/a.jsonnet",
+				"mixins/grafana_dashboards/b.jsonnet",
+			},
+			wantErr: false,
+		},
+		{
+			name: "wrong-extension",
+			dstNodes: []node{
+				{Path: "mixins/grafana_dashboards/a.somethingelse"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "excluded-file",
+			dstNodes: []node{
+				{Path: "mixins/grafana_dashboards/prometheus.libsonnet"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty",
+		},
+		{
+			name: "empty dir",
+			dstNodes: []node{
+				{Path: "mixins/grafana_dashboards", IsDir: true},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir, err := ioutil.TempDir("", tc.name)
+			if err != nil {
+				t.Fatalf("Failed creating temp dir: %v", err)
+			}
+			t.Cleanup(func() {
+				os.RemoveAll(tmpDir)
+			})
+			srcRootDir, dstRootDir := seedTempDir(t, tmpDir, tc.srcNodes, tc.dstNodes)
+			c := client{
+				srcPath: srcRootDir,
+				dstPath: dstRootDir,
+			}
+			if wantErr, gotErr := tc.wantErr, c.findConfigToUpdate(); (wantErr && (gotErr == nil)) || (!wantErr && (gotErr != nil)) {
+				t.Fatalf("Error mismatch. want: %v, got: %v", wantErr, gotErr)
+			}
+			if diff := cmp.Diff(tc.want, c.paths, cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			})); diff != "" {
+				t.Fatalf("Config files mismatch. want(-), got(+):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCopyFiles(t *testing.T) {
+	tests := []struct {
+		name     string
+		desc     string
+		srcNodes []node
+		dstNodes []node
+		paths    []string
+		want     []node
+		wantErr  bool
+	}{
+		{
+			name: "base",
+			srcNodes: []node{
+				{Path: "mixins/grafana_dashboards/a.jsonnet", Content: "123"},
+				{Path: "mixins/prometheus/a.libsonnet", Content: "123"},
+			},
+			dstNodes: []node{
+				{Path: "mixins/grafana_dashboards/a.jsonnet", Content: "456"},
+				{Path: "mixins/prometheus/a.libsonnet", Content: "456"},
+			},
+			paths: []string{
+				"mixins/grafana_dashboards/a.jsonnet",
+				"mixins/prometheus/a.libsonnet",
+			},
+			want: []node{
+				{Path: "mixins/grafana_dashboards/a.jsonnet", Content: "123"},
+				{Path: "mixins/prometheus/a.libsonnet", Content: "123"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "not exist upstream",
+			srcNodes: []node{
+				{Path: "mixins/grafana_dashboards/b.jsonnet"},
+			},
+			dstNodes: []node{
+				{Path: "mixins/grafana_dashboards/a.jsonnet"},
+			},
+			paths: []string{
+				"mixins/grafana_dashboards/a.jsonnet",
+			},
+			want: []node{
+				{Path: "mixins/grafana_dashboards/a.jsonnet"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir, err := ioutil.TempDir("", tc.name)
+			if err != nil {
+				t.Fatalf("Failed creating temp dir: %v", err)
+			}
+			t.Cleanup(func() {
+				os.RemoveAll(tmpDir)
+			})
+			srcRootDir, dstRootDir := seedTempDir(t, tmpDir, tc.srcNodes, tc.dstNodes)
+			c := client{
+				srcPath: srcRootDir,
+				dstPath: dstRootDir,
+				paths:   tc.paths,
+			}
+			if wantErr, gotErr := tc.wantErr, c.copyFiles(); (wantErr && (gotErr == nil)) || (!wantErr && (gotErr != nil)) {
+				t.Fatalf("Error mismatch. want: %v, got: %v", wantErr, gotErr)
+			}
+			var got []node
+			for _, p := range tc.paths {
+				got = append(got, pathToNode(t, dstRootDir, p))
+			}
+			if diff := cmp.Diff(tc.want, got, cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			})); diff != "" {
+				t.Fatalf("Config files mismatch. want(-), got(+):\n%s", diff)
+			}
+		})
+	}
+}
+
+type node struct {
+	Path    string
+	Content string
+	IsDir   bool
+}
+
+func pathToNode(t *testing.T, root, p string) node {
+	n := node{Path: p}
+
+	p = path.Join(root, p)
+	info, err := os.Lstat(p)
+	if err != nil {
+		t.Fatalf("Failed stats %q: %v", p, err)
+	}
+	if info.IsDir() {
+		n.IsDir = true
+	} else {
+		bs, err := ioutil.ReadFile(p)
+		if err != nil {
+			t.Fatalf("Failed to read %q: %v", p, err)
+		}
+		n.Content = string(bs)
+	}
+
+	return n
+}
+
+func seedTempDir(t *testing.T, root string, srcNodes, dstNodes []node) (string, string) {
+	srcRootDir := path.Join(root, "src")
+	dstRootDir := path.Join(root, "dst")
+
+	create := func(t *testing.T, root string, ns []node) {
+		for _, n := range ns {
+			p := path.Join(root, n.Path)
+			if n.IsDir {
+				if err := os.MkdirAll(p, 0755); err != nil {
+					t.Fatalf("Failed creating dir %q: %v", p, err)
+				}
+			} else {
+				dir := path.Dir(p)
+				if err := os.MkdirAll(dir, 0755); err != nil {
+					t.Fatalf("Failed creating dir %q: %v", dir, err)
+				}
+				if err := ioutil.WriteFile(p, []byte(n.Content), 0777); err != nil {
+					t.Fatalf("Failed creating file %q: %v", p, err)
+				}
+			}
+		}
+	}
+
+	create(t, srcRootDir, srcNodes)
+	create(t, dstRootDir, dstNodes)
+
+	return srcRootDir, dstRootDir
+}


### PR DESCRIPTION
This package will be used for replicating all improvements made in https://github.com/kubernetes/test-infra/tree/master/config/prow/cluster/monitoring/mixins to all other prow instances.

This package can be invoked manually for now. Once refactoring of generic-autobumper is completed will add PR creation logic to this package so that it could be used by prow jobs just like how prow images are bumped