### PR TITLE
logrusutil: pre-censor message

### DIFF
--- a/prow/logrusutil/BUILD.bazel
+++ b/prow/logrusutil/BUILD.bazel
@@ -32,6 +32,8 @@ go_test(
     srcs = ["logrusutil_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//prow/secretutil:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
     ],

--- a/prow/logrusutil/logrusutil.go
+++ b/prow/logrusutil/logrusutil.go
@@ -91,6 +91,12 @@ type CensoringFormatter struct {
 }
 
 func (f CensoringFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	// Depending on the formatter in the delegate, the message will actually
+	// change shape/content - think of a message with newlines or quotes going
+	// to a JSON output. In order to catch this, we need to pre-censor the message.
+	message := []byte(entry.Message)
+	f.censorer.Censor(&message)
+	entry.Message = string(message)
 	raw, err := f.delegate.Format(entry)
 	if err != nil {
 		return raw, err


### PR DESCRIPTION
In the previous implementation we only censored the formatted output of
a log line. This is not sufficient as the formatting step may
substantially change the content being printed. With this patch we
pre-censor the message being passed to us. A perfect approach would also
require that we pre-censor the `logrus.Fields` data but it's not
immediately clear how to turn a `map[string]interface{}` into
representative byte sequences for censoring.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @alvaroaleman @petr-muller 