### PR TITLE
Revert "Adjust the timeout to 40m for scheduler-plugins integration test"

### DIFF
--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-master.yaml
@@ -42,8 +42,6 @@ presubmits:
         - unit-test
   - name: pull-scheduler-plugins-integration-test-master
     decorate: true
-    decoration_config:
-      timeout: 40m
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
     - ^master$

--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.18.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.18.yaml
@@ -42,8 +42,6 @@ presubmits:
         - unit-test
   - name: pull-scheduler-plugins-integration-test-release-1-18
     decorate: true
-    decoration_config:
-      timeout: 40m
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
     - ^release-1.18$

--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.19.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.19.yaml
@@ -42,8 +42,6 @@ presubmits:
         - unit-test
   - name: pull-scheduler-plugins-integration-test-release-1-19
     decorate: true
-    decoration_config:
-      timeout: 40m
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
     - ^release-1.19$


### PR DESCRIPTION
This reverts PR #22212 as the timeout occurred in `go test` side, not prow.

