### PR TITLE
Enable WinDSR for GCE Windows in 2004 and containerd variants.

### DIFF
--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -22,6 +22,8 @@ presets:
     value: "containerd"
   - name: PREPULL_TIMEOUT
     value: "30m"
+  - name: WINDOWS_ENABLE_DSR
+    value: "true"
 - labels:
     preset-load-gce-windows: "true"
   env:
@@ -193,6 +195,8 @@ periodics:
       env:
       - name: WINDOWS_NODE_OS_DISTRIBUTION
         value: "win2004"
+      - name: WINDOWS_ENABLE_DSR
+        value: "true"
       - name: PREPULL_YAML
         value: "prepull-head.yaml"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210512-b8d1b30-master


### PR DESCRIPTION
This change is a continuation of enabling Windows DSR mode for GCE Windows. This change enables Windows DSR mode for 2004 and containerd test variants.

One of the containerd test variants include Windows Server 2019. If the tests continue to be green there I'll wrap up by enabling the tests for 1.21+ docker and all containerd for all GCE Windows dashboards.

Original PR: https://github.com/kubernetes/test-infra/pull/22202

/sig windows
/cc @anfernee 
/cc @ibabou 