### PR TITLE
Allow kops-maintainers to retry image pushing jobs

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-kops.yaml
+++ b/config/jobs/image-pushing/k8s-staging-kops.yaml
@@ -2,6 +2,10 @@ postsubmits:
   # this is the github repo we'll build from; this block needs to be repeated for each repo.
   kubernetes/kops:
     - name: kops-postsubmit-push-to-staging
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: kops-maintainers
       cluster: k8s-infra-prow-build-trusted
       annotations:
         # this is the name of some testgrid dashboard to report to.


### PR DESCRIPTION
The [kops-maintainers](https://github.com/orgs/kubernetes/teams/kops-maintainers) GitHub team correlates with the top-level approvers for the kops project. In case of flakes it can be useful to retry these image build jobs. This grants the necessary permission to retry the jobs.