### PR TITLE
Show pull info on job-history

### DIFF
--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -91,6 +91,9 @@ const (
 	// FinishedStatusFile is the JSON file that stores information about the build
 	// after its completion. See testgrid/metadata/job.go for more details.
 	FinishedStatusFile = "finished.json"
+
+	// ProwJobFile is the JSON file that stores the prowjob information.
+	ProwJobFile = "prowjob.json"
 )
 
 // +genclient

--- a/prow/cmd/deck/job_history.go
+++ b/prow/cmd/deck/job_history.go
@@ -366,9 +366,9 @@ func getBuildData(ctx context.Context, bucket storageBucket, dir string) (buildD
 	}
 
 	pj := prowapi.ProwJob{}
-	err = readJSON(ctx, bucket, path.Join(dir, "prowjob.json"), &pj)
+	err = readJSON(ctx, bucket, path.Join(dir, prowv1.ProwJobFile), &pj)
 	if err != nil {
-		logrus.Debugf("failed to read prowjob.json: %v", err)
+		logrus.WithError(err).Debugf("failed to read %s", prowv1.ProwJobFile)
 	} else {
 		if pj.Spec.Refs != nil && len(pj.Spec.Refs.Pulls) > 0 {
 			b.Pull = &pj.Spec.Refs.Pulls[0]

--- a/prow/cmd/deck/template/job-history.html
+++ b/prow/cmd/deck/template/job-history.html
@@ -17,7 +17,7 @@
   <table id="history-table" class="mdl-data-table mdl-js-data-table mdl-shadow--2dp" style="max-width: 1000px">
     <thead>
     <tr>
-      <th class="mdl-data-table__cell--non-numeric">Build ID</th>
+      <th class="mdl-data-table__cell--non-numeric">Build</th>
       <th class="mdl-data-table__cell--non-numeric">Started</th>
       <th class="mdl-data-table__cell--non-numeric">Duration</th>
       <th class="mdl-data-table__cell--non-numeric">Result</th>
@@ -29,6 +29,7 @@
         <td class="mdl-data-table__cell--non-numeric">
           {{if .SpyglassLink}}<a href="{{.SpyglassLink}}">{{.ID}}</a>
           {{else}}{{.ID}}{{end}}
+          {{if .Pull}}(#<a href={{.Pull.Link}}>{{.Pull.Number}}</a> by <a href={{.Pull.AuthorLink}}>{{.Pull.Author}}){{end}}
         </td>
         <td class="mdl-data-table__cell--non-numeric">{{.Started}}</td>
         <td class="mdl-data-table__cell--non-numeric">{{.Duration}}</td>

--- a/prow/crier/reporters/gcs/reporter.go
+++ b/prow/crier/reporters/gcs/reporter.go
@@ -138,7 +138,7 @@ func (gr *gcsReporter) reportProwjob(ctx context.Context, log *logrus.Entry, pj 
 		log.WithFields(logrus.Fields{"bucketName": bucketName, "dir": dir}).Debug("Would upload pod info")
 		return nil
 	}
-	return util.WriteContent(ctx, log, gr.author, bucketName, path.Join(dir, "prowjob.json"), true, output)
+	return util.WriteContent(ctx, log, gr.author, bucketName, path.Join(dir, prowv1.ProwJobFile), true, output)
 }
 
 func (gr *gcsReporter) GetName() string {

--- a/prow/crier/reporters/gcs/reporter_test.go
+++ b/prow/crier/reporters/gcs/reporter_test.go
@@ -256,17 +256,17 @@ func TestReportProwJob(t *testing.T) {
 		t.Fatalf("Unexpected error calling reportProwjob: %v", err)
 	}
 
-	if !strings.HasSuffix(ta.Path, "/prowjob.json") {
-		t.Errorf("Expected prowjob to be written to prowjob.json, got %q", ta.Path)
+	if !strings.HasSuffix(ta.Path, fmt.Sprintf("/%s", prowv1.ProwJobFile)) {
+		t.Errorf("Expected prowjob to be written to %s, got %q", prowv1.ProwJobFile, ta.Path)
 	}
 
 	if !ta.Overwrite {
-		t.Errorf("Expected prowjob.json to be written with overwrite enabled, but it was not.")
+		t.Errorf("Expected %s to be written with overwrite enabled, but it was not.", prowv1.ProwJobFile)
 	}
 
 	var result prowv1.ProwJob
 	if err := json.Unmarshal(ta.Content, &result); err != nil {
-		t.Fatalf("Couldn't unmarshal prowjob.json: %v", err)
+		t.Fatalf("Couldn't unmarshal %s: %v", prowv1.ProwJobFile, err)
 	}
 	if !cmp.Equal(*pj, result) {
 		t.Fatalf("Input prowjob mismatches output prowjob:\n%s", cmp.Diff(*pj, result))

--- a/prow/spyglass/lenses/metadata/lens.go
+++ b/prow/spyglass/lenses/metadata/lens.go
@@ -124,7 +124,7 @@ func (lens Lens) Body(artifacts []api.Artifact, resourceDir string, data string,
 			}
 		case "podinfo.json":
 			metadataViewData.Hint = hintFromPodInfo(read)
-		case "prowjob.json":
+		case prowv1.ProwJobFile:
 			// Only show the prowjob-based hint if we don't have a pod-based one
 			// (the pod-based ones are probably more useful when they exist)
 			if metadataViewData.Hint == "" {
@@ -261,7 +261,7 @@ func hintFromPodInfo(buf []byte) string {
 func hintFromProwJob(buf []byte) (string, bool) {
 	var pj prowv1.ProwJob
 	if err := json.Unmarshal(buf, &pj); err != nil {
-		logrus.WithError(err).Info("Failed to decode prowjob.json")
+		logrus.WithError(err).Infof("Failed to decode %s", prowv1.ProwJobFile)
 		return "", false
 	}
 


### PR DESCRIPTION
Add a new Pull pointer field for buildData struct.
The pull is being fetched from the prowjob.json file from gcs.
    
Each build on job history page would present pull data (if there is):
<build_id> (#<pull> by <author)

![Screenshot from 2021-05-22 18-42-43](https://user-images.githubusercontent.com/29873449/119232334-93a63d80-bb2d-11eb-9572-c8acab11a23f.png)
