### PR TITLE
Crier gerrit reporter: don't ignore aborted jobs

### DIFF
--- a/prow/crier/reporters/gerrit/reporter.go
+++ b/prow/crier/reporters/gerrit/reporter.go
@@ -237,9 +237,6 @@ func (c *Client) Report(ctx context.Context, logger *logrus.Entry, pj *v1.ProwJo
 			}
 		}
 		for _, pjOnRevisionWithSameLabel := range mostRecentJob {
-			if pjOnRevisionWithSameLabel.Status.State == v1.AbortedState {
-				continue
-			}
 			toReportJobs = append(toReportJobs, pjOnRevisionWithSameLabel)
 		}
 	}
@@ -258,7 +255,7 @@ func (c *Client) Report(ctx context.Context, logger *logrus.Entry, pj *v1.ProwJo
 
 	if report.Total <= 0 {
 		// Shouldn't happen but return if does
-		logger.Warn("Tried to report empty or aborted jobs.")
+		logger.Warn("Tried to report empty jobs.")
 		return nil, nil, nil
 	}
 	var reviewLabels map[string]string

--- a/prow/crier/reporters/gerrit/reporter_test.go
+++ b/prow/crier/reporters/gerrit/reporter_test.go
@@ -681,7 +681,7 @@ func TestReport(t *testing.T) {
 			numExpectedReport: 2,
 		},
 		{
-			name: "2 jobs, one passed, one aborted, should report but skip aborted job",
+			name: "2 jobs, one passed, one aborted, should report",
 			pj: &v1.ProwJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -702,7 +702,8 @@ func TestReport(t *testing.T) {
 					Refs: &v1.Refs{
 						Repo: "foo",
 					},
-					Job: "ci-foo",
+					Job:  "ci-foo",
+					Type: v1.PresubmitJob,
 				},
 			},
 			existingPJs: []*v1.ProwJob{
@@ -726,15 +727,15 @@ func TestReport(t *testing.T) {
 						Refs: &v1.Refs{
 							Repo: "bar",
 						},
-						Job: "ci-bar",
+						Job:  "ci-bar",
+						Type: v1.PresubmitJob,
 					},
 				},
 			},
 			expectReport:      true,
-			reportInclude:     []string{"1 out of 1", "ci-foo", "SUCCESS", "guber/foo"},
-			reportExclude:     []string{"2", "0", "FAILURE", "ABORTED", "ci-bar", "guber/bar"},
-			expectLabel:       map[string]string{codeReview: lgtm},
-			numExpectedReport: 1,
+			reportInclude:     []string{"1 out of 2", "ci-foo", "SUCCESS", "guber/foo"},
+			expectLabel:       map[string]string{codeReview: lbtm},
+			numExpectedReport: 2,
 		},
 		{
 			name: "postsubmit after presubmit on same revision, should report separately",


### PR DESCRIPTION
When there are 5 jobs, 4 passed, 1 aborted, gerrit reports +1 on the PR, while it should report -1 instead. This PR fixes the problem.

The concern of reporting all aborted jobs from previous batch was addressed by ShouldReport function