### PR TITLE
tide status: do not post statuses on PRs in archived repos

### DIFF
--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -607,7 +607,7 @@ func newBaseSHAGetter(baseSHAs map[string]string, ghc githubClient, org, repo, b
 }
 
 func openPRsQuery(orgs, repos []string, orgExceptions map[string]sets.String) string {
-	return "is:pr state:open sort:updated-asc " + orgRepoQueryString(orgs, repos, orgExceptions)
+	return "is:pr state:open sort:updated-asc archived:false " + orgRepoQueryString(orgs, repos, orgExceptions)
 }
 
 const indexNamePassingJobs = "tide-passing-jobs"


### PR DESCRIPTION
Archived repos areread only so attempts to post statuses on PRs in archived repos end up
with 403:

```
Failed to set status context from "" to "error" and description from "" to "Not mergeable. PR has a merge conflict.", error=the GitHub API request returns a 403 error: {"message":"Repository was archived so is read-only."
```

The other controller filters out archived repo too:
https://github.com/kubernetes/test-infra/blob/c78e5916da6f9f54f5180b8dff7d151433df2da3/prow/config/tide.go#L329