### PR TITLE
Enable docker-in-docker for pull-cip-auditor-e2e

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -111,6 +111,8 @@ presubmits:
     # Because we run e2e tests, we cannot run more than 1 instance at a time
     # (the e2e test resources are not isolated across test runs).
     max_concurrency: 1
+    labels:
+      preset-dind-enabled: "true"
     branches:
     - ^master$
     spec:
@@ -125,6 +127,9 @@ presubmits:
         - name: k8s-gcr-audit-test-prod-service-account-creds
           mountPath: /etc/k8s-gcr-audit-test-prod-service-account
           readOnly: true
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
       volumes:
       - name: k8s-gcr-audit-test-prod-service-account-creds
         secret:


### PR DESCRIPTION
The Prow job `pull-cip-auditor-e2e` requires docker-in-docker support when integrating archive loading within [CIP](https://github.com/kubernetes-sigs/k8s-container-image-promoter).
Blocking [#315](https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/315)