### PR TITLE
add csi-secrets-store periodic, postsubmit to sig-auth

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -18,7 +18,7 @@ presubmits:
         - make
         - test-style
     annotations:
-      testgrid-dashboards: sig-auth-secrets-store-csi-driver
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-lint
       description: "Run linting rules for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
@@ -66,7 +66,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-auth-secrets-store-csi-driver
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-sanity
       description: "Run sanity tests for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
@@ -95,7 +95,7 @@ presubmits:
           securityContext:
             privileged: true
     annotations:
-      testgrid-dashboards: sig-auth-secrets-store-csi-driver
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-image-scan
       description: "Run vulnerability scans for Secrets Store CSI driver images."
       testgrid-num-columns-recent: '30'
@@ -125,7 +125,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-auth-secrets-store-csi-driver
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-e2e-vault
       description: "Run e2e test with vault provider for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
@@ -157,7 +157,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-auth-secrets-store-csi-driver
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-e2e-azure
       description: "Run e2e test with azure provider for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
@@ -213,7 +213,7 @@ presubmits:
           - name: TEST_WINDOWS
             value: "true"
     annotations:
-      testgrid-dashboards: sig-auth-secrets-store-csi-driver
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-e2e-windows
       description: "Run E2E tests on a Windows cluster for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
@@ -245,7 +245,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-auth-secrets-store-csi-driver
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-e2e-gcp
       description: "Run e2e test with gcp provider for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
@@ -305,7 +305,7 @@ presubmits:
           - name: RELEASE
             value: "true"
     annotations:
-      testgrid-dashboards: sig-auth-secrets-store-csi-driver
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-release-signal
       testgrid-tab-name: release-secrets-store-csi-driver-e2e-vault
       description: "Run e2e test with vault provider for Secrets Store CSI driver release."
       testgrid-num-columns-recent: '30'
@@ -341,7 +341,7 @@ presubmits:
           - name: RELEASE
             value: "true"
     annotations:
-      testgrid-dashboards: sig-auth-secrets-store-csi-driver
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-release-signal
       testgrid-tab-name: release-secrets-store-csi-driver-e2e-azure
       description: "Run e2e test with azure provider for Secrets Store CSI driver release."
       testgrid-num-columns-recent: '30'
@@ -377,7 +377,7 @@ presubmits:
           - name: RELEASE
             value: "true"
     annotations:
-      testgrid-dashboards: sig-auth-secrets-store-csi-driver
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-release-signal
       testgrid-tab-name: release-secrets-store-csi-driver-e2e-gcp
       description: "Run e2e test with gcp provider for Secrets Store CSI driver release."
       testgrid-num-columns-recent: '30'
@@ -410,7 +410,7 @@ postsubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-auth-secrets-store-csi-driver
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-postsubmit
       testgrid-tab-name: secrets-store-csi-driver-e2e-vault-postsubmit
       description: "Run e2e test with vault provider for Secrets Store CSI driver postsubmit"
       testgrid-num-columns-recent: '30'
@@ -446,7 +446,7 @@ postsubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-auth-secrets-store-csi-driver
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-postsubmit
       testgrid-tab-name: secrets-store-csi-driver-e2e-azure-postsubmit
       description: "Run e2e test with azure provider for Secrets Store CSI driver postsubmit"
       testgrid-num-columns-recent: '30'
@@ -482,7 +482,7 @@ postsubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-auth-secrets-store-csi-driver
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-postsubmit
       testgrid-tab-name: secrets-store-csi-driver-e2e-gcp-postsubmit
       description: "Run e2e test with gcp provider for Secrets Store CSI driver postsubmit"
       testgrid-num-columns-recent: '30'
@@ -518,7 +518,7 @@ periodics:
         securityContext:
           privileged: true
   annotations:
-    testgrid-dashboards: sig-auth-secrets-store-csi-driver
+    testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-periodic
     testgrid-tab-name: secrets-store-csi-driver-image-scan
     testgrid-alert-email: kubernetes-secrets-store-csi-driver@googlegroups.com
     description: "Run vulnerability scans for Secrets Store CSI driver images."

--- a/config/testgrids/config.yaml
+++ b/config/testgrids/config.yaml
@@ -250,6 +250,10 @@ dashboards:
 - name: sig-big-data
 - name: sig-multicluster-kubemci
 - name: sig-auth-secrets-store-csi-driver
+- name: sig-auth-secrets-store-csi-driver-postsubmit
+- name: sig-auth-secrets-store-csi-driver-periodic
+- name: sig-auth-secrets-store-csi-driver-presubmit
+- name: sig-auth-secrets-store-csi-driver-release-signal
 - name: vmware-presubmits-cloud-provider-vsphere
 - name: vmware-postsubmits-cloud-provider-vsphere
 - name: vmware-presubmits-vsphere-csi-driver
@@ -298,3 +302,7 @@ dashboard_groups:
   dashboard_names:
   - sig-auth-gce
   - sig-auth-secrets-store-csi-driver
+  - sig-auth-secrets-store-csi-driver-postsubmit
+  - sig-auth-secrets-store-csi-driver-periodic
+  - sig-auth-secrets-store-csi-driver-presubmit
+  - sig-auth-secrets-store-csi-driver-release-signal


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

- Adds `sig-auth-secrets-store-csi-driver-postsubmit`, `sig-auth-secrets-store-csi-driver-periodic`, `sig-auth-secrets-store-csi-driver-presubmit` and `sig-auth-secrets-store-csi-driver-release-signal` to `sig-auth` dashboard group

/assign @ritazh 