### PR TITLE
Revert to a no-op presubmit for DNS

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -195,8 +195,7 @@ presubmits:
         - --upload=gs://kubernetes-jenkins/pr-logs
         - --scenario=execute
         - --
-        - make
-        - test
+        - "true"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
A followup will invoke a script instead of putting commands in the job spec directly.

Details in https://github.com/kubernetes/dns/issues/458