### PR TITLE
releng: Update releng-ci to use Golang version variants

### DIFF
--- a/config/jobs/kubernetes-sigs/downloadkubernetes/downloadkubernetes-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/downloadkubernetes/downloadkubernetes-presubmits.yaml
@@ -7,7 +7,8 @@ presubmits:
     path_alias: "sigs.k8s.io/downloadkubernetes"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+        imagePullPolicy: Always
         command:
         - make
         - verify-index
@@ -21,7 +22,8 @@ presubmits:
     path_alias: "sigs.k8s.io/downloadkubernetes"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+        imagePullPolicy: Always
         command:
         - make
         - verify

--- a/config/jobs/kubernetes-sigs/e2e-framework/e2e-framework-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/e2e-framework/e2e-framework-presubmits.yaml
@@ -6,7 +6,8 @@ presubmits:
     path_alias: sigs.k8s.io/e2e-framework
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+        imagePullPolicy: Always
         command:
         - make
         - verify
@@ -21,7 +22,8 @@ presubmits:
     path_alias: sigs.k8s.io/e2e-framework
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+        imagePullPolicy: Always
         command:
         - make
         - test

--- a/config/jobs/kubernetes-sigs/mdtoc/mdtoc-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/mdtoc/mdtoc-presubmits.yaml
@@ -6,7 +6,8 @@ presubmits:
     path_alias: sigs.k8s.io/mdtoc
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+        imagePullPolicy: Always
         command:
         - make
         - test
@@ -21,7 +22,8 @@ presubmits:
     path_alias: sigs.k8s.io/mdtoc
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+        imagePullPolicy: Always
         command:
         - make
         - verify

--- a/config/jobs/kubernetes-sigs/release-utils/release-utils-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/release-utils/release-utils-presubmits.yaml
@@ -6,7 +6,8 @@ presubmits:
     path_alias: "sigs.k8s.io/release-utils"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+        imagePullPolicy: Always
         command:
         - go
         args:
@@ -24,7 +25,8 @@ presubmits:
     path_alias: "sigs.k8s.io/release-utils"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+        imagePullPolicy: Always
         command:
         - go
         args:

--- a/config/jobs/kubernetes-sigs/zeitgeist/zeitgeist-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/zeitgeist/zeitgeist-presubmits.yaml
@@ -6,7 +6,8 @@ presubmits:
     path_alias: "sigs.k8s.io/zeitgeist"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+        imagePullPolicy: Always
         command:
         - make
         - build
@@ -21,7 +22,8 @@ presubmits:
     path_alias: "sigs.k8s.io/zeitgeist"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+        imagePullPolicy: Always
         command:
         - make
         - test
@@ -36,7 +38,8 @@ presubmits:
     path_alias: "sigs.k8s.io/zeitgeist"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+        imagePullPolicy: Always
         command:
         - make
         - verify

--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -46,7 +46,8 @@ presubmits:
     path_alias: k8s.io/release
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+        imagePullPolicy: Always
         command:
         - make
         - test
@@ -62,7 +63,8 @@ presubmits:
     path_alias: k8s.io/release
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+        imagePullPolicy: Always
         command:
         - make
         - test-go-integration
@@ -78,7 +80,8 @@ presubmits:
     path_alias: k8s.io/release
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+        imagePullPolicy: Always
         command:
         - make
         - verify

--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -155,7 +155,8 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.15
+        imagePullPolicy: Always
         command:
         - make
         - verify

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
@@ -43,7 +43,8 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-gcp-auditor
     containers:
-    - image: gcr.io/k8s-staging-releng/releng-ci:latest
+    - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+      imagePullPolicy: Always
       command:
       - bash
       args:


### PR DESCRIPTION
Companion PR for https://github.com/kubernetes/release/pull/2089.
Fixes [pull-cip-verify](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_k8s-container-image-promoter/291/pull-cip-verify/1397884129428639744) in https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/291 (FYI @listx @tylerferrara).

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @cpanato @saschagrunert
cc: @kubernetes/release-engineering 