### PR TITLE
Always run pull-aws-ebs-csi-driver-external-test-eks

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -137,7 +137,7 @@ presubmits:
       description: kubernetes/kubernetes external test on pull request
       testgrid-num-columns-recent: '30'
   - name: pull-aws-ebs-csi-driver-external-test-eks
-    always_run: false
+    always_run: true
     decorate: true
     skip_branches:
       - gh-pages


### PR DESCRIPTION
it works in https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/907, safe to always run.