### PR TITLE
remove aks-engine disk vmas job since capz job is stable

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
@@ -99,58 +99,6 @@ presubmits:
       testgrid-tab-name: pull-kubernetes-e2e-capz-azure-disk
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       testgrid-num-columns-recent: '30'
-  - name: pull-kubernetes-e2e-aks-engine-azure-disk-vmas
-    decorate: true
-    always_run: false
-    optional: true
-    run_if_changed: 'azure.*\.go'
-    path_alias: k8s.io/kubernetes
-    branches:
-    - master
-    labels:
-      preset-service-account: "true"
-      preset-azure-cred: "true"
-      preset-dind-enabled: "true"
-    extra_refs:
-    - org: kubernetes-sigs
-      repo: azuredisk-csi-driver
-      base_ref: master
-      path_alias: sigs.k8s.io/azuredisk-csi-driver
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210512-b8d1b30-master
-        command:
-        - runner.sh
-        - kubetest
-        args:
-        # Generic e2e test args
-        - --test
-        - --up
-        - --down
-        - --build=quick
-        - --dump=$(ARTIFACTS)
-        # Azure-specific test args
-        - --provider=skeleton
-        - --deployment=aksengine
-        - --aksengine-admin-username=azureuser
-        - --aksengine-creds=$(AZURE_CREDENTIALS)
-        - --aksengine-orchestratorRelease=1.22
-        - --aksengine-deploy-custom-k8s
-        - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
-        - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/test/e2e/manifest/in-tree.json
-        - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/nightly/aks-engine-nightly-linux-amd64.tar.gz
-        # Specific test args
-        - --test-azure-disk-csi-driver
-        securityContext:
-          privileged: true
-        env:
-        - name: AZURE_STORAGE_DRIVER
-          value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
-    annotations:
-      testgrid-dashboards: provider-azure-presubmit
-      testgrid-tab-name: pull-kubernetes-e2e-aks-engine-azure-disk-vmas
-      testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
-      testgrid-num-columns-recent: '30'
   - name: pull-kubernetes-e2e-aks-engine-azure-disk-vmss
     decorate: true
     always_run: false


### PR DESCRIPTION
Now that the https://k8s-testgrid.appspot.com/provider-azure-presubmit#pull-kubernetes-e2e-capz-azure-disk is in place and relatively stable, the aks-engine vmas job can be removed.

related: https://github.com/Azure/container-compute-upstream/issues/101

/cc @chewong @CecileRobertMichon 