### PR TITLE
CAPN Presubmit - removing old branch references

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-nested/cluster-api-provider-nested-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-nested/cluster-api-provider-nested-presubmits.yaml
@@ -8,7 +8,6 @@ presubmits:
     branches:
     # The script this job runs is not in all branches.
     - ^main$
-    - ^master$
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210512-b8d1b30-master
@@ -29,7 +28,6 @@ presubmits:
     branches:
     # The script this job runs is not in all branches.
     - ^main$
-    - ^master$
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210512-b8d1b30-master
@@ -53,7 +51,6 @@ presubmits:
     branches:
     # The script this job runs is not in all branches.
     - ^main$
-    - ^master$
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210512-b8d1b30-master


### PR DESCRIPTION
This cleans up the last references to `master` branch, although still is using image names with `master` in the tag, this will require more investigation.

## Related

Closes https://github.com/kubernetes-sigs/cluster-api-provider-nested/issues/67

Signed-off-by: Chris Hein <me@chrishein.com>