### PR TITLE
Update number of ginkgo nodes for windows capz e2e

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -239,6 +239,9 @@ presubmits:
         env:
         - name: WINDOWS
           value: "true"
+        # Windows isn't really conformance, we typically run at 4 to keep the time reasonable (~45 mins)
+        - name: CONFORMANCE_NODES
+          value: "4"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
Updating to increase the speed of the windows upstream e2e test: https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1119#discussion_r629673377

/cc @devigned @chewong @nader-ziada
