### PR TITLE
Fix gerrit onboarder bugs

### DIFF
--- a/experiment/gerrit-onboarder/onboarder_test.go
+++ b/experiment/gerrit-onboarder/onboarder_test.go
@@ -158,6 +158,12 @@ func TestConfigToMap(t *testing.T) {
 			configString: "[access]\n\towner = group Test Group\n\towner = group Test Group 2\n[access \"refs/*\"]\n\tread = group Test Group 3",
 			orderedIDs:   []string{"[access]", "[access \"refs/*\"]"},
 		},
+		{
+			name:         "empty line end of file",
+			configString: "[access]\n\towner=group Test Group\n",
+			configMap:    map[string][]string{"[access]": {"\towner=group Test Group"}},
+			orderedIDs:   []string{"[access]"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -469,6 +475,43 @@ func TestAddSection(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.expectedIDs, orderedKeys, cmpopts.SortSlices(func(x, y string) bool { return strings.Compare(x, y) > 0 })); diff != "" {
 				t.Errorf("configToMap returned unexpected ordredKeys value(-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetRepoClonedName(t *testing.T) {
+	cases := []struct {
+		name     string
+		repo     string
+		expected string
+	}{
+		{
+			name:     "No slashes",
+			repo:     "test-infra",
+			expected: "test-infra",
+		},
+		{
+			name:     "empty",
+			repo:     "",
+			expected: "",
+		},
+		{
+			name:     "one slash",
+			repo:     "testing/test-infra",
+			expected: "test-infra",
+		},
+		{
+			name:     "multiple slashes",
+			repo:     "testing/two/test-infra",
+			expected: "test-infra",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			workdir := getRepoClonedName(tc.repo)
+			if diff := cmp.Diff(workdir, tc.expected); diff != "" {
+				t.Errorf("configToMap returned unexpected map value(-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Three bugs in the gerrit onboarder needed to be fixed.
1) If the repo name contained a slash, the workdir would not have the slash. So cloud-k8s-engprod/test-infra needed git clone ...cloud-k8s-engprod/test-infra, but the workdir would just be test-infra.

2) If the All-Projects repo is not accessible due to Host restriction settings we now just assume that the All-Projects config does not contain anything and continue instead of failing. (This is a best attempt)

3) If adding to the last section in the project.config there would be a random empty line in the middle of the file after addition. We now ignore whitespace when generating project.config map.