### PR TITLE
Tide: De-Duplicate queries

### DIFF
--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -280,6 +280,25 @@ type TideQuery struct {
 	ExcludedRepos []string `json:"excludedRepos,omitempty"`
 }
 
+// tideQueryConfig contains the subset of attributes by which we de-duplicate
+// tide queries. Together with tideQueryTarget it must contain the full set
+// of all TideQuery properties.
+type tideQueryConfig struct {
+	Author                 string
+	ExcludedBranches       []string
+	IncludedBranches       []string
+	Labels                 []string
+	MissingLabels          []string
+	Milestone              string
+	ReviewApprovedRequired bool
+}
+
+type tideQueryTarget struct {
+	Orgs          []string
+	Repos         []string
+	ExcludedRepos []string
+}
+
 // constructQuery returns a map[org][]orgSpecificQueryParts (org, repo, -repo), remainingQueryString
 func (tq *TideQuery) constructQuery() (map[string][]string, string) {
 	// map org->repo directives (if any)


### PR DESCRIPTION
Each tide query has a minimum token cost, so increasing the number of
queries might result in increased token usage. When we implement Tide
config sharding, it is possible that ppl will have duplicate queries
that only differ in the org or repo they target. This change makes us
de-duplicate queries by all attributes except for target org/target
repo/excluded repo to avoid this.

Sidenode: The code that is added here is 99% a copy of code we use in downstream since ~November 2020, but in a tool that reads -> modifies -> writes the config rather than at config load: https://github.com/openshift/ci-tools/pull/1369

/assign @cjwagner @chaodaiG 