### PR TITLE
bump containerd version to v1.5.1

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -298,7 +298,7 @@ presubmits:
             - --build=quick
             - --cluster=
             - --env=KUBE_CONTAINER_RUNTIME=containerd
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.0
+            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.1
             - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc93
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=ENABLE_POD_SECURITY_POLICY=true
@@ -359,7 +359,7 @@ presubmits:
             - --build=quick
             - --cluster=
             - --env=KUBE_CONTAINER_RUNTIME=containerd
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.0
+            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.1
             - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc93
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=ENABLE_POD_SECURITY_POLICY=true
@@ -537,7 +537,7 @@ periodics:
           - --
           - --check-leaked-resources
           - --env=KUBE_CONTAINER_RUNTIME=containerd
-          - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.0
+          - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.1
           - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc93
           - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
           - --env=ENABLE_POD_SECURITY_POLICY=true

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -33,7 +33,7 @@ presubmits:
         - --env=ALLOW_PRIVILEGED=true
         - --env=NETWORK_POLICY_PROVIDER=calico
         - --env=KUBE_CONTAINER_RUNTIME=containerd
-        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.0
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.1
         - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc93
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -582,7 +582,7 @@ periodics:
       - --env=ALLOW_PRIVILEGED=true
       - --env=NETWORK_POLICY_PROVIDER=calico
       - --env=KUBE_CONTAINER_RUNTIME=containerd
-      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.0
+      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.1
       - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc93
       - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
       - --env=CONTAINER_RUNTIME_TEST_HANDLER=true


### PR DESCRIPTION
This PR bumps the `containerd` version to v1.5.1

Link to the new release: https://github.com/containerd/containerd/releases/tag/v1.5.1

Signed-off-by: Priyanka Saggu <priyankasaggu11929@gmail.com>