### PR TITLE
chore: change the vm sku to standard f2 for multi-pool autoscaler test

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -486,7 +486,7 @@ periodics:
       - --aksengine-creds=$(AZURE_CREDENTIALS)
       - --aksengine-orchestratorRelease=1.21
       - --aksengine-mastervmsize=Standard_DS2_v2
-      - --aksengine-agentvmsize=Standard_D4s_v3
+      - --aksengine-agentvmsize=Standard_F2
       - --aksengine-ccm
       - --aksengine-cnm
       - --aksengine-deploy-custom-k8s


### PR DESCRIPTION
The [multi-pool autoscaler test](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/cloud-provider-azure-autoscaling-multipool/1397535226816630784) is failing because of lacking in VM quota. Change the VM sku to a lighter one.

/area provider/azure