### PR TITLE
Prow job decoration: also trim underscore after truncating

### DIFF
--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -107,7 +107,7 @@ func LabelsAndAnnotationsForSpec(spec prowapi.ProwJobSpec, extraLabels, extraAnn
 		maybeTruncated := value
 		if len(value) > validation.LabelValueMaxLength {
 			// TODO(fejta): consider truncating middle rather than end.
-			maybeTruncated = strings.TrimRight(value[:validation.LabelValueMaxLength], ".-")
+			maybeTruncated = strings.TrimRight(value[:validation.LabelValueMaxLength], "._-")
 			log.WithFields(logrus.Fields{
 				"key":            key,
 				"value":          value,


### PR DESCRIPTION
Label ending with underscore is not valid either, also truncating it