### PR TITLE
[CAPN] Adding image builder

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
@@ -144,6 +144,30 @@ postsubmits:
               - --scratch-bucket=gs://k8s-staging-capi-kubeadm-gcb
               - --env-passthrough=PULL_BASE_REF
               - .
+  kubernetes-sigs/cluster-api-provider-nested:
+    - name: post-cluster-api-provider-nested-push-images
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        # this is the name of some testgrid dashboard to report to.
+        testgrid-dashboards: sig-cluster-lifecycle-image-pushes
+      decorate: true
+      branches:
+        - ^main$
+        - ^release-.+$
+        # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20210302-aa40187
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR images are pushed to.
+              - --project=k8s-staging-cluster-api-nested
+              - --scratch-bucket=gs://k8s-staging-cluster-api-nested-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - .
   kubernetes-sigs/cluster-api-provider-openstack:
     - name: post-cluster-api-provider-openstack-push-images
       cluster: k8s-infra-prow-build-trusted


### PR DESCRIPTION
Adding image building for CAPN so we can start to release binaries off `main` and subsequent `release-*` and `v*` branches/tags.

## Related

XRef: https://github.com/kubernetes-sigs/cluster-api-provider-nested/issues/60

Signed-off-by: Chris Hein <me@chrishein.com>