### PR TITLE
images/gcb-docker-gcloud: enable docker-buildx builds

### DIFF
--- a/images/gcb-docker-gcloud/Dockerfile
+++ b/images/gcb-docker-gcloud/Dockerfile
@@ -53,6 +53,7 @@ RUN cp /qemu-bin/qemu-* /usr/bin/ && \
     rm -rf /qemu-bin
 COPY --from=qemu-image /qemu-binfmt-conf.sh /qemu-binfmt-conf.sh
 COPY --from=qemu-image /register /register
+ADD ./buildx-entrypoint.sh /buildx-entrypoint
 
 RUN apk add qemu
 

--- a/images/gcb-docker-gcloud/Dockerfile
+++ b/images/gcb-docker-gcloud/Dockerfile
@@ -51,6 +51,8 @@ RUN mkdir -p  $HOME/.docker/cli-plugins \
 COPY --from=qemu-image /usr/bin /qemu-bin
 RUN cp /qemu-bin/qemu-* /usr/bin/ && \
     rm -rf /qemu-bin
+COPY --from=qemu-image /qemu-binfmt-conf.sh /qemu-binfmt-conf.sh
+COPY --from=qemu-image /register /register
 
 RUN apk add qemu
 

--- a/images/gcb-docker-gcloud/buildx-entrypoint.sh
+++ b/images/gcb-docker-gcloud/buildx-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+/register --reset -p yes
+/root/.docker/cli-plugins/docker-buildx create --use
+/root/.docker/cli-plugins/docker-buildx "$@"

--- a/images/gcb-docker-gcloud/cloudbuild.yaml
+++ b/images/gcb-docker-gcloud/cloudbuild.yaml
@@ -7,8 +7,14 @@ steps:
       - --build-arg=GO_VERSION=$_GO_VERSION
       - .
     dir: images/gcb-docker-gcloud/
+  - name: gcr.io/cloud-builders/docker
+    args:
+    - tag
+    - gcr.io/$PROJECT_ID/gcb-docker-gcloud:$_GIT_TAG
+    - gcr.io/$PROJECT_ID/gcb-docker-gcloud:latest
 substitutions:
   _GIT_TAG: '12345'
   _GO_VERSION: 1.16.2
 images:
   - 'gcr.io/$PROJECT_ID/gcb-docker-gcloud:$_GIT_TAG'
+  - 'gcr.io/$PROJECT_ID/gcb-docker-gcloud:latest'


### PR DESCRIPTION
These changes make the gcb-docker-gcloud image usable as a docker-buildx builder, like so (example from #22444):

```yaml
steps:
  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud
    entrypoint: /buildx-entrypoint
    args:
    - build
    - --tag=gcr.io/$PROJECT_ID/alpine:$_GIT_TAG
    - --tag=gcr.io/$PROJECT_ID/alpine:latest
    - --platform=linux/amd64,linux/arm64/v8
    - --build-arg=IMAGE_ARG=gcr.io/$PROJECT_ID/alpine:$_GIT_TAG
    - --push
    - .
    dir: .
substitutions:
  _GIT_TAG: '12345'

```

/cc @spiffxp 