### PR TITLE
running depstat prow job automatically when dependencies change

### DIFF
--- a/config/jobs/kubernetes/sig-arch/kubernetes-depstat.yaml
+++ b/config/jobs/kubernetes/sig-arch/kubernetes-depstat.yaml
@@ -5,6 +5,7 @@ presubmits:
     path_alias: k8s.io/kubernetes
     always_run: false
     optional: true
+    run_if_changed: '/go.(mod|sum)|vendor/'
     spec:
       containers:
       - image: golang

--- a/config/jobs/kubernetes/sig-arch/kubernetes-depstat.yaml
+++ b/config/jobs/kubernetes/sig-arch/kubernetes-depstat.yaml
@@ -5,7 +5,7 @@ presubmits:
     path_alias: k8s.io/kubernetes
     always_run: false
     optional: true
-    run_if_changed: '/go.(mod|sum)|vendor/'
+    run_if_changed: '^(go.mod|go.sum|vendor)'
     spec:
       containers:
       - image: golang


### PR DESCRIPTION
Signed-off-by: RinkiyaKeDad <arshsharma461@gmail.com>

As discussed in the last SIG-testing meeting, added `run_if_changed` for the depstat prow job so that it runs automatically whenever a PR with dependency changes is made.

/assign @dims @spiffxp 