### PR TITLE
Bump kubebuilder version from 1.15 to 1.16

### DIFF
--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - ^feature/plugins-.+$
     spec:
       containers:
-      - image: golang:1.15
+      - image: golang:1.16
         command:
         - ./test.sh
         resources:


### PR DESCRIPTION
Bump kubebuilder version from 1.15 to 1.16 https://github.com/kubernetes-sigs/kubebuilder/pull/2182

Signed-off-by: sujil02 <sujil.shah@gmail.com>