### PR TITLE
Introduce Win LTSC2019 to containerD dashboard

### DIFF
--- a/config/testgrids/kubernetes/sig-windows/config.yaml
+++ b/config/testgrids/kubernetes/sig-windows/config.yaml
@@ -68,6 +68,9 @@ dashboards:
   - name: win-2004-containerd-master-integration
     description: Runs containerd integration & cri-integration tests on Windows (SAC 2004)
     test_group_name: integration-containerd-windows-sac2004
+  - name: win-2019-containerd-master-integration
+    description: Runs containerd integration & cri-integration tests on Windows (LTSC 2019)
+    test_group_name: integration-containerd-windows-ltsc2019
 
 test_groups:
 # Flannel CNI on Windows test groups
@@ -98,4 +101,7 @@ test_groups:
 # Containerd Runtime integration test groups
 - name: integration-containerd-windows-sac2004
   gcs_prefix: containerd-integration/logs/windows-sac2004
+  disable_prowjob_analysis: true
+- name: integration-containerd-windows-ltsc2019
+  gcs_prefix: containerd-integration/logs/windows-ltsc2019
   disable_prowjob_analysis: true


### PR DESCRIPTION
Add the `containerd integration & cri-integration tests on Windows (LTSC 2019)` job to testgrid config file.