### PR TITLE
Supplemental plugin config loading: Return errors

### DIFF
--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/kubernetes"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"sigs.k8s.io/yaml"
@@ -267,6 +268,9 @@ func (pa *ConfigAgent) Load(path string, supplementalPluginConfigDirs []string, 
 
 	var errs []error
 	for _, supplementalPluginConfigDir := range supplementalPluginConfigDirs {
+		if supplementalPluginConfigFileSuffix == "" {
+			break
+		}
 		if err := filepath.Walk(supplementalPluginConfigDir, func(path string, info fs.FileInfo, err error) error {
 			if err != nil {
 				return err
@@ -296,6 +300,9 @@ func (pa *ConfigAgent) Load(path string, supplementalPluginConfigDirs []string, 
 		}); err != nil {
 			errs = append(errs, fmt.Errorf("failed to walk %s: %w", supplementalPluginConfigDir, err))
 		}
+	}
+	if err := utilerrors.NewAggregate(errs); err != nil {
+		return err
 	}
 
 	if err := np.Validate(); err != nil {


### PR DESCRIPTION
Right now we just silently swallow errors from reading or unmarshalling
supplemental plugin config files.

/cc @chaodaiG 
I thought the linter would notice assign-but-never-read-from-slice like here :(