### PR TITLE
Fix data race in tide tests

### DIFF
--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -748,6 +748,8 @@ func (f *fgc) Merge(org, repo string, number int, details github.MergeDetails) e
 }
 
 func (f *fgc) CreateStatus(org, repo, ref string, s github.Status) error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
 	switch s.State {
 	case github.StatusSuccess, github.StatusError, github.StatusPending, github.StatusFailure:
 		if f.statuses == nil {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/test-infra/issues/22540
/cc @chaodaiG @BenTheElder 

```
$ go test -race ./prow/tide/
ok  	k8s.io/test-infra/prow/tide	4.240s
```