### PR TITLE
add a job to run unit tests

### DIFF
--- a/config/jobs/kubernetes-sigs/e2e-framework/e2e-framework-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/e2e-framework/e2e-framework-presubmits.yaml
@@ -15,3 +15,20 @@ presubmits:
       testgrid-tab-name: pull-e2e-framework-verify
       testgrid-num-columns-recent: '30'
       testgrid-create-test-group: 'true'
+  - name: pull-e2e-framework-unit-tests
+    decorate: true
+    path_alias: sigs.k8s.io/e2e-framework
+    always_run: true
+    spec:
+      containers:
+        - image: golang:1.16
+          command:
+            - "go"
+          args:
+            - "test"
+            - "./..."
+          env:
+            - name: GO111MODULE
+              value: "on"
+    annotations:
+      description: "Run unit tests on e2e-framework."


### PR DESCRIPTION
### What type of PR is this?
/kind enhancement

### What this PR does / why we need it:
When PR is submitted on `kubernetes-sigs/e2e-framework` k8s-ci not validating the unit tests exists in the repo. 
This job is added to fix the same.

Which issue(s) this PR fixes:
Fixes #22223