### PR TITLE
Use --endpoint-updates-batch-period=500ms in OSS 5k tests

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -30,7 +30,7 @@ periodics:
       - --extract=ci/latest-fast
       - --extract-ci-bucket=k8s-release-dev
       # Overrides CONTROLLER_MANAGER_TEST_ARGS from preset-e2e-scalability-periodics.
-      - --env=CONTROLLER_MANAGER_TEST_ARGS=--profiling --kube-api-qps=100 --kube-api-burst=100 --endpointslice-updates-batch-period=500ms
+      - --env=CONTROLLER_MANAGER_TEST_ARGS=--profiling --kube-api-qps=100 --kube-api-burst=100 --endpointslice-updates-batch-period=500ms --endpoint-updates-batch-period=500ms
       - --gcp-master-image=gci
       - --gcp-node-image=gci
       - --gcp-node-size=e2-small
@@ -106,7 +106,7 @@ periodics:
       - --env=CL2_DELETE_TEST_THROUGHPUT=30
       - --env=CL2_ENABLE_HUGE_SERVICES=true
       # Overrides CONTROLLER_MANAGER_TEST_ARGS from preset-e2e-scalability-periodics.
-      - --env=CONTROLLER_MANAGER_TEST_ARGS=--profiling --kube-api-qps=100 --kube-api-burst=100 --endpointslice-updates-batch-period=500ms
+      - --env=CONTROLLER_MANAGER_TEST_ARGS=--profiling --kube-api-qps=100 --kube-api-burst=100 --endpointslice-updates-batch-period=500ms --endpoint-updates-batch-period=500ms
       - --env=CL2_ENABLE_API_AVAILABILITY_MEASUREMENT=true
       - --env=CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD=99.5
       - --test=false


### PR DESCRIPTION
Even now, when kube-proxy instances are using endpointslices, endpoints watch traffic is responsible for a significant part of network traffic in some part of tests, despite the fact that we have only ~300 kube-dns instances using endpoints (vs 5k kube-proxies using endpointslices):

![image](https://user-images.githubusercontent.com/2559168/121035958-a9af3180-c7ae-11eb-8e25-1fe9b96a8831.png)

We see some reliability issues around that time, so let's try to reduce unnecessary watch traffic load that time.

/assign @wojtek-t 
