### PR TITLE
Add test job for E2E Test Framework project

### DIFF
--- a/config/jobs/kubernetes-sigs/e2e-framework/OWNERS
+++ b/config/jobs/kubernetes-sigs/e2e-framework/OWNERS
@@ -1,15 +1,19 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - andrewsykim
-  - alejandrox1
-  - BenTheElder
-  - spiffxp
+- andrewsykim
+- BenTheElder
+- spiffxp
+- vladimirvivien
 reviewers:
-  - andrewsykim
-  - alejandrox1
-  - BenTheElder
-  - spiffxp
+- andrewsykim
+- BenTheElder
+- cpanato
+- spiffxp
+- vladimirvivien
+
+emeritus_approvers:
+- alejandrox1
 
 labels:
 - sig/testing

--- a/config/jobs/kubernetes-sigs/e2e-framework/e2e-framework-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/e2e-framework/e2e-framework-presubmits.yaml
@@ -15,3 +15,18 @@ presubmits:
       testgrid-tab-name: pull-e2e-framework-verify
       testgrid-num-columns-recent: '30'
       testgrid-create-test-group: 'true'
+  - name: pull-e2e-framework-test
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/e2e-framework
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest
+        command:
+        - make
+        - test
+    annotations:
+      testgrid-dashboards: sig-testing-e2e-framework
+      testgrid-tab-name: pull-e2e-framework-test
+      testgrid-num-columns-recent: '30'
+      testgrid-create-test-group: 'true'


### PR DESCRIPTION
- Add go test prow job for the E2E-test-framework project
- Sync OWNERS file 

Merge this first and then validate here: https://github.com/kubernetes-sigs/e2e-framework/pull/14

/assign @spiffxp @vladimirvivien 