### PR TITLE
Needs rebase take action: Time out after five minutes

### DIFF
--- a/prow/external-plugins/needs-rebase/plugin/plugin_test.go
+++ b/prow/external-plugins/needs-rebase/plugin/plugin_test.go
@@ -77,7 +77,7 @@ func (f *fghc) GetIssueLabels(org, repo string, number int) ([]github.Label, err
 	return f.initialLabels, nil
 }
 
-func (f *fghc) CreateComment(org, repo string, number int, comment string) error {
+func (f *fghc) CreateCommentWithContext(_ context.Context, org, repo string, number int, comment string) error {
 	f.commentCreated[testKey(org, repo, number)] = true
 	return nil
 }
@@ -86,13 +86,13 @@ func (f *fghc) BotUserChecker() (func(candidate string) bool, error) {
 	return func(candidate string) bool { return candidate == "k8s-ci-robot" }, nil
 }
 
-func (f *fghc) AddLabel(org, repo string, number int, label string) error {
+func (f *fghc) AddLabelWithContext(_ context.Context, org, repo string, number int, label string) error {
 	key := testKey(org, repo, number)
 	f.IssueLabelsAdded[key] = append(f.IssueLabelsAdded[key], label)
 	return nil
 }
 
-func (f *fghc) RemoveLabel(org, repo string, number int, label string) error {
+func (f *fghc) RemoveLabelWithContext(_ context.Context, org, repo string, number int, label string) error {
 	key := testKey(org, repo, number)
 	f.IssueLabelsRemoved[key] = append(f.IssueLabelsRemoved[key], label)
 	return nil
@@ -102,7 +102,7 @@ func (f *fghc) IsMergeable(org, repo string, number int, sha string) (bool, erro
 	return f.mergeable, nil
 }
 
-func (f *fghc) DeleteStaleComments(org, repo string, number int, comments []github.IssueComment, isStale func(github.IssueComment) bool) error {
+func (f *fghc) DeleteStaleCommentsWithContext(_ context.Context, org, repo string, number int, comments []github.IssueComment, isStale func(github.IssueComment) bool) error {
 	f.commentDeleted[testKey(org, repo, number)] = true
 	return nil
 }

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -2848,7 +2848,7 @@ func TestAuthHeaderGetsSet(t *testing.T) {
 			fake := &fakeHttpClient{}
 			c := &client{delegate: &delegate{client: fake}, logger: logrus.NewEntry(logrus.New())}
 			tc.mod(c)
-			if _, err := c.doRequest("POST", "/hello", "", "", nil); err != nil {
+			if _, err := c.doRequest(context.Background(), "POST", "/hello", "", "", nil); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			if tc.expectedHeader == nil {
@@ -2952,10 +2952,6 @@ func (rt testRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 // all requests made had an org header set.
 func TestAllMethodsThatDoRequestSetOrgHeader(t *testing.T) {
 	_, ghClient := NewAppsAuthClientWithFields(logrus.Fields{}, func(_ []byte) []byte { return nil }, "some-app-id", func() *rsa.PrivateKey { return nil }, "", "")
-	clientType := reflect.TypeOf(ghClient)
-	stringType := reflect.TypeOf("")
-	stringValue := reflect.ValueOf("org")
-
 	toSkip := sets.NewString(
 		// Doesn't support github apps
 		"Query",
@@ -2970,12 +2966,19 @@ func TestAllMethodsThatDoRequestSetOrgHeader(t *testing.T) {
 		"ListCurrentUserOrgInvitations",
 	)
 
-	for i := 0; i < clientType.NumMethod(); i++ {
-		if toSkip.Has(clientType.Method(i).Name) {
-			continue
-		}
-		t.Run(clientType.Method(i).Name, func(t *testing.T) {
-
+	clientMethods := getCallForAllClientMethodsThroughReflection(
+		ghClient,
+		func(methodName string) bool { return toSkip.Has(methodName) },
+		func(typeName string) interface{} {
+			if typeName == "string" {
+				return "org"
+			}
+			return nil
+		},
+	)
+	for _, clientMethod := range clientMethods {
+		methodName, call := clientMethod()
+		t.Run(methodName, func(t *testing.T) {
 			checkingRoundTripper := testRoundTripper{func(r *http.Request) (*http.Response, error) {
 				if !strings.HasPrefix(r.URL.Path, "/app") {
 					var orgVal string
@@ -2988,44 +2991,82 @@ func TestAllMethodsThatDoRequestSetOrgHeader(t *testing.T) {
 				}
 				return &http.Response{Body: ioutil.NopCloser(&bytes.Buffer{})}, nil
 			}}
-
 			ghClient.(*client).client.(*http.Client).Transport = checkingRoundTripper
 			ghClient.(*client).gqlc.(*graphQLGitHubAppsAuthClientWrapper).Client = githubv4.NewClient(&http.Client{Transport: checkingRoundTripper})
-			clientValue := reflect.ValueOf(ghClient)
-
-			var args []reflect.Value
-			// First arg is self, so start with second arg
-			for j := 1; j < clientType.Method(i).Func.Type().NumIn(); j++ {
-				arg := reflect.New(clientType.Method(i).Func.Type().In(j)).Elem()
-				if arg.Kind() == reflect.Ptr && arg.IsNil() {
-					arg.Set(reflect.New(arg.Type().Elem()))
-				}
-
-				if arg.Type() == stringType {
-					arg.Set(stringValue)
-				}
-
-				// We can not deal with interface types genererically, as there
-				// is no automatic way to figure out the concrete values they
-				// can or should be set to.
-				if arg.Type().String() == "context.Context" {
-					arg.Set(reflect.ValueOf(context.Background()))
-				}
-				if arg.Type().String() == "interface {}" {
-					arg.Set(reflect.ValueOf(map[string]interface{}{}))
-				}
-
-				// Just set all strings to a nonEmpty string, otherwise the header will not get set
-				args = append(args, arg)
-			}
-
-			if clientType.Method(i).Type.IsVariadic() {
-				args[len(args)-1] = reflect.New(args[len(args)-1].Type().Elem()).Elem()
-			}
 
 			// We don't care about the result at all, the verification happens via the roundTripper
-			_ = clientValue.Method(i).Call(args)
+			_ = call()
 		})
+	}
+}
+
+func getCallForAllClientMethodsThroughReflection(
+	c Client,
+	skip func(methodName string) bool,
+	typeOverrides ...func(typeName string) (override interface{}),
+) (getCalls []func() (methodName string, call func() error)) {
+
+	clientType := reflect.TypeOf(c)
+	clientValue := reflect.ValueOf(c)
+
+	for i := 0; i < clientType.NumMethod(); i++ {
+		i := i
+		if skip(clientType.Method(i).Name) {
+			continue
+		}
+		var args []reflect.Value
+		// First arg is self, so start with second arg
+		for j := 1; j < clientType.Method(i).Func.Type().NumIn(); j++ {
+			arg := reflect.New(clientType.Method(i).Func.Type().In(j)).Elem()
+			setValue(&arg, typeOverrides)
+
+			args = append(args, arg)
+		}
+
+		if clientType.Method(i).Type.IsVariadic() {
+			args[len(args)-1] = reflect.New(args[len(args)-1].Type().Elem()).Elem()
+		}
+
+		getCalls = append(getCalls, func() (methodName string, call func() error) {
+			return clientType.Method(i).Name, func() (err error) {
+				returnsValues := clientValue.Method(i).Call(args)
+
+				// If there are returns and the last return is a non-nil interface that has an Error method,
+				// we assume it is the error.
+				if len(returnsValues) > 0 &&
+					returnsValues[len(returnsValues)-1].Kind() == reflect.Interface &&
+					!returnsValues[len(returnsValues)-1].IsNil() &&
+					!reflect.DeepEqual(returnsValues[len(returnsValues)-1].MethodByName("Error"), reflect.Value{}) {
+					err = returnsValues[len(returnsValues)-1].Interface().(error)
+				}
+				return
+			}
+		})
+	}
+
+	return getCalls
+}
+
+func setValue(target *reflect.Value, typeOverrides []func(typeName string) (override interface{})) {
+	for _, typeOverride := range typeOverrides {
+		if override := typeOverride(target.Type().String()); override != nil {
+			target.Set(reflect.ValueOf(override))
+			return
+		}
+	}
+
+	if target.Kind() == reflect.Ptr && target.IsNil() {
+		target.Set(reflect.New(target.Type().Elem()))
+	}
+
+	// We can not deal with interface types genererically, as there
+	// is no automatic way to figure out the concrete values they
+	// can or should be set to.
+	if target.Type().String() == "context.Context" {
+		target.Set(reflect.ValueOf(context.Background()))
+	}
+	if target.Type().String() == "interface {}" {
+		target.Set(reflect.ValueOf(map[string]interface{}{}))
 	}
 }
 
@@ -3243,5 +3284,44 @@ func TestCreatePullRequestReviewComment(t *testing.T) {
 	c := getClient(ts.URL)
 	if err := c.CreatePullRequestReviewComment("k8s", "kuber", 5, ReviewComment{Body: "hello"}); err != nil {
 		t.Errorf("Didn't expect error: %v", err)
+	}
+}
+
+func TestThrottlerRespectsContexts(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer ts.Close()
+	c := getClient(ts.URL)
+
+	// Set the throttler, use up the one token we have for this hour
+	c.Throttle(1, 1)
+	if err := c.CreateReview("", "", 0, DraftReview{}); err != nil {
+		t.Fatalf("failed to use up the throttlers token: %v", err)
+	}
+
+	// Use a very low timeout so we don't have to wait
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+
+	clientMethods := getCallForAllClientMethodsThroughReflection(c,
+		// Skip all methods whose name doesn't end with 'WithContext'
+		func(methodName string) bool { return !strings.HasSuffix(methodName, "WithContext") },
+		// Insert our custom ctx for any arg of type context.Context
+		func(typeName string) interface{} {
+			if typeName == "context.Context" {
+				return ctx
+			}
+			return nil
+		},
+	)
+
+	for _, clientMethod := range clientMethods {
+		methodName, callMethod := clientMethod()
+		t.Run(methodName, func(t *testing.T) {
+			if actualErr := callMethod(); !errors.Is(actualErr, context.DeadlineExceeded) {
+				t.Errorf("expected to get %v error, got %v", context.DeadlineExceeded, actualErr)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/kubernetes/test-infra/issues/22259

This change adds a five minute timeout to the `takeAction` method of the needs-rebase plugin. This is needed because needs-rebase is a heavy token consumer and thus often gets throttled, which can result in manipulating labels or comments based on data that is hours or more old. It also means that in case of throttling, it will internally end up with a pile of events that wait for throttler quota and that once they get it (often during off-hours) will spam prs with multiple comments.

The PR is divided into two commits, the first one adds a bunch of WithContext methods to the GitHub client and extends the throttler to respect it, the second makes needs-rebase use those.

/cc @cjwagner @chaodaiG 