### PR TITLE
CAPZ: enable dind for verify presubmit job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -169,6 +169,9 @@ presubmits:
     optional: false
     decorate: true
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+    labels:
+      # required for shellcheck in container.
+      preset-dind-enabled: "true"
     branches:
     # The script this job runs is not in all branches.
     - ^master$
@@ -179,6 +182,8 @@ presubmits:
         - "runner.sh"
         - "make"
         - "verify"
+        securityContext:
+          privileged: true
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-verify-main


### PR DESCRIPTION
Related to https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1425

Enable docker-in-docker for the CAPZ presubmit verify job to allow running shellcheck in a container.

/assign @mboersma @devigned @fristonio