### PR TITLE
replace aks-engine with capz for disk presubmit

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
@@ -50,6 +50,55 @@ presubmits:
       testgrid-tab-name: pull-kubernetes-e2e-aks-engine-conformance
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       testgrid-num-columns-recent: '30'
+  - name: pull-kubernetes-e2e-capz-azure-disk
+    decorate: true
+    always_run: false
+    optional: true
+    run_if_changed: 'azure.*\.go'
+    path_alias: k8s.io/kubernetes
+    branches:
+      - master
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: cluster-api-provider-azure
+        base_ref: master
+        path_alias: sigs.k8s.io/cluster-api-provider-azure
+        workdir: true
+      - org: kubernetes-sigs
+        repo: azuredisk-csi-driver
+        base_ref: master
+        path_alias: sigs.k8s.io/azuredisk-csi-driver
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210512-b8d1b30-master
+          command:
+            - runner.sh
+            - ./scripts/ci-entrypoint.sh
+          args:
+            - bash
+            - -c
+            - >-
+              cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver &&
+              make e2e-test
+          env:
+            - name: AZURE_STORAGE_DRIVER
+              value: kubernetes.io/azure-disk # In-tree Azure disk storage class
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 1
+              memory: "4Gi"
+    annotations:
+      testgrid-dashboards: provider-azure-presubmit
+      testgrid-tab-name: pull-kubernetes-e2e-capz-azure-disk
+      testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+      testgrid-num-columns-recent: '30'
   - name: pull-kubernetes-e2e-aks-engine-azure-disk-vmas
     decorate: true
     always_run: false


### PR DESCRIPTION
Add presubmit disk job using Cluster API Provider Azure to provision cluster resources.

Related: https://github.com/Azure/container-compute-upstream/issues/101

/cc @chewong @CecileRobertMichon @andyzhangx 