### PR TITLE
Use golang 1.16 in prometheus-adapter

### DIFF
--- a/config/jobs/kubernetes-sigs/prometheus-adapter/prometheus-adapter-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/prometheus-adapter/prometheus-adapter-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     path_alias: sigs.k8s.io/prometheus-adapter
     spec:
       containers:
-      - image: golang:1.15
+      - image: golang:1.16
         command:
         - make
         args:


### PR DESCRIPTION
Prometheus-adapter go.mod now requires go 1.16.

/cc @s-urbaniak 