### PR TITLE
GHProxy: Add metrics about inode usage

### DIFF
--- a/greenhouse/diskutil/diskutil.go
+++ b/greenhouse/diskutil/diskutil.go
@@ -26,16 +26,19 @@ import (
 )
 
 // GetDiskUsage wraps syscall.Statfs for usage in GCing the disk
-func GetDiskUsage(path string) (percentBlocksFree float64, bytesFree, bytesUsed uint64, err error) {
+func GetDiskUsage(path string) (percentBlocksFree float64, bytesFree, bytesUsed uint64, percentInodeFree float64, inodeFree, inodeUsed uint64, err error) {
 	var stat syscall.Statfs_t
 	err = syscall.Statfs(path, &stat)
 	if err != nil {
-		return 0, 0, 0, err
+		return 0, 0, 0, 0, 0, 0, err
 	}
 	percentBlocksFree = float64(stat.Bfree) / float64(stat.Blocks) * 100
 	bytesFree = stat.Bfree * uint64(stat.Bsize)
 	bytesUsed = (stat.Blocks - stat.Bfree) * uint64(stat.Bsize)
-	return percentBlocksFree, bytesFree, bytesUsed, nil
+
+	percentInodeFree = float64(stat.Ffree) / float64(stat.Files) * 100
+	inodeUsed = stat.Files - stat.Ffree
+	return percentBlocksFree, bytesFree, bytesUsed, percentInodeFree, stat.Ffree, inodeUsed, nil
 }
 
 // GetATime the atime for a file, logging errors instead of failing

--- a/greenhouse/eviction.go
+++ b/greenhouse/eviction.go
@@ -37,7 +37,7 @@ func monitorDiskAndEvict(
 	// forever check if usage is past thresholds and evict
 	ticker := time.NewTicker(interval)
 	for ; true; <-ticker.C {
-		blocksFree, _, _, err := diskutil.GetDiskUsage(diskRoot)
+		blocksFree, _, _, _, _, _, err := diskutil.GetDiskUsage(diskRoot)
 		if err != nil {
 			logrus.WithError(err).Error("Failed to get disk usage!")
 			continue
@@ -72,7 +72,7 @@ func monitorDiskAndEvict(
 					promMetrics.LastEvictedAccessAge.Set(time.Since(entry.LastAccess).Hours())
 				}
 				// get new disk usage
-				blocksFree, _, _, err = diskutil.GetDiskUsage(diskRoot)
+				blocksFree, _, _, _, _, _, err = diskutil.GetDiskUsage(diskRoot)
 				logger = logrus.WithFields(logrus.Fields{
 					"sync-loop":   "MonitorDiskAndEvict",
 					"blocks-free": blocksFree,

--- a/greenhouse/main.go
+++ b/greenhouse/main.go
@@ -195,7 +195,7 @@ func updateMetrics(interval time.Duration, diskRoot string) {
 	ticker := time.NewTicker(interval)
 	for ; true; <-ticker.C {
 		logger.Info("tick")
-		_, bytesFree, bytesUsed, err := diskutil.GetDiskUsage(diskRoot)
+		_, bytesFree, bytesUsed, _, _, _, err := diskutil.GetDiskUsage(diskRoot)
 		if err != nil {
 			logger.WithError(err).Error("Failed to get disk metrics")
 		} else {


### PR DESCRIPTION
This change adds metrics about the inode usage to ghproxy. The
background is that ghproxy recently silently stopped to work because
there were no inodes left on its disk, which resulted in a hard to debug
"Somehow ghproxy doesn't cache anymore" situation.

The metrics in here allow to alert on that.