### PR TITLE
Crier slack reporter: support no default slack settings

### DIFF
--- a/prow/cmd/crier/main.go
+++ b/prow/cmd/crier/main.go
@@ -231,10 +231,11 @@ func main() {
 
 	var hasReporter bool
 	if o.slackWorkers > 0 {
-		if cfg().SlackReporterConfigs == nil {
-			logrus.Fatal("slackreporter is enabled but has no config")
-		}
-		slackConfig := func(refs *prowapi.Refs) config.SlackReporter {
+		slackConfig := func(refs *prowapi.Refs) *config.SlackReporter {
+			if cfg().SlackReporterConfigs == nil {
+				logrus.Info("slackreporter is enabled but has no config")
+				return nil
+			}
 			return cfg().SlackReporterConfigs.GetSlackReporter(refs)
 		}
 		tokensMap := make(map[string]func() []byte)

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1051,9 +1051,9 @@ type SlackReporter struct {
 
 // SlackReporterConfigs represents the config for the Slack reporter(s).
 // Use `org/repo`, `org` or `*` as key and an `SlackReporter` struct as value.
-type SlackReporterConfigs map[string]SlackReporter
+type SlackReporterConfigs map[string]*SlackReporter
 
-func (cfg SlackReporterConfigs) GetSlackReporter(refs *prowapi.Refs) SlackReporter {
+func (cfg SlackReporterConfigs) GetSlackReporter(refs *prowapi.Refs) *SlackReporter {
 	if refs == nil {
 		return cfg["*"]
 	}

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -3328,7 +3328,7 @@ func TestSlackReporterValidation(t *testing.T) {
 		{
 			name: "Valid config w/ wildcard slack_reporter_configs - no error",
 			config: func() Config {
-				slackCfg := map[string]SlackReporter{
+				slackCfg := map[string]*SlackReporter{
 					"*": {
 						Channel: "my-channel",
 					},
@@ -3344,7 +3344,7 @@ func TestSlackReporterValidation(t *testing.T) {
 		{
 			name: "Valid config w/ org/repo slack_reporter_configs - no error",
 			config: func() Config {
-				slackCfg := map[string]SlackReporter{
+				slackCfg := map[string]*SlackReporter{
 					"istio/proxy": {
 						Channel: "my-channel",
 					},
@@ -3360,7 +3360,7 @@ func TestSlackReporterValidation(t *testing.T) {
 		{
 			name: "Valid config w/ repo slack_reporter_configs - no error",
 			config: func() Config {
-				slackCfg := map[string]SlackReporter{
+				slackCfg := map[string]*SlackReporter{
 					"proxy": {
 						Channel: "my-channel",
 					},
@@ -3376,7 +3376,7 @@ func TestSlackReporterValidation(t *testing.T) {
 		{
 			name: "No channel w/ slack_reporter_configs - error",
 			config: func() Config {
-				slackCfg := map[string]SlackReporter{
+				slackCfg := map[string]*SlackReporter{
 					"*": {
 						JobTypesToReport: []prowapi.ProwJobType{"presubmit"},
 					},
@@ -3392,7 +3392,7 @@ func TestSlackReporterValidation(t *testing.T) {
 		{
 			name: "Empty config - no error",
 			config: func() Config {
-				slackCfg := map[string]SlackReporter{}
+				slackCfg := map[string]*SlackReporter{}
 				return Config{
 					ProwConfig: ProwConfig{
 						SlackReporterConfigs: slackCfg,
@@ -3404,7 +3404,7 @@ func TestSlackReporterValidation(t *testing.T) {
 		{
 			name: "Invalid template - error",
 			config: func() Config {
-				slackCfg := map[string]SlackReporter{
+				slackCfg := map[string]*SlackReporter{
 					"*": {
 						Channel:        "my-channel",
 						ReportTemplate: "{{ if .Spec.Name}}",
@@ -3421,7 +3421,7 @@ func TestSlackReporterValidation(t *testing.T) {
 		{
 			name: "Template accessed invalid property - error",
 			config: func() Config {
-				slackCfg := map[string]SlackReporter{
+				slackCfg := map[string]*SlackReporter{
 					"*": {
 						Channel:        "my-channel",
 						ReportTemplate: "{{ .Undef}}",

--- a/prow/crier/reporters/slack/reporter.go
+++ b/prow/crier/reporters/slack/reporter.go
@@ -130,6 +130,9 @@ func (sr *slackReporter) GetName() string {
 	return reporterName
 }
 
+// ShouldReport return true if:
+// - job state matches defined job types to be reported
+// - job type matches global config or slack channel defined in job config
 func (sr *slackReporter) ShouldReport(_ context.Context, logger *logrus.Entry, pj *v1.ProwJob) bool {
 	jobCfg := jobConfig(pj)
 	prowCfg := sr.getConfig(pj)
@@ -158,16 +161,17 @@ func (sr *slackReporter) ShouldReport(_ context.Context, logger *logrus.Entry, p
 	// Note the JobStatesToReport configured in the Prow job can overwrite the
 	// Prow config.
 	var stateShouldReport bool
+	var jobStatesToReport []v1.ProwJobState
 	if prowCfg != nil {
-		jobStatesToReport := prowCfg.JobStatesToReport
-		if jobCfg != nil && len(jobCfg.JobStatesToReport) != 0 {
-			jobStatesToReport = jobCfg.JobStatesToReport
-		}
-		for _, stateToReport := range jobStatesToReport {
-			if pj.Status.State == stateToReport {
-				stateShouldReport = true
-				break
-			}
+		jobStatesToReport = prowCfg.JobStatesToReport
+	}
+	if jobCfg != nil && len(jobCfg.JobStatesToReport) != 0 {
+		jobStatesToReport = jobCfg.JobStatesToReport
+	}
+	for _, stateToReport := range jobStatesToReport {
+		if pj.Status.State == stateToReport {
+			stateShouldReport = true
+			break
 		}
 	}
 

--- a/prow/crier/reporters/slack/reporter_test.go
+++ b/prow/crier/reporters/slack/reporter_test.go
@@ -195,8 +195,8 @@ func TestShouldReport(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		cfgGetter := func(*v1.Refs) config.SlackReporter {
-			return tc.config
+		cfgGetter := func(*v1.Refs) *config.SlackReporter {
+			return &tc.config
 		}
 		t.Run(tc.name, func(t *testing.T) {
 			reporter := &slackReporter{
@@ -212,8 +212,8 @@ func TestShouldReport(t *testing.T) {
 
 func TestReloadsConfig(t *testing.T) {
 	cfg := config.SlackReporter{}
-	cfgGetter := func(*v1.Refs) config.SlackReporter {
-		return cfg
+	cfgGetter := func(*v1.Refs) *config.SlackReporter {
+		return &cfg
 	}
 
 	pj := &v1.ProwJob{
@@ -253,7 +253,7 @@ func TestUsesChannelOverrideFromJob(t *testing.T) {
 		{
 			name: "No job-level config, use global default",
 			config: func() config.Config {
-				slackCfg := map[string]config.SlackReporter{
+				slackCfg := map[string]*config.SlackReporter{
 					"*": {
 						Host:    "global-default-host",
 						Channel: "global-default",
@@ -272,7 +272,7 @@ func TestUsesChannelOverrideFromJob(t *testing.T) {
 		{
 			name: "org/repo for ref exists in config, use it",
 			config: func() config.Config {
-				slackCfg := map[string]config.SlackReporter{
+				slackCfg := map[string]*config.SlackReporter{
 					"*": {
 						Channel: "global-default",
 					},
@@ -300,7 +300,7 @@ func TestUsesChannelOverrideFromJob(t *testing.T) {
 		{
 			name: "org for ref exists in config, use it",
 			config: func() config.Config {
-				slackCfg := map[string]config.SlackReporter{
+				slackCfg := map[string]*config.SlackReporter{
 					"*": {
 						Channel: "global-default",
 					},
@@ -327,7 +327,7 @@ func TestUsesChannelOverrideFromJob(t *testing.T) {
 		{
 			name: "org/repo takes precedence over org",
 			config: func() config.Config {
-				slackCfg := map[string]config.SlackReporter{
+				slackCfg := map[string]*config.SlackReporter{
 					"*": {
 						Channel: "global-default",
 					},
@@ -357,7 +357,7 @@ func TestUsesChannelOverrideFromJob(t *testing.T) {
 		{
 			name: "Job-level config present, use it",
 			config: func() config.Config {
-				slackCfg := map[string]config.SlackReporter{
+				slackCfg := map[string]*config.SlackReporter{
 					"*": {
 						Channel: "global-default",
 					},
@@ -389,7 +389,7 @@ func TestUsesChannelOverrideFromJob(t *testing.T) {
 		{
 			name: "No matching slack config",
 			config: func() config.Config {
-				slackCfg := map[string]config.SlackReporter{
+				slackCfg := map[string]*config.SlackReporter{
 					"istio": {
 						Channel: "org-config",
 					},
@@ -416,7 +416,7 @@ func TestUsesChannelOverrideFromJob(t *testing.T) {
 		{
 			name: "Refs unset but extra refs exist, use it",
 			config: func() config.Config {
-				slackCfg := map[string]config.SlackReporter{
+				slackCfg := map[string]*config.SlackReporter{
 					"istio/proxy": {
 						Channel: "org-repo-config",
 					},
@@ -442,7 +442,7 @@ func TestUsesChannelOverrideFromJob(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cfgGetter := func(refs *v1.Refs) config.SlackReporter {
+			cfgGetter := func(refs *v1.Refs) *config.SlackReporter {
 				return tc.config().SlackReporterConfigs.GetSlackReporter(refs)
 			}
 			sr := slackReporter{
@@ -473,14 +473,14 @@ func TestShouldReportDefaultsToExtraRefs(t *testing.T) {
 		},
 	}
 	sr := slackReporter{
-		config: func(r *v1.Refs) config.SlackReporter {
+		config: func(r *v1.Refs) *config.SlackReporter {
 			if r.Org == "org" {
-				return config.SlackReporter{
+				return &config.SlackReporter{
 					JobTypesToReport:  []v1.ProwJobType{v1.PeriodicJob},
 					JobStatesToReport: []v1.ProwJobState{v1.SuccessState},
 				}
 			}
-			return config.SlackReporter{}
+			return &config.SlackReporter{}
 		},
 	}
 
@@ -515,16 +515,16 @@ func TestReportDefaultsToExtraRefs(t *testing.T) {
 	}
 	fsc := &fakeSlackClient{}
 	sr := slackReporter{
-		config: func(r *v1.Refs) config.SlackReporter {
+		config: func(r *v1.Refs) *config.SlackReporter {
 			if r.Org == "org" {
-				return config.SlackReporter{
+				return &config.SlackReporter{
 					JobTypesToReport:  []v1.ProwJobType{v1.PeriodicJob},
 					JobStatesToReport: []v1.ProwJobState{v1.SuccessState},
 					Channel:           "emercengy",
 					ReportTemplate:    "there you go",
 				}
 			}
-			return config.SlackReporter{}
+			return &config.SlackReporter{}
 		},
 		clients: map[string]slackClient{DefaultHostName: fsc},
 	}


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/22600 allows no default slack token, which still fails crier deployment because default prow config missing. This PR allows no default slack settings