### PR TITLE
azure: add NetworkMode field

### DIFF
--- a/kubetest/aksengine_helpers.go
+++ b/kubetest/aksengine_helpers.go
@@ -151,6 +151,7 @@ type KubernetesConfig struct {
 	AzureCNIURLWindows               string            `json:"azureCNIURLWindows,omitempty"`
 	Addons                           []KubernetesAddon `json:"addons,omitempty"`
 	NetworkPolicy                    string            `json:"networkPolicy,omitempty"`
+	NetworkMode                      string            `json:"networkMode,omitempty"`
 	CloudProviderRateLimitQPS        float64           `json:"cloudProviderRateLimitQPS,omitempty"`
 	CloudProviderRateLimitBucket     int               `json:"cloudProviderRateLimitBucket,omitempty"`
 	APIServerConfig                  map[string]string `json:"apiServerConfig,omitempty"`


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

Adds `networkMode` to be able to parse api models for windows dual-stack.

Failure ref: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-dualstack-azure-e2e-master-windows/1404185032695746560

/assign @feiskyer 