### PR TITLE
Upload extra targets after the primary ones

### DIFF
--- a/prow/gcsupload/BUILD.bazel
+++ b/prow/gcsupload/BUILD.bazel
@@ -31,7 +31,8 @@ go_test(
         "//prow/flagutil:go_default_library",
         "//prow/pod-utils/downwardapi:go_default_library",
         "//prow/pod-utils/gcs:go_default_library",
-        "@io_k8s_apimachinery//pkg/util/diff:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
     ],
 )
 


### PR DESCRIPTION
This will allow us to upload the finished.json after the other targets,
which will minimize the amount of time between when finished.json is
uploaded and the prowjob completes.

fixes https://github.com/kubernetes/test-infra/issues/22285