### PR TITLE
skip_submodules: change comment to match its action

### DIFF
--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -882,7 +882,7 @@ type Refs struct {
 	// `https://github.com/org/repo.git`.
 	CloneURI string `json:"clone_uri,omitempty"`
 	// SkipSubmodules determines if submodules should be
-	// cloned when the job is run. Defaults to true.
+	// cloned when the job is run. Defaults to false.
 	SkipSubmodules bool `json:"skip_submodules,omitempty"`
 	// CloneDepth is the depth of the clone that will be used.
 	// A depth of zero will do a full clone.

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -418,7 +418,7 @@ type UtilityConfig struct {
 	// `https://github.com/org/repo.git`.
 	CloneURI string `json:"clone_uri,omitempty"`
 	// SkipSubmodules determines if submodules should be
-	// cloned when the job is run. Defaults to true.
+	// cloned when the job is run. Defaults to false.
 	SkipSubmodules bool `json:"skip_submodules,omitempty"`
 	// CloneDepth is the depth of the clone that will be used.
 	// A depth of zero will do a full clone.


### PR DESCRIPTION
The comment says default to true, but searching SkipSubmodules throughout the codebase and could not find evidence supporting it. So I believe it's defaulting to false