### PR TITLE
Run runner.sh for pull-cip-auditor-e2e

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -119,6 +119,8 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210615-c973edd-master
         command:
+        - runner.sh
+        args:
         - "./test-e2e/cip-auditor/entrypoint-from-container.sh"
         env:
         - name: CIP_E2E_KEY_FILE


### PR DESCRIPTION
Running [CIP's](https://github.com/kubernetes-sigs/k8s-container-image-promoter) auditor [entrypoint-script](https://github.com/kubernetes-sigs/k8s-container-image-promoter/blob/master/test-e2e/cip-auditor/entrypoint-from-container.sh) through the runner.sh enables docker-in-docker. This change should have been included in #22658

Blocking CIP PR: [#315](https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/315)

cc: @listx @amwat @justaugustus @kubernetes/release-engineering