### PR TITLE
Use external CCM with custom image for IPv6 test

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -712,12 +712,16 @@ def generate_misc():
                    distro="u2004",
                    k8s_version="stable",
                    networking="calico",
-                   feature_flags=["AWSIPv6"],
+                   feature_flags=["AWSIPv6",
+                                  "EnableExternalCloudController",
+                                  ],
                    runs_per_day=8,
                    extra_flags=['--ipv6',
-                                '--override=cluster.spec.nonMasqueradeCIDR=fd00:10:96::/64', # pylint: disable=line-too-long
+                                '--override=cluster.spec.cloudControllerManager.cloudProvider=aws',
+                                '--override=cluster.spec.cloudControllerManager.image=hakman/cloud-controller-manager:ipv6-1', # pylint: disable=line-too-long
+                                '--override=cluster.spec.nonMasqueradeCIDR=fd00:10:96::/64',
                                 '--override=cluster.spec.kubeDNS.upstreamNameservers=2620:119:53::53', # pylint: disable=line-too-long
-                                '--override=cluster.spec.networking.calico.awsSrcDstCheck=Disable', # pylint: disable=line-too-long
+                                '--override=cluster.spec.networking.calico.awsSrcDstCheck=Disable',
                                 ],
                    extra_dashboards=['kops-misc'],
                    use_new_skip_logic=True),

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -67,7 +67,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-scenario-arm64
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--ipv6 --override=cluster.spec.nonMasqueradeCIDR=fd00:10:96::/64 --override=cluster.spec.kubeDNS.upstreamNameservers=2620:119:53::53 --override=cluster.spec.networking.calico.awsSrcDstCheck=Disable", "feature_flags": "AWSIPv6", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--ipv6 --override=cluster.spec.cloudControllerManager.cloudProvider=aws --override=cluster.spec.cloudControllerManager.image=hakman/cloud-controller-manager:ipv6-1 --override=cluster.spec.nonMasqueradeCIDR=fd00:10:96::/64 --override=cluster.spec.kubeDNS.upstreamNameservers=2620:119:53::53 --override=cluster.spec.networking.calico.awsSrcDstCheck=Disable", "feature_flags": "AWSIPv6,EnableExternalCloudController", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-scenario-ipv6
   cron: '38 2-23/3 * * *'
   labels:
@@ -96,8 +96,8 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210610' --channel=alpha --networking=calico --container-runtime=containerd --ipv6 --override=cluster.spec.nonMasqueradeCIDR=fd00:10:96::/64 --override=cluster.spec.kubeDNS.upstreamNameservers=2620:119:53::53 --override=cluster.spec.networking.calico.awsSrcDstCheck=Disable" \
-          --env=KOPS_FEATURE_FLAGS=AWSIPv6 \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210610' --channel=alpha --networking=calico --container-runtime=containerd --ipv6 --override=cluster.spec.cloudControllerManager.cloudProvider=aws --override=cluster.spec.cloudControllerManager.image=hakman/cloud-controller-manager:ipv6-1 --override=cluster.spec.nonMasqueradeCIDR=fd00:10:96::/64 --override=cluster.spec.kubeDNS.upstreamNameservers=2620:119:53::53 --override=cluster.spec.networking.calico.awsSrcDstCheck=Disable" \
+          --env=KOPS_FEATURE_FLAGS=AWSIPv6,EnableExternalCloudController \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
           --test=kops \
@@ -124,8 +124,8 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --ipv6 --override=cluster.spec.nonMasqueradeCIDR=fd00:10:96::/64 --override=cluster.spec.kubeDNS.upstreamNameservers=2620:119:53::53 --override=cluster.spec.networking.calico.awsSrcDstCheck=Disable
-    test.kops.k8s.io/feature_flags: AWSIPv6
+    test.kops.k8s.io/extra_flags: --ipv6 --override=cluster.spec.cloudControllerManager.cloudProvider=aws --override=cluster.spec.cloudControllerManager.image=hakman/cloud-controller-manager:ipv6-1 --override=cluster.spec.nonMasqueradeCIDR=fd00:10:96::/64 --override=cluster.spec.kubeDNS.upstreamNameservers=2620:119:53::53 --override=cluster.spec.networking.calico.awsSrcDstCheck=Disable
+    test.kops.k8s.io/feature_flags: AWSIPv6,EnableExternalCloudController
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''


### PR DESCRIPTION
Run IPv6 test with a custom image containing the CCM IPv6 patch.

/cc @rifelpet @olemarkus @johngmyers 