### PR TITLE
Remove the 1.18 - 1.19 upgrade test.

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -115,58 +115,6 @@ periodics:
     testgrid-days-of-results: "30"
     testgrid-tab-name: kops-aws-kops-upgrade
 - interval: 1h # TODO(justinsb): reduce once working
-  name: e2e-kops-aws-upgrade-ko118-to-ko119
-  always_run: false
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-dind-enabled: "true"
-    preset-e2e-platform-aws: "true"
-  decorate: true
-  decoration_config:
-    timeout: 2h
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - ./tests/e2e/scenarios/upgrade-ab/run-test.sh
-      env:
-      - name: CLOUD_PROVIDER
-        value: aws
-      - name: CLUSTER_NAME
-        value: e2e-f9b0e6b3f9-a6ae4.test-cncf-aws.k8s.io
-      - name: KOPS_STATE_STORE
-        value: s3://k8s-kops-prow
-      - name: KOPS_VERSION_A
-        value: v1.18.3
-      - name: KOPS_VERSION_B
-        value: v1.19.2
-      - name: K8S_VERSION_A
-        value: v1.18.18
-      - name: K8S_VERSION_B
-        value: v1.18.18
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          memory: "6Gi"
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-misc, kops-kubetest2
-    testgrid-days-of-results: "30"
-    testgrid-tab-name: kops-aws-upgrade-ko118-to-ko119
-- interval: 1h # TODO(justinsb): reduce once working
   name: e2e-kops-aws-upgrade-k119-ko119-to-k120-ko120
   always_run: false
   labels:


### PR DESCRIPTION
kops 1.18 does not support the functionality required by kubetest2, so this will likely never pass. And none of these versions are supported soon anyway.

/cc @hakman @rifelpet 