### PR TITLE
Branchprotector: Allow to run for a subset of orgs/repos only

### DIFF
--- a/prow/cmd/branchprotector/protect.go
+++ b/prow/cmd/branchprotector/protect.go
@@ -52,11 +52,16 @@ type options struct {
 	tokens     int
 	tokenBurst int
 
-	github flagutil.GitHubOptions
+	github           flagutil.GitHubOptions
+	githubEnablement flagutil.GitHubEnablementOptions
 }
 
 func (o *options) Validate() error {
 	if err := o.github.Validate(!o.confirm); err != nil {
+		return err
+	}
+
+	if err := o.githubEnablement.Validate(!o.confirm); err != nil {
 		return err
 	}
 
@@ -91,6 +96,7 @@ func gatherOptions() options {
 	fs.IntVar(&o.tokenBurst, "token-burst", defaultBurst, "Allow consuming a subset of hourly tokens in a short burst. DEPRECATED: use --github-allowed-burst")
 	o.config.AddFlags(fs)
 	o.github.AddCustomizedFlags(fs, flagutil.ThrottlerDefaults(defaultTokens, defaultBurst))
+	o.githubEnablement.AddFlags(fs)
 	fs.Parse(os.Args[1:])
 	return o
 }
@@ -148,6 +154,7 @@ func main() {
 		completedRepos:     make(map[string]bool),
 		done:               make(chan []error),
 		verifyRestrictions: o.verifyRestrictions,
+		enabled:            o.githubEnablement.EnablementChecker(),
 	}
 
 	go p.configureBranches()
@@ -181,6 +188,7 @@ type protector struct {
 	completedRepos     map[string]bool
 	done               chan []error
 	verifyRestrictions bool
+	enabled            func(org, repo string) bool
 }
 
 func (p *protector) configureBranches() {
@@ -209,6 +217,9 @@ func (p *protector) protect() {
 
 	// Scan the branch-protection configuration
 	for orgName := range bp.Orgs {
+		if !p.enabled(orgName, "") {
+			continue
+		}
 		org := bp.GetOrg(orgName)
 		if err := p.UpdateOrg(orgName, *org); err != nil {
 			p.errors.add(fmt.Errorf("update %s: %v", orgName, err))
@@ -235,6 +246,9 @@ func (p *protector) protect() {
 		}
 		orgName := parts[0]
 		repoName := parts[1]
+		if !p.enabled(orgName, repoName) {
+			continue
+		}
 		repo := bp.GetOrg(orgName).GetRepo(repoName)
 		if err := p.UpdateRepo(orgName, repoName, *repo); err != nil {
 			p.errors.add(fmt.Errorf("update %s/%s: %v", orgName, repoName, err))
@@ -275,6 +289,9 @@ func (p *protector) UpdateOrg(orgName string, org config.Org) error {
 
 	var errs []error
 	for _, repoName := range repos {
+		if !p.enabled(orgName, repoName) {
+			continue
+		}
 		repo := org.GetRepo(repoName)
 		if err := p.UpdateRepo(orgName, repoName, *repo); err != nil {
 			errs = append(errs, fmt.Errorf("update %s: %v", repoName, err))


### PR DESCRIPTION
Branchprotector consumes a large amount of GitHub api quota, which means
that bigger Prow setups are forced to throttle it which means that it
runs very slowly.

This change allows to run multiple branchprotector instances that each
only manage a subset of org/repos and that each can use different GitHub
users.