### PR TITLE
Set timeouts on conformance and E2E tests for cloud-provider-gcp

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
@@ -3,6 +3,8 @@ periodics:
   cluster: k8s-infra-prow-build
   name: ci-cloud-provider-gcp-conformance-latest
   decorate: true
+  decoration_config:
+    timeout: 200m
   annotations:
     testgrid-tab-name: Conformance - Cloud Provider GCP - master
     testgrid-dashboards: provider-gcp-periodics

--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
@@ -4,7 +4,7 @@ periodics:
   name: ci-cloud-provider-gcp-conformance-latest
   decorate: true
   decoration_config:
-    timeout: 200m
+    timeout: 150m
   annotations:
     testgrid-tab-name: Conformance - Cloud Provider GCP - master
     testgrid-dashboards: provider-gcp-periodics

--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -75,6 +75,8 @@ presubmits:
     always_run: false
     optional: true
     decorate: true
+    decoration_config:
+      timeout: 80m
     path_alias: k8s.io/cloud-provider-gcp
     labels:
       preset-service-account: "true"


### PR DESCRIPTION
This PR sets timeouts on the conformance and E2E tests; the conformance timeout is taken from [here](https://github.com/kubernetes/test-infra/blob/9608d71e179b34ab09eaa49be4b6134ddd930eab/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml#L155), and the E2E timeout is taken from [here](https://github.com/kubernetes/test-infra/blob/4aa7d1d86274a7261f97b9a5a599bb257cab9673/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml#L320).
