### PR TITLE
Kops - decrease days_of_results for hourly jobs

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 import json
 import zlib
 import yaml
@@ -460,9 +461,13 @@ def build_test(cloud='aws',
     if extra_dashboards:
         dashboards.extend(extra_dashboards)
 
+    days_of_results = 90
+    if runs_per_week * days_of_results > 10000:
+        # testgrid has a limit on number of test runs to show for a job
+        days_of_results = math.floor(10000 / runs_per_week)
     annotations = {
         'testgrid-dashboards': ', '.join(sorted(dashboards)),
-        'testgrid-days-of-results': '90',
+        'testgrid-days-of-results': str(days_of_results),
         'testgrid-tab-name': tab,
     }
     for (k, v) in spec.items():

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -328,7 +328,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
+    testgrid-days-of-results: '59'
     testgrid-tab-name: kops-aws-misc-ha-euwest1
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004arm64", "extra_flags": "--zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large", "k8s_version": "latest", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
@@ -663,7 +663,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
+    testgrid-days-of-results: '59'
     testgrid-tab-name: kops-aws-misc-updown
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004arm64", "extra_flags": "--zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large --override=cluster.spec.networking.cilium.version=v1.10.0-rc2", "k8s_version": "latest", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}

--- a/config/jobs/kubernetes/kops/kops-periodics-pipeline.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-pipeline.yaml
@@ -65,7 +65,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-latest, kops-kubetest2, kops-latest, kops-versions, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
+    testgrid-days-of-results: '59'
     testgrid-tab-name: kops-pipeline-updown-kopsmaster
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
@@ -131,7 +131,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.21, kops-kubetest2, kops-latest, kops-versions, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
+    testgrid-days-of-results: '59'
     testgrid-tab-name: kops-pipeline-updown-kops121
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
@@ -197,7 +197,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.20, kops-kubetest2, kops-latest, kops-versions, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
+    testgrid-days-of-results: '59'
     testgrid-tab-name: kops-pipeline-updown-kops120
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
@@ -263,5 +263,5 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.19, kops-kubetest2, kops-latest, kops-versions, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
+    testgrid-days-of-results: '59'
     testgrid-tab-name: kops-pipeline-updown-kops119

--- a/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
@@ -66,7 +66,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-ci, kops-kubetest2, kops-latest, kops-versions, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
+    testgrid-days-of-results: '59'
     testgrid-tab-name: kops-aws-k8s-latest
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}


### PR DESCRIPTION
We're hitting a 500 error in testgrid, likely due to the number of tests * runs in the job history.
This caps the days_of_results based on the total number of runs expected in those days.

I dont know what we should reduce it to but the failing job is >15k (90 * 24 * 7), so I'm starting with a limit of 10k.

<img width="1229" alt="image" src="https://user-images.githubusercontent.com/1455650/119579048-40c5c380-bd83-11eb-9473-c64908b03808.png">


The updown pipeline jobs also being updated in this PR don't exhibit the issue, likely because they have fewer tests in each run. It should be acceptable to reduce their days_of_results though, rather than trying to incorporate the number of tests in each job which would be much more complex.