### PR TITLE
Add TG Validation to Configurator's validate-only mode

### DIFF
--- a/testgrid/cmd/configurator/main.go
+++ b/testgrid/cmd/configurator/main.go
@@ -230,6 +230,10 @@ func doOneshot(ctx context.Context, client *storage.Client, opt options, prowCon
 		return fmt.Errorf("could not apply prowjob annotations: %v", err)
 	}
 
+	if opt.validateConfigFile {
+		return tgCfgUtil.Validate(&c)
+	}
+
 	// Print proto if requested
 	if opt.printText {
 		if opt.writeYAML {


### PR DESCRIPTION
TestGrid's libraries will run Validate() on a config whenever it's [Marshaled to anything](https://github.com/GoogleCloudPlatform/testgrid/blob/9344e4c0c4c446d009119721e7d919e257e22756/config/config.go#L492-L514).

The`--validate-config-file` option should check that the resulting configuration is valid directly. Otherwise, a config might pass `--validate-config-file` and not actually Marshal to anything useful.