### PR TITLE
Remove directxman12 from OWNERS, sub in

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -268,7 +268,7 @@ aliases:
 
   # mostly copied from sigs.k8s.io/controller-runtime/OWNERS_ALIASES
   controller-runtime-admins:
-  - directxman12
+  - vincepri
   - mengqiy
 
   controller-runtime-maintainers:
@@ -289,7 +289,7 @@ aliases:
   # mostly copied from sigs.k8s.io/kubebuilder/OWNERS_ALIASES
   kubebuilder-admins:
   - mengqiy
-  - directxman12
+  - estroz
 
   kubebuilder-reviewers:
   - alexeldeib


### PR DESCRIPTION
As per
https://groups.google.com/g/kubebuilder/c/-5hOFa_adr4/m/Sp_Zb755AwAJ,
directxman12 is stepping down.

I've added in a couple of folks to make sure we have someone listed in
admins that's an active maintainer (since mengqiy hasn't been active in
a while).