### PR TITLE
Update ubuntu swap presubmit bootstrap args

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -582,10 +582,12 @@ presubmits:
       containers:
         - image: gcr.io/k8s-testimages/kubekins-e2e:v20210615-c973edd-master
           args:
-            - --repo=k8s.io/kubernetes=$(PULL_REFS)
-            - --repo=k8s.io/release
-            - --timeout=240
             - --root=/go/src
+            - "--job=$(JOB_NAME)"
+            - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+            - "--service-account=/etc/service-account/service-account.json"
+            - "--upload=gs://kubernetes-jenkins/pr-logs"
+            - "--timeout=240"
             - --scenario=kubernetes_e2e
             - --
             - --deployment=node
@@ -600,6 +602,9 @@ presubmits:
           env:
             - name: GOPATH
               value: /go
+          resources:
+            requests:
+              memory: "6Gi"
 
   - name: pull-kubernetes-node-swap-fedora
     skip_branches:


### PR DESCRIPTION
# Change
* Add additional memory request for Ubuntu swap 
* Explicitly specify upload directory in bootstrap args

# Test
* Tested locally and verify no regression in scenario args

```
ikema@n1-standard-2-ubuntu-gke-2004-1-20-v20210401-1b076eab:~$ free -h
              total        used        free      shared  buff/cache   available
Mem:          7.3Gi       589Mi       1.5Gi       0.0Ki       5.2Gi       6.4Gi
Swap:         1.0Gi       0.0Ki       1.0Gi
ikema@n1-standard-2-ubuntu-gke-2004-1-20-v20210401-1b076eab:~$ sudo docker run --memory 50m --memory-swap 50m --rm progrium/stress --vm 1 --vm-bytes 100m
stress: info: [1] dispatching hogs: 0 cpu, 0 io, 1 vm, 0 hdd
stress: dbug: [1] using backoff sleep of 3000us
stress: dbug: [1] --> hogvm worker 1 [6] forked
stress: FAIL: [1] (416) <-- worker 6 got signal 9
stress: WARN: [1] (418) now reaping child worker processes
stress: FAIL: [1] (422) kill error: No such process
stress: FAIL: [1] (452) failed run completed in 0s
ikema@n1-standard-2-ubuntu-gke-2004-1-20-v20210401-1b076eab:~$ sudo docker run --memory 50m --memory-swap -1 --rm progrium/stress --vm 1 --vm-bytes 100m --timeout 1s

stress: info: [1] dispatching hogs: 0 cpu, 0 io, 1 vm, 0 hdd
stress: dbug: [1] using backoff sleep of 3000us
stress: dbug: [1] setting timeout to 1s
stress: dbug: [1] --> hogvm worker 1 [7] forked
stress: dbug: [1] <-- worker 7 signalled normally
```