### PR TITLE
jobs: use latest image-builder for k8s-infra image-pushing jobs

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-infra-tools.yaml
+++ b/config/jobs/image-pushing/k8s-staging-infra-tools.yaml
@@ -11,7 +11,7 @@ postsubmits:
       spec:
         serviceAccountName: gcb-builder
         containers:
-          - image: gcr.io/k8s-testimages/image-builder:v20210302-aa40187
+          - image: gcr.io/k8s-testimages/image-builder:v20210607-0d70d1d
             command:
               - /run.sh
             args:
@@ -32,7 +32,7 @@ postsubmits:
       spec:
         serviceAccountName: gcb-builder
         containers:
-          - image: gcr.io/k8s-testimages/image-builder:v20210302-aa40187
+          - image: gcr.io/k8s-testimages/image-builder:v20210607-0d70d1d
             command:
               - /run.sh
             args:


### PR DESCRIPTION
Now that https://github.com/kubernetes/test-infra/pull/22464 has merged and a new `image-builder` image has been pushed, let's use it for `gcr.io/ks-staging-infra-tools/k8s-infra`

Once this merges, a followup PR in k8s.io needs to happen to trigger a new job using this new image, which should hopefully unblock https://github.com/kubernetes/test-infra/pull/22463