### PR TITLE
Prow: skip_if_only_changed, the inverse of run_if_changed

### DIFF
--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -965,7 +965,7 @@ func verifyPodQOSGuaranteed(spec *coreapi.PodSpec, required bool) (errs []error)
 // - reports (aka does not skip reporting)
 // - always runs OR runs if some path changed
 func isMergeBlocking(job cfg.Presubmit) bool {
-	return !job.Optional && !job.SkipReport && (job.AlwaysRun || job.RunIfChanged != "")
+	return !job.Optional && !job.SkipReport && (job.AlwaysRun || job.RunIfChanged != "" || job.SkipIfOnlyChanged != "")
 }
 
 func isKubernetesReleaseBlocking(job cfg.JobBase) bool {

--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -400,7 +400,7 @@ func hasAnyPrefix(s string, prefixes []string) bool {
 // - reports (aka does not skip reporting)
 // - always runs OR runs if some path changed
 func isMergeBlocking(job prow_config.Presubmit) bool {
-	return !job.Optional && !job.SkipReport && (job.AlwaysRun || job.RunIfChanged != "")
+	return !job.Optional && !job.SkipReport && (job.AlwaysRun || job.RunIfChanged != "" || job.SkipIfOnlyChanged != "")
 }
 
 // All jobs in presubmits-kuberentes-blocking must be merge-blocking for kubernetes/kubernetes

--- a/experiment/prowjob-report/main.go
+++ b/experiment/prowjob-report/main.go
@@ -255,7 +255,7 @@ func isPodQOSGuaranteed(spec *corev1.PodSpec) bool {
 // - reports (aka does not skip reporting)
 // - always runs OR runs if some path changed
 func isMergeBlocking(job cfg.Presubmit) bool {
-	return !job.Optional && !job.SkipReport && (job.AlwaysRun || job.RunIfChanged != "")
+	return !job.Optional && !job.SkipReport && (job.AlwaysRun || job.RunIfChanged != "" || job.SkipIfOnlyChanged != "")
 }
 
 func guessPeriodicRepoAndBranch(job cfg.Periodic) (repo, branch string) {

--- a/prow/config/branch_protection_test.go
+++ b/prow/config/branch_protection_test.go
@@ -337,6 +337,16 @@ func TestBranchRequirements(t *testing.T) {
 					},
 				},
 				{
+					RegexpChangeMatcher: RegexpChangeMatcher{
+						SkipIfOnlyChanged: "foo",
+					},
+					AlwaysRun: false,
+					Reporter: Reporter{
+						Context:    "skip-if-only-changed",
+						SkipReport: false,
+					},
+				},
+				{
 					AlwaysRun: false,
 					Reporter: Reporter{
 						Context:    "not-always",
@@ -363,10 +373,10 @@ func TestBranchRequirements(t *testing.T) {
 				},
 			},
 			masterExpected:  []string{"always-run"},
-			masterIfPresent: []string{"run-if-changed", "not-always"},
+			masterIfPresent: []string{"run-if-changed", "skip-if-only-changed", "not-always"},
 			masterOptional:  []string{"optional"},
 			otherExpected:   []string{"always-run"},
-			otherIfPresent:  []string{"run-if-changed", "not-always"},
+			otherIfPresent:  []string{"run-if-changed", "skip-if-only-changed", "not-always"},
 			otherOptional:   []string{"skip-report", "optional"},
 		},
 	}

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -5649,6 +5649,38 @@ func TestValidatePresubmits(t *testing.T) {
 			presubmits:    []Presubmit{{JobBase: JobBase{Name: "my-job"}}},
 			expectedError: "invalid presubmit job my-job: job is set to report but has no context configured",
 		},
+		{
+			name: "Mutually exclusive settings: always_run and run_if_changed",
+			presubmits: []Presubmit{{
+				JobBase:             JobBase{Name: "a"},
+				Reporter:            Reporter{Context: "foo"},
+				AlwaysRun:           true,
+				RegexpChangeMatcher: RegexpChangeMatcher{RunIfChanged: `\.go$`},
+			}},
+			expectedError: "job a is set to always run but also declares run_if_changed targets, which are mutually exclusive",
+		},
+		{
+			name: "Mutually exclusive settings: always_run and skip_if_only_changed",
+			presubmits: []Presubmit{{
+				JobBase:             JobBase{Name: "a"},
+				Reporter:            Reporter{Context: "foo"},
+				AlwaysRun:           true,
+				RegexpChangeMatcher: RegexpChangeMatcher{SkipIfOnlyChanged: `\.go$`},
+			}},
+			expectedError: "job a is set to always run but also declares skip_if_only_changed targets, which are mutually exclusive",
+		},
+		{
+			name: "Mutually exclusive settings: run_if_changed and skip_if_only_changed",
+			presubmits: []Presubmit{{
+				JobBase:  JobBase{Name: "a"},
+				Reporter: Reporter{Context: "foo"},
+				RegexpChangeMatcher: RegexpChangeMatcher{
+					RunIfChanged:      `\.go$`,
+					SkipIfOnlyChanged: `\.md`,
+				},
+			}},
+			expectedError: "job a declares run_if_changed and skip_if_only_changed, which are mutually exclusive",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/prow/more_prow.md
+++ b/prow/more_prow.md
@@ -15,8 +15,9 @@ Some Prow components expose prometheus metrics that can be used for monitoring, 
 You can easily make your Prow instance automatically update itself when changes
 are made to its component's kubernetes resource files. This is achieved with a
 postsubmit job that `kubectl apply`s the resource files whenever they are
-changed (based on a `run_if_changed` regexp). In order to `kubectl apply` to the
-cluster, the job will need to supply credentials (e.g. a kubeconfig file or
+changed (based on a `run_if_changed` or `skip_if_only_changed` regexp). In
+order to `kubectl apply` to the cluster, the job will need to supply credentials
+(e.g. a kubeconfig file or
 [GCP service account key-file](/prow/gcloud-deployer-service-account.sh)). Since
 this job requires priviledged credentials to deploy to the cluster, it is
 important that it is run in a separate build cluster that is isolated from all

--- a/prow/pjutil/filter_test.go
+++ b/prow/pjutil/filter_test.go
@@ -56,6 +56,15 @@ func TestTestAllFilter(t *testing.T) {
 				},
 				{
 					JobBase: config.JobBase{
+						Name: "runs-if-changed",
+					},
+					AlwaysRun: false,
+					RegexpChangeMatcher: config.RegexpChangeMatcher{
+						SkipIfOnlyChanged: "sometimes",
+					},
+				},
+				{
+					JobBase: config.JobBase{
 						Name: "runs-if-triggered",
 					},
 					Reporter: config.Reporter{
@@ -75,7 +84,7 @@ func TestTestAllFilter(t *testing.T) {
 					RerunCommand: "/test all",
 				},
 			},
-			expected: [][]bool{{true, false, false}, {true, false, false}, {false, false, false}, {false, false, false}},
+			expected: [][]bool{{true, false, false}, {true, false, false}, {true, false, false}, {false, false, false}, {false, false, false}},
 		},
 	}
 
@@ -226,6 +235,23 @@ func TestFilterPresubmits(t *testing.T) {
 				JobBase:             config.JobBase{Name: "errors"},
 				Reporter:            config.Reporter{Context: "first"},
 				RegexpChangeMatcher: config.RegexpChangeMatcher{RunIfChanged: "oopsie"},
+			}, {
+				JobBase:  config.JobBase{Name: "ignored"},
+				Reporter: config.Reporter{Context: "second"},
+			}},
+			changesError:      true,
+			expectedToTrigger: nil,
+			expectErr:         true,
+		},
+		{
+			name: "error detecting if something should run, nothing to skip",
+			filter: func(p config.Presubmit) (shouldRun bool, forcedToRun bool, defaultBehavior bool) {
+				return true, false, false
+			},
+			presubmits: []config.Presubmit{{
+				JobBase:             config.JobBase{Name: "errors"},
+				Reporter:            config.Reporter{Context: "first"},
+				RegexpChangeMatcher: config.RegexpChangeMatcher{SkipIfOnlyChanged: "oopsie"},
 			}, {
 				JobBase:  config.JobBase{Name: "ignored"},
 				Reporter: config.Reporter{Context: "second"},
@@ -413,6 +439,17 @@ func TestPresubmitFilter(t *testing.T) {
 				},
 				{
 					JobBase: config.JobBase{
+						Name: "runs-if-changed",
+					},
+					Reporter: config.Reporter{
+						Context: "runs-if-changed",
+					},
+					RegexpChangeMatcher: config.RegexpChangeMatcher{
+						SkipIfOnlyChanged: "sometimes",
+					},
+				},
+				{
+					JobBase: config.JobBase{
 						Name: "runs-if-triggered",
 					},
 					Reporter: config.Reporter{
@@ -422,7 +459,7 @@ func TestPresubmitFilter(t *testing.T) {
 					RerunCommand: "/test trigger",
 				},
 			},
-			expected: [][]bool{{true, false, false}, {true, false, false}, {false, false, false}},
+			expected: [][]bool{{true, false, false}, {true, false, false}, {true, false, false}, {false, false, false}},
 		},
 		{
 			name:          "honored ok-to-test comment selects all tests that don't need an explicit trigger",
@@ -454,6 +491,17 @@ func TestPresubmitFilter(t *testing.T) {
 				},
 				{
 					JobBase: config.JobBase{
+						Name: "runs-if-changed",
+					},
+					Reporter: config.Reporter{
+						Context: "runs-if-changed",
+					},
+					RegexpChangeMatcher: config.RegexpChangeMatcher{
+						SkipIfOnlyChanged: "sometimes",
+					},
+				},
+				{
+					JobBase: config.JobBase{
 						Name: "runs-if-triggered",
 					},
 					Reporter: config.Reporter{
@@ -463,7 +511,7 @@ func TestPresubmitFilter(t *testing.T) {
 					RerunCommand: "/test trigger",
 				},
 			},
-			expected: [][]bool{{true, false, false}, {true, false, false}, {false, false, false}},
+			expected: [][]bool{{true, false, false}, {true, false, false}, {true, false, false}, {false, false, false}},
 		},
 		{
 			name:          "not honored ok-to-test comment selects no tests",
@@ -495,6 +543,17 @@ func TestPresubmitFilter(t *testing.T) {
 				},
 				{
 					JobBase: config.JobBase{
+						Name: "runs-if-changed",
+					},
+					Reporter: config.Reporter{
+						Context: "runs-if-changed",
+					},
+					RegexpChangeMatcher: config.RegexpChangeMatcher{
+						SkipIfOnlyChanged: "sometimes",
+					},
+				},
+				{
+					JobBase: config.JobBase{
 						Name: "runs-if-triggered",
 					},
 					Reporter: config.Reporter{
@@ -504,7 +563,7 @@ func TestPresubmitFilter(t *testing.T) {
 					RerunCommand: "/test trigger",
 				},
 			},
-			expected: [][]bool{{false, false, false}, {false, false, false}, {false, false, false}},
+			expected: [][]bool{{false, false, false}, {false, false, false}, {false, false, false}, {false, false, false}},
 		},
 		{
 			name:       "statuses are not gathered unless retest is specified (will error but we should not see it)",
@@ -612,6 +671,19 @@ func TestPresubmitFilter(t *testing.T) {
 				},
 				{
 					JobBase: config.JobBase{
+						Name: "runs-if-changed",
+					},
+					Reporter: config.Reporter{
+						Context: "runs-if-changed",
+					},
+					RegexpChangeMatcher: config.RegexpChangeMatcher{
+						SkipIfOnlyChanged: "sometimes",
+					},
+					Trigger:      `(?m)^/test (?:.*? )?trigger(?: .*?)?$`,
+					RerunCommand: "/test trigger",
+				},
+				{
+					JobBase: config.JobBase{
 						Name: "runs-if-triggered",
 					},
 					Reporter: config.Reporter{
@@ -646,6 +718,19 @@ func TestPresubmitFilter(t *testing.T) {
 				},
 				{
 					JobBase: config.JobBase{
+						Name: "runs-if-changed",
+					},
+					Reporter: config.Reporter{
+						Context: "runs-if-changed",
+					},
+					RegexpChangeMatcher: config.RegexpChangeMatcher{
+						SkipIfOnlyChanged: "sometimes",
+					},
+					Trigger:      `(?m)^/test (?:.*? )?other-trigger(?: .*?)?$`,
+					RerunCommand: "/test other-trigger",
+				},
+				{
+					JobBase: config.JobBase{
 						Name: "runs-if-triggered",
 					},
 					Reporter: config.Reporter{
@@ -655,7 +740,16 @@ func TestPresubmitFilter(t *testing.T) {
 					RerunCommand: "/test other-trigger",
 				},
 			},
-			expected: [][]bool{{true, true, true}, {true, true, true}, {true, true, true}, {false, false, false}, {false, false, false}, {false, false, false}},
+			expected: [][]bool{
+				{true, true, true},
+				{true, true, true},
+				{true, true, true},
+				{true, true, true},
+				{false, false, false},
+				{false, false, false},
+				{false, false, false},
+				{false, false, false},
+			},
 		},
 		{
 			name: "comments matching more than one case will select the union of presubmits",
@@ -686,6 +780,19 @@ func TestPresubmitFilter(t *testing.T) {
 					},
 					RegexpChangeMatcher: config.RegexpChangeMatcher{
 						RunIfChanged: "sometimes",
+					},
+					Trigger:      `(?m)^/test (?:.*? )?other-trigger(?: .*?)?$`,
+					RerunCommand: "/test other-trigger",
+				},
+				{
+					JobBase: config.JobBase{
+						Name: "runs-if-changed",
+					},
+					Reporter: config.Reporter{
+						Context: "existing-successful",
+					},
+					RegexpChangeMatcher: config.RegexpChangeMatcher{
+						SkipIfOnlyChanged: "sometimes",
 					},
 					Trigger:      `(?m)^/test (?:.*? )?other-trigger(?: .*?)?$`,
 					RerunCommand: "/test other-trigger",
@@ -742,7 +849,17 @@ func TestPresubmitFilter(t *testing.T) {
 					},
 				},
 			},
-			expected: [][]bool{{true, false, false}, {true, false, false}, {true, true, true}, {false, false, false}, {false, false, false}, {true, false, true}, {true, false, true}, {true, false, false}},
+			expected: [][]bool{
+				{true, false, false},
+				{true, false, false},
+				{true, false, false},
+				{true, true, true},
+				{false, false, false},
+				{false, false, false},
+				{true, false, true},
+				{true, false, true},
+				{true, false, false},
+			},
 		},
 	}
 

--- a/prow/plugins/trigger/generic-comment_test.go
+++ b/prow/plugins/trigger/generic-comment_test.go
@@ -345,6 +345,33 @@ func TestHandleGenericComment(t *testing.T) {
 			StartsExactly: "pull-jab",
 		},
 		{
+			name:   "Retest of skip_if_only_changed job that hasn't run. Changes require job",
+			Author: "trusted-member",
+			Body:   "/retest",
+			State:  "open",
+			IsPR:   true,
+			Presubmits: map[string][]config.Presubmit{
+				"org/repo": {
+					{
+						JobBase: config.JobBase{
+							Name: "jab",
+						},
+						RegexpChangeMatcher: config.RegexpChangeMatcher{
+							SkipIfOnlyChanged: "CHANGED2",
+						},
+						Reporter: config.Reporter{
+							SkipReport: true,
+							Context:    "pull-jab",
+						},
+						Trigger:      `(?m)^/test (?:.*? )?jab(?: .*?)?$`,
+						RerunCommand: `/test jab`,
+					},
+				},
+			},
+			ShouldBuild:   true,
+			StartsExactly: "pull-jab",
+		},
+		{
 			name:   "Retest of run_if_changed job that failed. Changes require job",
 			Author: "trusted-member",
 			Body:   "/retest",
@@ -358,6 +385,32 @@ func TestHandleGenericComment(t *testing.T) {
 						},
 						RegexpChangeMatcher: config.RegexpChangeMatcher{
 							RunIfChanged: "CHANGED",
+						},
+						Reporter: config.Reporter{
+							Context: "pull-jib",
+						},
+						Trigger:      `(?m)^/test (?:.*? )?jib(?: .*?)?$`,
+						RerunCommand: `/test jib`,
+					},
+				},
+			},
+			ShouldBuild:   true,
+			StartsExactly: "pull-jib",
+		},
+		{
+			name:   "Retest of skip_if_only_changed job that failed. Changes require job",
+			Author: "trusted-member",
+			Body:   "/retest",
+			State:  "open",
+			IsPR:   true,
+			Presubmits: map[string][]config.Presubmit{
+				"org/repo": {
+					{
+						JobBase: config.JobBase{
+							Name: "jib",
+						},
+						RegexpChangeMatcher: config.RegexpChangeMatcher{
+							SkipIfOnlyChanged: "CHANGED2",
 						},
 						Reporter: config.Reporter{
 							Context: "pull-jib",
@@ -397,6 +450,32 @@ func TestHandleGenericComment(t *testing.T) {
 			StartsExactly: "pull-jub",
 		},
 		{
+			name:   "/test of skip_if_only_changed job that has passed",
+			Author: "trusted-member",
+			Body:   "/test jub",
+			State:  "open",
+			IsPR:   true,
+			Presubmits: map[string][]config.Presubmit{
+				"org/repo": {
+					{
+						JobBase: config.JobBase{
+							Name: "jub",
+						},
+						RegexpChangeMatcher: config.RegexpChangeMatcher{
+							SkipIfOnlyChanged: "CHANGED2",
+						},
+						Reporter: config.Reporter{
+							Context: "pull-jub",
+						},
+						Trigger:      `(?m)^/test (?:.*? )?jub(?: .*?)?$`,
+						RerunCommand: `/test jub`,
+					},
+				},
+			},
+			ShouldBuild:   true,
+			StartsExactly: "pull-jub",
+		},
+		{
 			name:   "Retest of run_if_changed job that failed. Changes do not require the job",
 			Author: "trusted-member",
 			Body:   "/retest",
@@ -422,6 +501,31 @@ func TestHandleGenericComment(t *testing.T) {
 			ShouldBuild: true,
 		},
 		{
+			name:   "Retest of skip_if_only_changed job that failed. Changes do not require the job",
+			Author: "trusted-member",
+			Body:   "/retest",
+			State:  "open",
+			IsPR:   true,
+			Presubmits: map[string][]config.Presubmit{
+				"org/repo": {
+					{
+						JobBase: config.JobBase{
+							Name: "jib",
+						},
+						RegexpChangeMatcher: config.RegexpChangeMatcher{
+							SkipIfOnlyChanged: "CHANGED",
+						},
+						Reporter: config.Reporter{
+							Context: "pull-jib",
+						},
+						Trigger:      `(?m)^/test (?:.*? )?jib(?: .*?)?$`,
+						RerunCommand: `/test jib`,
+					},
+				},
+			},
+			ShouldBuild: true,
+		},
+		{
 			name:   "Run if changed job triggered by /ok-to-test",
 			Author: "trusted-member",
 			Body:   "/ok-to-test",
@@ -435,6 +539,35 @@ func TestHandleGenericComment(t *testing.T) {
 						},
 						RegexpChangeMatcher: config.RegexpChangeMatcher{
 							RunIfChanged: "CHANGED",
+						},
+						Reporter: config.Reporter{
+							Context: "pull-jab",
+						},
+						Trigger:      `(?m)^/test (?:.*? )?jab(?: .*?)?$`,
+						RerunCommand: `/test jab`,
+					},
+				},
+			},
+			ShouldBuild:   true,
+			StartsExactly: "pull-jab",
+			IssueLabels:   issueLabels(labels.NeedsOkToTest),
+			AddedLabels:   issueLabels(labels.OkToTest),
+			RemovedLabels: issueLabels(labels.NeedsOkToTest),
+		},
+		{
+			name:   "Run if non-skipped job triggered by /ok-to-test",
+			Author: "trusted-member",
+			Body:   "/ok-to-test",
+			State:  "open",
+			IsPR:   true,
+			Presubmits: map[string][]config.Presubmit{
+				"org/repo": {
+					{
+						JobBase: config.JobBase{
+							Name: "jab",
+						},
+						RegexpChangeMatcher: config.RegexpChangeMatcher{
+							SkipIfOnlyChanged: "CHANGED2",
 						},
 						Reporter: config.Reporter{
 							Context: "pull-jab",
@@ -545,6 +678,31 @@ func TestHandleGenericComment(t *testing.T) {
 			},
 		},
 		{
+			name: "/retest of SkipIfOnlyChanged job that doesn't need to run and hasn't run",
+
+			Author: "trusted-member",
+			Body:   "/retest",
+			State:  "open",
+			IsPR:   true,
+			Presubmits: map[string][]config.Presubmit{
+				"org/repo": {
+					{
+						JobBase: config.JobBase{
+							Name: "jeb",
+						},
+						RegexpChangeMatcher: config.RegexpChangeMatcher{
+							SkipIfOnlyChanged: "CHANGED",
+						},
+						Reporter: config.Reporter{
+							Context: "pull-jeb",
+						},
+						Trigger:      `(?m)^/test (?:.*? )?jeb(?: .*?)?$`,
+						RerunCommand: `/test jeb`,
+					},
+				},
+			},
+		},
+		{
 			name: "explicit /test for RunIfChanged job that doesn't need to run",
 
 			Author: "trusted-member",
@@ -559,6 +717,32 @@ func TestHandleGenericComment(t *testing.T) {
 						},
 						RegexpChangeMatcher: config.RegexpChangeMatcher{
 							RunIfChanged: "CHANGED2",
+						},
+						Reporter: config.Reporter{
+							Context: "pull-jeb",
+						},
+						Trigger:      `(?m)^/test (?:.*? )?jeb(?: .*?)?$`,
+						RerunCommand: `/test jeb`,
+					},
+				},
+			},
+			ShouldBuild: false,
+		},
+		{
+			name: "explicit /test for SkipIfOnlyChanged job that doesn't need to run",
+
+			Author: "trusted-member",
+			Body:   "/test pull-jeb",
+			State:  "open",
+			IsPR:   true,
+			Presubmits: map[string][]config.Presubmit{
+				"org/repo": {
+					{
+						JobBase: config.JobBase{
+							Name: "jeb",
+						},
+						RegexpChangeMatcher: config.RegexpChangeMatcher{
+							SkipIfOnlyChanged: "CHANGED",
 						},
 						Reporter: config.Reporter{
 							Context: "pull-jeb",
@@ -597,6 +781,32 @@ func TestHandleGenericComment(t *testing.T) {
 			StartsExactly: "pull-jub",
 		},
 		{
+			name:   "/test all of skip_if_only_changed job that has passed and needs to run",
+			Author: "trusted-member",
+			Body:   "/test all",
+			State:  "open",
+			IsPR:   true,
+			Presubmits: map[string][]config.Presubmit{
+				"org/repo": {
+					{
+						JobBase: config.JobBase{
+							Name: "jub",
+						},
+						RegexpChangeMatcher: config.RegexpChangeMatcher{
+							SkipIfOnlyChanged: "CHANGED2",
+						},
+						Reporter: config.Reporter{
+							Context: "pull-jub",
+						},
+						Trigger:      `(?m)^/test (?:.*? )?jub(?: .*?)?$`,
+						RerunCommand: `/test jub`,
+					},
+				},
+			},
+			ShouldBuild:   true,
+			StartsExactly: "pull-jub",
+		},
+		{
 			name:   "/test all of run_if_changed job that has passed and doesn't need to run",
 			Author: "trusted-member",
 			Body:   "/test all",
@@ -610,6 +820,30 @@ func TestHandleGenericComment(t *testing.T) {
 						},
 						RegexpChangeMatcher: config.RegexpChangeMatcher{
 							RunIfChanged: "CHANGED2",
+						},
+						Reporter: config.Reporter{
+							Context: "pull-jub",
+						},
+						Trigger:      `(?m)^/test (?:.*? )?jub(?: .*?)?$`,
+						RerunCommand: `/test jub`,
+					},
+				},
+			},
+		},
+		{
+			name:   "/test all of skip_if_only_changed job that has passed and doesn't need to run",
+			Author: "trusted-member",
+			Body:   "/test all",
+			State:  "open",
+			IsPR:   true,
+			Presubmits: map[string][]config.Presubmit{
+				"org/repo": {
+					{
+						JobBase: config.JobBase{
+							Name: "jub",
+						},
+						RegexpChangeMatcher: config.RegexpChangeMatcher{
+							SkipIfOnlyChanged: "CHANGED",
 						},
 						Reporter: config.Reporter{
 							Context: "pull-jub",

--- a/prow/statusreconciler/controller.go
+++ b/prow/statusreconciler/controller.go
@@ -372,7 +372,7 @@ func addedBlockingPresubmits(old, new map[string][]config.Presubmit, log *logrus
 							"name": oldPresubmit.Name,
 						}).Debug("Identified a newly-reporting blocking presubmit.")
 					}
-					if oldPresubmit.RunIfChanged != newPresubmit.RunIfChanged {
+					if oldPresubmit.RunIfChanged != newPresubmit.RunIfChanged || oldPresubmit.SkipIfOnlyChanged != newPresubmit.SkipIfOnlyChanged {
 						added[repo] = append(added[repo], newPresubmit)
 						log.WithFields(logrus.Fields{
 							"repo": repo,

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -1755,6 +1755,14 @@ func testTakeAction(clients localgit.Clients, t *testing.T) {
 								RunIfChanged: "CHANGED",
 							},
 						},
+						{
+							Reporter:     config.Reporter{Context: "if-changed"},
+							Trigger:      "/test if-changed",
+							RerunCommand: "/test if-changed",
+							RegexpChangeMatcher: config.RegexpChangeMatcher{
+								SkipIfOnlyChanged: "CHANGED1",
+							},
+						},
 					},
 				},
 			); err != nil {


### PR DESCRIPTION
Introduce a new prow config option, `skip_if_only_changed`, which is the opposite of `run_if_changed`.

`run_if_changed` positively looks for changed paths matching a regex and triggers the job (which must also be `always_run: false`). This is painful to use when the intent is to skip jobs that *only* touch a certain subset of paths -- particularly since golang regexes don't support lookarounds. For example, in order to say "Skip this job for changes that only touch paths under the `docs/` subdirectory," it was previously necessary to do something like:

`run_if_changed: ^([^d]|d[^o]|do[^c]|doc[^s]|docs[^/])`

With this change, the same thing can be accomplished via:

`skip_if_only_changed: ^docs/`

which is much more scrutable.