### PR TITLE
sig-windows: add 1.21 dashboard and remove gce jobs from release informing

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/generate-presubmits.sh
+++ b/config/jobs/kubernetes-sigs/sig-windows/generate-presubmits.sh
@@ -58,10 +58,12 @@ for release in "$@"; do
       containerd_api_model="https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_1_19.json"
       ;;
     1.20)
-      dockershim_api_model="https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_release_staging.json"
-      containerd_api_model="https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_release_1_20.json"
+      dockershim_api_model="https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_release_1_20.json"
+      containerd_api_model="https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_1_20.json"
       ;;
     1.21)
+      dockershim_api_model="https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_release_1_21.json"
+      containerd_api_model="https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_1_21.json"
       ;;
     *)
       branch="master"

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.18-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.18-windows.yaml
@@ -49,7 +49,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-release-1.18-informing, sig-windows-1.18-release
+    testgrid-dashboards: sig-release-1.18-informing, sig-windows-signal, sig-windows-1.18-release
     testgrid-tab-name: aks-engine-windows-dockershim-1.18
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s 1.18 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.19-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.19-windows.yaml
@@ -49,7 +49,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-release-1.19-informing, sig-windows-1.19-release
+    testgrid-dashboards: sig-release-1.19-informing, sig-windows-signal, sig-windows-1.19-release
     testgrid-tab-name: aks-engine-windows-dockershim-1.19
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s 1.19 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.20-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.20-windows-presubmits.yaml
@@ -42,7 +42,7 @@ presubmits:
         - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
         - --aksengine-winZipBuildScript=$(WIN_BUILD)
         - --aksengine-orchestratorRelease=1.20
-        - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_release_staging.json
+        - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_release_1_20.json
         - --aksengine-win-binaries
         - --aksengine-deploy-custom-k8s
         - --aksengine-agentpoolcount=2
@@ -94,7 +94,7 @@ presubmits:
         - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
         - --aksengine-winZipBuildScript=$(WIN_BUILD)
         - --aksengine-orchestratorRelease=1.20
-        - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_release_1_20.json
+        - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_1_20.json
         - --aksengine-win-binaries
         - --aksengine-deploy-custom-k8s
         - --aksengine-agentpoolcount=2

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.21-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.21-windows-presubmits.yaml
@@ -42,7 +42,7 @@ presubmits:
         - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
         - --aksengine-winZipBuildScript=$(WIN_BUILD)
         - --aksengine-orchestratorRelease=1.21
-        - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_release_staging.json
+        - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_release_1_21.json
         - --aksengine-win-binaries
         - --aksengine-deploy-custom-k8s
         - --aksengine-agentpoolcount=2
@@ -94,7 +94,7 @@ presubmits:
         - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
         - --aksengine-winZipBuildScript=$(WIN_BUILD)
         - --aksengine-orchestratorRelease=1.21
-        - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_master.json
+        - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_1_21.json
         - --aksengine-win-binaries
         - --aksengine-deploy-custom-k8s
         - --aksengine-agentpoolcount=2

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.21-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.21-windows.yaml
@@ -1,6 +1,6 @@
 periodics:
 - interval: 24h
-  name: ci-kubernetes-e2e-aks-engine-azure-1-20-windows
+  name: ci-kubernetes-e2e-aks-engine-azure-1-21-windows
   decorate: true
   decoration_config:
     timeout: 3h
@@ -14,11 +14,11 @@ periodics:
   extra_refs:
   - org: kubernetes
     repo: kubernetes
-    base_ref: release-1.20
+    base_ref: release-1.21
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210509-00de27f-1.20
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210509-00de27f-1.21
       command:
       - runner.sh
       - kubetest
@@ -32,7 +32,7 @@ periodics:
       # Azure-specific test args
       - --deployment=aksengine
       - --provider=skeleton
-      - --aksengine-orchestratorRelease=1.20
+      - --aksengine-orchestratorRelease=1.21
       - --aksengine-admin-username=azureuser
       - --aksengine-admin-password=AdminPassw0rd
       - --aksengine-creds=$(AZURE_CREDENTIALS)
@@ -40,7 +40,7 @@ periodics:
       - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
       - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
       - --aksengine-winZipBuildScript=$(WIN_BUILD)
-      - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_release_1_20.json
+      - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_release_1_21.json
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
       # Specific test args
@@ -49,12 +49,12 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows-1.20-release
-    testgrid-tab-name: aks-engine-windows-dockershim-1.20
+    testgrid-dashboards: sig-windows-1.21-release
+    testgrid-tab-name: aks-engine-windows-dockershim-1.21
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
-    description: Runs SIG-Windows release tests on K8s 1.20 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
+    description: Runs SIG-Windows release tests on K8s 1.21 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 24h
-  name: ci-kubernetes-e2e-aks-engine-azure-1-20-windows-serial-slow
+  name: ci-kubernetes-e2e-aks-engine-azure-1-21-windows-serial-slow
   decorate: true
   decoration_config:
     timeout: 5h
@@ -68,11 +68,11 @@ periodics:
   extra_refs:
   - org: kubernetes
     repo: kubernetes
-    base_ref: release-1.20
+    base_ref: release-1.21
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210509-00de27f-1.20
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210509-00de27f-1.21
       command:
       - runner.sh
       - kubetest
@@ -86,7 +86,7 @@ periodics:
       # Azure-specific test args
       - --deployment=aksengine
       - --provider=skeleton
-      - --aksengine-orchestratorRelease=1.20
+      - --aksengine-orchestratorRelease=1.21
       - --aksengine-admin-username=azureuser
       - --aksengine-admin-password=AdminPassw0rd
       - --aksengine-creds=$(AZURE_CREDENTIALS)
@@ -94,7 +94,7 @@ periodics:
       - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
       - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
       - --aksengine-winZipBuildScript=$(WIN_BUILD)
-      - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_release_1_20_serial.json
+      - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_release_1_21_serial.json
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
       # Specific test args
@@ -103,66 +103,67 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows-1.20-release
-    testgrid-tab-name: aks-engine-windows-dockershim-serial-slow-1.20
+    testgrid-dashboards: sig-windows-1.21-release
+    testgrid-tab-name: aks-engine-windows-dockershim-serial-slow-1.21
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
-    description: Runs SIG-Windows release serial tests on K8s 1.20 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
+    description: Runs SIG-Windows release serial tests on K8s 1.21 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
+# This job lives in config/jobs/kubernetes/sig-release/release-branch-jobs/1.21.yaml instead
+# - interval: 24h
+#   name: ci-kubernetes-e2e-aks-engine-azure-1-21-windows-containerd
+#   decorate: true
+#   decoration_config:
+#     timeout: 3h
+#   labels:
+#     preset-service-account: "true"
+#     preset-azure-cred: "true"
+#     preset-azure-windows: "true"
+#     preset-windows-repo-list: "true"
+#     preset-k8s-ssh: "true"
+#     preset-dind-enabled: "true"
+#   extra_refs:
+#   - org: kubernetes
+#     repo: kubernetes
+#     base_ref: release-1.21
+#     path_alias: k8s.io/kubernetes
+#   spec:
+#     containers:
+#     - image: gcr.io/k8s-testimages/kubekins-e2e:v20210509-00de27f-1.21
+#       command:
+#       - runner.sh
+#       - kubetest
+#       args:
+#       # Generic e2e test args
+#       - --test
+#       - --up
+#       - --down
+#       - --build=quick
+#       - --dump=$(ARTIFACTS)
+#       # Azure-specific test args
+#       - --deployment=aksengine
+#       - --provider=skeleton
+#       - --aksengine-orchestratorRelease=1.21
+#       - --aksengine-admin-username=azureuser
+#       - --aksengine-admin-password=AdminPassw0rd
+#       - --aksengine-creds=$(AZURE_CREDENTIALS)
+#       - --aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz
+#       - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
+#       - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
+#       - --aksengine-winZipBuildScript=$(WIN_BUILD)
+#       - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_1_21.json
+#       - --aksengine-win-binaries
+#       - --aksengine-deploy-custom-k8s
+#       # Specific test args
+#       - --test_args=--node-os-distro=windows --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
+#       - --ginkgo-parallel=4
+#       securityContext:
+#         privileged: true
+#   annotations:
+#     testgrid-dashboards: sig-release-1.21-informing, sig-windows-1.21-release
+#     testgrid-tab-name: aks-engine-windows-containerd-1.21
+#     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+#     description: Runs SIG-Windows release tests on K8s 1.21 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud#
 - interval: 24h
-  name: ci-kubernetes-e2e-aks-engine-azure-1-20-windows-containerd
-  decorate: true
-  decoration_config:
-    timeout: 3h
-  labels:
-    preset-service-account: "true"
-    preset-azure-cred: "true"
-    preset-azure-windows: "true"
-    preset-windows-repo-list: "true"
-    preset-k8s-ssh: "true"
-    preset-dind-enabled: "true"
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: release-1.20
-    path_alias: k8s.io/kubernetes
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210509-00de27f-1.20
-      command:
-      - runner.sh
-      - kubetest
-      args:
-      # Generic e2e test args
-      - --test
-      - --up
-      - --down
-      - --build=quick
-      - --dump=$(ARTIFACTS)
-      # Azure-specific test args
-      - --deployment=aksengine
-      - --provider=skeleton
-      - --aksengine-orchestratorRelease=1.20
-      - --aksengine-admin-username=azureuser
-      - --aksengine-admin-password=AdminPassw0rd
-      - --aksengine-creds=$(AZURE_CREDENTIALS)
-      - --aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz
-      - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
-      - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
-      - --aksengine-winZipBuildScript=$(WIN_BUILD)
-      - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_1_20.json
-      - --aksengine-win-binaries
-      - --aksengine-deploy-custom-k8s
-      # Specific test args
-      - --test_args=--node-os-distro=windows --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
-      - --ginkgo-parallel=4
-      securityContext:
-        privileged: true
-  annotations:
-    testgrid-dashboards: sig-release-1.20-informing, sig-windows-signal, sig-windows-1.20-release
-    testgrid-tab-name: aks-engine-windows-containerd-1.20
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
-    description: Runs SIG-Windows release tests on K8s 1.20 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
-- interval: 24h
-  name: ci-kubernetes-e2e-aks-engine-azure-1-20-windows-containerd-serial-slow
+  name: ci-kubernetes-e2e-aks-engine-azure-1-21-windows-containerd-serial-slow
   decorate: true
   decoration_config:
     timeout: 5h
@@ -176,11 +177,11 @@ periodics:
   extra_refs:
   - org: kubernetes
     repo: kubernetes
-    base_ref: release-1.20
+    base_ref: release-1.21
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210509-00de27f-1.20
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210509-00de27f-1.21
       command:
       - runner.sh
       - kubetest
@@ -194,7 +195,7 @@ periodics:
       # Azure-specific test args
       - --deployment=aksengine
       - --provider=skeleton
-      - --aksengine-orchestratorRelease=1.20
+      - --aksengine-orchestratorRelease=1.21
       - --aksengine-admin-username=azureuser
       - --aksengine-admin-password=AdminPassw0rd
       - --aksengine-creds=$(AZURE_CREDENTIALS)
@@ -202,7 +203,7 @@ periodics:
       - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
       - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
       - --aksengine-winZipBuildScript=$(WIN_BUILD)
-      - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_1_20_serial.json
+      - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_1_21_serial.json
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
       # Specific test args
@@ -211,7 +212,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows-1.20-release
-    testgrid-tab-name: aks-engine-windows-containerd-serial-slow-1.20
+    testgrid-dashboards: sig-windows-1.21-release
+    testgrid-tab-name: aks-engine-windows-containerd-serial-slow-1.21
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
-    description: Runs SIG-Windows release serial tests on K8s 1.20 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
+    description: Runs SIG-Windows release serial tests on K8s 1.21 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -634,7 +634,7 @@ periodics:
       name: ""
       resources: {}
 - annotations:
-    testgrid-dashboards: google-windows, sig-windows-gce, sig-release-1.18-informing, sig-windows-1.18-release
+    testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-1.18-release
     testgrid-tab-name: gce-windows-1909-1.18
   decorate: true
   extra_refs:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -542,7 +542,7 @@ periodics:
       securityContext:
         privileged: true
 - annotations:
-    testgrid-dashboards: google-windows, sig-windows-gce, sig-release-1.19-informing, sig-windows-1.19-release
+    testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-1.19-release
     testgrid-tab-name: gce-windows-2019-1.19
   decorate: true
   extra_refs:
@@ -584,7 +584,7 @@ periodics:
       name: ""
       resources: {}
 - annotations:
-    testgrid-dashboards: google-windows, sig-windows-gce, sig-release-1.19-informing, sig-windows-1.19-release
+    testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-1.19-release
     testgrid-tab-name: gce-windows-1909-1.19
   decorate: true
   extra_refs:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
@@ -540,7 +540,7 @@ periodics:
       securityContext:
         privileged: true
 - annotations:
-    testgrid-dashboards: google-windows, sig-windows-gce, sig-release-1.20-informing, sig-windows-1.20-release
+    testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-1.20-release
     testgrid-tab-name: gce-windows-2019-1.20
   decorate: true
   extra_refs:
@@ -583,7 +583,7 @@ periodics:
       name: ""
       resources: {}
 - annotations:
-    testgrid-dashboards: google-windows, sig-windows-gce, sig-release-1.20-informing, sig-windows-1.20-release
+    testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-1.20-release
     testgrid-tab-name: gce-windows-1909-1.20
   decorate: true
   extra_refs:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.21.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.21.yaml
@@ -532,7 +532,7 @@ periodics:
       securityContext:
         privileged: true
 - annotations:
-    testgrid-dashboards: google-windows, sig-windows-gce, sig-release-1.21-informing, sig-windows-signal
+    testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-1.21-release
     testgrid-tab-name: gce-windows-2019-1.21
   decorate: true
   decoration_config:
@@ -580,7 +580,7 @@ periodics:
       name: ""
       resources: {}
 - annotations:
-    testgrid-dashboards: google-windows, sig-windows-gce, sig-release-1.21-informing, sig-windows-signal, sig-windows-master-release
+    testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-1.21-release
     testgrid-tab-name: gce-windows-20h2-1.21
   decorate: true
   decoration_config:
@@ -628,7 +628,7 @@ periodics:
       name: ""
       resources: {}
 - annotations:
-    testgrid-dashboards: google-windows, sig-windows-gce, sig-release-1.21-informing, sig-windows-master-release
+    testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-1.21-release
     testgrid-tab-name: gce-windows-2004-1.21
   decorate: true
   decoration_config:
@@ -771,7 +771,7 @@ periodics:
         privileged: true
 - annotations:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
-    testgrid-dashboards: sig-release-1.21-informing, sig-windows-signal, sig-windows-master-release
+    testgrid-dashboards: sig-release-1.21-informing, sig-windows-signal, sig-windows-1.21-release
     testgrid-tab-name: aks-engine-windows-containerd-1.21
   decorate: true
   decoration_config:
@@ -790,7 +790,7 @@ periodics:
     preset-service-account: "true"
     preset-windows-private-registry-cred: "true"
     preset-windows-repo-list-master: "true"
-  name: ci-kubernetes-e2e-aks-engine-azure-master-windows-containerd-1-21
+  name: ci-kubernetes-e2e-aks-engine-azure-1-21-windows-containerd
   spec:
     containers:
     - args:
@@ -809,7 +809,7 @@ periodics:
       - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
       - --aksengine-winZipBuildScript=$(WIN_BUILD)
       - --aksengine-orchestratorRelease=1.21
-      - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_master.json
+      - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_1_21.json
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
       - --test_args=--node-os-distro=windows -docker-config-file=$(DOCKER_CONFIG_FILE) --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows

--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -97,7 +97,7 @@ periodics:
   annotations:
     fork-per-release: "true"
     fork-per-release-replacements: "--extract=ci/latest -> --extract=ci/latest-{{.Version}}"
-    testgrid-dashboards: google-windows, sig-windows-gce, sig-release-master-informing, sig-windows-signal
+    testgrid-dashboards: google-windows, sig-windows-gce
     testgrid-tab-name: gce-windows-2019-master
     description: Runs tests on a Kubernetes cluster with Windows 2019 nodes on GCE
 
@@ -147,7 +147,7 @@ periodics:
   annotations:
     fork-per-release: "true"
     fork-per-release-replacements: "--extract=ci/latest -> --extract=ci/latest-{{.Version}}"
-    testgrid-dashboards: google-windows, sig-windows-gce, sig-release-master-informing, sig-windows-signal, sig-windows-master-release
+    testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-master-release
     testgrid-tab-name: gce-windows-20h2-master
     description: Runs tests on a Kubernetes cluster with Windows 20H2 nodes on GCE
 
@@ -197,7 +197,7 @@ periodics:
   annotations:
     fork-per-release: "true"
     fork-per-release-replacements: "--extract=ci/latest -> --extract=ci/latest-{{.Version}}"
-    testgrid-dashboards: google-windows, sig-windows-gce, sig-release-master-informing, sig-windows-master-release
+    testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-master-release
     testgrid-tab-name: gce-windows-2004-master
     description: Runs tests on a Kubernetes cluster with Windows 2004 nodes on GCE
 

--- a/config/testgrids/kubernetes/sig-windows/config.yaml
+++ b/config/testgrids/kubernetes/sig-windows/config.yaml
@@ -5,6 +5,7 @@ dashboard_groups:
     - sig-windows-1.18-release
     - sig-windows-1.19-release
     - sig-windows-1.20-release
+    - sig-windows-1.21-release
     - sig-windows-master-release
     - sig-windows-presubmit
     - sig-windows-gce
@@ -12,12 +13,13 @@ dashboard_groups:
     - sig-windows-containerd-hyperv
     - sig-windows-networking
     - sig-windows-containerd-runtime-signal
-      
+
 dashboards:
 - name: sig-windows-signal
 - name: sig-windows-1.18-release
 - name: sig-windows-1.19-release
 - name: sig-windows-1.20-release
+- name: sig-windows-1.21-release
 - name: sig-windows-master-release
 - name: sig-windows-presubmit
 - name: sig-windows-gce
@@ -66,7 +68,7 @@ dashboards:
   - name: win-2004-containerd-master-integration
     description: Runs containerd integration & cri-integration tests on Windows (SAC 2004)
     test_group_name: integration-containerd-windows-sac2004
- 
+
 test_groups:
 # Flannel CNI on Windows test groups
 - name: k8s-e2e-ltsc2019-docker-flannel-winbridge-dsr-disabled-master
@@ -97,5 +99,3 @@ test_groups:
 - name: integration-containerd-windows-sac2004
   gcs_prefix: containerd-integration/logs/windows-sac2004
   disable_prowjob_analysis: true
- 
-     


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

- created 1.21 release dashboard for sig-windows
- added additional aks-engine jobs for 1.20 with dockershim 
- removed all GCE jobs from sig-release-informing dashboards 

/hold
until https://github.com/kubernetes-sigs/windows-testing/pull/266 is merged