### PR TITLE
Add test for commit mentions escaped with zero width unicode

### DIFF
--- a/prow/plugins/invalidcommitmsg/invalidcommitmsg_test.go
+++ b/prow/plugins/invalidcommitmsg/invalidcommitmsg_test.go
@@ -102,6 +102,7 @@ func TestHandlePullRequest(t *testing.T) {
 				{SHA: "sha1", Commit: github.GitCommit{Message: "this is a valid message"}},
 				{SHA: "sha2", Commit: github.GitCommit{Message: "fixing k/k#9999"}},
 				{SHA: "sha3", Commit: github.GitCommit{Message: "not a @ mention"}},
+				{SHA: "sha4", Commit: github.GitCommit{Message: "escape @\u200bmention with zero width unicode"}},
 			},
 			hasInvalidCommitMessageLabel: false,
 		},


### PR DESCRIPTION
This PR adds unit test to prow invalid commit msg check to ensure commit messages with mentions escaped with `\u200b` are not labelled as `do-not-merge/invalid-commit-message`

Part of #21534 