### PR TITLE
tide: stop adding query strings to errors

### DIFF
--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -437,7 +437,7 @@ func (c *Controller) query() (map[string]PullRequest, error) {
 	wg := sync.WaitGroup{}
 	prs := make(map[string]PullRequest)
 	var errs []error
-	for _, query := range c.config().Tide.Queries {
+	for i, query := range c.config().Tide.Queries {
 
 		// Use org-sharded queries only when GitHub apps auth is in use
 		var queries map[string]string
@@ -457,7 +457,8 @@ func (c *Controller) query() (map[string]PullRequest, error) {
 				defer lock.Unlock()
 
 				if err != nil && len(results) == 0 {
-					errs = append(errs, fmt.Errorf("query %q, err: %v", q, err))
+					c.logger.WithField("query", q).WithError(err).Warn("Failed to execute query.")
+					errs = append(errs, fmt.Errorf("query %d, err: %v", i, err))
 					return
 				}
 				if err != nil {


### PR DESCRIPTION
Since we've got structured logging, we should emit a log with the query
in a structured manner so as to not bubble up what is usually a multi-
thousand-character query string to callers. Right now, it's very
annoying to have logs filtered by error fairly unreadable due to this
type of logging. A user can opt into reading the query if they want by
looking at the more verbose log.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @alvaroaleman @cjwagner 