### PR TITLE
kOps - Replace bazel-build with bazel-version-dist in pre-submits

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -18,7 +18,7 @@ presubmits:
         - runner.sh
         args:
         - "make"
-        - "bazel-build"
+        - "bazel-version-dist"
         resources:
           requests:
             memory: "2Gi"


### PR DESCRIPTION
This will allow to test changes to release builds before merging any changes.

/cc @olemarkus @rifelpet 