### PR TITLE
add presubmit lint check

### DIFF
--- a/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits.yaml
@@ -38,3 +38,22 @@ presubmits:
       testgrid-dashboards: sig-cloud-provider-apiserver-network-proxy
       testgrid-tab-name: pr-docker-build-all
       description: Build via Docker all the arch release for the apiserver-network-proxy
+  - name: pull-apiserver-network-proxy-make-lint
+    always_run: true
+    skip_report: false
+    decorate: true
+    path_alias: sigs.k8s.io/apiserver-network-proxy
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210512-b8d1b30-master
+        command:
+        - "runner.sh"
+        args:
+        - make
+        - lint
+    annotations:
+      testgrid-dashboards: sig-cloud-provider-apiserver-network-proxy
+      testgrid-tab-name: pr-make-lint
+      description: Run lint target for the apiserver-network-proxy


### PR DESCRIPTION
this PR adds presubmit lint check as it was suggested few months ago: https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/170#issuecomment-776233595

resolves: https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/229