### PR TITLE
Update Prow configuration for CIP e2e test

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -74,12 +74,16 @@ presubmits:
     # Because we run e2e tests, we cannot run more than 1 instance at a time
     # (the e2e test resources are not isolated across test runs).
     max_concurrency: 1
+    labels:
+      preset-dind-enabled: "true"
     branches:
     - ^master$
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210610-c72cf72-master
         command:
+        - runner.sh
+        args:
         - "./test-e2e/cip/e2e-entrypoint-from-container.sh"
         env:
         - name: CIP_E2E_KEY_FILE
@@ -88,6 +92,9 @@ presubmits:
         - name: k8s-cip-test-prod-service-account-creds
           mountPath: /etc/k8s-cip-test-prod-service-account
           readOnly: true
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
       volumes:
       - name: k8s-cip-test-prod-service-account-creds
         secret:


### PR DESCRIPTION
This change should allow e2e tests access the docker daemon.
Required for Issue: [#304](https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/304) and PR [#306](https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/306) within [CIP](https://github.com/kubernetes-sigs/k8s-container-image-promoter).

cc:  @listx @amwat @justaugustus @kubernetes-sigs/release-engineering