### PR TITLE
Add Pull missing Title field when tide controller is triggered

### DIFF
--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -1335,6 +1335,7 @@ func (c *Controller) trigger(sp subpool, presubmits []config.Presubmit, prs []Pu
 			refs.Pulls,
 			prowapi.Pull{
 				Number: int(pr.Number),
+				Title:  string(pr.Title),
 				Author: string(pr.Author.Login),
 				SHA:    string(pr.HeadRefOID),
 			},


### PR DESCRIPTION
On https://github.com/kubernetes/test-infra/pull/22341 Pulls were set
with their Title field, hence presubmit ProwJobs had this field and it
was viewable on Deck when hovering the Revision column.

Retested jobs are cloning the original pr metadata but the title field
was still missing.

Resolves https://github.com/kubernetes/test-infra/issues/22301