### PR TITLE
Enable DSR mode for Windows 20H2 test runs

### DIFF
--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -141,6 +141,8 @@ periodics:
       env:
       - name: WINDOWS_NODE_OS_DISTRIBUTION
         value: "win20h2"
+      - name: WINDOWS_ENABLE_DSR
+        value: "true"
       - name: PREPULL_YAML
         value: "prepull-head.yaml"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210509-00de27f-master


### PR DESCRIPTION
Enables running GCE Windows 20H2 test runs with kube-proxy configured to run with DSR mode.
/sig windows
/cc @anfernee 