### PR TITLE
Bump kustomize pre-submit test to use Go 1.16

### DIFF
--- a/config/jobs/kubernetes-sigs/kustomize/kustomize-presubmit-master.yaml
+++ b/config/jobs/kubernetes-sigs/kustomize/kustomize-presubmit-master.yaml
@@ -8,7 +8,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: golang:1.13
+      - image: golang:1.16
         command:
         - make
         args:


### PR DESCRIPTION
@monopole This is why presubmit is failing on my latest PR. Can we upgrade to 1.16? https://github.com/kubernetes-sigs/kustomize/pull/3899