### PR TITLE
Kops - skip failing GCE test

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
@@ -37,7 +37,7 @@ periodics:
           --test-args="-test.timeout=60m -num-nodes=0" \
           --test-package-marker=latest.txt \
           --parallel=25 \
-          --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Firewall|Dashboard|RuntimeClass|RuntimeHandler|kube-dns|run.a.Pod.requesting.a.RuntimeClass|should.set.TCP.CLOSE_WAIT|Services.*rejected.*endpoints"
+          --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Firewall|Dashboard|RuntimeClass|RuntimeHandler|kube-dns|run.a.Pod.requesting.a.RuntimeClass|should.set.TCP.CLOSE_WAIT|Services.*rejected.*endpoints|should.be.mountable.when.non-attachable"
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/ssh-key-secret/ssh-private
@@ -104,7 +104,7 @@ periodics:
           --test-package-dir=ci \
           --test-package-marker=latest.txt \
           --parallel=25 \
-          --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Firewall|Dashboard|RuntimeClass|RuntimeHandler|kube-dns|run.a.Pod.requesting.a.RuntimeClass|should.set.TCP.CLOSE_WAIT|Services.*rejected.*endpoints"
+          --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Firewall|Dashboard|RuntimeClass|RuntimeHandler|kube-dns|run.a.Pod.requesting.a.RuntimeClass|should.set.TCP.CLOSE_WAIT|Services.*rejected.*endpoints|should.be.mountable.when.non-attachable"
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/ssh-key-secret/ssh-private


### PR DESCRIPTION
This test assumes that GCE clusters are running COS. Ours are currently using Ubuntu, so until the test is updated to detect this (like other e2e tests do) we'll need to skip it.

See https://github.com/kubernetes/kubernetes/blob/dc6b04c142a47885bff38a1d6f7c547c91d0343e/test/e2e/storage/flexvolume.go#L129-L136

and 

https://github.com/kubernetes/kubernetes/blob/dc6b04c142a47885bff38a1d6f7c547c91d0343e/test/e2e/storage/flexvolume.go#L42-L47