### PR TITLE
Switch WI bind script array expansion to a syntax compatible with bash versions < 4.4

### DIFF
--- a/workload-identity/bind-service-accounts.sh
+++ b/workload-identity/bind-service-accounts.sh
@@ -66,7 +66,7 @@ members=($(
 
 want="serviceAccount:$project.svc.id.goog[$namespace/$name]"
 fix_policy=yes
-for member in "${members[@]}"; do
+for member in "${members[@]+"${members[@]}"}"; do
   if [[ "$want" == "$member" ]]; then
     fix_policy=
     break


### PR DESCRIPTION
This syntax is a bit weird, but it is recommended [here](https://stackoverflow.com/questions/7577052/bash-empty-array-expansion-with-set-u) and seems to work with older and newer bash versions.
/assign @fejta 