### PR TITLE
Tide status: Ignore 404 when trying to create a StatusContext

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -791,6 +791,7 @@ type request struct {
 }
 
 type requestError struct {
+	StatusCode  int
 	ClientError error
 	ErrorString string
 }
@@ -832,6 +833,10 @@ func IsNotFound(err error) bool {
 	var requestErr requestError
 	if !errors.As(err, &requestErr) {
 		return false
+	}
+
+	if requestErr.StatusCode == http.StatusNotFound {
+		return true
 	}
 
 	for _, errorMsg := range requestErr.ErrorMessages() {
@@ -890,6 +895,7 @@ func (c *client) requestRawWithContext(ctx context.Context, r *request) (int, []
 	if !okCode {
 		clientError := unmarshalClientError(b)
 		err = requestError{
+			StatusCode:  resp.StatusCode,
 			ClientError: clientError,
 			ErrorString: fmt.Sprintf("status code %d not one of %v, body: %s", resp.StatusCode, r.exitCodes, string(b)),
 		}

--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -401,7 +401,7 @@ func (sc *statusController) setStatuses(all []PullRequest, pool map[string]PullR
 					State:       wantState,
 					Description: wantDesc,
 					TargetURL:   targetURL(c, pr, log),
-				}); err != nil {
+				}); err != nil && !github.IsNotFound(err) {
 				log.WithError(err).Errorf(
 					"Failed to set status context from %q to %q and description from %q to %q",
 					actualState,


### PR DESCRIPTION
A commit might disappear for example because someone pushed rapidly, so
this is not an acutal error.