### PR TITLE
kubernetes-csi: more fixes for distributed provisioning

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-manual-job-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-manual-job-config.yaml
@@ -32,12 +32,17 @@ presubmits:
           value: "1.21.0"
         - name: CSI_PROW_DEPLOYMENT
           value: "kubernetes-distributed"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v3.0.3"
         - name: CSI_PROW_TESTS
           value: "sanity serial parallel serial-alpha parallel-alpha"
+        - name: CSI_PROW_SANITY_POD
+          # The hostpath pod is part of a DaemonSet with an unpredictable
+          # name. There's also more than one. We can list all them by
+          # their label, but then still need to filter by node name
+          # to find the one that is on the same host as the socat pod
+          # which exposes the CSI socket for us.
+          value: kubectl get pods -l app.kubernetes.io/name=csi-hostpathplugin -o "jsonpath={.items[?(@.spec.nodeName==\"$(kubectl get pods/csi-hostpath-socat-0 -o jsonpath={.spec.nodeName})\")].metadata.name}"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -48,6 +53,7 @@ presubmits:
             memory: "9000Mi"
             # during the tests more like 3-20m is used
             cpu: 2000m
+
 periodics:
 - interval: 6h
   # 1.21 is used because the distributed deployment also
@@ -70,7 +76,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   annotations:
     testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: distributed-on-master
+    testgrid-tab-name: distributed-on-1-21
     testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
     description: periodic Kubernetes-CSI job for distributed provisioning on Kubernetes master, with CSIStorageCapacity
   spec:
@@ -94,6 +100,13 @@ periodics:
         value: "sanity serial parallel serial-alpha parallel-alpha"
       - name: CSI_PROW_DEPLOYMENT
         value: "kubernetes-distributed"
+      - name: CSI_PROW_SANITY_POD
+        # The hostpath pod is part of a DaemonSet with an unpredictable
+        # name. There's also more than one. We can list all them by
+        # their label, but then still need to filter by node name
+        # to find the one that is on the same host as the socat pod
+        # which exposes the CSI socket for us.
+        value: kubectl get pods -l app.kubernetes.io/name=csi-hostpathplugin -o "jsonpath={.items[?(@.spec.nodeName==\"$(kubectl get pods/csi-hostpath-socat-0 -o jsonpath={.spec.nodeName})\")].metadata.name}"
       # Replace images....
       - name: CSI_PROW_HOSTPATH_CANARY
         value: "canary"

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-manual-job-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-manual-job-config.yaml
@@ -34,7 +34,12 @@ presubmits:
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v4.0.0"
         - name: CSI_PROW_TESTS
-          value: "sanity serial parallel serial-alpha parallel-alpha"
+          # sanity intentionally not included: it needs special
+          # support for CSI_PROW_SANITY_POD as a shell command
+          # (not in any stable release yet) and
+          # it doesn't involve the external-provisioner (therefore
+          # it doesn't make sense in this job).
+          value: "serial parallel serial-alpha parallel-alpha"
         - name: CSI_PROW_DEPLOYMENT
           value: "kubernetes-distributed"
         # docker-in-docker needs privileged mode


### PR DESCRIPTION
The default csi-hostpathplugin-0 does *not* work for the DaemonSet
that is used for distributed provisioning. Instead, the node and thus
the driver pod are selected through co-scheduling of the socat port
proxy pod. That pod has a predictable name. We can use that to find
the right driver pod.

The necessary support for storing a shell expression in
CSI_PROW_SANITY_POD is only going to be available in
csi-driver-host-path master. For pull requests into
external-provisioner we don't need sanity testing and thus
can avoid the problem.

Some other changes:
- setting CSI_PROW_DRIVER_VERSION is unnecessary when testing
  a PR for csi-driver-host-path
- the Kubernetes version for the periodic canary job gets bumped
  to 1.21 (now supported by KinD 0.11.0) and the job name in
  the dashboard gets fixed (wasn't really "master")