### PR TITLE
Add sig-docs testgrid dashboard

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-sig-docs.yaml
+++ b/config/jobs/image-pushing/k8s-staging-sig-docs.yaml
@@ -1,0 +1,22 @@
+postsubmits:
+  kubernetes/website:
+    - name: post-website-push-image-k8s-website-hugo
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-docs-website
+        testgrid-tab-name: post-website-push-image-k8s-website-hugo
+      decorate: true
+      run_if_changed: "^Dockerfile$"
+      branches:
+        - ^main$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20210607-0d70d1d
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-sig-docs
+              - --scratch-bucket=gs://k8s-staging-infra-sig-docs-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - .

--- a/config/testgrids/kubernetes/sig-docs/OWNERS
+++ b/config/testgrids/kubernetes/sig-docs/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+- sig-docs-leads
+approvers:
+- sig-docs-leads
+labels:
+- sig/docs

--- a/config/testgrids/kubernetes/sig-docs/config.yaml
+++ b/config/testgrids/kubernetes/sig-docs/config.yaml
@@ -1,0 +1,9 @@
+# Dashboard Group
+
+dashboard_groups:
+- name: sig-docs
+  dashboard_names:
+  - sig-docs-website
+
+dashboards:
+- name: sig-docs-website


### PR DESCRIPTION
Add a dashboard for jobs related to sig-docs
Followup of https://github.com/kubernetes/website/pull/24387.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>

/sig docs
/assign @BenTheElder @spiffxp 
cc @irvifa @jimangel @kbhawkey @sftim