### PR TITLE
[sig-node] Remove failing, unused NodeConformance job

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -71,38 +71,6 @@ periodics:
     testgrid-dashboards: sig-node-kubelet
     testgrid-tab-name: node-kubelet-alpha
 
-- name: ci-kubernetes-node-kubelet-conformance
-  interval: 2h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-    preset-dind-enabled: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210707-0f9c540-master
-      args:
-      - --repo=k8s.io/kubernetes=master
-      - --timeout=90
-      - --root=/go/src
-      - --scenario=kubernetes_e2e
-      - --
-      - --deployment=node
-      - --gcp-project-type=node-e2e-project
-      - --gcp-zone=us-west1-b
-      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
-      - --node-test-args=--feature-gates=DynamicKubeletConfig=true --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
-      - --node-tests=true
-      - --provider=gce
-      - --test_args=--nodes=1 --focus="\[NodeConformance\]" --skip="\[Flaky\]"
-      - --timeout=65m
-      env:
-      - name: GOPATH
-        value: /go
-  annotations:
-    testgrid-dashboards: sig-node-kubelet
-    testgrid-tab-name: node-kubelet-conformance
-    testgrid-alert-email: kubernetes-sig-node+testgrid@googlegroups.com,kubernetes-sig-node-test-failures@googlegroups.com
-
 - name: ci-kubernetes-node-kubelet-features
   cluster: k8s-infra-prow-build
   interval: 1h

--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -21,8 +21,6 @@ dashboards:
 - name: sig-node-release-blocking # Tabs included in this group are defined in the jobs that are included.
 - name: sig-node-critical
   dashboard_tab:
-    - name: kubelet-NodeConformance
-      test_group_name: ci-kubernetes-node-kubelet-conformance
     - name: containerd-NodeConformance
       test_group_name: ci-containerd-node-e2e
 
@@ -104,13 +102,6 @@ dashboards:
 test_groups:
 - name: ci-kubernetes-node-kubelet-alpha
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-alpha
-  test_name_config:
-    name_elements:
-    - target_config: Tests name
-    - target_config: Context
-    name_format: '%s [%s]'
-- name: ci-kubernetes-node-kubelet-conformance
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-conformance
   test_name_config:
     name_elements:
     - target_config: Tests name


### PR DESCRIPTION
As mentioned in https://github.com/kubernetes/test-infra/issues/18973#issuecomment-856144317 the only difference between this and the ci-kubernetes-node-kubelet job is that one skips Serial tests. However, I couldn't find any NodeConformance tests marked Serial, so I don't think it makes any difference.

This job has been failing for months and was believed to be a duplicate; I think we should just remove it.

Fixes  #18973 and https://github.com/kubernetes/kubernetes/issues/97130.

/cc @SergeyKanzhelev @pacoxu 