### PR TITLE
Kops - Create a periodic job for DigitalOcean

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -218,3 +218,62 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-misc, kops-kubetest2
     testgrid-days-of-results: "30"
     testgrid-tab-name: kops-aws-upgrade-k119-ko119-to-k120-ko120
+- name: e2e-kops-do-calico
+  cron: '54 4-23/8 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-do-credential: "true"
+    preset-do-spaces-credential: "true"
+    preset-do-ssh: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+          make test-e2e-install
+          kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=digitalocean \
+          --env S3_ENDPOINT=sfo3.digitaloceanspaces.com \
+          --create-args "--networking=calico --api-loadbalancer-type=public --node-count=2 --master-count=3" \
+          --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.21.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-package-marker=stable-1.21.txt \
+          --parallel 25 \
+          --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*NodePort.*listening.*same.*port|TCP.CLOSE_WAIT|should.*run.*through.*the.*lifecycle.*of.*Pods.*and.*PodStatus"
+      resources:
+        limits:
+          memory: "3Gi"
+        requests:
+          cpu: "2"
+          memory: "3Gi"
+  annotations:
+    test.kops.k8s.io/cloud: digitalocean
+    test.kops.k8s.io/k8s_version: '1.21'
+    test.kops.k8s.io/kops_channel: stable
+    test.kops.k8s.io/kops_version: '1.21'
+    test.kops.k8s.io/networking: 'calico'
+    testgrid-dashboards: google-aws, kops-1.21, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops, kops-misc
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: e2e-kops-do-calico


### PR DESCRIPTION
With https://github.com/kubernetes/kops/pull/10963 merged we should be all set for a periodic job on DigitalOcean. I copied most of the flags from the presubmit job.

/hold for input from @srikiz regarding frequency - as-is this will run 3 times per day. I'm fine with increasing or decreasing that frequency based on your preference.