### PR TITLE
GitHub delete comment: Tolerate 404

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -1686,7 +1686,7 @@ func (c *client) DeleteCommentWithContext(ctx context.Context, org, repo string,
 		method:    http.MethodDelete,
 		path:      fmt.Sprintf("/repos/%s/%s/issues/comments/%d", org, repo, id),
 		org:       org,
-		exitCodes: []int{204},
+		exitCodes: []int{204, 404},
 	}, nil)
 	return err
 }


### PR DESCRIPTION
Trying to delete a comment that doesn't exist anymore is not an error,
as the desired outcome of "Comment is absent" was achieved.

Fixes https://github.com/kubernetes/test-infra/issues/22257