### PR TITLE
added path alias for depstat prow job

### DIFF
--- a/config/jobs/kubernetes/sig-arch/kubernetes-depstat.yaml
+++ b/config/jobs/kubernetes/sig-arch/kubernetes-depstat.yaml
@@ -2,6 +2,7 @@ presubmits:
   kubernetes/kubernetes:
   - name: check-dependency-stats
     decorate: true
+    path_alias: k8s.io/kubernetes
     always_run: false
     optional: true
     spec:


### PR DESCRIPTION
Signed-off-by: RinkiyaKeDad <arshsharma461@gmail.com>

Fix for the depstat prow job not running properly and giving the error:
```
/bin/bash: line 5: cd: /go/src/k8s.io/kubernetes: No such file or directory
```

/assign @dims 