### PR TITLE
Slackreporter: Log channel on reporting errors

### DIFF
--- a/prow/slack/client.go
+++ b/prow/slack/client.go
@@ -143,5 +143,8 @@ func (sl *Client) WriteMessage(text, channel string) error {
 	uv.Add("channel", channel)
 	uv.Add("text", text)
 
-	return sl.postMessage(chatPostMessage, uv)
+	if err := sl.postMessage(chatPostMessage, uv); err != nil {
+		return fmt.Errorf("failed to post message to #%s: %w", channel, err)
+	}
+	return nil
 }


### PR DESCRIPTION
We have a bunch of errors because the channel wasn't found, but the
error doesn't include the info which channel this is about:

```
failed to write Slack message: request failed: channel_not_found
```