### PR TITLE
add: labels for kubernetes-sigs/contributor-tweets

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -12,6 +12,7 @@
 - [Labels that apply to kubernetes-sigs/cluster-api-provider-aws, for both issues and PRs](#labels-that-apply-to-kubernetes-sigscluster-api-provider-aws-for-both-issues-and-prs)
 - [Labels that apply to kubernetes-sigs/cluster-api-provider-aws, only for issues](#labels-that-apply-to-kubernetes-sigscluster-api-provider-aws-only-for-issues)
 - [Labels that apply to kubernetes-sigs/cluster-api-provider-azure, for both issues and PRs](#labels-that-apply-to-kubernetes-sigscluster-api-provider-azure-for-both-issues-and-prs)
+- [Labels that apply to kubernetes-sigs/contributor-tweets, for both issues and PRs](#labels-that-apply-to-kubernetes-sigscontributor-tweets-for-both-issues-and-prs)
 - [Labels that apply to kubernetes-sigs/gateway-api, only for issues](#labels-that-apply-to-kubernetes-sigsgateway-api-only-for-issues)
 - [Labels that apply to kubernetes-sigs/k8s-container-image-promoter, for both issues and PRs](#labels-that-apply-to-kubernetes-sigsk8s-container-image-promoter-for-both-issues-and-prs)
 - [Labels that apply to kubernetes-sigs/kind, for both issues and PRs](#labels-that-apply-to-kubernetes-sigskind-for-both-issues-and-prs)
@@ -233,6 +234,12 @@ larger set of contributors to apply/remove them.
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
 | <a id="kind/proposal" href="#kind/proposal">`kind/proposal`</a> | Issues or PRs related to proposals.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+
+## Labels that apply to kubernetes-sigs/contributor-tweets, for both issues and PRs
+
+| Name | Description | Added By | Prow Plugin |
+| ---- | ----------- | -------- | --- |
+| <a id="kind/tweet" href="#kind/tweet">`kind/tweet`</a> | Issues to parse and tweet from K8sContributor handle| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 
 ## Labels that apply to kubernetes-sigs/gateway-api, only for issues
 

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -1793,3 +1793,11 @@ repos:
           - name: area/release-infra
         target: both
         addedBy: label
+  kubernetes-sigs/contributor-tweets:
+    labels:
+      - color: 0052cc
+        description: Issues to parse and tweet from K8sContributor handle
+        name: kind/tweet
+        target: both
+        addedBy: anyone
+        prowPlugin: label


### PR DESCRIPTION
Signed-off-by: Karthikeyan Govindaraj <github.gkarthiks@gmail.com>

This Pull request is to add a new label `kind/tweet` for the [contributor-tweets](https://github.com/kubernetes-sigs/contributor-tweets/) repository.

This repository is used to handle all the tweets that are going via the [@K8sContributors](https://twitter.com/K8sContributors/) Twitter handle. There's a new feature added to that repository for semi-automated tweeting. It follows the below steps.

**Step 1**: Creating an issue with the content that needs to be tweeted via the above-mentioned handle.
**Step 2**: The GitHub Actions will be triggered and the issue will be parsed and the content will be added into a new `.tweet` file and a PR will be created automatically. 
**Step 3**: Once the PR is approved by the list of owners of that repo, the Actions will get triggered and the content will be tweeted.

We have done a guard railing on parsing of the issues. The GitHub Actions will parse the issues that are only marked with a specific label. Our preferred label is `kind/tweet`. And hence this PR.