### PR TITLE
capdo/branch: remove master branch reference

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
@@ -81,7 +81,7 @@ postsubmits:
         testgrid-alert-email: k8s-infra-staging-cluster-api-do@kubernetes.io
       decorate: true
       branches:
-        - ^master$
+        - ^main$
         - ^release-0.3$
         # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
         - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
@@ -7,7 +7,6 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
     branches:
     - ^main$
-    - ^master$
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210601-ea6aa4e-master
@@ -23,7 +22,6 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
     branches:
     - ^main$
-    - ^master$
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210601-ea6aa4e-master
@@ -39,7 +37,6 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
     branches:
     - ^main$
-    - ^master$
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210601-ea6aa4e-master
@@ -57,7 +54,6 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
     branches:
     - ^main$
-    - ^master$
     spec:
       containers:
       - image: golangci/golangci-lint:v1.32.2
@@ -82,7 +78,6 @@ presubmits:
       preset-do-credential: "true"
     branches:
     - ^main$
-    - ^master$
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210601-ea6aa4e-master
@@ -112,7 +107,6 @@ presubmits:
       preset-do-credential: "true"
     branches:
     - ^main$
-    - ^master$
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210601-ea6aa4e-master
@@ -145,7 +139,6 @@ presubmits:
       preset-do-credential: "true"
     branches:
     - ^main$
-    - ^master$
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210601-ea6aa4e-master


### PR DESCRIPTION
Branch renamed for https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean to main

cleaning up the master reference from the jobs

Fixes: https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/issues/261

/assign @timoreimann @prksu @MorrisLaw 