### PR TITLE
fix broken depstat periodic job

### DIFF
--- a/config/jobs/kubernetes/sig-arch/kubernetes-depstat-periodical.yaml
+++ b/config/jobs/kubernetes/sig-arch/kubernetes-depstat-periodical.yaml
@@ -27,10 +27,7 @@ periodics:
           go install github.com/kubernetes-sigs/depstat@latest
           popd
 
-          depstat stats --json > "${WORKDIR}/stats.json"
-          git checkout -b base "${PULL_BASE_SHA}";
-          depstat stats --json > "${WORKDIR}/stats-base.json"
-          diff -s -u --ignore-all-space "${WORKDIR}"/stats-base.json "${WORKDIR}"/stats.json || true
+          depstat stats --json | tee "${WORKDIR}/stats-base.json";
     annotations:
       testgrid-create-test-group: "true"
       testgrid-dashboards: sig-testing-misc


### PR DESCRIPTION
pushed a wrong change in https://github.com/kubernetes/test-infra/commit/6435f39d6cf0885ad0e58909ddb9ef3e7b986c8c to the periodic job. we don't have/need a comparison, we just log the json.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>