### PR TITLE
Add a canary job for ci-kubernetes-kubemark-gce-scale

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -508,6 +508,87 @@ periodics:
           cpu: 6
           memory: "16Gi"
 
+- name: ci-kubernetes-kubemark-gce-scale-canary
+  cluster: k8s-infra-prow-build
+  tags:
+  - "perfDashPrefix: kubemark-5000Nodes"
+  - "perfDashJobType: performance"
+  # Run twice a day (at 00:01 and 16:01 UTC) on the odd days of each month. The
+  # job is expected to take ~12-14h, hence the 16 hour gap.
+  cron: '1 0,16 1-31/2 * *'
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-dind-enabled: "true"
+    preset-e2e-kubemark-common: "true"
+    preset-e2e-kubemark-gce-scale: "true"
+    preset-e2e-scalability-periodics: "true"
+    preset-e2e-scalability-periodics-master: "true"
+  decorate: true
+  decoration_config:
+    timeout: 1100m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: perf-tests
+    base_ref: master
+    path_alias: k8s.io/perf-tests
+  annotations:
+    testgrid-dashboards: sig-testing-canaries
+    testgrid-tab-name: kubemark-5000
+    testgrid-num-failures-to-alert: '1'
+    testgrid-num-columns-recent: '3'
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210509-00de27f-master
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=kubemark-5000
+      - --extract=ci/latest
+      - --gcp-node-image=gci
+      - --gcp-node-size=e2-standard-8
+      - --gcp-nodes=84
+      - --gcp-project=scalability-project
+      - --gcp-zone=us-east1-b
+      - --kubemark
+      - --kubemark-nodes=5000
+      - --provider=gce
+      - --metadata-sources=cl2-metadata.json
+      - --test=false
+      - --test_args=--ginkgo.focus=xxxx
+      - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
+      - --test-cmd-args=cluster-loader2
+      - --test-cmd-args=--experimental-gcp-snapshot-prometheus-disk=true
+      - --test-cmd-args=--experimental-prometheus-disk-snapshot-name=$(JOB_NAME)-$(BUILD_ID)
+      - --test-cmd-args=--nodes=5000
+      - --test-cmd-args=--provider=kubemark
+      - --env=CL2_ENABLE_PVS=false # TODO(https://github.com/kubernetes/perf-tests/issues/803): Fix me
+      - --test-cmd-args=--report-dir=$(ARTIFACTS)
+      - --test-cmd-args=--testconfig=testing/load/config.yaml
+      - --test-cmd-args=--testconfig=testing/access-tokens/config.yaml
+      - --test-cmd-args=--testoverrides=./testing/experiments/enable_restart_count_check.yaml
+      - --test-cmd-args=--testoverrides=./testing/experiments/ignore_known_kubemark_container_restarts.yaml
+      - --test-cmd-args=--testoverrides=./testing/overrides/kubemark_5000_nodes.yaml
+      - --test-cmd-name=ClusterLoaderV2
+      - --timeout=1080m
+      - --use-logexporter
+      - --logexporter-gcs-path=gs://sig-scalability-logs/$(JOB_NAME)/$(BUILD_ID)
+      # docker-in-docker needs privilged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 6
+          memory: "16Gi"
+        limits:
+          cpu: 6
+          memory: "16Gi"
+
 - name: ci-kubernetes-kubemark-gce-scale-scheduler
   tags:
   - "perfDashPrefix: kubemark-5000Nodes-scheduler"


### PR DESCRIPTION
Ref: https://github.com/kubernetes/k8s.io/issues/1469

Add a canary job to ensure ci-kubernetes-kubermark-gce-scale can run on
the community build clusters and use boskos project type
`scalability-project`.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>