### PR TITLE
Hostprocess and containerd 1.5 job

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -699,3 +699,59 @@ periodics:
     testgrid-tab-name: ci-kubernetes-e2e-aks-engine-azure-master-windows-containerd-hostprocess-alpha
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs Windows alpha HostProcess tests (https://github.com/Azure/aks-engine) on Azure cloud
+- interval: 3h
+  name: ci-kubernetes-e2e-aks-engine-azure-master-windows-containerd-1-5
+  decorate: true
+  decoration_config:
+    timeout: 3h
+  labels:
+    preset-service-account: "true"
+    preset-azure-cred: "true"
+    preset-azure-windows: "true"
+    preset-windows-repo-list-master: "true"
+    preset-k8s-ssh: "true"
+    preset-dind-enabled: "true"
+    preset-windows-private-registry-cred: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210610-c72cf72-master
+      command:
+      - runner.sh
+      - kubetest
+      args:
+      # Generic e2e test args
+      - --test
+      - --up
+      - --down
+      - --build=quick
+      - --dump=$(ARTIFACTS)
+      # Azure-specific test args
+      - --deployment=aksengine
+      - --provider=skeleton
+      - --aksengine-admin-username=azureuser
+      - --aksengine-admin-password=AdminPassw0rd
+      - --aksengine-creds=$(AZURE_CREDENTIALS)
+      - --aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz
+      - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
+      - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
+      - --aksengine-winZipBuildScript=$(WIN_BUILD)
+      - --aksengine-orchestratorRelease=1.22
+      - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_1_5.json
+      - --aksengine-win-binaries
+      - --aksengine-deploy-custom-k8s
+      # Specific test args
+      - --test_args=--node-os-distro=windows -docker-config-file=$(DOCKER_CONFIG_FILE) --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
+      - --ginkgo-parallel=4
+      securityContext:
+        privileged: true
+  annotations:
+    fork-per-release: "true"
+    testgrid-dashboards: sig-windows-master-release
+    testgrid-tab-name: aks-engine-windows-containerd--1-5-master
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    description: Runs Windows tests on a Kubernetes cluster running containerd provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -752,6 +752,6 @@ periodics:
   annotations:
     fork-per-release: "true"
     testgrid-dashboards: sig-windows-master-release
-    testgrid-tab-name: aks-engine-windows-containerd--1-5-master
+    testgrid-tab-name: aks-engine-windows-containerd-1-5-master
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs Windows tests on a Kubernetes cluster running containerd provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -644,3 +644,58 @@ periodics:
     testgrid-tab-name: aks-engine-windows-containerd-azure-file-master
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure File e2e test with Azure File in a Windows cluster configured with CSI proxy and containerd.
+- interval: 12h
+  name: ci-kubernetes-e2e-aks-engine-azure-master-windows-containerd-hostprocess-alpha
+  decorate: true
+  decoration_config:
+    timeout: 3h
+  labels:
+    preset-service-account: "true"
+    preset-azure-cred: "true"
+    preset-azure-windows: "true"
+    preset-windows-repo-list-master: "true"
+    preset-k8s-ssh: "true"
+    preset-dind-enabled: "true"
+    preset-windows-private-registry-cred: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210610-c72cf72-master
+      command:
+      - runner.sh
+      - kubetest
+      args:
+      # Generic e2e test args
+      - --test
+      - --up
+      - --down
+      - --build=quick
+      - --dump=$(ARTIFACTS)
+      # Azure-specific test args
+      - --deployment=aksengine
+      - --provider=skeleton
+      - --aksengine-admin-username=azureuser
+      - --aksengine-admin-password=AdminPassw0rd
+      - --aksengine-creds=$(AZURE_CREDENTIALS)
+      - --aksengine-download-url=https://testgridjs.blob.core.windows.net/containerd/aks-engine-709e76638-linux-amd64.tar.gz
+      - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
+      - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
+      - --aksengine-winZipBuildScript=$(WIN_BUILD)
+      - --aksengine-orchestratorRelease=1.22
+      - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_master-hostprocess.json
+      - --aksengine-win-binaries
+      - --aksengine-deploy-custom-k8s
+      # Specific test args
+      - --test_args=--feature-gates="WindowsHostProcessContainers=true"  --node-os-distro=windows -docker-config-file=$(DOCKER_CONFIG_FILE) --ginkgo.focus=WindowsHostProcessContainers --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
+      - --ginkgo-parallel=4
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-windows-master-release
+    testgrid-tab-name: ci-kubernetes-e2e-aks-engine-azure-master-windows-containerd-hostprocess-alpha
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    description: Runs Windows alpha HostProcess tests (https://github.com/Azure/aks-engine) on Azure cloud


### PR DESCRIPTION
Add a hostprocess job. This job uses a custom build of aks-e for testing while waiting for CRI support in containerd: https://github.com/Azure/aks-engine/pull/4472

Adds a containerd 1.5 job 

/sig windows
/assign @chewong 


/hold
for https://github.com/kubernetes/kubernetes/pull/102965 and https://github.com/kubernetes-sigs/windows-testing/pull/272 