### PR TITLE
Make onboarding and WI scripts require bash >= 4.4.

### DIFF
--- a/prow/create-build-cluster.sh
+++ b/prow/create-build-cluster.sh
@@ -54,6 +54,16 @@ ADMIN_IAM_MEMBER="${ADMIN_IAM_MEMBER:-group:mdb.cloud-kubernetes-engprod-oncall@
 # Overriding output
 OUT_FILE="${OUT_FILE:-build-cluster-kubeconfig.yaml}"
 
+
+# Require bash version >= 4.4
+if ((${BASH_VERSINFO[0]}<4)) || ( ((${BASH_VERSINFO[0]}==4)) && ((${BASH_VERSINFO[1]}<4)) ); then
+  echo "ERROR: This script requires a minimum bash version of 4.4, but got version of ${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}"
+  if [ "$(uname)" = 'Darwin' ]; then
+    echo "On macOS with homebrew 'brew install bash' is sufficient."
+  fi
+  exit 1
+fi
+
 # Macos specific settings
 SED="sed"
 if command -v gsed &>/dev/null; then

--- a/workload-identity/bind-service-accounts.sh
+++ b/workload-identity/bind-service-accounts.sh
@@ -23,6 +23,15 @@ if [[ $# != 6 ]]; then
   exit 1
 fi
 
+# Require bash version >= 4.4
+if ((${BASH_VERSINFO[0]}<4)) || ( ((${BASH_VERSINFO[0]}==4)) && ((${BASH_VERSINFO[1]}<4)) ); then
+  echo "ERROR: This script requires a minimum bash version of 4.4, but got version of ${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}"
+  if [ "$(uname)" = 'Darwin' ]; then
+    echo "On macOS with homebrew 'brew install bash' is sufficient."
+  fi
+  exit 1
+fi
+
 project=$1
 zone=$2
 cluster=$3

--- a/workload-identity/enable-workload-identity.sh
+++ b/workload-identity/enable-workload-identity.sh
@@ -25,6 +25,15 @@ if [[ $# != 3 ]]; then
   exit 1
 fi
 
+# Require bash version >= 4.4
+if ((${BASH_VERSINFO[0]}<4)) || ( ((${BASH_VERSINFO[0]}==4)) && ((${BASH_VERSINFO[1]}<4)) ); then
+  echo "ERROR: This script requires a minimum bash version of 4.4, but got version of ${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}"
+  if [ "$(uname)" = 'Darwin' ]; then
+    echo "On macOS with homebrew 'brew install bash' is sufficient."
+  fi
+  exit 1
+fi
+
 project=$1
 zone=$2
 cluster=$3


### PR DESCRIPTION
Some bash features like array expansion have changed since older versions of bash. We don't want to support such versions or have to debug issues that end up being caused by version skew.  Notably this will forbid the old version of bash that is installed on Macs by default.
/assign @fejta 