### PR TITLE
added timeout for depstat jobs

### DIFF
--- a/config/jobs/kubernetes/sig-arch/kubernetes-depstat-periodical.yaml
+++ b/config/jobs/kubernetes/sig-arch/kubernetes-depstat-periodical.yaml
@@ -2,6 +2,8 @@ periodics:
   - interval: 6h
     name: check-dependency-stats-periodical
     decorate: true
+    decoration_config:
+      timeout: 5m
     extra_refs:
     - org: kubernetes
       repo: kubernetes

--- a/config/jobs/kubernetes/sig-arch/kubernetes-depstat.yaml
+++ b/config/jobs/kubernetes/sig-arch/kubernetes-depstat.yaml
@@ -2,6 +2,8 @@ presubmits:
   kubernetes/kubernetes:
   - name: check-dependency-stats
     decorate: true
+    decoration_config:
+      timeout: 5m
     path_alias: k8s.io/kubernetes
     always_run: false
     optional: true


### PR DESCRIPTION
Signed-off-by: RinkiyaKeDad <arshsharma461@gmail.com>

Added a timeout of 5 mins for both the depstat jobs. For context, running on k/k currently takes ~1 min. Timeout will help detect if we face the long time to produce results problem for k/k also at some point.

/assign @dims 