### PR TITLE
Adding ingress-nginx to merge_method squash

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -583,6 +583,7 @@ tide:
     kubernetes-sigs/minibroker: squash
     kubernetes/cloud-provider-openstack: squash
     kubernetes/dashboard: squash
+    kubernetes/ingress-nginx: squash
   pr_status_base_urls:
     '*': https://prow.k8s.io/pr
   blocker_label: tide/merge-blocker


### PR DESCRIPTION
This adds ingress-nginx to merge method squash, so we don't need to keep asking people to squash the commits :)