### PR TITLE
Add label area/sctp

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -340,6 +340,7 @@ larger set of contributors to apply/remove them.
 | <a id="area/deflake" href="#area/deflake">`area/deflake`</a> | Issues or PRs related to deflaking kubernetes tests| label | |
 | <a id="area/e2e-test-framework" href="#area/e2e-test-framework">`area/e2e-test-framework`</a> | Issues or PRs related to refactoring the kubernetes e2e test framework| label | |
 | <a id="area/network-policy" href="#area/network-policy">`area/network-policy`</a> | Issues or PRs related to Network Policy subproject| label | |
+| <a id="area/sctp" href="#area/sctp">`area/sctp`</a> | Issues or PRs related to the SCTP protocol| label | |
 | <a id="area/release-eng" href="#area/release-eng">`area/release-eng`</a> | Issues or PRs related to the Release Engineering subproject <br><br> This was previously `area/release-infra`, | label | |
 | <a id="deprecated/hyperkube" href="#deprecated/hyperkube">`deprecated/hyperkube`</a> | Issues or PRs related to the hyperkube subproject <br><br> This was previously `area/hyperkube`, | label | |
 

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -1010,6 +1010,11 @@ repos:
         target: both
         addedBy: label
       - color: 0052cc
+        description: Issues or PRs related the SCTP protocol
+        name: area/sctp
+        target: both
+        addedBy: label
+      - color: 0052cc
         description: Issues or PRs related to the Release Engineering subproject
         name: area/release-eng
         previously:


### PR DESCRIPTION
SCTP is a somewhat special area in `sig/network`. The number of issues has increased since it became beta in v1.20.
 