### PR TITLE
images: add docker-buildx image

### DIFF
--- a/images/docker-buildx/Dockerfile
+++ b/images/docker-buildx/Dockerfile
@@ -1,0 +1,28 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM docker:latest
+
+ARG BUILDX_VERSION=0.5.1
+
+ENV DOCKER_BUILDKIT=1
+ENV DOCKER_CLI_EXPERIMENTAL=enabled
+
+RUN mkdir -p $HOME/.docker/cli-plugins && \
+    wget -O $HOME/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-amd64 && \
+    chmod a+x $HOME/.docker/cli-plugins/docker-buildx
+
+COPY entrypoint.sh /usr/local/bin/
+
+ENTRYPOINT ["entrypoint.sh"]

--- a/images/docker-buildx/Makefile
+++ b/images/docker-buildx/Makefile
@@ -1,0 +1,21 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+push-prod:
+	bazel run //images/builder -- --project=k8s-prow --scratch-bucket=gs://k8s-testimages-scratch images/docker-buildx
+
+push:
+	bazel run //images/builder -- --allow-dirty images/docker-buildx
+
+.PHONY: push push-prod

--- a/images/docker-buildx/cloudbuild.yaml
+++ b/images/docker-buildx/cloudbuild.yaml
@@ -1,0 +1,19 @@
+steps:
+  - name: docker
+    args:
+    - build
+    - -t
+    - gcr.io/$PROJECT_ID/docker-buildx:$_GIT_TAG
+    - --build-arg=IMAGE_ARG=gcr.io/$PROJECT_ID/docker-buildx:$_GIT_TAG
+    - .
+    dir: .
+  - name: docker
+    args:
+    - tag
+    - gcr.io/$PROJECT_ID/docker-buildx:$_GIT_TAG
+    - gcr.io/$PROJECT_ID/docker-buildx:latest
+substitutions:
+  _GIT_TAG: '12345'
+images:
+  - 'gcr.io/$PROJECT_ID/docker-buildx:$_GIT_TAG'
+  - 'gcr.io/$PROJECT_ID/docker-buildx:latest'

--- a/images/docker-buildx/entrypoint.sh
+++ b/images/docker-buildx/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+docker run --rm --privileged multiarch/qemu-user-static@sha256:c772ee1965aa0be9915ee1b018a0dd92ea361b4fa1bcab5bbc033517749b2af4 --reset -p yes
+
+/root/.docker/cli-plugins/docker-buildx create --use
+/root/.docker/cli-plugins/docker-buildx "$@"


### PR DESCRIPTION
This adds an image which can be used as a `docker buildx` builder in Google Cloud Build.

An example of how to use this can be seen in https://github.com/kubernetes/test-infra/pull/22444

/cc @fejta 
/cc @spiffxp 
/cc @stevekuznetsov 

/hold