### PR TITLE
images/builder: update to cloud-sdk 343.0

### DIFF
--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM google/cloud-sdk:258.0.0-alpine
+FROM google/cloud-sdk:343.0.0-alpine
 COPY builder run.sh /
 CMD ["/run.sh"]


### PR DESCRIPTION
I think the version of `gcloud builds submit` at 258.0.0 doesn't understand `options.machineType` which is breaking the job introduced in https://github.com/kubernetes/test-infra/pull/22458 which is supposed to build https://github.com/kubernetes/k8s.io/pull/2134