### PR TITLE
cvelist-public: grab the validation script from the validate branch

### DIFF
--- a/config/jobs/kubernetes/sig-security/cvelist-public.yaml
+++ b/config/jobs/kubernetes/sig-security/cvelist-public.yaml
@@ -15,6 +15,7 @@ presubmits:
         - |
           set -euo pipefail; \
           apt update && apt -y install jq; \
+          [[ -f validate-k8s.sh ]] || git checkout validate -- validate-k8s.sh; \
           git diff --name-only --diff-filter=d $PULL_BASE_SHA...$PULL_PULL_SHA | grep "\/CVE.*json$" | xargs ./validate-k8s.sh
     annotations:
       testgrid-create-test-group: "true"


### PR DESCRIPTION
I want to move the `validate-k8s.sh` script out of the `master` branch, so that the master branch tracks the upstream (https://github.com/CVEProject/cvelist), and we can open PRs against the upstream directly from our fork.

I check for absence  of the script as a hack to allow testing changes to the script against the `validate` branch itself. Open to suggestions for a better way to do this.

/committee product-security
/cc @dims @nikhita 