### PR TITLE
set merge_method as squash for kubernetes-sigs/vsphere-csi-driver repository

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -589,6 +589,7 @@ tide:
     kubernetes-sigs/service-catalog: squash
     kubernetes-sigs/go-open-service-broker-client: squash
     kubernetes-sigs/minibroker: squash
+    kubernetes-sigs/vsphere-csi-driver: squash
     kubernetes/cloud-provider-openstack: squash
     kubernetes/dashboard: squash
     kubernetes/ingress-nginx: squash


### PR DESCRIPTION
merge method for vSphere CSI driver is `merge`. We want to switch the merge method to `squash` so developers do not require to manually squash commits on the repository before prow merge the PR.

Refer to : 
https://github.com/kubernetes/test-infra/blob/master/prow/cmd/tide/config.md
> merge_method: A key/value pair of an org/repo as the key and merge method to override the default method of merge as value. Valid options are squash, rebase, and merge. Defaults to merge.
