### PR TITLE
prow/clonerefs: If multiple refs share repos but not paths, allow

### DIFF
--- a/prow/clonerefs/BUILD.bazel
+++ b/prow/clonerefs/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/pod-utils/clone:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
-        "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
     ],
 )
 


### PR DESCRIPTION
clonerefs has simple detection of an error "you can't clone this repo twice". However, with addition of PathAlias it would be safe
to allow someone to clone two repos at two different paths (such as when setting up a job that did a diff between two versions of the tree or did a before/after test by running code in each).

Alter clonerefs to check the destination which is the true conflict (clone twice to same path is wierd). To preserve backwards
compatibility, only error when the repo/org are the same and have the same path (normal error), and warn if two different refs would collide because path_alias collides (not ideal, but we don't know how many others could be in that state today).

Example new error message:

```
{"component":"unset","file":"/home/clayton/projects/origin/src/k8s.io/test-infra/prow/cmd/clonerefs/main.go:36","func":"main.main","level":"fatal","msg":"Invalid options: clone ref config 1 (for openshift/cluster-kube-apiserver-operator) will be extracted to /tmp/biz/src/github.com/openshift/cluster-kube-apiserver-operator, which clone ref 0 (for openshift/cluster-kube-apiserver-operator) is also using","severity":"fatal","time":"2021-05-18T17:29:25-04:00"}
```

Enables using a prow job that can compile code from two different PRs / versions of the repo and compare the results.