### PR TITLE
add dual-stack master windows test job

### DIFF
--- a/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml
@@ -261,7 +261,64 @@ periodics:
     testgrid-tab-name: dualstack-azure-e2e-master-ipvs
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Dual-stack and Conformance e2e tests on a Kubernetes cluster provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud in ipvs mode"
-
+- interval: 24h
+  name: ci-dualstack-azure-e2e-master-windows
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-service-account: "true"
+    preset-azure-cred: "true"
+    preset-dind-enabled: "true"
+    preset-azure-windows: "true"
+    preset-k8s-ssh: "true"
+    preset-windows-private-registry-cred: "true"
+    preset-windows-repo-list-master: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210601-ea6aa4e-master
+      command:
+      - runner.sh
+      - kubetest
+      args:
+      # Generic e2e test args
+      - --test
+      - --up
+      - --down
+      - --build=quick
+      - --dump=$(ARTIFACTS)
+      # Azure-specific test args
+      - --provider=skeleton
+      - --deployment=aksengine
+      - --aksengine-agentpoolcount=2
+      - --aksengine-admin-username=azureuser
+      - --aksengine-admin-password=AdminPassw0rd
+      - --aksengine-creds=$(AZURE_CREDENTIALS)
+      - --aksengine-orchestratorRelease=1.22
+      - --aksengine-mastervmsize=Standard_DS2_v2
+      - --aksengine-agentvmsize=Standard_D4s_v3
+      - --aksengine-deploy-custom-k8s
+      - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
+      - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
+      - --aksengine-winZipBuildScript=$(WIN_BUILD)
+      - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/windows-dual-stack.json
+      - --aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz
+      - --aksengine-win-binaries
+      # Specific test args
+      - --test_args=--ginkgo.focus=\[Feature:IPv6DualStack\] --ginkgo.skip=\[LinuxOnly\]
+      - --ginkgo-parallel=1
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-network-dualstack-azure-e2e, provider-azure-dualstack
+    testgrid-tab-name: dualstack-azure-e2e-master-windows
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    description: "Dual-stack windows tests on a Kubernetes cluster provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"
 
 presubmits:
   kubernetes/kubernetes:


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

- Adds dual-stack master windows test job
  - This will be a experimental job to get the dual-stack tests working with windows. After the entire dual-stack test suite is enabled to run for windows, we can add `Conformance` tests to the focus.

ref https://github.com/kubernetes/kubernetes/issues/100870