### PR TITLE
Disable konnectivity in kubemark

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -95,6 +95,10 @@ presets:
     value: true
   - name: DUMP_TO_GCS_ONLY
     value: true
+  # Disable konnectivity in kubemark as it doesn't work (see https://github.com/kubernetes/perf-tests/issues/1828)
+  # TODO(https://github.com/kubernetes/perf-tests/issues/1828): Use konnectivity in kubemark.
+  - name: KUBE_ENABLE_KONNECTIVITY_SERVICE
+    value: false
 
 ### kubemark-gce-scale
 - labels:


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/102661 enables konnectivity in all tests, incl. kubemark where it doesn't work (not sure why). This makes the test consistently failing and blocks perf-tests merge queue. 

https://github.com/kubernetes/perf-tests/issues/1828 tracks enabling it back
/assign @wojtek-t 