### PR TITLE
Kops - explicitly specify kubenet for default networking

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -266,7 +266,7 @@ def k8s_version_info(k8s_version):
     return marker, k8s_deploy_url, test_package_bucket, test_package_dir
 
 def create_args(kops_channel, networking, container_runtime, extra_flags, kops_image):
-    args = f"--channel={kops_channel} --networking=" + (networking or "kubenet")
+    args = f"--channel={kops_channel} --networking=" + networking
     if container_runtime:
         args += f" --container-runtime={container_runtime}"
 
@@ -336,7 +336,7 @@ distros_ssh_user = {
 # Returns a string representing the periodic prow job and the number of job invocations per week
 def build_test(cloud='aws',
                distro='u2004',
-               networking=None,
+               networking='kubenet',
                container_runtime='containerd',
                k8s_version='latest',
                kops_channel='alpha',
@@ -399,7 +399,7 @@ def build_test(cloud='aws',
     suffix = ""
     if cloud and cloud != "aws":
         suffix += "-" + cloud
-    if networking:
+    if networking and networking != "kubenet":
         suffix += "-" + networking
     if distro:
         suffix += "-" + distro
@@ -489,7 +489,7 @@ def build_test(cloud='aws',
 def presubmit_test(branch='master',
                    cloud='aws',
                    distro='u2004',
-                   networking=None,
+                   networking='kubenet',
                    container_runtime='containerd',
                    k8s_version='latest',
                    kops_channel='alpha',
@@ -591,7 +591,7 @@ def presubmit_test(branch='master',
 ####################
 
 networking_options = [
-    None,
+    'kubenet',
     'calico',
     'cilium',
     'flannel',

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -2,7 +2,7 @@
 # 488 jobs, total of 968 runs per week
 periodics:
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-amzn2-k19-docker
   cron: '37 3 * * 3'
   labels:
@@ -61,12 +61,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-amzn2-k19-ko20-docker
   cron: '21 10 * * 2'
   labels:
@@ -125,12 +125,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-amzn2, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k19-ko20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-amzn2-k19-ko21-docker
   cron: '43 12 * * 0'
   labels:
@@ -189,12 +189,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k19-ko21-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-amzn2-k20-docker
   cron: '35 5 * * 0'
   labels:
@@ -253,12 +253,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-amzn2-k20-ko20-docker
   cron: '34 1 * * 4'
   labels:
@@ -317,12 +317,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k20-ko20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-amzn2-k20-ko21-docker
   cron: '36 7 * * 0'
   labels:
@@ -381,12 +381,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k20-ko21-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-amzn2-k21-docker
   cron: '9 11 * * 5'
   labels:
@@ -445,12 +445,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.21'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k21-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-amzn2-k21-ko21-docker
   cron: '25 2 * * 2'
   labels:
@@ -509,12 +509,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.21'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k21-ko21-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-deb9-k19-ko20-docker
   cron: '11 22 * * 3'
   labels:
@@ -573,12 +573,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-deb9, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k19-ko20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-deb9-k19-ko21-docker
   cron: '53 16 * * 1'
   labels:
@@ -637,12 +637,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k19-ko21-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-deb9-k20-ko20-docker
   cron: '52 21 * * 6'
   labels:
@@ -701,12 +701,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-deb9, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k20-ko20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-deb9-k20-ko21-docker
   cron: '38 19 * * 1'
   labels:
@@ -765,12 +765,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k20-ko21-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-deb9-k21-ko21-docker
   cron: '59 22 * * 3'
   labels:
@@ -829,12 +829,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.21'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k21-ko21-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-deb10-k19-docker
   cron: '45 11 * * 1'
   labels:
@@ -893,12 +893,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-deb10-k19-ko20-docker
   cron: '6 13 * * 1'
   labels:
@@ -957,12 +957,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-deb10, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k19-ko20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-deb10-k19-ko21-docker
   cron: '40 19 * * 6'
   labels:
@@ -1021,12 +1021,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k19-ko21-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-deb10-k20-docker
   cron: '19 13 * * 5'
   labels:
@@ -1085,12 +1085,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-deb10-k20-ko20-docker
   cron: '57 6 * * 1'
   labels:
@@ -1149,12 +1149,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k20-ko20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-deb10-k20-ko21-docker
   cron: '31 0 * * 3'
   labels:
@@ -1213,12 +1213,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k20-ko21-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-deb10-k21-docker
   cron: '21 19 * * 6'
   labels:
@@ -1277,12 +1277,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.21'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k21-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-deb10-k21-ko21-docker
   cron: '6 5 * * 3'
   labels:
@@ -1341,12 +1341,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.21'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k21-ko21-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-flatcar-k19-docker
   cron: '57 7 * * 6'
   labels:
@@ -1406,12 +1406,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-flatcar-k19-ko20-docker
   cron: '14 10 * * 4'
   labels:
@@ -1471,12 +1471,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-flatcar, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k19-ko20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-flatcar-k19-ko21-docker
   cron: '28 20 * * 3'
   labels:
@@ -1536,12 +1536,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k19-ko21-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-flatcar-k20-docker
   cron: '15 9 * * 5'
   labels:
@@ -1601,12 +1601,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-flatcar-k20-ko20-docker
   cron: '9 9 * * 1'
   labels:
@@ -1666,12 +1666,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k20-ko20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-flatcar-k20-ko21-docker
   cron: '51 15 * * 3'
   labels:
@@ -1731,12 +1731,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k20-ko21-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-flatcar-k21-docker
   cron: '53 7 * * 6'
   labels:
@@ -1796,12 +1796,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.21'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k21-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-flatcar-k21-ko21-docker
   cron: '38 10 * * 3'
   labels:
@@ -1861,12 +1861,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.21'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k21-ko21-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel7-k19-ko20-docker
   cron: '6 9 * * 4'
   labels:
@@ -1925,12 +1925,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-rhel7, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k19-ko20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel7-k19-ko21-docker
   cron: '40 15 * * 1'
   labels:
@@ -1989,12 +1989,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k19-ko21-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel7-k20-ko20-docker
   cron: '41 2 * * 4'
   labels:
@@ -2053,12 +2053,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-rhel7, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k20-ko20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel7-k20-ko21-docker
   cron: '43 20 * * 3'
   labels:
@@ -2117,12 +2117,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k20-ko21-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel7-k21-ko21-docker
   cron: '46 1 * * 5'
   labels:
@@ -2181,12 +2181,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.21'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k21-ko21-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-rhel8-k19-docker
   cron: '26 20 * * 6'
   labels:
@@ -2245,12 +2245,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel8-k19-ko20-docker
   cron: '11 12 * * 4'
   labels:
@@ -2309,12 +2309,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-rhel8, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k19-ko20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel8-k19-ko21-docker
   cron: '53 10 * * 6'
   labels:
@@ -2373,12 +2373,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k19-ko21-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-rhel8-k20-docker
   cron: '48 10 * * 0'
   labels:
@@ -2437,12 +2437,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel8-k20-ko20-docker
   cron: '20 23 * * 2'
   labels:
@@ -2501,12 +2501,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k20-ko20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel8-k20-ko21-docker
   cron: '6 1 * * 1'
   labels:
@@ -2565,12 +2565,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k20-ko21-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-rhel8-k21-docker
   cron: '50 12 * * 5'
   labels:
@@ -2629,12 +2629,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.21'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k21-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel8-k21-ko21-docker
   cron: '55 4 * * 2'
   labels:
@@ -2693,12 +2693,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.21'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k21-ko21-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-u1804-k19-ko20-docker
   cron: '46 13 * * 4'
   labels:
@@ -2757,12 +2757,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-u1804, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k19-ko20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-u1804-k19-ko21-docker
   cron: '16 3 * * 4'
   labels:
@@ -2821,12 +2821,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k19-ko21-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-u1804-k20-ko20-docker
   cron: '41 14 * * 4'
   labels:
@@ -2885,12 +2885,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-u1804, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k20-ko20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-u1804-k20-ko21-docker
   cron: '47 16 * * 3'
   labels:
@@ -2949,12 +2949,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k20-ko21-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-u1804-k21-ko21-docker
   cron: '18 13 * * 0'
   labels:
@@ -3013,12 +3013,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.21'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k21-ko21-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-u2004-k19-docker
   cron: '36 6 * * *'
   labels:
@@ -3077,12 +3077,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k19-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-u2004-k19-ko20-docker
   cron: '5 10 * * *'
   labels:
@@ -3141,12 +3141,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-u2004, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k19-ko20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-u2004-k19-ko21-docker
   cron: '7 12 * * *'
   labels:
@@ -3205,12 +3205,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k19-ko21-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-u2004-k20-docker
   cron: '10 0 * * *'
   labels:
@@ -3269,12 +3269,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-u2004-k20-ko20-docker
   cron: '54 17 * * *'
   labels:
@@ -3333,12 +3333,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k20-ko20-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-u2004-k20-ko21-docker
   cron: '56 23 * * *'
   labels:
@@ -3397,12 +3397,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k20-ko21-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-u2004-k21-docker
   cron: '32 14 * * *'
   labels:
@@ -3461,12 +3461,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.21'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k21-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-u2004-k21-ko21-docker
   cron: '5 2 * * *'
   labels:
@@ -3525,7 +3525,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.21'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k21-ko21-docker
@@ -15650,7 +15650,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k21-ko21-docker
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-amzn2-k19-containerd
   cron: '48 17 * * 2'
   labels:
@@ -15709,12 +15709,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-amzn2-k19-ko20-containerd
   cron: '3 5 * * 2'
   labels:
@@ -15773,12 +15773,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-amzn2, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k19-ko20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-amzn2-k19-ko21-containerd
   cron: '16 18 * * 5'
   labels:
@@ -15837,12 +15837,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k19-ko21-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-amzn2-k20-containerd
   cron: '39 14 * * 6'
   labels:
@@ -15901,12 +15901,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-amzn2-k20-ko20-containerd
   cron: '52 10 * * 1'
   labels:
@@ -15965,12 +15965,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k20-ko20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-amzn2-k20-ko21-containerd
   cron: '43 5 * * 2'
   labels:
@@ -16029,12 +16029,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k20-ko21-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-amzn2-k21-containerd
   cron: '36 1 * * 0'
   labels:
@@ -16093,12 +16093,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.21'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k21-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-amzn2-k21-ko21-containerd
   cron: '44 14 * * 4'
   labels:
@@ -16157,12 +16157,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.21'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k21-ko21-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-deb9-k19-ko20-containerd
   cron: '41 10 * * 1'
   labels:
@@ -16221,12 +16221,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-deb9, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k19-ko20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-deb9-k19-ko21-containerd
   cron: '42 21 * * 2'
   labels:
@@ -16285,12 +16285,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k19-ko21-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-deb9-k20-ko20-containerd
   cron: '2 5 * * 0'
   labels:
@@ -16349,12 +16349,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-deb9, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k20-ko20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-deb9-k20-ko21-containerd
   cron: '41 2 * * 3'
   labels:
@@ -16413,12 +16413,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k20-ko21-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-deb9-k21-ko21-containerd
   cron: '42 9 * * 4'
   labels:
@@ -16477,12 +16477,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.21'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k21-ko21-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-deb10-k19-containerd
   cron: '29 0 * * 4'
   labels:
@@ -16541,12 +16541,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-deb10-k19-ko20-containerd
   cron: '45 15 * * 4'
   labels:
@@ -16605,12 +16605,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-deb10, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k19-ko20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-deb10-k19-ko21-containerd
   cron: '26 16 * * 4'
   labels:
@@ -16669,12 +16669,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k19-ko21-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-deb10-k20-containerd
   cron: '34 15 * * 1'
   labels:
@@ -16733,12 +16733,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-deb10-k20-ko20-containerd
   cron: '34 8 * * 2'
   labels:
@@ -16797,12 +16797,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k20-ko20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-deb10-k20-ko21-containerd
   cron: '21 7 * * 3'
   labels:
@@ -16861,12 +16861,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k20-ko21-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-deb10-k21-containerd
   cron: '25 8 * * 3'
   labels:
@@ -16925,12 +16925,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.21'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k21-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-deb10-k21-ko21-containerd
   cron: '30 12 * * 6'
   labels:
@@ -16989,12 +16989,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.21'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k21-ko21-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-flatcar-k19-containerd
   cron: '1 10 * * 0'
   labels:
@@ -17054,12 +17054,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-flatcar-k19-ko20-containerd
   cron: '6 18 * * 2'
   labels:
@@ -17119,12 +17119,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-flatcar, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k19-ko20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-flatcar-k19-ko21-containerd
   cron: '13 13 * * 5'
   labels:
@@ -17184,12 +17184,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k19-ko21-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-flatcar-k20-containerd
   cron: '2 21 * * 4'
   labels:
@@ -17249,12 +17249,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-flatcar-k20-ko20-containerd
   cron: '45 21 * * 5'
   labels:
@@ -17314,12 +17314,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k20-ko20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-flatcar-k20-ko21-containerd
   cron: '46 18 * * 6'
   labels:
@@ -17379,12 +17379,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k20-ko21-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-flatcar-k21-containerd
   cron: '29 10 * * 3'
   labels:
@@ -17444,12 +17444,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.21'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k21-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-flatcar-k21-ko21-containerd
   cron: '5 17 * * 5'
   labels:
@@ -17509,12 +17509,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.21'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k21-ko21-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel7-k19-ko20-containerd
   cron: '3 9 * * 5'
   labels:
@@ -17573,12 +17573,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-rhel7, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k19-ko20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel7-k19-ko21-containerd
   cron: '48 22 * * 5'
   labels:
@@ -17637,12 +17637,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k19-ko21-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel7-k20-ko20-containerd
   cron: '40 22 * * 3'
   labels:
@@ -17701,12 +17701,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-rhel7, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k20-ko20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel7-k20-ko21-containerd
   cron: '31 17 * * 4'
   labels:
@@ -17765,12 +17765,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k20-ko21-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel7-k21-ko21-containerd
   cron: '36 18 * * 1'
   labels:
@@ -17829,12 +17829,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.21'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k21-ko21-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-rhel8-k19-containerd
   cron: '22 15 * * 0'
   labels:
@@ -17893,12 +17893,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel8-k19-ko20-containerd
   cron: '17 7 * * 4'
   labels:
@@ -17957,12 +17957,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-rhel8, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k19-ko20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel8-k19-ko21-containerd
   cron: '14 8 * * 4'
   labels:
@@ -18021,12 +18021,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k19-ko21-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-rhel8-k20-containerd
   cron: '13 0 * * 0'
   labels:
@@ -18085,12 +18085,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel8-k20-ko20-containerd
   cron: '18 0 * * 4'
   labels:
@@ -18149,12 +18149,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k20-ko20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel8-k20-ko21-containerd
   cron: '33 23 * * 4'
   labels:
@@ -18213,12 +18213,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k20-ko21-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-rhel8-k21-containerd
   cron: '30 7 * * 2'
   labels:
@@ -18277,12 +18277,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.21'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k21-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel8-k21-ko21-containerd
   cron: '50 12 * * 3'
   labels:
@@ -18341,12 +18341,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.21'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k21-ko21-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-u1804-k19-ko20-containerd
   cron: '54 0 * * 0'
   labels:
@@ -18405,12 +18405,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-u1804, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k19-ko20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-u1804-k19-ko21-containerd
   cron: '21 7 * * 1'
   labels:
@@ -18469,12 +18469,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k19-ko21-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-u1804-k20-ko20-containerd
   cron: '9 7 * * 1'
   labels:
@@ -18533,12 +18533,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-u1804, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k20-ko20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-u1804-k20-ko21-containerd
   cron: '50 0 * * 3'
   labels:
@@ -18597,12 +18597,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k20-ko21-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-u1804-k21-ko21-containerd
   cron: '1 3 * * 4'
   labels:
@@ -18661,12 +18661,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.21'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k21-ko21-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-u2004-k19-containerd
   cron: '24 21 * * *'
   labels:
@@ -18725,12 +18725,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.19, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k19-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-u2004-k19-ko20-containerd
   cron: '12 22 * * *'
   labels:
@@ -18789,12 +18789,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-u2004, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k19-ko20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-u2004-k19-ko21-containerd
   cron: '23 17 * * *'
   labels:
@@ -18853,12 +18853,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.19, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k19-ko21-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-u2004-k20-containerd
   cron: '55 18 * * *'
   labels:
@@ -18917,12 +18917,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.20", "networking": "kubenet"}
 - name: e2e-kops-grid-u2004-k20-ko20-containerd
   cron: '35 1 * * *'
   labels:
@@ -18981,12 +18981,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.20'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.20, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k20-ko20-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-u2004-k20-ko21-containerd
   cron: '44 14 * * *'
   labels:
@@ -19045,12 +19045,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k20-ko21-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-u2004-k21-containerd
   cron: '40 13 * * *'
   labels:
@@ -19109,12 +19109,12 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.21'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k21-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": "1.21", "networking": "kubenet"}
 - name: e2e-kops-grid-u2004-k21-ko21-containerd
   cron: '11 21 * * *'
   labels:
@@ -19173,7 +19173,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.21'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k21-ko21-containerd

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -2,7 +2,7 @@
 # 13 jobs, total of 399 runs per week
 periodics:
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004arm64", "extra_flags": "--zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large", "k8s_version": "latest", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004arm64", "extra_flags": "--zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large", "k8s_version": "latest", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-scenario-arm64
   cron: '33 16 * * *'
   labels:
@@ -62,12 +62,12 @@ periodics:
     test.kops.k8s.io/k8s_version: latest
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-u2004arm64, kops-k8s-latest, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-scenario-arm64
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--api-loadbalancer-type=public --override=cluster.spec.serviceAccountIssuerDiscovery.discoveryStore=s3://k8s-kops-prow/e2e-dc69f71486-5831d.test-cncf-aws.k8s.io/discovery --override=cluster.spec.serviceAccountIssuerDiscovery.enableAWSOIDCProvider=true", "feature_flags": "UseServiceAccountIAM", "k8s_version": "latest", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--api-loadbalancer-type=public --override=cluster.spec.serviceAccountIssuerDiscovery.discoveryStore=s3://k8s-kops-prow/e2e-dc69f71486-5831d.test-cncf-aws.k8s.io/discovery --override=cluster.spec.serviceAccountIssuerDiscovery.enableAWSOIDCProvider=true", "feature_flags": "UseServiceAccountIAM", "k8s_version": "latest", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-scenario-service-account-iam
   cron: '45 6-23/8 * * *'
   labels:
@@ -129,7 +129,7 @@ periodics:
     test.kops.k8s.io/k8s_version: latest
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-latest, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-scenario-service-account-iam
@@ -199,7 +199,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-warm-pool
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--override=cluster.spec.cloudControllerManager.cloudProvider=aws", "feature_flags": "EnableExternalCloudController,SpecOverrideFlag", "k8s_version": "latest", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--override=cluster.spec.cloudControllerManager.cloudProvider=aws", "feature_flags": "EnableExternalCloudController,SpecOverrideFlag", "k8s_version": "latest", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-scenario-aws-cloud-controller-manager
   cron: '28 6-23/8 * * *'
   labels:
@@ -261,12 +261,12 @@ periodics:
     test.kops.k8s.io/k8s_version: latest
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-latest, kops-kubetest2, kops-latest, kops-misc, provider-aws-cloud-provider-aws, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-scenario-aws-cloud-controller-manager
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-scenario-terraform
   cron: '14 4 * * *'
   labels:
@@ -326,7 +326,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.20'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.20, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-scenario-terraform
@@ -596,7 +596,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-misc-arm64-conformance
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--node-size=c5.large --master-size=c5.large", "k8s_version": "ci", "kops_channel": "alpha", "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--node-size=c5.large --master-size=c5.large", "k8s_version": "ci", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-aws-misc-amd64-conformance
   cron: '24 3-23/8 * * *'
   labels:
@@ -659,7 +659,7 @@ periodics:
     test.kops.k8s.io/k8s_version: ci
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
-    test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-ci, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-misc-amd64-conformance

--- a/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes/kops:
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.21", "kops_channel": "alpha", "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.21", "kops_channel": "alpha", "networking": "kubenet"}
   - name: pull-kops-e2e-k8s-docker
     branches:
     - master
@@ -64,7 +64,7 @@ presubmits:
       test.kops.k8s.io/distro: u2004
       test.kops.k8s.io/k8s_version: '1.21'
       test.kops.k8s.io/kops_channel: alpha
-      test.kops.k8s.io/networking: ''
+      test.kops.k8s.io/networking: kubenet
       testgrid-dashboards: kops-distro-u2004, kops-k8s-1.21, kops-kubetest2, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-docker


### PR DESCRIPTION
No functional change to jobs, just their annotations and comments. This is in preparation of building all of the --skip-regex patterns in a separate function. having the `networking` variable set to `kubenet` rather than `None` will make it a bit more intuitive.