### PR TITLE
label_sync(releng): Add area/release-eng label to kubernetes/website

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -458,6 +458,7 @@ larger set of contributors to apply/remove them.
 | ---- | ----------- | -------- | --- |
 | <a id="area/blog" href="#area/blog">`area/blog`</a> | Issues or PRs related to the Kubernetes Blog subproject| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="area/contributor-comms" href="#area/contributor-comms">`area/contributor-comms`</a> | Issues or PRs related to the upstream marketing team| humans | |
+| <a id="area/release-eng" href="#area/release-eng">`area/release-eng`</a> | Issues or PRs related to the Release Engineering subproject| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="area/web-development" href="#area/web-development">`area/web-development`</a> | Issues or PRs related to the kubernetes.io's infrastructure, design, or build processes| humans | |
 | <a id="language/ar" href="#language/ar">`language/ar`</a> | Issues or PRs related to Arabic language| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="language/de" href="#language/de">`language/de`</a> | Issues or PRs related to German language| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -1388,6 +1388,12 @@ repos:
         target: both
         addedBy: humans
       - color: 0052cc
+        description: Issues or PRs related to the Release Engineering subproject
+        name: area/release-eng
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: 0052cc
         description: Issues or PRs related to the kubernetes.io's infrastructure, design, or build processes
         name: area/web-development
         target: both


### PR DESCRIPTION
SIG Release / Release Engineering content is actively being migrated
to kubernetes/website. This gives us a way to label/filter issues/PRs
for review.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

Needed for https://github.com/kubernetes/website/pull/27997.
cc: @kubernetes/release-engineering @sftim 