### PR TITLE
added periodical for depstat

### DIFF
--- a/config/jobs/kubernetes/sig-arch/kubernetes-depstat-periodical.yaml
+++ b/config/jobs/kubernetes/sig-arch/kubernetes-depstat-periodical.yaml
@@ -1,0 +1,30 @@
+periodics:
+  kubernetes/kubernetes:
+  - interval: 6h
+    name: check-dependency-stats-periodical
+    decorate: true
+    path_alias: k8s.io/kubernetes
+    always_run: false
+    optional: true
+    spec:
+      containers:
+      - image: golang
+        command:
+        - /bin/bash
+        args:
+        - -c
+        - |
+          set -euo; \
+          export PATH=$PATH:$GOPATH/bin; \
+          mkdir -p "${ARTIFACTS}"; \
+          pushd "$ARTIFACTS"; \
+          go install github.com/kubernetes-sigs/depstat@latest; \
+          popd; \
+          depstat stats --json > "${ARTIFACTS}/stats.json"; \
+          git checkout -b base "${PULL_BASE_SHA}"; \
+          depstat stats --json > "${ARTIFACTS}/stats-base.json"; \
+          diff -s --ignore-all-space "${ARTIFACTS}"/stats-base.json "${ARTIFACTS}"/stats.json || true;
+    annotations:
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: sig-testing-misc
+      description: Generates dependency statistics by running depstat for base and current PR periodically

--- a/config/jobs/kubernetes/sig-arch/kubernetes-depstat-periodical.yaml
+++ b/config/jobs/kubernetes/sig-arch/kubernetes-depstat-periodical.yaml
@@ -1,9 +1,12 @@
 periodics:
-  kubernetes/kubernetes:
   - interval: 6h
     name: check-dependency-stats-periodical
     decorate: true
-    path_alias: k8s.io/kubernetes
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     always_run: false
     optional: true
     spec:

--- a/config/jobs/kubernetes/sig-arch/kubernetes-depstat-periodical.yaml
+++ b/config/jobs/kubernetes/sig-arch/kubernetes-depstat-periodical.yaml
@@ -7,8 +7,6 @@ periodics:
       repo: kubernetes
       base_ref: master
       path_alias: k8s.io/kubernetes
-    always_run: false
-    optional: true
     spec:
       containers:
       - image: golang


### PR DESCRIPTION
Signed-off-by: RinkiyaKeDad <arshsharma461@gmail.com>

Added a periodical job for depstat based on the [previous one](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-arch/kubernetes-depstat.yaml). Please let me know if [name](https://github.com/kubernetes/test-infra/compare/master...RinkiyaKeDad:depstat_periodical?expand=1#diff-9ae83e83dcb890a759fd567fc08d0b8c2bd4671f11ece4fe79e1ad5b62b58514R4), [description](https://github.com/kubernetes/test-infra/compare/master...RinkiyaKeDad:depstat_periodical?expand=1#diff-9ae83e83dcb890a759fd567fc08d0b8c2bd4671f11ece4fe79e1ad5b62b58514R30) or something else needs to be changed.

/assign @dims 