### PR TITLE
images/git: Build for arm64

### DIFF
--- a/images/git/Dockerfile
+++ b/images/git/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-prow/alpine:v20200605-44f6c96
+FROM gcr.io/k8s-prow/alpine:v20210618-2814345
 
 ARG IMAGE_ARG
 ENV IMAGE=${IMAGE_ARG}

--- a/images/git/cloudbuild.yaml
+++ b/images/git/cloudbuild.yaml
@@ -1,19 +1,21 @@
 steps:
-  - name: gcr.io/cloud-builders/docker
+  - name: gcr.io/k8s-testimages/gcb-docker-gcloud
+    entrypoint: /buildx-entrypoint
     args:
     - build
-    - -t
-    - gcr.io/$PROJECT_ID/git:$_GIT_TAG
+    - --tag=gcr.io/$PROJECT_ID/git:$_GIT_TAG
+    - --platform=linux/amd64,linux/arm64/v8
     - --build-arg=IMAGE_ARG=gcr.io/$PROJECT_ID/git:$_GIT_TAG
+    - --push
     - .
     dir: .
-  - name: gcr.io/cloud-builders/docker
+  - name: gcr.io/k8s-testimages/gcb-docker-gcloud
+    entrypoint: gcloud
     args:
-    - tag
+    - container
+    - images
+    - add-tag
     - gcr.io/$PROJECT_ID/git:$_GIT_TAG
     - gcr.io/$PROJECT_ID/git:latest
 substitutions:
   _GIT_TAG: '12345'
-images:
-  - 'gcr.io/$PROJECT_ID/git:$_GIT_TAG'
-  - 'gcr.io/$PROJECT_ID/git:latest'


### PR DESCRIPTION
This commit adds a Google Cloud Build definition for building git
arm64 images and pushing them as a manifest list together with their
amd64 counterparts.

This is a prereq for #16588 and #22362

~~Blocked on: https://github.com/kubernetes/test-infra/pull/22599  https://github.com/kubernetes/test-infra/pull/22444~~

/cc @stevekuznetsov