### PR TITLE
images/alpine: Build for arm64

### DIFF
--- a/images/alpine/cloudbuild.yaml
+++ b/images/alpine/cloudbuild.yaml
@@ -1,19 +1,21 @@
 steps:
-  - name: gcr.io/cloud-builders/docker
+  - name: gcr.io/k8s-testimages/gcb-docker-gcloud
+    entrypoint: /buildx-entrypoint
     args:
     - build
-    - -t
-    - gcr.io/$PROJECT_ID/alpine:$_GIT_TAG
+    - --tag=gcr.io/$PROJECT_ID/alpine:$_GIT_TAG
+    - --platform=linux/amd64,linux/arm64/v8
     - --build-arg=IMAGE_ARG=gcr.io/$PROJECT_ID/alpine:$_GIT_TAG
+    - --push
     - .
     dir: .
-  - name: gcr.io/cloud-builders/docker
+  - name: gcr.io/k8s-testimages/gcb-docker-gcloud
+    entrypoint: gcloud
     args:
-    - tag
+    - container
+    - images
+    - add-tag
     - gcr.io/$PROJECT_ID/alpine:$_GIT_TAG
     - gcr.io/$PROJECT_ID/alpine:latest
 substitutions:
   _GIT_TAG: '12345'
-images:
-  - 'gcr.io/$PROJECT_ID/alpine:$_GIT_TAG'
-  - 'gcr.io/$PROJECT_ID/alpine:latest'


### PR DESCRIPTION
This commit adds a Google Cloud Build definition for building alpine
arm64 images and pushing them as a manifest list together with their
amd64 counterparts.

This is a prereq for #16588 and #22362

~~Blocked on: https://github.com/kubernetes/test-infra/pull/22599~~

/cc @stevekuznetsov 