### PR TITLE
Execute only `make test` as part of DNS presubmit.

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -195,13 +195,8 @@ presubmits:
         - --upload=gs://kubernetes-jenkins/pr-logs
         - --scenario=execute
         - --
-        - bash
-        - -c
-        - |
-          make build
-          make test
-          make all-containers
-          bash test/e2e/sidecar/e2e.sh
+        - make
+        - test
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
If this works, I can make a script in k/dns repo with all the required steps and trigger that from the prow job. 
This is a follow-up to https://github.com/kubernetes/test-infra/pull/22646