### PR TITLE
Fix pod CIDR in cluster-api ipv6 test config

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -163,7 +163,7 @@ presubmits:
           - name: DOCKER_SERVICE_CIDRS
             value: "fd00:100:64::/108"
           - name: DOCKER_POD_CIDRS
-            value: "fd00:100:64::/108"
+            value: "fd00:100:96::/48"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true


### PR DESCRIPTION
Pod CIDR needs to be something larger than /64, which is the default CIDR allocated to each node.

The service CIDR value was mistakenly copied to the pod CIDR value, causing cluster deploy to fail, hanging here:
```
STEP: Waiting for the control plane to be ready
```
https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api/4649/pull-cluster-api-e2e-ipv6-main/1396812291046903808

In the logs for `kube-controller-manger` it shows `CIDRNotAvailaable`:
```
kubectl logs -n kube-system kube-controller-manager-quick-start-e942cv-control-plane-gph79 | tail -n 1
I0524 14:00:42.076850       1 event.go:291] "Event occurred" object="quick-start-e942cv-md-0-bd6754bcc-bn4pc" kind="Node" apiVersion="v1" type="Normal" reason="CIDRNotAvailable" message="Node quick-start-e942cv-md-0-bd6754bcc-bn4pc status is now: CIDRNotAvailable"
```

cc @fabriziopandini 