### PR TITLE
capg: add lint as required check for PRs

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -452,6 +452,10 @@ branch-protection:
           branches:
             gh-pages:
               protect: false
+        cluster-api-provider-gcp:
+          required_status_checks:
+            contexts:
+            - lint
         kube-batch:
           required_status_checks:
             contexts:


### PR DESCRIPTION
continuation of the work: https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/387

add the `lint` as required status check for merge PRs for CAPG


/assign @dims 