### PR TITLE
Adjust the timeout to 40m for scheduler-plugins integration test

### DIFF
--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-master.yaml
@@ -42,6 +42,8 @@ presubmits:
         - unit-test
   - name: pull-scheduler-plugins-integration-test-master
     decorate: true
+    decoration_config:
+      timeout: 40m
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
     - ^master$

--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.18.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.18.yaml
@@ -42,6 +42,8 @@ presubmits:
         - unit-test
   - name: pull-scheduler-plugins-integration-test-release-1-18
     decorate: true
+    decoration_config:
+      timeout: 40m
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
     - ^release-1.18$

--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.19.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.19.yaml
@@ -42,6 +42,8 @@ presubmits:
         - unit-test
   - name: pull-scheduler-plugins-integration-test-release-1-19
     decorate: true
+    decoration_config:
+      timeout: 40m
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
     - ^release-1.19$


### PR DESCRIPTION
The scheduler-plugins doesn't store /vendor folder, also the integration test may need to download and install etcd. These steps take a certain amount of execution time in the integration test suite. Recently we added several integration tests, and noticed the test times out frequent than before.

This PR specifies the timeout as 40m (default value is 10m?) to help us narrow down the root cause: if the timeout is due to coding bugs, or pure time out.