### PR TITLE
Revert "temporarily drop csi-hostpath driver from kind presubmit"

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -26,9 +26,8 @@ presubmits:
         - name: FOCUS
           value: "."
         # TODO(bentheelder): reduce the skip list further
-        # TODO: add back csi-hostpath in the future
         - name: SKIP
-          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|NFS|nfs|inline.execution.and.attach|should.be.rejected.when.no.endpoints.exist|Driver:.csi-hostpath
+          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|NFS|nfs|inline.execution.and.attach|should.be.rejected.when.no.endpoints.exist
         - name: PARALLEL
           value: "true"
         # we need privileged mode in order to do docker in docker


### PR DESCRIPTION
This reverts commit bacf156f046818b0194c66e406215c37c73d5ce0.

Closes: https://github.com/kubernetes/kubernetes/issues/101913