### PR TITLE
jobs: use k8s-infra image for wg-k8s-infra jobs

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/k8sio-presubmit.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/k8sio-presubmit.yaml
@@ -11,12 +11,13 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: golang:1.13
+      - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
         command:
-        - bash
+        - make
         args:
-        - -c
-        - "cd groups && go test"
+        - -C
+        - ./groups
+        - test
         env:
         - name: GO111MODULE
           value: "on"
@@ -37,9 +38,10 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/gcb-docker-gcloud:v20210331-c732583
+      - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
         command:
         - hack/verify-terraform.sh
+        args:
         - infra/gcp/clusters/projects/kubernetes-public/aaa
         resources:
           limits:
@@ -65,9 +67,10 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/gcb-docker-gcloud:v20210331-c732583
+      - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
         command:
         - hack/verify-terraform.sh
+        args:
         - infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build
         resources:
           limits:
@@ -93,9 +96,10 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/gcb-docker-gcloud:v20210331-c732583
+      - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
         command:
         - hack/verify-terraform.sh
+        args:
         - infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted
         resources:
           limits:
@@ -112,8 +116,6 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210601-ea6aa4e-master
+      - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
         command:
-        - runner.sh
-        args:
         - ./hack/verify.sh

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
@@ -15,12 +15,15 @@ periodics:
   spec:
     serviceAccountName: gsuite-groups-manager
     containers:
-    - image: golang:1.13
+    - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
       command:
-      - bash
+      - make
       args:
-      - -c
-      - "cd groups && make run -- --confirm"
+      - -C
+      - groups
+      - run
+      - --
+      - --confirm
 - name: ci-k8sio-audit
   interval: 6h
   cluster: k8s-infra-prow-build-trusted
@@ -46,7 +49,7 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-gcp-auditor
     containers:
-    - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+    - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
       imagePullPolicy: Always
       command:
       - ./audit/create-or-update-audit-pr.sh
@@ -82,12 +85,15 @@ postsubmits:
     spec:
       serviceAccountName: gsuite-groups-manager
       containers:
-      - image: golang:1.13
+      - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
         command:
-        - bash
+        - make
         args:
-        - -c
-        - "cd groups && make run -- --confirm"
+        - -C
+        - groups
+        - run
+        - --
+        - --confirm
   - name: post-k8sio-dns-update
     cluster: k8s-infra-prow-build-trusted
     decorate: true
@@ -134,7 +140,7 @@ postsubmits:
     spec:
       serviceAccountName: prow-deployer
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-in-go:v20200824-5d057db
+      - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
         command:
         - bash
         args:
@@ -144,9 +150,16 @@ postsubmits:
           if [[ -x ./deploy.sh ]]; then
             ./deploy.sh
           else
-            gcloud container clusters get-credentials prow-build --project=k8s-infra-prow-build --region=us-central1
-            kubectl --context=gke_k8s-infra-prow-build_us-central1_prow-build \
-              apply -f ./prow-build/resources --recursive
+            gcloud \
+              container clusters get-credentials \
+              --project=k8s-infra-prow-build \
+              --region=us-central1 \
+              prow-build
+            kubectl \
+              --context=gke_k8s-infra-prow-build_us-central1_prow-build \
+              apply \
+                -f ./prow-build/resources \
+                --recursive
           fi
   - name: post-k8sio-deploy-prow-build-trusted-resources
     cluster: k8s-infra-prow-build-trusted
@@ -169,7 +182,7 @@ postsubmits:
     spec:
       serviceAccountName: prow-deployer
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-in-go:v20200824-5d057db
+      - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
         command:
         - bash
         args:
@@ -179,7 +192,14 @@ postsubmits:
           if [[ -x ./deploy.sh ]]; then
             ./deploy.sh
           else
-            gcloud container clusters get-credentials prow-build-trusted --project=k8s-infra-prow-build-trusted --region=us-central1
-            kubectl --context=gke_k8s-infra-prow-build-trusted_us-central1_prow-build-trusted \
-              apply -f ./prow-build-trusted/resources --recursive
+            gcloud \
+              container clusters get-credentials \
+              --project=k8s-infra-prow-build-trusted \
+              --region=us-central1 \
+              prow-build-trusted
+            kubectl \
+              --context=gke_k8s-infra-prow-build-trusted_us-central1_prow-build-trusted \
+              apply \
+                -f ./prow-build-trusted/resources \
+                --recursive
           fi


### PR DESCRIPTION
Now that https://github.com/kubernetes/k8s.io/pull/2134 has merged

The job added in https://github.com/kubernetes/test-infra/pull/22458 has built `gcr.io/k8s-staging-infra-tools/k8s-infra:latest`

Use it for all wg-k8s-infra jobs