### PR TITLE
prow/plank/README: Fix default_decoration_configs -> default_decoration_config_entries

### DIFF
--- a/prow/getting_started_deploy.md
+++ b/prow/getting_started_deploy.md
@@ -278,7 +278,7 @@ ProwJob configuration:
 * ensure that `clone_uri` and `path_alias` are always set:
   * `clone_uri`: `https://<<github-hostname>>/<<org>>/<<repo>>.git`
   * `path_alias`: `<<github-hostname>>/<<org>>/<<repo>>`
-* it might be necessary to configure `plank.default_decoration_configs[].ssh_host_fingerprints`
+* it might be necessary to configure `plank.default_decoration_config_entries[].ssh_host_fingerprints`
 
 ## Next Steps
 
@@ -306,11 +306,11 @@ In order to configure the bucket, follow the following steps:
 - Either use a Kubernetes service account bound to the GCP service account (recommended on GKE):
     1. Create a Kubernetes service account in the namespace where jobs will run.
     1. [Bind](/workload-identity#overview) the Kubernetes service account to the GCP service account.
-    1. edit the `plank` configuration for `default_decoration_configs[].config.default_service_account_name` to point to the Kubernetes service account.
+    1. edit the `plank` configuration for `default_decoration_config_entries[].config.default_service_account_name` to point to the Kubernetes service account.
 - OR use a GCP service account key file:
     1. [serialize](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) a key for the service account
     1. upload the key to a `Secret` under the `service-account.json` key
-    1. edit the `plank` configuration for `default_decoration_configs[].config.gcs_credentials_secret` to point to the `Secret` above
+    1. edit the `plank` configuration for `default_decoration_config_entries[].config.gcs_credentials_secret` to point to the `Secret` above
 
 After [downloading](https://cloud.google.com/sdk/gcloud/) the `gcloud` tool and authenticating,
 the following collection of commands will execute the above steps for you:
@@ -327,19 +327,19 @@ $ kubectl -n test-pods create secret generic gcs-credentials --from-file=service
 
 #### Configure the version of plank's utility images
 
-Before we can update plank's `default_decoration_configs[]` we'll need to retrieve the version of plank. Check the deployment file or use the following:
+Before we can update plank's `default_decoration_config_entries[]` we'll need to retrieve the version of plank. Check the deployment file or use the following:
 
 ```sh
 $ kubectl get pod -n prow -l app=plank -o jsonpath='{.items[0].spec.containers[0].image}' | cut -d: -f2
 v20191108-08fbf64ac
 ```
-Then, we can use that tag to retrieve the corresponding utility images in `default_decoration_configs[]` in `config.yaml`:
+Then, we can use that tag to retrieve the corresponding utility images in `default_decoration_config_entries[]` in `config.yaml`:
 
 For more information on how the pod utility images for prow are versioned see [autobump](/prow/cmd/autobump/README.md)
 
 ```yaml
 plank:
-  default_decoration_configs:
+  default_decoration_config_entries:
   - config:
       utility_images: # using the tag we identified above
         clonerefs: "gcr.io/k8s-prow/clonerefs:v20191108-08fbf64ac"

--- a/prow/plank/README.md
+++ b/prow/plank/README.md
@@ -20,7 +20,7 @@ plank:
   # used to link to job results for non decorated jobs (without pod utilities)
   job_url_template: 'https://<domain>/view/<bucket-name>/pr-logs/pull/{{.Spec.Refs.Repo}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}'
   report_template: '[Full PR test history](https://<domain>/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}})'
-  default_decoration_configs:
+  default_decoration_config_entries:
   # All entries that match a job are used, later entries override previous values.
   # Omission of 'repo' and 'cluster' fields makes this entry match all jobs.
   - config:

--- a/prow/spyglass/README.md
+++ b/prow/spyglass/README.md
@@ -110,5 +110,5 @@ deck:
 ### Accessing custom storage buckets
 
 By default, spyglass has access to all storage buckets defined globally
-(`plank.default_decoration_configs[...].gcs_configuration`) or on individual jobs (`<path-to-job>.gcs_configuration.bucket`).
+(`plank.default_decoration_config_entries[...].gcs_configuration`) or on individual jobs (`<path-to-job>.gcs_configuration.bucket`).
 In order to access additional/custom storage buckets, those buckets must be listed in `deck.additional_storage_buckets`.


### PR DESCRIPTION
Catching up with 1acac76284 (#20656), which transitioned the content from a map to an entry.  Maybe there's some code I'm not finding that will automatically determine if `default_decoration_configs` is a map or slice and load it without these changes?  CC @cjwagner