### PR TITLE
Bump Go version for cli-utils build

### DIFF
--- a/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
+++ b/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
@@ -8,7 +8,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: golang:1.13
+      - image: golang:1.16.4
         command:
         - make
         args:


### PR DESCRIPTION
This is to fix builds e.g. https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cli-utils/361/cli-utils-presubmit-master/1397537370949029888#1:build-log.txt%3A668

Ran into this while working on https://github.com/kubernetes-sigs/cli-utils/pull/361.