### PR TITLE
Disable SCTP tests for ci-kubernetes-e2e-gce-cos-k8sstable2-alphafeatures

### DIFF
--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -497,7 +497,7 @@ periodics:
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,CSIMigration=false
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --runtime-config=api/all=true
-      - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
+      - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:(Volumes|SCTPConnectivity) --minStartupPods=8
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
       resources:

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -151,7 +151,7 @@ jobs:
     - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
     - --runtime-config=api/all=true
     - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking
-      --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
+      --ginkgo.skip=Networking-Performance|IPv6|Feature:(Volumes|SCTPConnectivity) --minStartupPods=8
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
 


### PR DESCRIPTION
The following two test suites are failing in `gce-cos-k8sstable2-alphafeatures` on the sig-release-1.19-blocking dashboard for a long time:

* `[sig-network] Networking Granular Checks: Services should function for pod-Service: sctp [Feature:SCTPConnectivity]`
* `[sig-network] Networking should function for pod-pod: sctp [Feature:SCTPConnectivity]`

I've investigated a bit and found that we disabled those tests for other `alphafeatures` jobs. From #17125:

> The tests tagged as [Feature:SCTPConnectivity]" were not supposed to run on Kubernetes CI, however, the regex in the job ci-kubernetes-e2e-gci-gce-alpha-features wasn't excluding it and started to run them, with the problem that they started to fail :)

/assign @justaugustus 
cc: @kubernetes/release-engineering 