### PR TITLE
Add ExternalSecret CR for snyk_token

### DIFF
--- a/config/prow/cluster/build_kubernetes-external-secrets_customresource.yaml
+++ b/config/prow/cluster/build_kubernetes-external-secrets_customresource.yaml
@@ -17,12 +17,12 @@ spec:
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
-  name: snyk_token
+  name: snyk-token
   namespace: test-pods
 spec:
   backendType: gcpSecretsManager
   projectId: k8s-infra-prow-build-trusted # gsm project id
   data:
-  - key: snyk_token  # name of the GCP secret
+  - key: snyk-token  # name of the GCP secret
     name: SNYK_TOKEN  # key name in the k8s secret
     version: latest

--- a/config/prow/cluster/build_kubernetes-external-secrets_customresource.yaml
+++ b/config/prow/cluster/build_kubernetes-external-secrets_customresource.yaml
@@ -21,7 +21,7 @@ metadata:
   namespace: test-pods
 spec:
   backendType: gcpSecretsManager
-  projectId: kubernetes-upstream # gsm project id
+  projectId: k8s-infra-prow-build-trusted # gsm project id
   data:
   - key: snyk_token  # name of the GCP secret
     name: SNYK_TOKEN  # key name in the k8s secret

--- a/config/prow/cluster/build_kubernetes-external-secrets_customresource.yaml
+++ b/config/prow/cluster/build_kubernetes-external-secrets_customresource.yaml
@@ -13,3 +13,16 @@ spec:
   - key: azure-cred
     name: credentials
     version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: snyk_token
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: kubernetes-upstream # gsm project id
+  data:
+  - key: snyk_token  # name of the GCP secret
+    name: SNYK_TOKEN  # key name in the k8s secret
+    version: latest

--- a/config/prow/cluster/kubernetes_external_secrets.yaml
+++ b/config/prow/cluster/kubernetes_external_secrets.yaml
@@ -39,3 +39,16 @@ spec:
   - key: gke_k8s-prow_us-central1-f_prow__prow-monitoring__grafana
     name: password
     version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: snyk_token
+  namespace: prow-test
+spec:
+  backendType: gcpSecretsManager
+  projectId: k8s-prow
+  data:
+  - key: snyk_token  # name of the GCP secret
+    name: SNYK_TOKEN  # key name in the k8s secret
+    version: latest

--- a/config/prow/cluster/kubernetes_external_secrets.yaml
+++ b/config/prow/cluster/kubernetes_external_secrets.yaml
@@ -39,16 +39,3 @@ spec:
   - key: gke_k8s-prow_us-central1-f_prow__prow-monitoring__grafana
     name: password
     version: latest
----
-apiVersion: kubernetes-client.io/v1
-kind: ExternalSecret
-metadata:
-  name: snyk_token
-  namespace: prow-test
-spec:
-  backendType: gcpSecretsManager
-  projectId: k8s-prow
-  data:
-  - key: snyk_token  # name of the GCP secret
-    name: SNYK_TOKEN  # key name in the k8s secret
-    version: latest


### PR DESCRIPTION
 - This CR brings snyk_token defined in google secret manager
   into test infra for running periodic snyk CI job.
 - this secret is referred in https://github.com/kubernetes/test-infra/pull/22293

xref:  https://github.com/kubernetes/kubernetes/issues/101528
 
/cc: @cjwagner @spiffxp 