### PR TITLE
Fix empty dir handling in phaino

### DIFF
--- a/prow/cmd/phaino/local.go
+++ b/prow/cmd/phaino/local.go
@@ -277,7 +277,12 @@ func (opts *options) convertToLocal(ctx context.Context, log *logrus.Entry, pj p
 	}
 	// Add args for volume mounts.
 	for target, src := range volumeMounts {
-		localArgs = append(localArgs, "-v", src+":"+target)
+		// empty dirs have "" as src
+		if src == "" {
+			localArgs = append(localArgs, "-v", target)
+		} else {
+			localArgs = append(localArgs, "-v", src+":"+target)
+		}
 	}
 	// Add args for env vars.
 	for envKey, envVal := range envs {


### PR DESCRIPTION
If there's an `emptyDir` present in the volumes section, the function
`resolveVolumeMounts` puts an empty string in the map. This restores
the handling of that case. Otherwise errors occur like these:

```
docker: Error response from daemon: failed to create shim: OCI runtime
create failed: invalid mount {Destination::/mount-name Type:bind
Source:/var/lib/docker/volumes/a187...adfe/_data Options:[rbind]}:
mount destination :/mount-name not absolute: unknown.
```

Can also be seen when phaino is run in the log:
```
...
"-v" \
 ":/mount-name" \
...
```