### PR TITLE
Generic autobumper: use bumper package as prcreator instead

### DIFF
--- a/prow/cmd/generic-autobumper/BUILD.bazel
+++ b/prow/cmd/generic-autobumper/BUILD.bazel
@@ -1,14 +1,18 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("//prow:def.bzl", "prow_image")
 
 NAME = "generic-autobumper"
 
 go_library(
     name = "go_default_library",
-    srcs = ["main.go"],
+    srcs = [
+        "helper.go",
+        "main.go",
+    ],
     importpath = "k8s.io/test-infra/prow/cmd/generic-autobumper",
     visibility = ["//visibility:private"],
     deps = [
+        "//experiment/image-bumper/bumper:go_default_library",
         "//prow/cmd/generic-autobumper/bumper:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_spf13_pflag//:go_default_library",
@@ -46,4 +50,18 @@ prow_image(
     directory = "/",
     files = [":generic-autobumper"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "helper_test.go",
+        "main_test.go",
+    ],
+    data = glob(["testdata/**"]),
+    embed = [":go_default_library"],
+    deps = [
+        "@com_github_google_go_cmp//cmp:go_default_library",
+        "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
+    ],
 )

--- a/prow/cmd/generic-autobumper/helper.go
+++ b/prow/cmd/generic-autobumper/helper.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	imagebumper "k8s.io/test-infra/experiment/image-bumper/bumper"
+)
+
+// Extract image tag from image name
+func tagFromName(name string) string {
+	parts := strings.Split(name, ":")
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[1]
+}
+
+// Extract prow component name from image
+func componentFromName(name string) string {
+	s := strings.SplitN(strings.Split(name, ":")[0], "/", 3)
+	return s[len(s)-1]
+}
+
+func formatTagDate(d string) string {
+	if len(d) != 8 {
+		return d
+	}
+	// &#x2011; = U+2011 NON-BREAKING HYPHEN, to prevent line wraps.
+	return fmt.Sprintf("%s&#x2011;%s&#x2011;%s", d[0:4], d[4:6], d[6:8])
+}
+
+// commitToRef converts git describe part of a tag to a ref (commit or tag).
+//
+// v0.0.30-14-gdeadbeef => deadbeef
+// v0.0.30 => v0.0.30
+// deadbeef => deadbeef
+func commitToRef(commit string) string {
+	tag, _, commit := imagebumper.DeconstructCommit(commit)
+	if commit != "" {
+		return commit
+	}
+	return tag
+}
+
+// Format variant for PR summary
+func formatVariant(variant string) string {
+	if variant == "" {
+		return ""
+	}
+	return fmt.Sprintf("(%s)", strings.TrimPrefix(variant, "-"))
+}
+
+// Check whether the path is under the given path
+func isUnderPath(name string, paths []string) bool {
+	for _, p := range paths {
+		if p != "" && strings.HasPrefix(name, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// isBumpedPrefix takes a prefix and a map of new tags resulted from bumping
+// : the images using those tags and itterates over the map to find if the
+// prefix is found. If it is, this means it has been bumped.
+func isBumpedPrefix(prefix Prefix, versions map[string][]string) (string, bool) {
+	for tag, imageList := range versions {
+		for _, image := range imageList {
+			if strings.HasPrefix(image, prefix.Prefix) {
+				return tag, true
+			}
+		}
+	}
+	return "", false
+}

--- a/prow/cmd/generic-autobumper/helper.go
+++ b/prow/cmd/generic-autobumper/helper.go
@@ -80,7 +80,7 @@ func isUnderPath(name string, paths []string) bool {
 // isBumpedPrefix takes a prefix and a map of new tags resulted from bumping
 // : the images using those tags and itterates over the map to find if the
 // prefix is found. If it is, this means it has been bumped.
-func isBumpedPrefix(prefix Prefix, versions map[string][]string) (string, bool) {
+func isBumpedPrefix(prefix prefix, versions map[string][]string) (string, bool) {
 	for tag, imageList := range versions {
 		for _, image := range imageList {
 			if strings.HasPrefix(image, prefix.Prefix) {

--- a/prow/cmd/generic-autobumper/helper_test.go
+++ b/prow/cmd/generic-autobumper/helper_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+)
+
+func TestCommitToRef(t *testing.T) {
+	cases := []struct {
+		name     string
+		commit   string
+		expected string
+	}{
+		{
+			name: "basically works",
+		},
+		{
+			name:     "just tag works",
+			commit:   "v0.0.30",
+			expected: "v0.0.30",
+		},
+		{
+			name:     "just commit works",
+			commit:   "deadbeef",
+			expected: "deadbeef",
+		},
+		{
+			name:     "commits past tag works",
+			commit:   "v0.0.30-14-gdeadbeef",
+			expected: "deadbeef",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if actual, expected := commitToRef(tc.commit), tc.expected; actual != tc.expected {
+				t.Errorf("commitToRef(%q) got %q want %q", tc.commit, actual, expected)
+			}
+		})
+	}
+}
+
+func TestIsUnderPath(t *testing.T) {
+	cases := []struct {
+		description string
+		paths       []string
+		file        string
+		expected    bool
+	}{
+		{
+			description: "file is under the direct path",
+			paths:       []string{"config/prow/"},
+			file:        "config/prow/config.yaml",
+			expected:    true,
+		},
+		{
+			description: "file is under the indirect path",
+			paths:       []string{"config/prow-staging/"},
+			file:        "config/prow-staging/jobs/config.yaml",
+			expected:    true,
+		},
+		{
+			description: "file is under one path but not others",
+			paths:       []string{"config/prow/", "config/prow-staging/"},
+			file:        "config/prow-staging/jobs/whatever-repo/whatever-file",
+			expected:    true,
+		},
+		{
+			description: "file is not under the path but having the same prefix",
+			paths:       []string{"config/prow/"},
+			file:        "config/prow-staging/config.yaml",
+			expected:    false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			actual := isUnderPath(tc.file, tc.paths)
+			if actual != tc.expected {
+				t.Errorf("expected to be %t but actual is %t", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/prow/cmd/generic-autobumper/main.go
+++ b/prow/cmd/generic-autobumper/main.go
@@ -19,15 +19,70 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
 
 	flag "github.com/spf13/pflag"
 
 	"github.com/sirupsen/logrus"
 
+	imagebumper "k8s.io/test-infra/experiment/image-bumper/bumper"
 	"k8s.io/test-infra/prow/cmd/generic-autobumper/bumper"
 
 	"sigs.k8s.io/yaml"
 )
+
+const (
+	latestVersion          = "latest"
+	upstreamVersion        = "upstream"
+	upstreamStagingVersion = "upstream-staging"
+	tagVersion             = "vYYYYMMDD-deadbeef"
+	defaultUpstreamURLBase = "https://raw.githubusercontent.com/kubernetes/test-infra/master"
+)
+
+var (
+	tagRegexp    = regexp.MustCompile("v[0-9]{8}-[a-f0-9]{6,9}")
+	imageMatcher = regexp.MustCompile(`(?s)^.+image:(.+):(v[a-zA-Z0-9_.-]+)`)
+)
+
+// Options is the options for autobumper operations.
+type Options struct {
+	// The URL where upstream image references are located. Only required if Target Version is "upstream" or "upstreamStaging". Use "https://raw.githubusercontent.com/{ORG}/{REPO}"
+	// Images will be bumped based off images located at the address using this URL and the refConfigFile or stagingRefConigFile for each Prefix.
+	UpstreamURLBase string `yaml:"upstreamURLBase"`
+	// The config paths to be included in this bump, in which only .yaml files will be considered. By default all files are included.
+	IncludedConfigPaths []string `yaml:"includedConfigPaths"`
+	// The config paths to be excluded in this bump, in which only .yaml files will be considered.
+	ExcludedConfigPaths []string `yaml:"excludedConfigPaths"`
+	// The extra non-yaml file to be considered in this bump.
+	ExtraFiles []string `yaml:"extraFiles"`
+	// The target version to bump images version to, which can be one of latest, upstream, upstream-staging and vYYYYMMDD-deadbeef.
+	TargetVersion string `yaml:"targetVersion"`
+	// List of prefixes that the autobumped is looking for, and other information needed to bump them. Must have at least 1 prefix.
+	Prefixes []Prefix `yaml:"prefixes"`
+}
+
+// Prefix is the information needed for each prefix being bumped.
+type Prefix struct {
+	// Name of the tool being bumped
+	Name string `yaml:"name"`
+	// The image prefix that the autobumper should look for
+	Prefix string `yaml:"prefix"`
+	// File that is looked at to determine current upstream image when bumping to upstream. Required only if targetVersion is "upstream"
+	RefConfigFile string `yaml:"refConfigFile"`
+	// File that is looked at to determine current upstream staging image when bumping to upstream staging. Required only if targetVersion is "upstream-staging"
+	StagingRefConfigFile string `yaml:"stagingRefConfigFile"`
+	// The repo where the image source resides for the images with this prefix. Used to create the links to see comparisons between images in the PR summary.
+	Repo string `yaml:"repo"`
+	// Whether or not the format of the PR summary for this prefix should be summarised.
+	Summarise bool `yaml:"summarise"`
+	// Whether the prefix tags should be consistent after the bump
+	ConsistentImages bool `yaml:"consistentImages"`
+}
 
 func parseOptions() (*bumper.Options, error) {
 	var config string
@@ -51,6 +106,319 @@ func parseOptions() (*bumper.Options, error) {
 		o.Labels = labelsOverride
 	}
 	return &o, nil
+}
+
+func validateOptions(o *bumper.Options) error {
+	if len(o.Prefixes) == 0 {
+		return fmt.Errorf("Must have at least one Prefix specified")
+	}
+	if len(o.IncludedConfigPaths) == 0 {
+		return fmt.Errorf("includedConfigPaths is mandatory")
+	}
+	if o.TargetVersion != latestVersion && o.TargetVersion != upstreamVersion &&
+		o.TargetVersion != upstreamStagingVersion && !tagRegexp.MatchString(o.TargetVersion) {
+		logrus.Warnf("Warning: targetVersion is not one of %v so it might not work properly.",
+			[]string{latestVersion, upstreamVersion, upstreamStagingVersion, tagVersion})
+	}
+	if o.TargetVersion == upstreamVersion {
+		for _, prefix := range o.Prefixes {
+			if prefix.RefConfigFile == "" {
+				return fmt.Errorf("targetVersion can't be %q without refConfigFile for each prefix. %q is missing one", upstreamVersion, prefix.Name)
+			}
+		}
+	}
+	if o.TargetVersion == upstreamStagingVersion {
+		for _, prefix := range o.Prefixes {
+			if prefix.StagingRefConfigFile == "" {
+				return fmt.Errorf("targetVersion can't be %q without stagingRefConfigFile for each prefix. %q is missing one", upstreamStagingVersion, prefix.Name)
+			}
+		}
+	}
+	if (o.TargetVersion == upstreamVersion || o.TargetVersion == upstreamStagingVersion) && o.UpstreamURLBase == "" {
+		o.UpstreamURLBase = defaultUpstreamURLBase
+		logrus.Warnf("targetVersion can't be 'upstream' or 'upstreamStaging` without upstreamURLBase set. Default upstreamURLBase is %q", defaultUpstreamURLBase)
+	}
+
+	return nil
+}
+
+// UpdateReferences update the references of prow-images and/or boskos-images and/or testimages
+// in the files in any of "subfolders" of the includeConfigPaths but not in excludeConfigPaths
+// if the file is a yaml file (*.yaml) or extraFiles[file]=true
+func UpdateReferences(o *Options) (map[string]string, error) {
+	logrus.Info("Bumping image references...")
+	var allPrefixes []string
+	for _, prefix := range o.Prefixes {
+		allPrefixes = append(allPrefixes, prefix.Prefix)
+	}
+	filterRegexp := regexp.MustCompile(strings.Join(allPrefixes, "|"))
+	imageBumperCli := imagebumper.NewClient()
+	return updateReferences(imageBumperCli, filterRegexp, o)
+}
+
+type imageBumper interface {
+	FindLatestTag(imageHost, imageName, currentTag string) (string, error)
+	UpdateFile(tagPicker func(imageHost, imageName, currentTag string) (string, error), path string, imageFilter *regexp.Regexp) error
+	GetReplacements() map[string]string
+	AddToCache(image, newTag string)
+	TagExists(imageHost, imageName, currentTag string) (bool, error)
+}
+
+func updateReferences(imageBumperCli imageBumper, filterRegexp *regexp.Regexp, o *Options) (map[string]string, error) {
+	var tagPicker func(string, string, string) (string, error)
+	var err error
+
+	switch o.TargetVersion {
+	case latestVersion:
+		tagPicker = imageBumperCli.FindLatestTag
+	case upstreamVersion, upstreamStagingVersion:
+		tagPicker, err = upstreamImageVersionResolver(o, o.TargetVersion, parseUpstreamImageVersion, imageBumperCli)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve the %s image version: %w", o.TargetVersion, err)
+		}
+	default:
+		tagPicker = func(imageHost, imageName, currentTag string) (string, error) { return o.TargetVersion, nil }
+	}
+
+	updateFile := func(name string) error {
+		logrus.Infof("Updating file %s", name)
+		if err := imageBumperCli.UpdateFile(tagPicker, name, filterRegexp); err != nil {
+			return fmt.Errorf("failed to update the file: %w", err)
+		}
+		return nil
+	}
+	updateYAMLFile := func(name string) error {
+		if strings.HasSuffix(name, ".yaml") && !isUnderPath(name, o.ExcludedConfigPaths) {
+			return updateFile(name)
+		}
+		return nil
+	}
+
+	// Updated all .yaml files under the included config paths but not under excluded config paths.
+	for _, path := range o.IncludedConfigPaths {
+		info, err := os.Stat(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get the file info for %q", path)
+		}
+		if info.IsDir() {
+			err := filepath.Walk(path, func(subpath string, info os.FileInfo, err error) error {
+				return updateYAMLFile(subpath)
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to update yaml files under %q: %w", path, err)
+			}
+		} else {
+			if err := updateYAMLFile(path); err != nil {
+				return nil, fmt.Errorf("failed to update the yaml file %q: %w", path, err)
+			}
+		}
+	}
+
+	// Update the extra files in any case.
+	for _, file := range o.ExtraFiles {
+		if err := updateFile(file); err != nil {
+			return nil, fmt.Errorf("failed to update the extra file %q: %w", file, err)
+		}
+	}
+
+	return imageBumperCli.GetReplacements(), nil
+}
+
+// used by updateReferences
+func upstreamImageVersionResolver(
+	o *Options, upstreamVersionType string, parse func(upstreamAddress, prefix string) (string, error), imageBumperCli imageBumper) (func(imageHost, imageName, currentTag string) (string, error), error) {
+	upstreamVersions, err := upstreamConfigVersions(upstreamVersionType, o, parse)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(imageHost, imageName, currentTag string) (string, error) {
+		imageFullPath := imageHost + "/" + imageName + ":" + currentTag
+		for prefix, version := range upstreamVersions {
+			if strings.HasPrefix(imageFullPath, prefix) {
+				exists, err := imageBumperCli.TagExists(imageHost, imageName, version)
+				if err != nil {
+					return "", err
+				}
+				if exists {
+					imageBumperCli.AddToCache(imageFullPath, version)
+					return version, nil
+				} else {
+					imageBumperCli.AddToCache(imageFullPath, currentTag)
+					return "", fmt.Errorf("Unable to bump to %s, image tag %s does not exist for %s", imageFullPath, version, imageName)
+				}
+			}
+		}
+		return currentTag, nil
+	}, nil
+}
+
+// used by upstreamImageVersionResolver
+func upstreamConfigVersions(upstreamVersionType string, o *Options, parse func(upstreamAddress, prefix string) (string, error)) (versions map[string]string, err error) {
+	versions = make(map[string]string)
+	var upstreamAddress string
+	for _, prefix := range o.Prefixes {
+		if upstreamVersionType == upstreamVersion {
+			upstreamAddress = o.UpstreamURLBase + "/" + prefix.RefConfigFile
+		} else if upstreamVersionType == upstreamStagingVersion {
+			upstreamAddress = o.UpstreamURLBase + "/" + prefix.StagingRefConfigFile
+		} else {
+			return nil, fmt.Errorf("unsupported upstream version type: %s, must be one of %v",
+				upstreamVersionType, []string{upstreamVersion, upstreamStagingVersion})
+		}
+		version, err := parse(upstreamAddress, prefix.Prefix)
+		if err != nil {
+			return nil, err
+		}
+		versions[prefix.Prefix] = version
+	}
+
+	return versions, nil
+}
+
+// used by updateReferences
+func parseUpstreamImageVersion(upstreamAddress, prefix string) (string, error) {
+	resp, err := http.Get(upstreamAddress)
+	if err != nil {
+		return "", fmt.Errorf("error sending GET request to %q: %w", upstreamAddress, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("HTTP error %d (%q) fetching upstream config file", resp.StatusCode, resp.Status)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("error reading the response body: %w", err)
+	}
+	for _, line := range strings.Split(strings.TrimSuffix(string(body), "\n"), "\n") {
+		res := imageMatcher.FindStringSubmatch(string(line))
+		if len(res) > 2 && strings.Contains(res[1], prefix) {
+			return res[2], nil
+		}
+	}
+	return "", fmt.Errorf("unable to find match for %s in upstream refConfigFile", prefix)
+}
+
+// getVersionsAndCheckConisistency takes a list of Prefixes and a map of
+// all the images found in the code before the bump : their versions after the bump
+// For example {"gcr.io/k8s-prow/test1:tag": "newtag", "gcr.io/k8s-prow/test2:tag": "newtag"},
+// and returns a map of new versions resulted from bumping : the images using those versions.
+// It will error if one of the Prefixes was bumped inconsistently when it was not supposed to
+func getVersionsAndCheckConsistency(prefixes []Prefix, images map[string]string) (map[string][]string, error) {
+	// Key is tag, value is full image.
+	versions := map[string][]string{}
+	consistencyChecker := map[string]string{}
+	for _, prefix := range prefixes {
+		for k, v := range images {
+			if strings.HasPrefix(k, prefix.Prefix) {
+				found, ok := consistencyChecker[prefix.Prefix]
+				if ok && (found != v) && prefix.ConsistentImages {
+					return nil, fmt.Errorf("%q was supposed to be bumped consistntly but was not", prefix.Name)
+				} else if !ok {
+					consistencyChecker[prefix.Prefix] = v
+				}
+
+				//Only add bumped images to the new versions map
+				if !strings.Contains(k, v) {
+					versions[v] = append(versions[v], k)
+				}
+
+			}
+		}
+	}
+	return versions, nil
+}
+
+// makeCommitSummary takes a list of Prefixes and a map of new tags resulted
+// from bumping : the images using those tags and returns a summary of what was
+// bumped for use in the commit message
+func makeCommitSummary(prefixes []Prefix, versions map[string][]string) string {
+	var allPrefixes []string
+	for _, prefix := range prefixes {
+		allPrefixes = append(allPrefixes, prefix.Name)
+	}
+	if len(versions) == 0 {
+		return fmt.Sprintf("Update %s images as necessary", strings.Join(allPrefixes, ", "))
+	}
+	var inconsistentBumps []string
+	var consistentBumps []string
+	for _, prefix := range prefixes {
+		tag, bumped := isBumpedPrefix(prefix, versions)
+		if !prefix.ConsistentImages && bumped {
+			inconsistentBumps = append(inconsistentBumps, prefix.Name)
+		} else if prefix.ConsistentImages && bumped {
+			consistentBumps = append(consistentBumps, fmt.Sprintf("%s to %s", prefix.Name, tag))
+		}
+	}
+	var msgs []string
+	if len(consistentBumps) != 0 {
+		msgs = append(msgs, strings.Join(consistentBumps, ", "))
+	}
+	if len(inconsistentBumps) != 0 {
+		msgs = append(msgs, fmt.Sprintf("%s as needed", strings.Join(inconsistentBumps, ", ")))
+	}
+	return fmt.Sprintf("Update %s", strings.Join(msgs, " and "))
+
+}
+
+// Generate PR summary for github
+func generateSummary(name, repo, prefix string, summarise bool, images map[string]string) string {
+	type delta struct {
+		oldCommit string
+		newCommit string
+		oldDate   string
+		newDate   string
+		variant   string
+		component string
+	}
+	versions := map[string][]delta{}
+	for image, newTag := range images {
+		if !strings.HasPrefix(image, prefix) {
+			continue
+		}
+		if strings.HasSuffix(image, ":"+newTag) {
+			continue
+		}
+		oldDate, oldCommit, oldVariant := imagebumper.DeconstructTag(tagFromName(image))
+		newDate, newCommit, _ := imagebumper.DeconstructTag(newTag)
+		oldCommit = commitToRef(oldCommit)
+		newCommit = commitToRef(newCommit)
+		k := oldCommit + ":" + newCommit
+		d := delta{
+			oldCommit: oldCommit,
+			newCommit: newCommit,
+			oldDate:   oldDate,
+			newDate:   newDate,
+			variant:   formatVariant(oldVariant),
+			component: componentFromName(image),
+		}
+		versions[k] = append(versions[k], d)
+	}
+
+	switch {
+	case len(versions) == 0:
+		return fmt.Sprintf("No %s changes.", prefix)
+	case len(versions) == 1 && summarise:
+		for k, v := range versions {
+			s := strings.Split(k, ":")
+			return fmt.Sprintf("%s changes: %s/compare/%s...%s (%s → %s)", prefix, repo, s[0], s[1], formatTagDate(v[0].oldDate), formatTagDate(v[0].newDate))
+		}
+	default:
+		changes := make([]string, 0, len(versions))
+		for k, v := range versions {
+			s := strings.Split(k, ":")
+			names := make([]string, 0, len(v))
+			for _, d := range v {
+				names = append(names, d.component+d.variant)
+			}
+			sort.Strings(names)
+			changes = append(changes, fmt.Sprintf("%s/compare/%s...%s | %s&nbsp;&#x2192;&nbsp;%s | %s",
+				repo, s[0], s[1], formatTagDate(v[0].oldDate), formatTagDate(v[0].newDate), strings.Join(names, ", ")))
+		}
+		sort.Slice(changes, func(i, j int) bool { return strings.Split(changes[i], "|")[1] < strings.Split(changes[j], "|")[1] })
+		return fmt.Sprintf("Multiple distinct %s changes:\n\nCommits | Dates | Images\n--- | --- | ---\n%s\n", prefix, strings.Join(changes, "\n"))
+	}
+	panic("unreachable!")
 }
 
 func main() {

--- a/prow/cmd/generic-autobumper/main_test.go
+++ b/prow/cmd/generic-autobumper/main_test.go
@@ -1,0 +1,843 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestValidateOptions(t *testing.T) {
+	emptyStr := ""
+	whateverStr := "whatever"
+	emptyArr := make([]string, 0)
+	emptyPrefixes := make([]Prefix, 0)
+	latestPrefixes := []Prefix{{
+		Name:                 "test",
+		Prefix:               "gcr.io/test/",
+		RefConfigFile:        "",
+		StagingRefConfigFile: "",
+	}}
+	upstreamPrefixes := []Prefix{{
+		Name:                 "test",
+		Prefix:               "gcr.io/test/",
+		RefConfigFile:        "ref",
+		StagingRefConfigFile: "stagingRef",
+	}}
+	upstreamVersion := "upstream"
+	stagingVersion := "upstream-staging"
+	cases := []struct {
+		name                string
+		targetVersion       *string
+		includeConfigPaths  *[]string
+		prefixes            *[]Prefix
+		upstreamURLBase     *string
+		err                 bool
+		upstreamBaseChanged bool
+	}{
+		{
+			name: "Everything correct",
+			err:  false,
+		},
+		{
+			name:          "unformatted TargetVersion is also allowed",
+			targetVersion: &whateverStr,
+			err:           false,
+		},
+		{
+			name:               "must include at least one config path",
+			includeConfigPaths: &emptyArr,
+			err:                true,
+		},
+		{
+			name:                "must include upstreamURLBase if target version is upstream",
+			upstreamURLBase:     &emptyStr,
+			targetVersion:       &upstreamVersion,
+			prefixes:            &upstreamPrefixes,
+			err:                 false,
+			upstreamBaseChanged: true,
+		},
+		{
+			name:                "must include upstreamURLBase if target version is upstreamStaging",
+			upstreamURLBase:     &emptyStr,
+			targetVersion:       &stagingVersion,
+			prefixes:            &upstreamPrefixes,
+			err:                 false,
+			upstreamBaseChanged: true,
+		},
+		{
+			name:     "must include at least one prefix",
+			prefixes: &emptyPrefixes,
+			err:      true,
+		},
+		{
+			name:          "must have ref files for upstream version",
+			targetVersion: &upstreamVersion,
+			prefixes:      &latestPrefixes,
+			err:           true,
+		},
+		{
+			name:          "must have stagingRef files for Stagingupstream version",
+			targetVersion: &stagingVersion,
+			prefixes:      &latestPrefixes,
+			err:           true,
+		},
+		{
+			name:                "don't use default upstreamURLbase if not needed for upstream",
+			upstreamURLBase:     &whateverStr,
+			targetVersion:       &upstreamVersion,
+			prefixes:            &upstreamPrefixes,
+			err:                 false,
+			upstreamBaseChanged: false,
+		},
+		{
+			name:                "don't use default upstreamURLbase if not neededfor upstreamStaging",
+			upstreamURLBase:     &whateverStr,
+			targetVersion:       &stagingVersion,
+			prefixes:            &upstreamPrefixes,
+			err:                 false,
+			upstreamBaseChanged: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defaultOption := &Options{
+				UpstreamURLBase:     "whatever-URLBase",
+				Prefixes:            latestPrefixes,
+				TargetVersion:       latestVersion,
+				IncludedConfigPaths: []string{"whatever-config-path1", "whatever-config-path2"},
+			}
+
+			if tc.targetVersion != nil {
+				defaultOption.TargetVersion = *tc.targetVersion
+			}
+			if tc.includeConfigPaths != nil {
+				defaultOption.IncludedConfigPaths = *tc.includeConfigPaths
+			}
+			if tc.prefixes != nil {
+				defaultOption.Prefixes = *tc.prefixes
+			}
+			if tc.upstreamURLBase != nil {
+				defaultOption.UpstreamURLBase = *tc.upstreamURLBase
+			}
+
+			err := validateOptions(defaultOption)
+			t.Logf("err is: %v", err)
+			if err == nil && tc.err {
+				t.Errorf("Expected to get an error for %#v but got nil", defaultOption)
+			}
+			if err != nil && !tc.err {
+				t.Errorf("Expected to not get an error for %#v but got %v", defaultOption, err)
+			}
+			if tc.upstreamBaseChanged && defaultOption.UpstreamURLBase != defaultUpstreamURLBase {
+				t.Errorf("UpstreamURLBase should have been changed to %q, but was %q", defaultOption.UpstreamURLBase, defaultUpstreamURLBase)
+			}
+			if !tc.upstreamBaseChanged && defaultOption.UpstreamURLBase == defaultUpstreamURLBase {
+				t.Errorf("UpstreamURLBase should not have been changed to default, but was")
+			}
+		})
+	}
+}
+
+type fakeImageBumperCli struct {
+	replacements map[string]string
+	tagCache     map[string]string
+}
+
+func (c *fakeImageBumperCli) FindLatestTag(imageHost, imageName, currentTag string) (string, error) {
+	return "fake-latest", nil
+}
+
+func (c *fakeImageBumperCli) UpdateFile(tagPicker func(imageHost, imageName, currentTag string) (string, error),
+	path string, imageFilter *regexp.Regexp) error {
+	targetTag, _ := tagPicker("", "", "")
+	c.replacements[path] = targetTag
+	return nil
+}
+
+func (c *fakeImageBumperCli) GetReplacements() map[string]string {
+	return c.replacements
+}
+
+func (c *fakeImageBumperCli) AddToCache(image, newTag string) {
+	c.tagCache[image] = newTag
+}
+
+func (cli *fakeImageBumperCli) TagExists(imageHost, imageName, currentTag string) (bool, error) {
+	if currentTag == "DNE" {
+		return false, nil
+	}
+	return true, nil
+}
+
+func TestUpdateReferences(t *testing.T) {
+	cases := []struct {
+		description        string
+		targetVersion      string
+		includeConfigPaths []string
+		excludeConfigPaths []string
+		extraFiles         []string
+		expectedRes        map[string]string
+		expectError        bool
+	}{
+		{
+			description:        "update the images to the latest version",
+			targetVersion:      latestVersion,
+			includeConfigPaths: []string{"testdata/dir/subdir1", "testdata/dir/subdir2"},
+			expectedRes: map[string]string{
+				"testdata/dir/subdir1/test1-1.yaml": "fake-latest",
+				"testdata/dir/subdir1/test1-2.yaml": "fake-latest",
+				"testdata/dir/subdir2/test2-1.yaml": "fake-latest",
+			},
+			expectError: false,
+		},
+		{
+			description:        "update the images to a specific version",
+			targetVersion:      "v20200101-livebull",
+			includeConfigPaths: []string{"testdata/dir/subdir2"},
+			expectedRes: map[string]string{
+				"testdata/dir/subdir2/test2-1.yaml": "v20200101-livebull",
+			},
+			expectError: false,
+		},
+		{
+			description:        "by default only yaml files will be updated",
+			targetVersion:      latestVersion,
+			includeConfigPaths: []string{"testdata/dir/subdir3"},
+			expectedRes: map[string]string{
+				"testdata/dir/subdir3/test3-1.yaml": "fake-latest",
+			},
+			expectError: false,
+		},
+		{
+			description:        "files under the excluded paths will not be updated",
+			targetVersion:      latestVersion,
+			includeConfigPaths: []string{"testdata/dir"},
+			excludeConfigPaths: []string{"testdata/dir/subdir1", "testdata/dir/subdir2"},
+			expectedRes: map[string]string{
+				"testdata/dir/subdir3/test3-1.yaml": "fake-latest",
+			},
+			expectError: false,
+		},
+		{
+			description:        "non YAML files could be configured by specifying extraFiles",
+			targetVersion:      latestVersion,
+			includeConfigPaths: []string{"testdata/dir/subdir3"},
+			extraFiles:         []string{"testdata/dir/extra-file", "testdata/dir/subdir3/test3-2"},
+			expectedRes: map[string]string{
+				"testdata/dir/subdir3/test3-1.yaml": "fake-latest",
+				"testdata/dir/extra-file":           "fake-latest",
+				"testdata/dir/subdir3/test3-2":      "fake-latest",
+			},
+			expectError: false,
+		},
+		{
+			description:        "updating non-existed files will return an error",
+			targetVersion:      latestVersion,
+			includeConfigPaths: []string{"testdata/dir/whatever-subdir"},
+			expectError:        true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			option := &Options{
+				TargetVersion:       tc.targetVersion,
+				IncludedConfigPaths: tc.includeConfigPaths,
+				ExtraFiles:          tc.extraFiles,
+				ExcludedConfigPaths: tc.excludeConfigPaths,
+			}
+			cli := &fakeImageBumperCli{replacements: map[string]string{}}
+			res, err := updateReferences(cli, nil, option)
+			if tc.expectError && err == nil {
+				t.Errorf("Expected to get an error but the result is nil")
+			}
+			if !tc.expectError && err != nil {
+				t.Errorf("Expected to not get an error but got one: %v", err)
+			}
+
+			if !reflect.DeepEqual(res, tc.expectedRes) {
+				t.Errorf("Expected to get the result map as %v but got %v", tc.expectedRes, res)
+			}
+		})
+	}
+}
+
+func TestParseUpstreamImageVersion(t *testing.T) {
+	cases := []struct {
+		description            string
+		upstreamURL            string
+		upstreamServerResponse string
+		expectedRes            string
+		expectError            bool
+		prefix                 string
+	}{
+		{
+			description:            "empty upstream URL will return an error",
+			upstreamURL:            "",
+			upstreamServerResponse: "",
+			expectedRes:            "",
+			expectError:            true,
+			prefix:                 "gcr.io/k8s-prow/",
+		},
+		{
+			description:            "an invalid upstream URL will return an error",
+			upstreamURL:            "whatever-url",
+			upstreamServerResponse: "",
+			expectedRes:            "",
+			expectError:            true,
+			prefix:                 "gcr.io/k8s-prow/",
+		},
+		{
+			description:            "an invalid response will return an error",
+			upstreamURL:            "auto",
+			upstreamServerResponse: "whatever-response",
+			expectedRes:            "",
+			expectError:            true,
+			prefix:                 "gcr.io/k8s-prow/",
+		},
+		{
+			description:            "a valid response will return the correct tag",
+			upstreamURL:            "auto",
+			upstreamServerResponse: "     image: gcr.io/k8s-prow/deck:v20200717-cf288082e1",
+			expectedRes:            "v20200717-cf288082e1",
+			expectError:            false,
+			prefix:                 "gcr.io/k8s-prow/",
+		},
+		{
+			description:            "a valid response will return the correct tag with other prefixes in the same file",
+			upstreamURL:            "auto",
+			upstreamServerResponse: "other random garbage\n image: gcr.io/k8s-other/deck:v22222222-cf288082e1\n image: gcr.io/k8s-prow/deck:v20200717-cf288082e1\n     image: gcr.io/k8s-another/deck:v11111111-cf288082e1",
+			expectedRes:            "v20200717-cf288082e1",
+			expectError:            false,
+			prefix:                 "gcr.io/k8s-prow/",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			if tc.upstreamURL == "auto" {
+				// generate a test server so we can capture and inspect the request
+				testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					res.Write([]byte(tc.upstreamServerResponse))
+				}))
+				defer func() { testServer.Close() }()
+				tc.upstreamURL = testServer.URL
+			}
+
+			res, err := parseUpstreamImageVersion(tc.upstreamURL, tc.prefix)
+			if res != tc.expectedRes {
+				t.Errorf("The expected result %q != the actual result %q", tc.expectedRes, res)
+			}
+			if tc.expectError && err == nil {
+				t.Errorf("Expected to get an error but the result is nil")
+			}
+			if !tc.expectError && err != nil {
+				t.Errorf("Expected to not get an error but got one: %v", err)
+			}
+		})
+	}
+}
+
+func TestUpstreamImageVersionResolver(t *testing.T) {
+	prowProdFakeVersion := "v-prow-prod-version"
+	prowStagingFakeVersion := "v-prow-staging-version"
+	boskosProdFakeVersion := "v-boskos-prod-version"
+	boskosStagingFakeVersion := "v-boskos-staging-version"
+	prowRefConfigFile := "prow-prod"
+	boskosRefConfigFile := "boskos-prod"
+	prowStagingRefConfigFile := "prow-staging"
+	boskosStagingRefConfigFile := "boskos-staging"
+	fakeUpstreamURLBase := "test.com"
+	prowPrefix := "gcr.io/k8s-prow/"
+	boskosPrefix := "gcr.io/k8s-boskos/"
+	doesNotExistPrefix := "gcr.io/dne"
+	doesNotExist := "DNE"
+
+	prowPrefixStruct := Prefix{
+		Prefix:               prowPrefix,
+		RefConfigFile:        prowRefConfigFile,
+		StagingRefConfigFile: prowStagingRefConfigFile,
+	}
+	boskosPrefixStruct := Prefix{
+		Prefix:               boskosPrefix,
+		RefConfigFile:        boskosRefConfigFile,
+		StagingRefConfigFile: boskosStagingRefConfigFile,
+	}
+	//Prefix used to test when a tag does not exist. This is used to have parser return a tag that will make TagExists return false
+	tagDoesNotExistPrefix := Prefix{
+		Prefix:               doesNotExistPrefix,
+		RefConfigFile:        doesNotExist,
+		StagingRefConfigFile: doesNotExist,
+	}
+
+	fakeImageVersionParser := func(upstreamAddress, prefix string) (string, error) {
+		switch upstreamAddress {
+		case fakeUpstreamURLBase + "/" + doesNotExist:
+			return doesNotExist, nil
+		case fakeUpstreamURLBase + "/" + prowRefConfigFile:
+			return prowProdFakeVersion, nil
+		case fakeUpstreamURLBase + "/" + prowStagingRefConfigFile:
+			return prowStagingFakeVersion, nil
+		case fakeUpstreamURLBase + "/" + boskosRefConfigFile:
+			return boskosProdFakeVersion, nil
+		case fakeUpstreamURLBase + "/" + boskosStagingRefConfigFile:
+			return boskosStagingFakeVersion, nil
+		default:
+			return "", fmt.Errorf("unsupported upstream address %q for parsing the image version", upstreamAddress)
+		}
+	}
+
+	cases := []struct {
+		description         string
+		upstreamVersionType string
+		imageHost           string
+		imageName           string
+		currentTag          string
+		expectedTargetTag   string
+		expectError         bool
+		resolverError       bool
+		prefixes            []Prefix
+	}{
+		{
+			description:         "resolve image version with an invalid version type",
+			upstreamVersionType: "whatever-version-type",
+			expectError:         true,
+			prefixes:            []Prefix{prowPrefixStruct, boskosPrefixStruct},
+		},
+		{
+			description:         "resolve image with two prefixes possible and upstreamVersion",
+			upstreamVersionType: upstreamVersion,
+			expectError:         false,
+			prefixes:            []Prefix{prowPrefixStruct, boskosPrefixStruct},
+			imageHost:           prowPrefix,
+			currentTag:          "whatever-current-tag",
+			expectedTargetTag:   prowProdFakeVersion,
+		},
+		{
+			description:         "resolve image with two prefixes possible and staging version",
+			upstreamVersionType: upstreamStagingVersion,
+			expectError:         false,
+			prefixes:            []Prefix{prowPrefixStruct, boskosPrefixStruct},
+			imageHost:           boskosPrefix,
+			currentTag:          "whatever-current-tag",
+			expectedTargetTag:   boskosStagingFakeVersion,
+		},
+		{
+			description:         "resolve image when unknown prefix",
+			upstreamVersionType: upstreamVersion,
+			expectError:         false,
+			prefixes:            []Prefix{boskosPrefixStruct},
+			imageHost:           prowPrefix,
+			currentTag:          "whatever-current-tag",
+			expectedTargetTag:   "whatever-current-tag",
+		},
+		{
+			description:         "tag does not exist",
+			upstreamVersionType: upstreamVersion,
+			expectError:         false,
+			prefixes:            []Prefix{tagDoesNotExistPrefix},
+			imageHost:           doesNotExistPrefix,
+			currentTag:          "doesNotExist",
+			expectedTargetTag:   "",
+			resolverError:       true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			option := &Options{
+				UpstreamURLBase: fakeUpstreamURLBase,
+				Prefixes:        tc.prefixes,
+			}
+			cli := &fakeImageBumperCli{replacements: map[string]string{}, tagCache: map[string]string{}}
+			resolver, err := upstreamImageVersionResolver(option, tc.upstreamVersionType, fakeImageVersionParser, cli)
+			if tc.expectError && err == nil {
+				t.Errorf("Expected to get an error but the result is nil")
+				return
+			}
+			if !tc.expectError && err != nil {
+				t.Errorf("Expected to not get an error but got one: %v", err)
+				return
+			}
+
+			if err == nil && resolver == nil {
+				t.Error("Expected to get an image resolver but got nil")
+				return
+			}
+
+			if resolver != nil {
+				res, resErr := resolver(tc.imageHost, tc.imageName, tc.currentTag)
+				if !tc.resolverError && resErr != nil {
+					t.Errorf("Expected resolver to return without error, but received error: %v", resErr)
+				}
+				if tc.resolverError && resErr == nil {
+					t.Error("Expected resolver to return with error, but did not receive one")
+				}
+				if tc.expectedTargetTag != res {
+					t.Errorf("Expected to get target tag %q but got %q", tc.expectedTargetTag, res)
+				}
+
+			}
+
+		})
+	}
+}
+
+func TestUpstreamConfigVersions(t *testing.T) {
+	prowProdFakeVersion := "v-prow-prod-version"
+	prowStagingFakeVersion := "v-prow-staging-version"
+	boskosProdFakeVersion := "v-boskos-prod-version"
+	boskosStagingFakeVersion := "v-boskos-staging-version"
+	prowRefConfigFile := "prow-prod"
+	boskosRefConfigFile := "boskos-prod"
+	prowStagingRefConfigFile := "prow-staging"
+	boskosStagingRefConfigFile := "boskos-staging"
+	fakeUpstreamURLBase := "test.com"
+	prowPrefix := "gcr.io/k8s-prow/"
+	boskosPrefix := "gcr.io/k8s-boskos/"
+
+	prowPrefixStruct := Prefix{
+		Prefix:               prowPrefix,
+		RefConfigFile:        prowRefConfigFile,
+		StagingRefConfigFile: prowStagingRefConfigFile,
+	}
+	boskosPrefixStruct := Prefix{
+		Prefix:               boskosPrefix,
+		RefConfigFile:        boskosRefConfigFile,
+		StagingRefConfigFile: boskosStagingRefConfigFile,
+	}
+
+	fakeImageVersionParser := func(upstreamAddress, prefix string) (string, error) {
+		switch upstreamAddress {
+		case fakeUpstreamURLBase + "/" + prowRefConfigFile:
+			return prowProdFakeVersion, nil
+		case fakeUpstreamURLBase + "/" + prowStagingRefConfigFile:
+			return prowStagingFakeVersion, nil
+		case fakeUpstreamURLBase + "/" + boskosRefConfigFile:
+			return boskosProdFakeVersion, nil
+		case fakeUpstreamURLBase + "/" + boskosStagingRefConfigFile:
+			return boskosStagingFakeVersion, nil
+		default:
+			return "", fmt.Errorf("unsupported upstream address %q for parsing the image version", upstreamAddress)
+		}
+	}
+	cases := []struct {
+		description         string
+		upstreamVersionType string
+		expectedResult      map[string]string
+		expectError         bool
+		prefixes            []Prefix
+	}{
+		{
+			description:         "resolve image version with an invalid version type",
+			upstreamVersionType: "whatever-version-type",
+			expectError:         true,
+			prefixes:            []Prefix{prowPrefixStruct, boskosPrefixStruct},
+		},
+		{
+			description:         "correct versions map for production",
+			upstreamVersionType: upstreamVersion,
+			expectError:         false,
+			prefixes:            []Prefix{prowPrefixStruct, boskosPrefixStruct},
+			expectedResult:      map[string]string{prowPrefix: prowProdFakeVersion, boskosPrefix: boskosProdFakeVersion},
+		},
+		{
+			description:         "correct versions map for staging",
+			upstreamVersionType: upstreamStagingVersion,
+			expectError:         false,
+			prefixes:            []Prefix{prowPrefixStruct, boskosPrefixStruct},
+			expectedResult:      map[string]string{prowPrefix: prowStagingFakeVersion, boskosPrefix: boskosStagingFakeVersion},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			option := &Options{
+				UpstreamURLBase: fakeUpstreamURLBase,
+				Prefixes:        tc.prefixes,
+			}
+			versions, err := upstreamConfigVersions(tc.upstreamVersionType, option, fakeImageVersionParser)
+			if tc.expectError && err == nil {
+				t.Errorf("Expected to get an error but the result is nil")
+				return
+			}
+			if !tc.expectError && err != nil {
+				t.Errorf("Expected to not get an error but got one: %v", err)
+				return
+			}
+			if err == nil && versions == nil {
+				t.Error("Expected to get an versions but did not")
+				return
+			}
+		})
+	}
+
+}
+
+func TestGetVersionsAndCheckConsistency(t *testing.T) {
+	prowPrefix := Prefix{Prefix: "gcr.io/k8s-prow/", ConsistentImages: true}
+	boskosPrefix := Prefix{Prefix: "gcr.io/k8s-boskos/", ConsistentImages: true}
+	inconsistentPrefix := Prefix{Prefix: "inconsistent/", ConsistentImages: false}
+	testCases := []struct {
+		name             string
+		images           map[string]string
+		prefixes         []Prefix
+		expectedVersions map[string][]string
+		err              bool
+	}{
+		{
+			name:             "two prefixes being bumped with consistent tags",
+			prefixes:         []Prefix{prowPrefix, boskosPrefix},
+			images:           map[string]string{"gcr.io/k8s-prow/test:tag1": "newtag1", "gcr.io/k8s-prow/test2:tag1": "newtag1"},
+			err:              false,
+			expectedVersions: map[string][]string{"newtag1": {"gcr.io/k8s-prow/test:tag1", "gcr.io/k8s-prow/test2:tag1"}},
+		},
+		{
+			name:     "two prefixes being bumped with inconsistent tags",
+			prefixes: []Prefix{prowPrefix, boskosPrefix},
+			images:   map[string]string{"gcr.io/k8s-prow/test:tag1": "newtag1", "gcr.io/k8s-prow/test2:tag1": "tag1"},
+			err:      true,
+		},
+		{
+			name:             "two prefixes being bumped with no bumps",
+			prefixes:         []Prefix{prowPrefix, boskosPrefix},
+			images:           map[string]string{},
+			err:              false,
+			expectedVersions: map[string][]string{},
+		},
+		{
+			name:             "Prefix being bumped with inconsistent tags",
+			prefixes:         []Prefix{inconsistentPrefix},
+			images:           map[string]string{"inconsistent/test:tag1": "newtag1", "inconsistent/test2:tag2": "newtag2"},
+			err:              false,
+			expectedVersions: map[string][]string{"newtag1": {"inconsistent/test:tag1"}, "newtag2": {"inconsistent/test2:tag2"}},
+		},
+		{
+			name:             "One of the image types wasn't bumped. Do not include in versions.",
+			prefixes:         []Prefix{prowPrefix, boskosPrefix},
+			images:           map[string]string{"gcr.io/k8s-prow/test:tag1": "newtag1", "gcr.io/k8s-prow/test2:tag1": "newtag1", "gcr.io/k8s-boskos/nobumped:tag1": "tag1"},
+			err:              false,
+			expectedVersions: map[string][]string{"newtag1": {"gcr.io/k8s-prow/test:tag1", "gcr.io/k8s-prow/test2:tag1"}},
+		},
+		{
+			name:             "Two of the images in one type wasn't bumped. Do not include in versions. Do not error",
+			prefixes:         []Prefix{prowPrefix, boskosPrefix},
+			images:           map[string]string{"gcr.io/k8s-prow/test:tag1": "newtag1", "gcr.io/k8s-prow/test2:tag1": "newtag1", "gcr.io/k8s-boskos/nobumped:tag1": "tag1", "gcr.io/k8s-boskos/nobumped2:tag1": "tag1"},
+			err:              false,
+			expectedVersions: map[string][]string{"newtag1": {"gcr.io/k8s-prow/test:tag1", "gcr.io/k8s-prow/test2:tag1"}},
+		},
+		{
+			name:             "prefix was not consistent before bump and now is",
+			prefixes:         []Prefix{prowPrefix},
+			images:           map[string]string{"gcr.io/k8s-prow/test:tag1": "newtag1", "gcr.io/k8s-prow/test2:tag2": "newtag1"},
+			err:              false,
+			expectedVersions: map[string][]string{"newtag1": {"gcr.io/k8s-prow/test:tag1", "gcr.io/k8s-prow/test2:tag2"}},
+		},
+		{
+			name:             "prefix was not consistent before bump one was bumped ahead manually",
+			prefixes:         []Prefix{prowPrefix},
+			images:           map[string]string{"gcr.io/k8s-prow/test:tag1": "newtag1", "gcr.io/k8s-prow/test2:newtag1": "newtag1"},
+			err:              false,
+			expectedVersions: map[string][]string{"newtag1": {"gcr.io/k8s-prow/test:tag1"}},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			versions, err := getVersionsAndCheckConsistency(tc.prefixes, tc.images)
+			if tc.err && err == nil {
+				t.Errorf("expected error but did not get one")
+			}
+			if !tc.err && err != nil {
+				t.Errorf("expected no error, but got one: %v", err)
+			}
+			if diff := cmp.Diff(tc.expectedVersions, versions, cmpopts.SortSlices(func(x, y string) bool { return strings.Compare(x, y) > 0 })); diff != "" {
+				t.Errorf("versions returned unexpected value (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestMakeCommitSummary(t *testing.T) {
+	prowPrefix := Prefix{Name: "Prow", Prefix: "gcr.io/k8s-prow/", ConsistentImages: true}
+	boskosPrefix := Prefix{Name: "Boskos", Prefix: "gcr.io/k8s-boskos/", ConsistentImages: true}
+	inconsistentPrefix := Prefix{Name: "Inconsistent", Prefix: "gcr.io/inconsistent/", ConsistentImages: false}
+	testCases := []struct {
+		name           string
+		prefixes       []Prefix
+		versions       map[string][]string
+		consistency    bool
+		expectedResult string
+	}{
+		{
+			name:           "Two prefixes, but only one bumped",
+			prefixes:       []Prefix{prowPrefix, boskosPrefix},
+			versions:       map[string][]string{"tag1": {"gcr.io/k8s-prow/test:tag1"}},
+			expectedResult: "Update Prow to tag1",
+		},
+		{
+			name:           "Two prefixes, both bumped",
+			prefixes:       []Prefix{prowPrefix, boskosPrefix},
+			versions:       map[string][]string{"tag1": {"gcr.io/k8s-prow/test:tag1"}, "tag2": {"gcr.io/k8s-boskos/test:tag2"}},
+			expectedResult: "Update Prow to tag1, Boskos to tag2",
+		},
+		{
+			name:           "Empty versions",
+			prefixes:       []Prefix{prowPrefix, boskosPrefix},
+			versions:       map[string][]string{},
+			expectedResult: "Update Prow, Boskos images as necessary",
+		},
+		{
+			name:           "One bumped inconsistently",
+			prefixes:       []Prefix{prowPrefix, boskosPrefix, inconsistentPrefix},
+			versions:       map[string][]string{"tag1": {"gcr.io/k8s-prow/test:tag1"}, "tag2": {"gcr.io/k8s-boskos/test:tag2"}, "tag3": {"gcr.io/inconsistent/test:tag3"}},
+			expectedResult: "Update Prow to tag1, Boskos to tag2 and Inconsistent as needed",
+		},
+		{
+			name:           "inconsistent tag was not bumped, do not include in result",
+			prefixes:       []Prefix{prowPrefix, boskosPrefix, inconsistentPrefix},
+			versions:       map[string][]string{"tag1": {"gcr.io/k8s-prow/test:tag1"}, "tag2": {"gcr.io/k8s-boskos/test:tag2"}},
+			expectedResult: "Update Prow to tag1, Boskos to tag2",
+		},
+		{
+			name:           "Two images bumped to same version",
+			prefixes:       []Prefix{prowPrefix, boskosPrefix, inconsistentPrefix},
+			versions:       map[string][]string{"tag1": {"gcr.io/k8s-prow/test:tag1", "gcr.io/inconsistent/test:tag3"}, "tag2": {"gcr.io/k8s-boskos/test:tag2"}},
+			expectedResult: "Update Prow to tag1, Boskos to tag2 and Inconsistent as needed",
+		},
+		{
+			name:           "only bump inconsistent",
+			prefixes:       []Prefix{inconsistentPrefix},
+			versions:       map[string][]string{"tag1": {"gcr.io/k8s-prow/test:tag1", "gcr.io/inconsistent/test:tag3"}, "tag2": {"gcr.io/k8s-boskos/test:tag2"}},
+			expectedResult: "Update Inconsistent as needed",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := makeCommitSummary(tc.prefixes, tc.versions)
+			if res != tc.expectedResult {
+				t.Errorf("expected commit string to be %q, but was %q", tc.expectedResult, res)
+			}
+		})
+	}
+}
+
+func TestGenerateSummary(t *testing.T) {
+	beforeCommit := "2b1234567"
+	afterCommit := "3a1234567"
+	beforeDate := "20210128"
+	afterDate := "20210129"
+	beforeCommit2 := "1c1234567"
+	afterCommit2 := "4f1234567"
+	beforeDate2 := "20210125"
+	afterDate2 := "20210126"
+	unsummarizedOutHeader := `Multiple distinct %s changes:
+
+Commits | Dates | Images
+--- | --- | ---`
+
+	unsummarizedOutLine := "github.com/test/repo/compare/%s...%s | %s&nbsp;&#x2192;&nbsp;%s | %s"
+
+	sampleImages := map[string]string{
+		fmt.Sprintf("gcr.io/bumped/bumpName:v%s-%s", beforeDate, beforeCommit):      fmt.Sprintf("v%s-%s", afterDate, afterCommit),
+		fmt.Sprintf("gcr.io/variant/name:v%s-%s-first", beforeDate, beforeCommit):   fmt.Sprintf("v%s-%s", afterDate, afterCommit),
+		fmt.Sprintf("gcr.io/variant/name:v%s-%s-second", beforeDate, beforeCommit):  fmt.Sprintf("v%s-%s", afterDate, afterCommit),
+		fmt.Sprintf("gcr.io/inconsistent/first:v%s-%s", beforeDate2, beforeCommit2): fmt.Sprintf("v%s-%s", afterDate2, afterCommit2),
+		fmt.Sprintf("gcr.io/inconsistent/second:v%s-%s", beforeDate, beforeCommit):  fmt.Sprintf("v%s-%s", afterDate, afterCommit),
+	}
+	testCases := []struct {
+		testName  string
+		name      string
+		repo      string
+		prefix    string
+		summarize bool
+		images    map[string]string
+		expected  string
+	}{
+		{
+			testName:  "Image not bumped unsummarized",
+			name:      "Test",
+			repo:      "repo",
+			prefix:    "gcr.io/none",
+			summarize: true,
+			images:    sampleImages,
+			expected:  "No gcr.io/none changes.",
+		},
+		{
+			testName:  "Image not bumped summarized",
+			name:      "Test",
+			repo:      "repo",
+			prefix:    "gcr.io/none",
+			summarize: true,
+			images:    sampleImages,
+			expected:  "No gcr.io/none changes.",
+		},
+		{
+			testName:  "Image bumped: summarized",
+			name:      "Test",
+			repo:      "github.com/test/repo",
+			prefix:    "gcr.io/bumped",
+			summarize: true,
+			images:    sampleImages,
+			expected:  fmt.Sprintf("gcr.io/bumped changes: github.com/test/repo/compare/%s...%s (%s → %s)", beforeCommit, afterCommit, formatTagDate(beforeDate), formatTagDate(afterDate)),
+		},
+		{
+			testName:  "Image bumped: not summarized",
+			name:      "Test",
+			repo:      "github.com/test/repo",
+			prefix:    "gcr.io/bumped",
+			summarize: false,
+			images:    sampleImages,
+			expected:  fmt.Sprintf("%s\n%s\n", fmt.Sprintf(unsummarizedOutHeader, "gcr.io/bumped"), fmt.Sprintf(unsummarizedOutLine, beforeCommit, afterCommit, formatTagDate(beforeDate), formatTagDate(afterDate), "bumpName")),
+		},
+		{
+			testName:  "Image bumped: not summarized",
+			name:      "Test",
+			repo:      "github.com/test/repo",
+			prefix:    "gcr.io/variant",
+			summarize: false,
+			images:    sampleImages,
+			expected:  fmt.Sprintf("%s\n%s\n", fmt.Sprintf(unsummarizedOutHeader, "gcr.io/variant"), fmt.Sprintf(unsummarizedOutLine, beforeCommit, afterCommit, formatTagDate(beforeDate), formatTagDate(afterDate), "name(first), name(second)")),
+		},
+		{
+			testName:  "Image bumped, inconsistent: not summarized",
+			name:      "Test",
+			repo:      "github.com/test/repo",
+			prefix:    "gcr.io/inconsistent",
+			summarize: false,
+			images:    sampleImages,
+			expected:  fmt.Sprintf("%s\n%s\n%s\n", fmt.Sprintf(unsummarizedOutHeader, "gcr.io/inconsistent"), fmt.Sprintf(unsummarizedOutLine, beforeCommit2, afterCommit2, formatTagDate(beforeDate2), formatTagDate(afterDate2), "first"), fmt.Sprintf(unsummarizedOutLine, beforeCommit, afterCommit, formatTagDate(beforeDate), formatTagDate(afterDate), "second")),
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.testName, func(t *testing.T) {
+			want, got := tc.expected, generateSummary(tc.name, tc.repo, tc.prefix, tc.summarize, tc.images)
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("generateSummary returned unexpected value (-want +got):\n%s", diff)
+			}
+		})
+
+	}
+}


### PR DESCRIPTION
This is the second PR as breaking down of https://github.com/kubernetes/test-infra/pull/21952. This PR moves the prow images bumping logic into the main package, haven't done any cleaning up yet for maintaining backwards compatibility.