### PR TITLE
kubernetes-csi: add jsafrane + pohly, fix reviewers

### DIFF
--- a/config/jobs/kubernetes-csi/OWNERS
+++ b/config/jobs/kubernetes-csi/OWNERS
@@ -1,12 +1,14 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
-reviewers:
-- msau42
-- saad-ali
-- xing-yang
 approvers:
 - msau42
 - saad-ali
 - xing-yang
+- jsafrane
+- pohly
+
 reviewers:
+- msau42
+- xing-yang
+- jsafrane
 - pohly


### PR DESCRIPTION
The double reviewers entry had the effect that the first one was
ignored.

Adding Jan and myself ensures that changes can be made while the folks
in the US are not at work yet, which sometimes is useful.

/cc @jsafrane 
/assign @msau42 