### PR TITLE
WIP: config/jobs: Use gcb-docker-gcloud image for building alpine and git images

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -44,7 +44,7 @@ postsubmits:
     spec:
       serviceAccountName: pusher
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-bazel:v20210128-v0.6-11-gf1c6399
+      - image: gcr.io/k8s-testimages/gcb-docker-gcloud:v20210617-6d302b2
         command:
         - images/builder/ci-runner.sh
         args:
@@ -85,7 +85,7 @@ postsubmits:
     spec:
       serviceAccountName: pusher
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-bazel:v20210128-v0.6-11-gf1c6399
+      - image: gcr.io/k8s-testimages/gcb-docker-gcloud:v20210617-6d302b2
         command:
         - images/builder/ci-runner.sh
         args:


### PR DESCRIPTION
#22444 has broken the alpine postsubmit job.
In #22450 the git image is supposed to get the same treatment, so I'm changing the base for both jobs here already.

I'm not sure fixing it is as easy as this. PTAL.

Edit: Nope, this won't work

/cc @BenTheElder 
/cc @fejta 
