### PR TITLE
CAPN Periodic Wrong Base Ref

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-nested/cluster-api-provider-nested-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-nested/cluster-api-provider-nested-periodics.yaml
@@ -30,7 +30,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-nested
-    base_ref: master
+    base_ref: main
     path_alias: "sigs.k8s.io/cluster-api-provider-nested"
   labels:
     preset-service-account: "true"


### PR DESCRIPTION
Accidently missed making sure the periodic test had the proper `base_ref` based on tracking `main`.

Signed-off-by: Chris Hein <me@chrishein.com>