### PR TITLE
imagebuilder/gcp: remove preset-service-account and reduce the job interval for debugging

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/image-builder/image-builder-periodics.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/image-builder/image-builder-periodics.yaml
@@ -1,15 +1,13 @@
 periodics:
 - name: periodic-image-builder-gcp-all-nightly
   cluster: k8s-infra-prow-build-trusted
-  interval: 24h
+  interval: 2h
   decorate: true
   extra_refs:
   - org: kubernetes-sigs
     repo: image-builder
     base_ref: master
     path_alias: "sigs.k8s.io/image-builder"
-  labels:
-    preset-service-account: "true"
   spec:
     serviceAccountName: gcb-builder-cluster-api-gcp
     containers:


### PR DESCRIPTION
- remove the `preset-service-account` because we already set the `serviceAccountName` to be used
- reduce the job interval for debugging purposes