### PR TITLE
Reduce number of parallel tests to 15

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -268,7 +268,7 @@ periodics:
           -- \
           --ginkgo-args="--debug" \
           --test-package-marker=stable-1.21.txt \
-          --parallel 25 \
+          --parallel 15 \
           --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*NodePort.*listening.*same.*port|TCP.CLOSE_WAIT|should.*run.*through.*the.*lifecycle.*of.*Pods.*and.*PodStatus"
       resources:
         limits:


### PR DESCRIPTION
There are few tests sporadically failing due to etcdserver timeouts. Ex: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-do-calico/1402247725184978944

Instead of increasing the DO droplet sizing, I wanted to first try reducing the number of parallel tests to see if it helps.

Please let me know if you have any questions.

FYI - @rifelpet @timoreimann 