### PR TITLE
jobs: k8s-infra job changes

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
@@ -139,25 +139,7 @@ postsubmits:
       containers:
       - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
         command:
-        - bash
-        args:
-        - -c
-        - |
-          cd ./infra/gcp/clusters/projects/k8s-infra-prow-build
-          if [[ -x ./deploy.sh ]]; then
-            ./deploy.sh
-          else
-            gcloud \
-              container clusters get-credentials \
-              --project=k8s-infra-prow-build \
-              --region=us-central1 \
-              prow-build
-            kubectl \
-              --context=gke_k8s-infra-prow-build_us-central1_prow-build \
-              apply \
-                -f ./prow-build/resources \
-                --recursive
-          fi
+        - ./infra/gcp/clusters/projects/k8s-infra-prow-build/deploy.sh
   - name: post-k8sio-deploy-prow-build-trusted-resources
     cluster: k8s-infra-prow-build-trusted
     decorate: true
@@ -181,22 +163,4 @@ postsubmits:
       containers:
       - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
         command:
-        - bash
-        args:
-        - -c
-        - |
-          cd ./infra/gcp/clusters/projects/k8s-infra-prow-build-trusted
-          if [[ -x ./deploy.sh ]]; then
-            ./deploy.sh
-          else
-            gcloud \
-              container clusters get-credentials \
-              --project=k8s-infra-prow-build-trusted \
-              --region=us-central1 \
-              prow-build-trusted
-            kubectl \
-              --context=gke_k8s-infra-prow-build-trusted_us-central1_prow-build-trusted \
-              apply \
-                -f ./prow-build-trusted/resources \
-                --recursive
-          fi
+        - ./infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/deploy.sh

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
@@ -25,7 +25,7 @@ periodics:
       - --
       - --confirm
 - name: ci-k8sio-audit
-  interval: 6h
+  interval: 3h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
   max_concurrency: 1
@@ -33,9 +33,6 @@ periodics:
   - org: kubernetes
     repo: k8s.io
     base_ref: main
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
   annotations:
     testgrid-dashboards: wg-k8s-infra-k8sio
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io


### PR DESCRIPTION
Two changes here:
- drop the embedded bash for k8s-infra prow postsubmits now that we're using in-repo deploy scripts (added in https://github.com/kubernetes/k8s.io/pull/2153, fixed in https://github.com/kubernetes/k8s.io/pull/2189)
- make ci-k8sio-audit run twice as frequently (every 3h) to pick up changes sooner