### PR TITLE
wg-k8s-infra: Add presubmits for build clusters and aaa

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/k8sio-presubmit.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/k8sio-presubmit.yaml
@@ -20,6 +20,90 @@ presubmits:
         env:
         - name: GO111MODULE
           value: "on"
+  - name: pull-k8sio-terraform-aaa
+    annotations:
+      description: verify terraform files for GKE cluster aaa
+      testgrid-create-test-group: 'true'
+      testgrid-dashboards: wg-k8s-infra-k8sio
+      testgrid-tab-name: pull-k8sio-terraform-aaa
+      testgrid-alert-email: ameukam@gmail.com,spiffxp@gmail.com,spiffxp@google.com
+      testgrid-num-failures-to-alert: '1'
+    decorate: true
+    max_concurrency: 1
+    cluster: k8s-infra-prow-build
+    path_alias: k8s.io/k8s.io
+    run_if_changed: "^(infra/gcp/clusters/modules/.*.tf$|infra/gcp/clusters/projects/kubernetes-public/aaa/*.tf$)"
+    branches:
+    - ^main$
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/gcb-docker-gcloud:v20210331-c732583
+        command:
+        - hack/verify-terraform.sh
+        - infra/gcp/clusters/projects/kubernetes-public/aaa
+        resources:
+          limits:
+            cpu: 1
+            memory: "512Mi"
+          requests:
+            cpu: 1
+            memory: "512Mi"
+  - name: pull-k8sio-terraform-prow-build
+    annotations:
+      description: verify terraform files for GKE build cluster prow-build
+      testgrid-create-test-group: 'true'
+      testgrid-dashboards: wg-k8s-infra-k8sio,sig-testing-prow
+      testgrid-tab-name: pull-k8sio-terraform-prow-build
+      testgrid-alert-email: ameukam@gmail.com,spiffxp@gmail.com,spiffxp@google.com
+      testgrid-num-failures-to-alert: '1'
+    decorate: true
+    max_concurrency: 1
+    cluster: k8s-infra-prow-build
+    path_alias: k8s.io/k8s.io
+    run_if_changed: "^(infra/gcp/clusters/modules/.*.tf$|infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/*.tf$)"
+    branches:
+    - ^main$
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/gcb-docker-gcloud:v20210331-c732583
+        command:
+        - hack/verify-terraform.sh
+        - infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build
+        resources:
+          limits:
+            cpu: 1
+            memory: "512Mi"
+          requests:
+            cpu: 1
+            memory: "512Mi"
+  - name: pull-k8sio-terraform-prow-build-trusted
+    annotations:
+      description: verify terraform files for GKE build cluster prow-build-trusted
+      testgrid-create-test-group: 'true'
+      testgrid-dashboards: wg-k8s-infra-k8sio,sig-testing-prow
+      testgrid-tab-name: pull-k8sio-terraform-prow-build-trusted
+      testgrid-alert-email: ameukam@gmail.com,spiffxp@gmail.com,spiffxp@google.com
+      testgrid-num-failures-to-alert: '1'
+    decorate: true
+    max_concurrency: 1
+    cluster: k8s-infra-prow-build
+    path_alias: k8s.io/k8s.io
+    run_if_changed: "^(infra/gcp/clusters/modules/.*.tf$|infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/*.tf$)"
+    branches:
+    - ^main$
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/gcb-docker-gcloud:v20210331-c732583
+        command:
+        - hack/verify-terraform.sh
+        - infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted
+        resources:
+          limits:
+            cpu: 1
+            memory: "512Mi"
+          requests:
+            cpu: 1
+            memory: "512Mi"
   - name: pull-k8sio-verify
     annotations:
       testgrid-dashboards: wg-k8s-infra-k8sio


### PR DESCRIPTION
Add presubmits prowjobs that validate terraform changes for the build
clusters and GKE cluster `aaa`.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>