### PR TITLE
Split eviction tests out from node-serial job

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -203,6 +203,36 @@ periodics:
     description: "Contains all uncategorized tests, these are tests which are not marked with a [Node] tag. All node tests should be marked with [NodeFeature] or [NodeSpecialFeature] or [NodeAlphaFeature] or [NodeConformance] classification. Also skipped are [Flaky], [Benchmark], [Legacy]."
 
 - name: ci-kubernetes-node-kubelet-serial
+  interval: 4h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210601-ea6aa4e-master
+      args:
+      - --repo=k8s.io/kubernetes=master
+      - --timeout=240
+      - --root=/go/src
+      - --scenario=kubernetes_e2e
+      - --
+      - --deployment=node
+      - --gcp-project-type=node-e2e-project
+      - --gcp-zone=us-west1-b
+      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial.yaml
+      - --node-test-args=--feature-gates=DynamicKubeletConfig=true,LocalStorageCapacityIsolation=true --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
+      - --node-tests=true
+      - --provider=gce
+      - --test_args=--nodes=1 --focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeAlphaFeature:.+\]|\[NodeFeature:Eviction\]"
+      - --timeout=180m
+      env:
+      - name: GOPATH
+        value: /go
+  annotations:
+    testgrid-dashboards: sig-node-kubelet
+    testgrid-tab-name: node-kubelet-serial
+
+- name: ci-kubernetes-node-kubelet-eviction
   interval: 4h30m
   labels:
     preset-service-account: "true"
@@ -223,14 +253,14 @@ periodics:
       - --node-test-args=--feature-gates=DynamicKubeletConfig=true,LocalStorageCapacityIsolation=true --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
       - --node-tests=true
       - --provider=gce
-      - --test_args=--nodes=1 --focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeAlphaFeature:.+\]"
+      - --test_args=--nodes=1 --focus="\[NodeFeature:Eviction\]"
       - --timeout=300m
       env:
       - name: GOPATH
         value: /go
   annotations:
     testgrid-dashboards: sig-node-kubelet
-    testgrid-tab-name: node-kubelet-serial
+    testgrid-tab-name: node-kubelet-eviction
 
 - name: ci-kubernetes-node-kubelet-serial-cpu-manager
   interval: 4h

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -221,6 +221,40 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210601-ea6aa4e-master
         args:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - --timeout=240
+        - --root=/go/src
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - --scenario=kubernetes_e2e
+        - --
+        - --deployment=node
+        - --gcp-project-type=node-e2e-project
+        - --gcp-zone=us-west1-b
+        - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial.yaml
+        - --node-test-args=--feature-gates=DynamicKubeletConfig=true,LocalStorageCapacityIsolation=true --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
+        - --node-tests=true
+        - --provider=gce
+        - --test_args=--nodes=1 --focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeAlphaFeature:.+\]|\[NodeFeature:Eviction\]"
+        - --timeout=180m
+        env:
+        - name: GOPATH
+          value: /go
+  - name: pull-kubernetes-node-kubelet-eviction
+    always_run: false
+    optional: true
+    skip_report: false
+    skip_branches:
+    - release-\d+\.\d+  # per-release image
+    annotations:
+      testgrid-dashboards: sig-node-kubelet
+      testgrid-tab-name: pr-node-kubelet-eviction
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210601-ea6aa4e-master
+        args:
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - --timeout=440
         - --root=/go/src
         - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -233,7 +267,7 @@ presubmits:
         - --node-test-args=--feature-gates=DynamicKubeletConfig=true,LocalStorageCapacityIsolation=true --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
         - --node-tests=true
         - --provider=gce
-        - --test_args=--nodes=1 --focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeAlphaFeature:.+\]"
+        - --test_args=--nodes=1 --focus="\[NodeFeature:Eviction\]"
         - --timeout=420m
         env:
         - name: GOPATH


### PR DESCRIPTION
~Note: this is only for the PR job so we can test this.~

~Seeing if excluding these tests from the serial job will avoid the 7h timeout...~

~I suggest if this succeeds that we split these into their own job, wdyt?~

Splits the node serial jobs in half so the eviction tests have their own job. Without them, per tests on https://github.com/kubernetes/kubernetes/pull/102691 and https://github.com/kubernetes/kubernetes/pull/102708 the serial tests take under 90m.

xref https://github.com/kubernetes/kubernetes/issues/102148#issuecomment-854777565

/cc @fromanirh @SergeyKanzhelev @dims 