### PR TITLE
owners: add puerco/cpanato to the sig-release-leads

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -84,7 +84,6 @@ aliases:
     - dchen1107
     - derekwaynecarr
   sig-release-leads:
-    - alejandrox1
     - cpanato
     - hasheddan
     - jeremyrickard
@@ -230,22 +229,17 @@ aliases:
   #   k/test-infra jobs and overall CI Signal
   #
   release-engineering-approvers:
-    - alejandrox1 # SIG Technical Lead / emergency approval
-    - cpanato # SIG Technical Lead / Release Manager / EU backup approval coverage
-    - hasheddan # SIG Technical Lead / Release Manager / US backup approval coverage
+    - cpanato # SIG Technical Lead / RelEng subproject owner / Release Manager
+    - hasheddan # SIG Technical Lead / RelEng subproject owner / Release Manager
     - justaugustus # SIG Chair / RelEng subproject owner / Release Manager
-    - puerco # SIG Technical Lead / Release Manager
-    - saschagrunert # SIG Technical Lead / RelEng subproject owner / Release Manager
-    - tpepper # SIG Chair / RelEng subproject owner / Release Manager
+    - puerco # SIG Technical Lead / RelEng subproject owner / Release Manager
+    - saschagrunert # SIG Chair / RelEng subproject owner / Release Manager
   release-engineering-reviewers:
-    - cpanato # SIG Technical Lead / Release Manager
-    - feiskyer # Release Manager
-    - hasheddan # Release Manager
-    - hoegaarden # Release Manager
+    - cpanato # SIG Technical Lead / RelEng subproject owner / Release Manager
+    - hasheddan # SIG Technical Lead / RelEng subproject owner / Release Manager
     - justaugustus # SIG Chair / RelEng subproject owner / Release Manager
-    - puerco # SIG Technical Lead / Release Manager
-    - saschagrunert # SIG Technical Lead / RelEng subproject owner / Release Manager
-    - tpepper # SIG Chair / RelEng subproject owner / Release Manager
+    - puerco # SIG Technical Lead / RelEng subproject owner / Release Manager
+    - saschagrunert # SIG Chair / RelEng subproject owner / Release Manager
     - xmudrii # Release Manager
 
   # copied from git.k8s.io/enhancements/OWNERS_ALIASES

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -85,9 +85,11 @@ aliases:
     - derekwaynecarr
   sig-release-leads:
     - alejandrox1
+    - cpanato
     - hasheddan
     - jeremyrickard
     - justaugustus
+    - puerco
     - saschagrunert
   sig-scalability-leads:
     - mm4tt
@@ -229,17 +231,19 @@ aliases:
   #
   release-engineering-approvers:
     - alejandrox1 # SIG Technical Lead / emergency approval
-    - cpanato # Release Manager / EU backup approval coverage
-    - hasheddan # Release Manager / US backup approval coverage
+    - cpanato # SIG Technical Lead / Release Manager / EU backup approval coverage
+    - hasheddan # SIG Technical Lead / Release Manager / US backup approval coverage
     - justaugustus # SIG Chair / RelEng subproject owner / Release Manager
+    - puerco # SIG Technical Lead / Release Manager
     - saschagrunert # SIG Technical Lead / RelEng subproject owner / Release Manager
     - tpepper # SIG Chair / RelEng subproject owner / Release Manager
   release-engineering-reviewers:
-    - cpanato # Release Manager
+    - cpanato # SIG Technical Lead / Release Manager
     - feiskyer # Release Manager
     - hasheddan # Release Manager
     - hoegaarden # Release Manager
     - justaugustus # SIG Chair / RelEng subproject owner / Release Manager
+    - puerco # SIG Technical Lead / Release Manager
     - saschagrunert # SIG Technical Lead / RelEng subproject owner / Release Manager
     - tpepper # SIG Chair / RelEng subproject owner / Release Manager
     - xmudrii # Release Manager


### PR DESCRIPTION
#### What type of PR is this:
/kind documentation

#### What this PR does / why we need it:

As part of the onboard described in this issue: https://github.com/kubernetes/sig-release/issues/1590



/assign @justaugustus @saschagrunert @jeremyrickard @hasheddan 