### PR TITLE
kubernetes-csi: test csi-release-tools against csi-driver-host-path

### DIFF
--- a/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
@@ -176,3 +176,51 @@ presubmits:
         resources:
           requests:
             cpu: 2000m
+  - name: pull-kubernetes-csi-release-tools-csi-driver-host-path
+    always_run: true
+    optional: true # cannot be required because updates in csi-release-tools may include breaking changes
+    decorate: true
+    skip_report: false
+    extra_refs:
+    - org: kubernetes-csi
+      repo: csi-driver-host-path
+      base_ref: master
+      workdir: false
+      # Checked out in /home/prow/go/src/github.com/kubernetes-csi/csi-driver-host-path
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-other
+      testgrid-tab-name: pull-csi-release-tools-in-csi-driver-host-path
+      description: Kubernetes-CSI pull job in repo csi-release-tools for csi-driver-host-path, using deployment 1.20 on Kubernetes 1.20
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210418-e5f251e-master
+        command:
+        - runner.sh
+        args:
+        - ./pull-test.sh # provided by csi-release-tools
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.20.0"
+        - name: CSI_PROW_USE_BAZEL
+          value: "true"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.20"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.6.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v4.0.0"
+        - name: CSI_PROW_TESTS
+          value: "unit sanity parallel"
+        - name: PULL_TEST_REPO_DIR
+          value: /home/prow/go/src/github.com/kubernetes-csi/csi-driver-host-path
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 2000m

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -66,11 +66,12 @@ node-driver-registrar
 # All kubernetes-csi repos for which want to define pull tests for
 # the csi-release-tools repo. Ideally, this list should represent
 # different ways of using csi-release-tools (for example, single image
-# vs. multiple images per repo).
+# vs. multiple images per repo). csi-sanity tests are used by csi-driver-host-path.
 csi_release_tools_repos="
 csi-test
 external-provisioner
 external-snapshotter
+csi-driver-host-path
 "
 
 # kubernetes-csi repos which only need to be tested against at most a


### PR DESCRIPTION
Only csi-driver-host-path uses the csi-sanity support in
prow.sh. Because it wasn't tested, a regression slipped through pull
testing (https://github.com/kubernetes-csi/csi-release-tools/pull/148#issuecomment-844246869).