### PR TITLE
crier: wait longer for lister

### DIFF
--- a/prow/crier/controller.go
+++ b/prow/crier/controller.go
@@ -97,7 +97,7 @@ func (r *reconciler) updateReportState(ctx context.Context, pj *prowv1.ProwJob, 
 	// that also does reporting dont trigger another report because our lister doesn't yet contain
 	// the updated Status
 	name := types.NamespacedName{Namespace: pj.Namespace, Name: pj.Name}
-	if err := wait.Poll(100*time.Millisecond, 3*time.Second, func() (bool, error) {
+	if err := wait.Poll(100*time.Millisecond, 10*time.Second, func() (bool, error) {
 		if err := r.pjclientset.Get(ctx, name, pj); err != nil {
 			return false, err
 		}


### PR DESCRIPTION
It is not clear why the shorter time period was chosen originally and
we're seeing this timeout get hit all the time organically, so we can
just lengthen it.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>