### PR TITLE
kubernetes-csi: update distributed provisioning testing

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-manual-job-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-manual-job-config.yaml
@@ -2,60 +2,11 @@
 
 presubmits:
   kubernetes-csi/csi-driver-host-path:
-  - name: pull-kubernetes-csi-csi-driver-host-path-distributed-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
-      testgrid-tab-name: distributed-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo csi-driver-host-path for distributed deployment on Kubernetes master, with CSIStorageCapacity
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210512-b8d1b30-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_DEPLOYMENT
-          value: "kubernetes-distributed"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v3.0.3"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel serial-alpha parallel-alpha"
-        - name: CSI_PROW_SANITY_POD
-          value: csi-hostpath-socat-0
-        - name: CSI_PROW_SANITY_CONTAINER
-          value: socat
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
   - name: pull-kubernetes-csi-csi-driver-host-distributed-on-kubernetes-1-19
-    # Explicitly needs to be started with /test.
     # Will only work on branches with https://github.com/kubernetes-csi/csi-driver-host-path/pull/248 merged.
-    always_run: false
+    # That was merged into master and we don't maintain any older branches, so always
+    # running it is fine.
+    always_run: true
     optional: true
     decorate: true
     skip_report: false
@@ -82,7 +33,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT
           value: "kubernetes-distributed"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v3.0.3"
         - name: CSI_PROW_TESTS
@@ -99,7 +50,14 @@ presubmits:
             cpu: 2000m
 periodics:
 - interval: 6h
-  name: ci-kubernetes-csi-distributed-on-kubernetes-master
+  # 1.20 is used because we currently have pre-built images for it.
+  # The Kubernetes version does not matter much here, we just care
+  # about exercising distributed provisioning on some Kubernetes version.
+  #
+  # This job is meant to detect regressions in upcoming releases
+  # that slipped through pre-merge testing, so we have to use canary
+  # images.
+  name: ci-kubernetes-csi-canary-distributed-on-kubernetes-1-20
   decorate: true
   extra_refs:
   - org: kubernetes-csi
@@ -125,7 +83,7 @@ periodics:
       - ./.prow.sh
       env:
       - name: CSI_PROW_KUBERNETES_VERSION
-        value: "latest"
+        value: "1.20.0"
       - name: CSI_PROW_USE_BAZEL
         value: "false"
       - name: CSI_SNAPSHOTTER_VERSION
@@ -140,6 +98,9 @@ periodics:
         value: socat
       - name: CSI_PROW_DEPLOYMENT
         value: "kubernetes-distributed"
+      # Replace images....
+      - name: CSI_PROW_HOSTPATH_CANARY
+        value: "canary"
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-manual-job-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-manual-job-config.yaml
@@ -2,12 +2,9 @@
 
 presubmits:
   kubernetes-csi/external-provisioner:
-  - name: pull-kubernetes-csi-external-provisioner-distributed-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    always_run: false
-    optional: true
+  - name: pull-kubernetes-csi-external-provisioner-distributed-on-kubernetes-1-20
+    always_run: true
+    optional: false
     decorate: true
     skip_report: false
     labels:
@@ -29,13 +26,13 @@ presubmits:
         - ./.prow.sh
         env:
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
+          value: "1.20.0"
         - name: CSI_PROW_USE_BAZEL
-          value: "false"
+          value: "true"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.6.0"
+          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
+          value: "v4.0.0"
         - name: CSI_PROW_TESTS
           value: "sanity serial parallel serial-alpha parallel-alpha"
         - name: CSI_PROW_SANITY_POD
@@ -47,10 +44,6 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+        resources:
+          requests:
+            cpu: 2000m


### PR DESCRIPTION
These jobs were initially created while still preparing that feature
and not sufficient to catch regressions (like
https://github.com/kubernetes-csi/external-provisioner/pull/635).

Distributed provisioning now always gets tested before merging
external-provisioner or csi-driver-host-path changes in
pull-kubernetes-csi-external-provisioner-distributed-on-kubernetes-1.20
respectively
pull-kubernetes-csi-csi-driver-host-distributed-on-kubernetes-1-19.

Regressions in canary images get detected by
ci-kubernetes-csi-canary-distributed-on-kubernetes-1.20.