### PR TITLE
Set REGISTRY for e2e tests running in gce

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-smb/csi-driver-smb-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-smb/csi-driver-smb-config.yaml
@@ -347,6 +347,8 @@ presubmits:
           value: "win2019"
         - name: PREPULL_YAML
           value: "prepull-head.yaml"
+        - name: REGISTRY
+          value: "gcr.io/kubernetes-e2e-test-images"
         image: gcr.io/k8s-testimages/kubekins-e2e:v20210601-ea6aa4e-master
         securityContext:
             privileged: true


### PR DESCRIPTION
Use gcr.io/kubernetes-e2e-test-images as registry for e2e tests running in prow. 