### PR TITLE
Add an Openshift Serverless board to Openshift's testgrid

### DIFF
--- a/config/testgrids/openshift/groups.yaml
+++ b/config/testgrids/openshift/groups.yaml
@@ -40,4 +40,5 @@ dashboard_groups:
   - redhat-openshift-presubmit-master-gcp
   - redhat-osd
   - redhat-single-node
+  - redhat-openshift-serverless
   name: redhat

--- a/config/testgrids/openshift/serverless.yaml
+++ b/config/testgrids/openshift/serverless.yaml
@@ -1,0 +1,28 @@
+dashboards:
+- name: redhat-openshift-serverless
+  dashboard_tab:
+  - name: main-continuous-4.6
+    test_group_name: periodic-ci-openshift-knative-serverless-operator-main-4.6-e2e-aws-ocp-46-continuous
+    base_options: width=10
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    file_bug_template:
+      options:
+      - key: classification
+        value: Red Hat
+      - key: product
+        value: Openshift Serverless
+      - key: short_desc
+        value: 'test: <test-name>'
+      - key: cf_environment
+        value: 'test: <test-name>'
+      - key: comment
+        value: 'test: <test-name> failed, see job: <test-url>'
+      url: https://bugzilla.redhat.com/enter_bug.cgi
+    open_bug_template:
+      url: https://github.com/openshift-knative/serverless-operator/issues/
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    code_search_path: https://github.com/openshift-knative/serverless-operator/search
+    code_search_url_template:
+      url: https://github.com/openshift-knative/serverless-operator/compare/<start-custom-0>...<end-custom-0>

--- a/config/testgrids/openshift/serverless.yaml
+++ b/config/testgrids/openshift/serverless.yaml
@@ -3,7 +3,7 @@ dashboards:
   dashboard_tab:
   - name: main-continuous-4.6
     test_group_name: periodic-ci-openshift-knative-serverless-operator-main-4.6-e2e-aws-ocp-46-continuous
-    base_options: width=10
+    base_options: width=14
     open_test_template:
       url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     file_bug_template:
@@ -26,3 +26,7 @@ dashboards:
     code_search_path: https://github.com/openshift-knative/serverless-operator/search
     code_search_url_template:
       url: https://github.com/openshift-knative/serverless-operator/compare/<start-custom-0>...<end-custom-0>
+test_groups:
+- days_of_results: 14
+  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.6-e2e-aws-ocp-46-continuous
+  name: periodic-ci-openshift-knative-serverless-operator-main-4.6-e2e-aws-ocp-46-continuous


### PR DESCRIPTION
As per title. This adds just one job for now to test this works as intended.

/assign @stevekuznetsov 