### PR TITLE
cluster-api-provider-openstack: stop skipping unknown contexts

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -604,10 +604,6 @@ tide:
         repos:
           dashboard:
             from-branch-protection: true
-      kubernetes-sigs:
-        repos:
-          cluster-api-provider-openstack:
-            skip-unknown-contexts: true
   batch_size_limit:
     "kubernetes/kubernetes": 15
   priority:


### PR DESCRIPTION
@jichenjc this setting made our OpenLab tests optional. As we're not using OpenLab anymore, we don't need the setting anymore.