### PR TITLE
Add triage and maintain to peribolos

### DIFF
--- a/prow/cmd/peribolos/main.go
+++ b/prow/cmd/peribolos/main.go
@@ -1209,6 +1209,10 @@ func configureTeamRepos(client teamRepoClient, githubTeams map[string]github.Tea
 			err = client.UpdateTeamRepo(gt.ID, orgName, repo, github.RepoPush)
 		case github.Read:
 			err = client.UpdateTeamRepo(gt.ID, orgName, repo, github.RepoPull)
+		case github.Triage:
+			err = client.UpdateTeamRepo(gt.ID, orgName, repo, github.RepoTriage)
+		case github.Maintain:
+			err = client.UpdateTeamRepo(gt.ID, orgName, repo, github.RepoMaintain)
 		}
 
 		if err != nil {

--- a/prow/cmd/peribolos/main_test.go
+++ b/prow/cmd/peribolos/main_test.go
@@ -2343,19 +2343,25 @@ func TestConfigureTeamRepos(t *testing.T) {
 			teamName:    "team",
 			team: org.Team{
 				Repos: map[string]github.RepoPermissionLevel{
-					"read":  github.Read,
-					"write": github.Write,
-					"admin": github.Admin,
+					"read":     github.Read,
+					"triage":   github.Triage,
+					"write":    github.Write,
+					"maintain": github.Maintain,
+					"admin":    github.Admin,
 				},
 			},
 			existingRepos: map[int][]github.Repo{1: {
 				{Name: "read", Permissions: github.RepoPermissions{Pull: true}},
+				{Name: "triage", Permissions: github.RepoPermissions{Pull: true, Triage: true}},
 				{Name: "write", Permissions: github.RepoPermissions{Pull: true, Triage: true, Push: true}},
+				{Name: "maintain", Permissions: github.RepoPermissions{Pull: true, Triage: true, Push: true, Maintain: true}},
 				{Name: "admin", Permissions: github.RepoPermissions{Pull: true, Triage: true, Push: true, Maintain: true, Admin: true}},
 			}},
 			expected: map[int][]github.Repo{1: {
 				{Name: "read", Permissions: github.RepoPermissions{Pull: true}},
+				{Name: "triage", Permissions: github.RepoPermissions{Pull: true, Triage: true}},
 				{Name: "write", Permissions: github.RepoPermissions{Pull: true, Triage: true, Push: true}},
+				{Name: "maintain", Permissions: github.RepoPermissions{Pull: true, Triage: true, Push: true, Maintain: true}},
 				{Name: "admin", Permissions: github.RepoPermissions{Pull: true, Triage: true, Push: true, Maintain: true, Admin: true}},
 			}},
 		},


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/21526/ added `triage` and `maintain` GitHub permissions to the GitHub library. This adds those same permissions to peribolos.