### PR TITLE
kubernetes-csi: use hostpath driver v1.7.2

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
@@ -39,7 +39,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v3.0.3"
         - name: CSI_PROW_TESTS
@@ -81,7 +81,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -135,7 +135,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v3.0.3"
         - name: CSI_PROW_TESTS
@@ -177,7 +177,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -231,7 +231,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v4.0.0"
         - name: CSI_PROW_TESTS
@@ -273,7 +273,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -327,7 +327,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v4.0.0"
         - name: CSI_PROW_TESTS
@@ -373,7 +373,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -427,7 +427,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v4.0.0"
         - name: CSI_PROW_TESTS
@@ -475,7 +475,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: "-test"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v3.0.3"
         - name: CSI_PROW_TESTS
@@ -517,7 +517,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: "-test"
         - name: CSI_SNAPSHOTTER_VERSION
@@ -571,7 +571,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: "-test"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v3.0.3"
         - name: CSI_PROW_TESTS
@@ -613,7 +613,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: "-test"
         - name: CSI_SNAPSHOTTER_VERSION
@@ -667,7 +667,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: "-test"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v4.0.0"
         - name: CSI_PROW_TESTS
@@ -709,7 +709,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: "-test"
         - name: CSI_SNAPSHOTTER_VERSION
@@ -763,7 +763,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: "-test"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v4.0.0"
         - name: CSI_PROW_TESTS
@@ -809,7 +809,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: "-test"
         - name: CSI_SNAPSHOTTER_VERSION
@@ -863,7 +863,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: "-test"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v4.0.0"
         - name: CSI_PROW_TESTS

--- a/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
@@ -67,7 +67,7 @@ presubmits:
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
           value: "1.20"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v4.0.0"
         - name: CSI_PROW_TESTS
@@ -115,7 +115,7 @@ presubmits:
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
           value: "1.20"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v4.0.0"
         - name: CSI_PROW_TESTS
@@ -163,7 +163,7 @@ presubmits:
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
           value: "1.20"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v4.0.0"
         - name: CSI_PROW_TESTS
@@ -211,7 +211,7 @@ presubmits:
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
           value: "1.20"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v4.0.0"
         - name: CSI_PROW_TESTS

--- a/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
+++ b/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
@@ -39,7 +39,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v3.0.3"
         - name: CSI_PROW_TESTS
@@ -81,7 +81,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -135,7 +135,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v3.0.3"
         - name: CSI_PROW_TESTS
@@ -177,7 +177,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -231,7 +231,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v4.0.0"
         - name: CSI_PROW_TESTS
@@ -273,7 +273,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -327,7 +327,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v4.0.0"
         - name: CSI_PROW_TESTS
@@ -373,7 +373,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -427,7 +427,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v4.0.0"
         - name: CSI_PROW_TESTS

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
@@ -39,7 +39,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v3.0.3"
         - name: CSI_PROW_TESTS
@@ -81,7 +81,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -135,7 +135,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v3.0.3"
         - name: CSI_PROW_TESTS
@@ -177,7 +177,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -231,7 +231,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v4.0.0"
         - name: CSI_PROW_TESTS
@@ -273,7 +273,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -327,7 +327,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v4.0.0"
         - name: CSI_PROW_TESTS
@@ -373,7 +373,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -427,7 +427,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v4.0.0"
         - name: CSI_PROW_TESTS

--- a/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
+++ b/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
@@ -39,7 +39,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v3.0.3"
         - name: CSI_PROW_TESTS
@@ -81,7 +81,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -135,7 +135,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v3.0.3"
         - name: CSI_PROW_TESTS
@@ -177,7 +177,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -231,7 +231,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v4.0.0"
         - name: CSI_PROW_TESTS
@@ -273,7 +273,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -327,7 +327,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v4.0.0"
         - name: CSI_PROW_TESTS
@@ -373,7 +373,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -427,7 +427,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v4.0.0"
         - name: CSI_PROW_TESTS

--- a/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
+++ b/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
@@ -39,7 +39,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v3.0.3"
         - name: CSI_PROW_TESTS
@@ -81,7 +81,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -135,7 +135,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v3.0.3"
         - name: CSI_PROW_TESTS
@@ -177,7 +177,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -231,7 +231,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v4.0.0"
         - name: CSI_PROW_TESTS
@@ -273,7 +273,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -327,7 +327,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v4.0.0"
         - name: CSI_PROW_TESTS
@@ -373,7 +373,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -427,7 +427,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v4.0.0"
         - name: CSI_PROW_TESTS

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -45,7 +45,7 @@ experimental_k8s_version="1.21"
 latest_stable_k8s_version="1.20" # TODO: bump to 1.21 after testing a pull job
 
 # Tag of the hostpath driver we should use for sidecar pull jobs
-hostpath_driver_version="v1.6.0"
+hostpath_driver_version="v1.7.2"
 
 # We need this image because it has Docker in Docker and go.
 dind_image="gcr.io/k8s-testimages/kubekins-e2e:v20210512-b8d1b30-master"

--- a/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
+++ b/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
@@ -39,7 +39,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v3.0.3"
         - name: CSI_PROW_TESTS
@@ -81,7 +81,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -135,7 +135,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v3.0.3"
         - name: CSI_PROW_TESTS
@@ -177,7 +177,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -231,7 +231,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v4.0.0"
         - name: CSI_PROW_TESTS
@@ -273,7 +273,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -327,7 +327,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v4.0.0"
         - name: CSI_PROW_TESTS
@@ -373,7 +373,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -427,7 +427,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v4.0.0"
         - name: CSI_PROW_TESTS

--- a/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
+++ b/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
@@ -39,7 +39,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v3.0.3"
         - name: CSI_PROW_TESTS
@@ -81,7 +81,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -135,7 +135,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v3.0.3"
         - name: CSI_PROW_TESTS
@@ -177,7 +177,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -231,7 +231,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v4.0.0"
         - name: CSI_PROW_TESTS
@@ -273,7 +273,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -327,7 +327,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v4.0.0"
         - name: CSI_PROW_TESTS
@@ -373,7 +373,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -427,7 +427,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v4.0.0"
         - name: CSI_PROW_TESTS


### PR DESCRIPTION
That version has the fix for the deploy issue that made 1.7.1 unusable.