### PR TITLE
Increase CPU/Memory requests for cluster-api-provider-aws tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-0-6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-0-6.yaml
@@ -32,8 +32,8 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 1
-          memory: "4Gi"
+          cpu: 2
+          memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
     testgrid-tab-name: periodic-e2e-v1alpha3
@@ -74,8 +74,8 @@ periodics:
           privileged: true
         resources:
           requests:
-            cpu: 1
-            memory: "4Gi"
+            cpu: 2
+            memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
     testgrid-tab-name: periodic-capi-e2e-v1alpha3
@@ -112,8 +112,8 @@ periodics:
           privileged: true
         resources:
           requests:
-            cpu: 1
-            memory: "4Gi"
+            cpu: 2
+            memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
     testgrid-tab-name: periodic-e2e-conformance-v1alpha3
@@ -166,9 +166,9 @@ periodics:
           requests:
             # these are both a bit below peak usage during build
             # this is mostly for building kubernetes
-            memory: "9000Mi"
+            memory: "9Gi"
             # during the tests more like 3-20m is used
-            cpu: 2000m
+            cpu: 2
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws, sig-release-master-informing
     testgrid-tab-name: capa-conformance-v1alpha3-k8s-master

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
@@ -32,8 +32,8 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 1
-          memory: "4Gi"
+          cpu: 2
+          memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
     testgrid-tab-name: periodic-e2e
@@ -74,8 +74,8 @@ periodics:
           privileged: true
         resources:
           requests:
-            cpu: 1
-            memory: "4Gi"
+            cpu: 2
+            memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
     testgrid-tab-name: periodic-capi-e2e
@@ -112,8 +112,8 @@ periodics:
           privileged: true
         resources:
           requests:
-            cpu: 1
-            memory: "4Gi"
+            cpu: 2
+            memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
     testgrid-tab-name: periodic-e2e-conformance
@@ -166,9 +166,8 @@ periodics:
           requests:
             # these are both a bit below peak usage during build
             # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            memory: "9Gi"
+            cpu: 2
   annotations:
     # TODO: Change back to once v1alpha4 is stable:
     # testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws, sig-release-master-informing

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
@@ -29,8 +29,8 @@ postsubmits:
               privileged: true
             resources:
               requests:
-                cpu: 1
-                memory: "4Gi"
+                cpu: 2
+                memory: "9Gi"
       annotations:
         testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
         testgrid-tab-name: ci-e2e
@@ -63,8 +63,8 @@ postsubmits:
               privileged: true
             resources:
               requests:
-                cpu: 1
-                memory: "4Gi"
+                cpu: 2
+                memory: "9Gi"
       annotations:
         testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
         testgrid-tab-name: ci-e2e-conformance

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-0.6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-0.6.yaml
@@ -96,7 +96,7 @@ presubmits:
             requests:
               # these are both a bit below peak usage during build
               # this is mostly for building kubernetes
-              memory: "9000Mi"
+              memory: "9Gi"
               # during the tests more like 3-20m is used
               cpu: 2000m
     annotations:
@@ -138,8 +138,8 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 1
-              memory: "4Gi"
+              cpu: 2
+              memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
       testgrid-tab-name: pr-conformance-k8s-master-release-0-6
@@ -178,8 +178,8 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 1
-              memory: "4Gi"
+              cpu: 2
+              memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
       testgrid-tab-name: pr-e2e-release-0-6
@@ -218,8 +218,8 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 1
-              memory: "4Gi"
+              cpu: 2
+              memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
       testgrid-tab-name: pr-e2e-eks-release-0-6

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -96,9 +96,8 @@ presubmits:
             requests:
               # these are both a bit below peak usage during build
               # this is mostly for building kubernetes
-              memory: "9000Mi"
-              # during the tests more like 3-20m is used
-              cpu: 2000m
+              memory: "9Gi"
+              cpu: 2
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
       testgrid-tab-name: pr-conformance
@@ -139,8 +138,8 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 1
-              memory: "4Gi"
+              cpu: 2
+              memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
       testgrid-tab-name: pr-conformance-k8s-master
@@ -180,8 +179,8 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 1
-              memory: "4Gi"
+              cpu: 2
+              memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
       testgrid-tab-name: pr-e2e
@@ -221,8 +220,8 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 1
-              memory: "4Gi"
+              cpu: 2
+              memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
       testgrid-tab-name: pr-e2e-eks


### PR DESCRIPTION
We are observing test failures due to resource exhaustion. Increasing memory and CPU requests for cluster-api-aws tests.

/assign @randomvariable 