### PR TITLE
Use kubernetes/test-infra log_dump.sh to dump logs.

### DIFF
--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -8,6 +8,8 @@ presets:
     value: "windows"
   - name: KUBELET_TEST_ARGS
     value: "--feature-gates=KubeletPodResources=false"
+  - name: USE_TEST_INFRA_LOG_DUMPING
+    value: "true"
 - labels:
     preset-e2e-gce-windows: "true"
   env:


### PR DESCRIPTION
The log_dump.sh in k/k repo is migrated to k/test-infra: https://github.com/kubernetes/kubernetes/blob/master/cluster/log-dump/README.md. 
So according to the migration steps, need to add `USE_TEST_INFRA_LOG_DUMPING=true` to use it.

On the other hand, I use this PR for verification as well, as running kubetest locally seems not easy. And we can run `/test pull-kubernetes-e2e-windows-gce` to trigger a test to verify whether expected logs are collected in artifacts.