### PR TITLE
Kops - update runtime default for jobs to use containerd

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -337,7 +337,7 @@ distros_ssh_user = {
 def build_test(cloud='aws',
                distro='u2004',
                networking=None,
-               container_runtime='docker',
+               container_runtime='containerd',
                k8s_version='latest',
                kops_channel='alpha',
                kops_version=None,
@@ -484,7 +484,7 @@ def build_test(cloud='aws',
 def presubmit_test(cloud='aws',
                    distro='u2004',
                    networking=None,
-                   container_runtime='docker',
+                   container_runtime='containerd',
                    k8s_version='latest',
                    kops_channel='alpha',
                    name=None,
@@ -667,7 +667,6 @@ def generate_misc():
 
         # A special test for AWS Cloud-Controller-Manager
         build_test(name_override="kops-grid-scenario-aws-cloud-controller-manager",
-                   container_runtime='containerd',
                    cloud="aws",
                    distro="u2004",
                    k8s_version="stable",
@@ -678,7 +677,6 @@ def generate_misc():
                    extra_dashboards=['provider-aws-cloud-provider-aws', 'kops-misc']),
 
         build_test(name_override="kops-grid-scenario-terraform",
-                   container_runtime='containerd',
                    k8s_version="1.20",
                    terraform_version="0.14.6",
                    extra_dashboards=['kops-misc']),
@@ -693,7 +691,6 @@ def generate_misc():
 
         build_test(name_override="kops-aws-misc-arm64-release",
                    k8s_version="latest",
-                   container_runtime="containerd",
                    distro="u2004arm64",
                    networking="calico",
                    kops_channel="alpha",
@@ -706,7 +703,6 @@ def generate_misc():
 
         build_test(name_override="kops-aws-misc-arm64-ci",
                    k8s_version="ci",
-                   container_runtime="containerd",
                    distro="u2004arm64",
                    networking="calico",
                    kops_channel="alpha",
@@ -719,7 +715,6 @@ def generate_misc():
 
         build_test(name_override="kops-aws-misc-arm64-conformance",
                    k8s_version="ci",
-                   container_runtime="containerd",
                    distro="u2004arm64",
                    networking="calico",
                    kops_channel="alpha",
@@ -733,7 +728,6 @@ def generate_misc():
 
         build_test(name_override="kops-aws-misc-amd64-conformance",
                    k8s_version="ci",
-                   container_runtime="containerd",
                    distro='u2004',
                    kops_channel="alpha",
                    runs_per_day=3,
@@ -745,7 +739,6 @@ def generate_misc():
 
         build_test(name_override="kops-aws-misc-updown",
                    k8s_version="stable",
-                   container_runtime="containerd",
                    networking="calico",
                    distro='u2004',
                    kops_channel="alpha",
@@ -796,7 +789,6 @@ def generate_distros():
         results.append(
             build_test(distro=distro_short,
                        networking='calico',
-                       container_runtime='containerd',
                        k8s_version='stable',
                        kops_channel='alpha',
                        name_override=f"kops-aws-distro-image{distro}",
@@ -832,7 +824,6 @@ def generate_network_plugins():
             networking_arg = 'kube-router'
         results.append(
             build_test(
-                container_runtime='containerd',
                 k8s_version='stable',
                 kops_channel='alpha',
                 name_override=f"kops-aws-cni-{plugin}",
@@ -852,7 +843,6 @@ def generate_versions():
     skip_regex = r'\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler' # pylint: disable=line-too-long
     results = [
         build_test(
-            container_runtime='containerd',
             k8s_version='ci',
             kops_channel='alpha',
             name_override='kops-aws-k8s-latest',
@@ -868,7 +858,6 @@ def generate_versions():
         distro = 'deb9' if version == '1.17' else 'u2004'
         results.append(
             build_test(
-                container_runtime='containerd',
                 distro=distro,
                 k8s_version=version,
                 kops_channel='alpha',
@@ -893,7 +882,6 @@ def generate_pipeline():
         kops_version = f"https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/{branch}/latest-ci.txt" # pylint: disable=line-too-long
         results.append(
             build_test(
-                container_runtime='containerd',
                 k8s_version=version.replace('master', 'latest'),
                 kops_version=kops_version,
                 kops_channel='alpha',
@@ -939,7 +927,6 @@ def generate_presubmits_network_plugins():
             skip_regex += r'|up\sand\sdown|headless|service-proxy-name'
         results.append(
             presubmit_test(
-                container_runtime='containerd',
                 k8s_version='stable',
                 kops_channel='alpha',
                 name=f"pull-kops-e2e-cni-{plugin}",
@@ -971,7 +958,6 @@ def generate_presubmits_e2e():
             skip_override=skip_regex,
         ),
         presubmit_test(
-            container_runtime='containerd',
             k8s_version='1.21',
             kops_channel='alpha',
             name='pull-kops-e2e-kubernetes-aws',
@@ -981,7 +967,6 @@ def generate_presubmits_e2e():
             skip_override=skip_regex,
         ),
         presubmit_test(
-            container_runtime='containerd',
             k8s_version='1.21',
             kops_channel='alpha',
             name='pull-kops-e2e-k8s-containerd-ha',
@@ -1004,7 +989,6 @@ def generate_presubmits_e2e():
         ),
         presubmit_test(
             cloud='gce',
-            container_runtime='containerd',
             k8s_version='1.21',
             kops_channel='alpha',
             name='pull-kops-e2e-k8s-gce',

--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -321,7 +321,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-misc, kops-kubetest2
     testgrid-days-of-results: "30"
     testgrid-tab-name: kops-scenario-aws-ebs-csi-driver
-- interval: 1h
+- interval: 24h
   name: e2e-kops-aws-aws-load-balancer-controller
   always_run: false
   labels:

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -2,7 +2,7 @@
 # 12 jobs, total of 476 runs per week
 periodics:
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004arm64", "extra_flags": "--zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large", "k8s_version": "latest", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004arm64", "extra_flags": "--zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large", "k8s_version": "latest", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-scenario-arm64
   cron: '33 16 * * *'
   labels:
@@ -31,7 +31,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20210510' --channel=alpha --networking=kubenet --container-runtime=docker --zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20210510' --channel=alpha --networking=kubenet --container-runtime=containerd --zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/latest.txt \
           --test=kops \
@@ -56,7 +56,7 @@ periodics:
           memory: 3Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004arm64
     test.kops.k8s.io/extra_flags: --zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large
     test.kops.k8s.io/k8s_version: latest
@@ -67,7 +67,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-scenario-arm64
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--api-loadbalancer-type=public", "feature_flags": "UseServiceAccountIAM", "k8s_version": "latest", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--api-loadbalancer-type=public", "feature_flags": "UseServiceAccountIAM", "k8s_version": "latest", "kops_channel": "alpha", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-scenario-service-account-iam
   cron: '45 6 * * *'
   labels:
@@ -96,7 +96,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210518' --channel=alpha --networking=kubenet --container-runtime=docker --api-loadbalancer-type=public" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210518' --channel=alpha --networking=kubenet --container-runtime=containerd --api-loadbalancer-type=public" \
           --env=KOPS_FEATURE_FLAGS=UseServiceAccountIAM \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/latest.txt \
@@ -122,7 +122,7 @@ periodics:
           memory: 3Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/extra_flags: --api-loadbalancer-type=public
     test.kops.k8s.io/feature_flags: UseServiceAccountIAM
@@ -266,7 +266,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-scenario-terraform
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--master-count=3 --zones=eu-west-1a,eu-west-1b,eu-west-1c", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--master-count=3 --zones=eu-west-1a,eu-west-1b,eu-west-1c", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-aws-misc-ha-euwest1
   cron: '24 0-23/1 * * *'
   labels:
@@ -295,7 +295,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210518' --channel=alpha --networking=calico --container-runtime=docker --master-count=3 --zones=eu-west-1a,eu-west-1b,eu-west-1c" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210518' --channel=alpha --networking=calico --container-runtime=containerd --master-count=3 --zones=eu-west-1a,eu-west-1b,eu-west-1c" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
           --test=kops \
@@ -320,7 +320,7 @@ periodics:
           memory: 3Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/extra_flags: --master-count=3 --zones=eu-west-1a,eu-west-1b,eu-west-1c
     test.kops.k8s.io/k8s_version: stable
@@ -666,7 +666,7 @@ periodics:
     testgrid-days-of-results: '59'
     testgrid-tab-name: kops-aws-misc-updown
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004arm64", "extra_flags": "--zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large --override=cluster.spec.networking.cilium.version=v1.10.0-rc2", "k8s_version": "latest", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004arm64", "extra_flags": "--zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large --override=cluster.spec.networking.cilium.version=v1.10.0-rc2", "k8s_version": "latest", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-scenario-cilium10-arm64
   cron: '25 13-23/24 * * *'
   labels:
@@ -695,7 +695,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20210510' --channel=alpha --networking=cilium --container-runtime=docker --zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large --override=cluster.spec.networking.cilium.version=v1.10.0-rc2" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20210510' --channel=alpha --networking=cilium --container-runtime=containerd --zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large --override=cluster.spec.networking.cilium.version=v1.10.0-rc2" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/latest.txt \
           --test=kops \
@@ -720,7 +720,7 @@ periodics:
           memory: 3Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004arm64
     test.kops.k8s.io/extra_flags: --zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large --override=cluster.spec.networking.cilium.version=v1.10.0-rc2
     test.kops.k8s.io/k8s_version: latest
@@ -731,7 +731,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-scenario-cilium10-arm64
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--zones=eu-central-1a --override=cluster.spec.networking.cilium.version=v1.10.0-rc2", "k8s_version": "latest", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--zones=eu-central-1a --override=cluster.spec.networking.cilium.version=v1.10.0-rc2", "k8s_version": "latest", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-scenario-cilium10-amd64
   cron: '39 19-23/24 * * *'
   labels:
@@ -760,7 +760,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210518' --channel=alpha --networking=cilium --container-runtime=docker --zones=eu-central-1a --override=cluster.spec.networking.cilium.version=v1.10.0-rc2" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210518' --channel=alpha --networking=cilium --container-runtime=containerd --zones=eu-central-1a --override=cluster.spec.networking.cilium.version=v1.10.0-rc2" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/latest.txt \
           --test=kops \
@@ -785,7 +785,7 @@ periodics:
           memory: 3Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/extra_flags: --zones=eu-central-1a --override=cluster.spec.networking.cilium.version=v1.10.0-rc2
     test.kops.k8s.io/k8s_version: latest


### PR DESCRIPTION
Also decrease the frequency of the aws-load-balancer-controller job to daily. it has been consistently passing for a while now.