### PR TITLE
Don't use repo-list for Windows capz e2e test

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -315,8 +315,6 @@ presubmits:
             # Windows isn't really conformance, we typically run at 4 to keep the time reasonable (~45 mins)
             - name: CONFORMANCE_NODES
               value: "4"
-            - name: WIN_REPO_LIST
-              value: https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list-master
           securityContext:
             privileged: true
           resources:


### PR DESCRIPTION
The capz test framework will control the repo-list so that versions can be modified as needed based on versions being run.

xref: https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1388#issuecomment-858999686

/sig windows
/assign @chewong @CecileRobertMichon 