### PR TITLE
releng: Image promoter job updates

### DIFF
--- a/config/jobs/image-pushing/releng/k8s-staging-artifact-promoter.yaml
+++ b/config/jobs/image-pushing/releng/k8s-staging-artifact-promoter.yaml
@@ -28,10 +28,10 @@ postsubmits:
         github_team_ids:
           - 2241179 # release-managers
   kubernetes-sigs/k8s-container-image-promoter:
-    - name: cip-postsubmit-push-to-staging
+    - name: post-cip-push-image-cip
       cluster: k8s-infra-prow-build-trusted
       annotations:
-        testgrid-dashboards: sig-release-releng-blocking
+        testgrid-dashboards: sig-release-releng-blocking, sig-release-master-informing, sig-release-image-pushes
         testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
         testgrid-num-failures-to-alert: '1'
       decorate: true
@@ -48,3 +48,9 @@ postsubmits:
               - --scratch-bucket=gs://k8s-staging-artifact-promoter-gcb
               - --env-passthrough=PULL_BASE_REF
               - .
+            env:
+              - name: LOG_TO_STDOUT
+                value: "y"
+      rerun_auth_config:
+        github_team_ids:
+          - 2241179 # release-managers

--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -133,6 +133,41 @@ presubmits:
       testgrid-dashboards: sig-release-releng-presubmits
       testgrid-num-columns-recent: '30'
       testgrid-alert-email: release-managers+alerts@kubernetes.io
+  - name: pull-cip-image-cip
+    cluster: k8s-infra-prow-build
+    decorate: true
+    path_alias: "sigs.k8s.io/k8s-container-image-promoter"
+    # TODO(releng): Run unconditionally once the job runs successfully
+    always_run: false
+    spec:
+      serviceAccountName: gcb-builder-releng-test
+      containers:
+        - image: gcr.io/k8s-testimages/image-builder:v20210607-0d70d1d
+          command:
+            - /run.sh
+          args:
+            - --project=k8s-staging-releng-test
+            - --scratch-bucket=gs://k8s-staging-releng-test
+            - --env-passthrough=PULL_BASE_REF
+            - .
+          env:
+            - name: LOG_TO_STDOUT
+              value: "y"
+            - name: REGISTRY
+              value: "gcr.io/k8s-staging-releng-test"
+          resources:
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+    annotations:
+      testgrid-dashboards: sig-release-releng-presubmits
+      testgrid-tab-name: cip-image-cip
+      testgrid-num-failures-to-alert: '10'
+      testgrid-alert-email: release-managers+alerts@kubernetes.io
+      testgrid-num-columns-recent: '30'
   # Build all binaries and also run unit tests.
   - name: pull-cip-unit-tests
     decorate: true


### PR DESCRIPTION
Cleanup as part of https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/311.

- Update job name to `post-cip-push-image-cip`
- Add to dashboards:
  - sig-release-master-informing
  - sig-release-image-pushes
- Log job runs to stdout in Prow
- Allow jobs to be rerun by Release Managers
- Add presubmit for image promoter container pushes

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/hold for presubmit addition