### PR TITLE
provider-openstack: add v1.21 and removed v1.18

### DIFF
--- a/config/testgrids/kubernetes/sig-cloud-provider/openstack/config.yaml
+++ b/config/testgrids/kubernetes/sig-cloud-provider/openstack/config.yaml
@@ -11,11 +11,6 @@ dashboards:
       test_group_name: ci-presubmit-cloud-provider-openstack-acceptance-test-e2e-conformance
       alert_options:
         alert_mail_to_addresses: provider.openstack+testgrid@gmail.com
-    - name: presubmit-v1.18
-      description: Runs conformance tests using kubetest against kubernetes v1.18 with cloud-provider-openstack
-      test_group_name: ci-presubmit-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.18
-      alert_options:
-        alert_mail_to_addresses: provider.openstack+testgrid@gmail.com
     - name: presubmit-v1.19
       description: Runs conformance tests using kubetest against kubernetes v1.19 with cloud-provider-openstack
       test_group_name: ci-presubmit-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.19
@@ -26,14 +21,14 @@ dashboards:
       test_group_name: ci-presubmit-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.20
       alert_options:
         alert_mail_to_addresses: provider.openstack+testgrid@gmail.com
+    - name: presubmit-v1.21
+      description: Runs conformance tests using kubetest against kubernetes v1.21 with cloud-provider-openstack
+      test_group_name: ci-presubmit-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.21
+      alert_options:
+        alert_mail_to_addresses: provider.openstack+testgrid@gmail.com
     - name: periodic-master
       description: Runs conformance tests using kubetest against latest kubernetes master with cloud-provider-openstack
       test_group_name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance
-      alert_options:
-        alert_mail_to_addresses: provider.openstack+testgrid@gmail.com
-    - name: periodic-v1.18
-      description: Runs conformance tests using kubetest against kubernetes v1.18 with cloud-provider-openstack
-      test_group_name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.18
       alert_options:
         alert_mail_to_addresses: provider.openstack+testgrid@gmail.com
     - name: periodic-v1.19
@@ -46,15 +41,15 @@ dashboards:
       test_group_name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.20
       alert_options:
         alert_mail_to_addresses: provider.openstack+testgrid@gmail.com
+    - name: periodic-v1.21
+      description: Runs conformance tests using kubetest against kubernetes v1.21 with cloud-provider-openstack
+      test_group_name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.21
+      alert_options:
+        alert_mail_to_addresses: provider.openstack+testgrid@gmail.com
 
 test_groups:
 - name: ci-presubmit-cloud-provider-openstack-acceptance-test-e2e-conformance
   gcs_prefix: k8s-conform-provider-openstack/pr-logs/ci-cloud-provider-openstack-acceptance-test-e2e-conformance
-  alert_stale_results_hours: 24
-  num_failures_to_alert: 1
-  disable_prowjob_analysis: true
-- name: ci-presubmit-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.18
-  gcs_prefix: k8s-conform-provider-openstack/pr-logs/ci-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.18
   alert_stale_results_hours: 24
   num_failures_to_alert: 1
   disable_prowjob_analysis: true
@@ -68,13 +63,13 @@ test_groups:
   alert_stale_results_hours: 24
   num_failures_to_alert: 1
   disable_prowjob_analysis: true
-- name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance
-  gcs_prefix: k8s-conform-provider-openstack/periodic-logs/ci-cloud-provider-openstack-acceptance-test-e2e-conformance
+- name: ci-presubmit-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.21
+  gcs_prefix: k8s-conform-provider-openstack/pr-logs/ci-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.21
   alert_stale_results_hours: 24
   num_failures_to_alert: 1
   disable_prowjob_analysis: true
-- name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.18
-  gcs_prefix: k8s-conform-provider-openstack/periodic-logs/ci-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.18
+- name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance
+  gcs_prefix: k8s-conform-provider-openstack/periodic-logs/ci-cloud-provider-openstack-acceptance-test-e2e-conformance
   alert_stale_results_hours: 24
   num_failures_to_alert: 1
   disable_prowjob_analysis: true
@@ -85,6 +80,11 @@ test_groups:
   disable_prowjob_analysis: true
 - name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.20
   gcs_prefix: k8s-conform-provider-openstack/periodic-logs/ci-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.20
+  alert_stale_results_hours: 24
+  num_failures_to_alert: 1
+  disable_prowjob_analysis: true
+- name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.21
+  gcs_prefix: k8s-conform-provider-openstack/periodic-logs/ci-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.21
   alert_stale_results_hours: 24
   num_failures_to_alert: 1
   disable_prowjob_analysis: true


### PR DESCRIPTION
This PR adds results for test of cloud-provider-openstack for the
release v1.21.

v1.18 is removed, because of EOL.