### PR TITLE
drop KUBE_RACE from unit test CI definition

### DIFF
--- a/config/jobs/kubernetes/sig-testing/make-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/make-test.yaml
@@ -19,9 +19,6 @@ presubmits:
           command:
             - make
             - test
-            # TODO: enable KUBE_RACE by default or remove?
-            # ref: https://github.com/kubernetes/kubernetes/issues/102607
-            - KUBE_RACE=-race
           # TODO: direct copy from pull-kubernetes-bazel-test, tune these
           resources:
             limits:
@@ -55,9 +52,6 @@ presubmits:
           command:
             - make
             - test
-            # TODO: enable KUBE_RACE by default or remove?
-            # ref: https://github.com/kubernetes/kubernetes/issues/102607
-            - KUBE_RACE=-race
           # TODO: direct copy from pull-kubernetes-bazel-test, tune these
           resources:
             limits:
@@ -89,9 +83,6 @@ periodics:
           command:
             - make
             - test
-            # todo: enable KUBE_RACE by default or remove?
-            # ref: https://github.com/kubernetes/kubernetes/issues/102607
-            - KUBE_RACE=-race
           # TODO: direct copy from pull-kubernetes-bazel-test, tune these
           resources:
             limits:


### PR DESCRIPTION
this is defaulted in the make target now

follow up to https://github.com/kubernetes/kubernetes/pull/102960