### PR TITLE
Checkconfig: Validate additional plugins configs are in org/repo hirarchy

### DIFF
--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -25,7 +25,6 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
-	"path/filepath"
 	"reflect"
 	"strings"
 
@@ -369,7 +368,7 @@ func validate(o options) error {
 
 	if o.warningEnabled(validateSupplementalProwConfigOrgRepoHirarchy) {
 		for _, supplementalProwConfigDir := range o.config.SupplementalProwConfigDirs.Strings() {
-			errs = append(errs, validateAdditionalProwConfigIsInOrgRepoDirectoryStructure(supplementalProwConfigDir, os.DirFS("./")))
+			errs = append(errs, validateAdditionalProwConfigIsInOrgRepoDirectoryStructure(supplementalProwConfigDir, os.DirFS("./"), o.config.SupplementalProwConfigsFileNameSuffix))
 		}
 	}
 
@@ -1119,7 +1118,7 @@ func validateCluster(cfg *config.Config) error {
 	return utilerrors.NewAggregate(errs)
 }
 
-func validateAdditionalProwConfigIsInOrgRepoDirectoryStructure(root string, filesystem fs.FS) error {
+func validateAdditionalProwConfigIsInOrgRepoDirectoryStructure(root string, filesystem fs.FS, supplementalProwConfigsFileNameSuffix string) error {
 	var errs []error
 	errs = append(errs, fs.WalkDir(filesystem, root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -1139,7 +1138,7 @@ func validateAdditionalProwConfigIsInOrgRepoDirectoryStructure(root string, file
 
 		fs.ReadFile(filesystem, path)
 
-		if d.IsDir() || (filepath.Ext(path) != ".yaml" && filepath.Ext(path) != ".yml") {
+		if d.IsDir() || (!strings.HasSuffix(path, supplementalProwConfigsFileNameSuffix)) {
 			return nil
 		}
 

--- a/prow/cmd/checkconfig/main_test.go
+++ b/prow/cmd/checkconfig/main_test.go
@@ -1754,7 +1754,7 @@ tide:
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			var errMsg string
-			err := validateAdditionalProwConfigIsInOrgRepoDirectoryStructure(root, tc.fs)
+			err := validateAdditionalProwConfigIsInOrgRepoDirectoryStructure(root, tc.fs, ".yaml")
 			if err != nil {
 				errMsg = err.Error()
 			}

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -6188,7 +6188,7 @@ func TestHasConfigFor(t *testing.T) {
 			},
 		},
 		{
-			name: "Any config that is empty except for branchprotection.orgs with empty repoo is considered to be for those orgs",
+			name: "Any config that is empty except for branchprotection.orgs with empty repo is considered to be for those orgs",
 			resultGenerator: func(fuzzedConfig *ProwConfig) (toCheck *ProwConfig, exceptGlobal bool, expectOrgs sets.String, expectRepos sets.String) {
 				expectOrgs = sets.String{}
 				result := &ProwConfig{BranchProtection: BranchProtection{Orgs: map[string]Org{}}}

--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"reflect"
 	"regexp"
 	"sort"
 	"strings"
@@ -1803,4 +1804,21 @@ func (p *Plugins) mergeFrom(other *Plugins) error {
 	}
 
 	return utilerrors.NewAggregate(errs)
+}
+
+func (c *Configuration) HasConfigFor() (global bool, orgs sets.String, repos sets.String) {
+	if !reflect.DeepEqual(c, &Configuration{Plugins: c.Plugins}) {
+		global = true
+	}
+	orgs = sets.String{}
+	repos = sets.String{}
+	for orgOrRepo := range c.Plugins {
+		if strings.Contains(orgOrRepo, "/") {
+			repos.Insert(orgOrRepo)
+		} else {
+			orgs.Insert(orgOrRepo)
+		}
+	}
+
+	return global, orgs, repos
 }


### PR DESCRIPTION
This extends checkconfig to also be able to check if additional plugin configs are in an org repo hirarchy. This doesn't have any actual use yet, because flags to actually configure that aren't plugged through yet, I will do that in a follow-up.