### PR TITLE
kubernetes-csi: fix csi-sanity config in distributed deployment jobs

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-manual-job-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-manual-job-config.yaml
@@ -38,10 +38,6 @@ presubmits:
           value: "v3.0.3"
         - name: CSI_PROW_TESTS
           value: "sanity serial parallel serial-alpha parallel-alpha"
-        - name: CSI_PROW_SANITY_POD
-          value: csi-hostpath-socat-0
-        - name: CSI_PROW_SANITY_CONTAINER
-          value: socat
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -92,10 +88,6 @@ periodics:
         value: "false"
       - name: CSI_PROW_TESTS
         value: "sanity serial parallel serial-alpha parallel-alpha"
-      - name: CSI_PROW_SANITY_POD
-        value: csi-hostpath-socat-0
-      - name: CSI_PROW_SANITY_CONTAINER
-        value: socat
       - name: CSI_PROW_DEPLOYMENT
         value: "kubernetes-distributed"
       # Replace images....

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-manual-job-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-manual-job-config.yaml
@@ -35,10 +35,6 @@ presubmits:
           value: "v4.0.0"
         - name: CSI_PROW_TESTS
           value: "sanity serial parallel serial-alpha parallel-alpha"
-        - name: CSI_PROW_SANITY_POD
-          value: csi-hostpath-socat-0
-        - name: CSI_PROW_SANITY_CONTAINER
-          value: socat
         - name: CSI_PROW_DEPLOYMENT
           value: "kubernetes-distributed"
         # docker-in-docker needs privileged mode


### PR DESCRIPTION
Overriding the defaults was a mistake, the defaults (pod
csi-hostpathplugin-0, container hostpath) work fine also for
distributed deployment.

The result of this misconfiguration was that paths were created in
/tmp of the socat pod. This accidentally worked in almost all tests
because the driver was too permissive (see
https://github.com/kubernetes-csi/csi-driver-host-path/pull/307) but
failed in the "NodeUnpublishVolume should remove target path" test
because it didn't find the target path in the socat pod.