### PR TITLE
Tide query deduplication: Sort to keep config loading deterministic

### DIFF
--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -25,7 +24,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -6546,18 +6544,6 @@ func TestDeduplicateTideQueries(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed: %v", err)
 			}
-
-			sort.SliceStable(result, func(i, j int) bool {
-				iSerialized, err := json.Marshal(result[i])
-				if err != nil {
-					t.Fatalf("failed to marshal %+v: %v", result[i], err)
-				}
-				jSerialized, err := json.Marshal(result[j])
-				if err != nil {
-					t.Fatalf("failed to marshal %+v: %v", result[j], err)
-				}
-				return string(iSerialized) < string(jSerialized)
-			})
 
 			if diff := cmp.Diff(result, tc.expected); diff != "" {
 				t.Errorf("Result differs from expected: %v", diff)


### PR DESCRIPTION
When we added the tide query deduplication, we moved the final sort from
the production in the test code. This causes issues with tooling that
loads, alters and writes the config, because their output is not
determindeterministic anymore.