### PR TITLE
Add pull-cluster-api-e2e-ipv6-main

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -138,6 +138,41 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-e2e-main
+  - name: pull-cluster-api-e2e-ipv6-main
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decorate: true
+    optional: true
+    branches:
+    # The script this job runs is not in all branches.
+    - ^master$
+    path_alias: sigs.k8s.io/cluster-api
+    run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|errors|exp|feature|hack|scripts|test|third_party|util)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210509-00de27f-go-canary
+        args:
+          - runner.sh
+          - "./scripts/ci-e2e.sh"
+        env:
+          - name: GINKGO_FOCUS
+            value: "\\[PR-Blocking\\]"
+          - name: IP_FAMILY
+            value: "IPv6"
+          - name: DOCKER_SERVICE_CIDRS
+            value: "fd00:100:64::/108"
+          - name: DOCKER_POD_CIDRS
+            value: "fd00:100:64::/108"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 7300m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+      testgrid-tab-name: capi-pr-e2e-main-ipv6
   - name: pull-cluster-api-e2e-full-main
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
This runs the "quickstart" e2e test w/ IPv6 configuration again pull requests to Cluster API as an optional job.

That test is currently the only test marked as `[PR-Blocking]`, though this job is tagged as `optional: true` so it won't block merging PRs. An initial PR for IPv6 support in CAPD was just recently merged so we are marking this optional until we have more confidence in the stability of the feature and test.

Related PR in cluster-api:
https://github.com/kubernetes-sigs/cluster-api/pull/4558

cc @fabriziopandini @christianang