### PR TITLE
Kops - move to kubetest2-tester-kops skip-regex logic for most presubmits

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -159,11 +159,13 @@ presubmit_template = """
             --test-package-dir={{test_package_dir}} \\
             {%- endif %}
             --test-package-marker={{marker}} \\
-            --parallel={{test_parallelism}} \\
             {%- if focus_regex %}
             --focus-regex="{{focus_regex}}" \\
             {%- endif %}
-            --skip-regex="{{skip_regex}}"
+            {%- if skip_regex %}
+            --skip-regex="{{skip_regex}}" \\
+            {%- endif %}
+            --parallel={{test_parallelism}}
         securityContext:
           privileged: true
         env:
@@ -483,7 +485,7 @@ def presubmit_test(branch='master',
                    extra_dashboards=None,
                    test_parallelism=25,
                    test_timeout_minutes=60,
-                   skip_override=None,
+                   skip_regex='',
                    focus_regex=None,
                    run_if_changed=None,
                    skip_report=False,
@@ -493,10 +495,6 @@ def presubmit_test(branch='master',
         kops_image = distro_images[distro]
         kops_ssh_user = distros_ssh_user[distro]
         kops_ssh_key_path = '/etc/aws-ssh/aws-ssh-private'
-        # TODO(rifelpet): Remove once k8s tags has been created that include
-        #  https://github.com/kubernetes/kubernetes/pull/101443
-        if k8s_version in ('stable', '1.21'):
-            skip_override += r'|Invalid.AWS.KMS.key'
 
     elif cloud == 'gce':
         kops_image = None
@@ -519,7 +517,7 @@ def presubmit_test(branch='master',
         job_timeout=str(test_timeout_minutes + 30) + 'm',
         test_timeout=str(test_timeout_minutes) + 'm',
         marker=marker,
-        skip_regex=skip_override,
+        skip_regex=skip_regex,
         kops_feature_flags=','.join(feature_flags),
         test_package_bucket=test_package_bucket,
         test_package_dir=test_package_dir,
@@ -949,21 +947,10 @@ def generate_presubmits_network_plugins():
         'weave': r'^(upup\/models\/cloudup\/resources\/addons\/networking\.weave\/|upup\/pkg\/fi\/cloudup\/template_functions.go)' # pylint: disable=line-too-long
     }
     results = []
-    skip_base = r'\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|\[Driver:.nfs\]|Dashboard|RuntimeClass|RuntimeHandler' # pylint: disable=line-too-long
     for plugin, run_if_changed in plugins.items():
         networking_arg = plugin
-        skip_regex = skip_base
-        if plugin in ('cilium', 'cilium-etcd'):
-            skip_regex += r'|should.set.TCP.CLOSE_WAIT'
-        else:
-            skip_regex += r'|Services.*functioning.*NodePort'
-        if plugin in ['calico', 'canal', 'weave', 'cilium', 'cilium-etcd']:
-            skip_regex += r'|Services.*rejected.*endpoints|external.IP.is.not.assigned.to.a.node|hostPort.but.different.hostIP|same.port.number.but.different.protocols' # pylint: disable=line-too-long
         if plugin == 'kuberouter':
-            skip_regex += r'|load-balancer|hairpin|affinity\stimeout|service\.kubernetes\.io|CLOSE_WAIT' # pylint: disable=line-too-long
             networking_arg = 'kube-router'
-        if plugin in ['canal', 'flannel']:
-            skip_regex += r'|up\sand\sdown|headless|service-proxy-name'
         results.append(
             presubmit_test(
                 k8s_version='stable',
@@ -973,7 +960,6 @@ def generate_presubmits_network_plugins():
                 networking=networking_arg,
                 extra_flags=['--node-size=t3.large'],
                 extra_dashboards=['kops-network-plugins'],
-                skip_override=skip_regex,
                 run_if_changed=run_if_changed,
                 skip_report=False,
                 always_run=False,
@@ -994,7 +980,6 @@ def generate_presubmits_e2e():
             name='pull-kops-e2e-k8s-docker',
             tab_name='e2e-docker',
             always_run=False,
-            skip_override=skip_regex,
         ),
         presubmit_test(
             k8s_version='1.21',
@@ -1003,7 +988,6 @@ def generate_presubmits_e2e():
             networking='calico',
             tab_name='e2e-containerd',
             always_run=True,
-            skip_override=skip_regex,
         ),
         presubmit_test(
             k8s_version='1.21',
@@ -1013,7 +997,7 @@ def generate_presubmits_e2e():
             extra_flags=["--master-count=3", "--zones=eu-central-1a,eu-central-1b,eu-central-1c"],
             tab_name='e2e-containerd-ha',
             always_run=False,
-            skip_override=skip_regex+'|Multi-AZ',
+            skip_regex=skip_regex+'|Multi-AZ|Invalid.AWS.KMS.key',
         ),
         presubmit_test(
             distro="u2010",
@@ -1024,7 +1008,6 @@ def generate_presubmits_e2e():
             name='pull-kops-e2e-k8s-crio',
             tab_name='e2e-crio',
             always_run=False,
-            skip_override=skip_regex,
         ),
         presubmit_test(
             cloud='gce',
@@ -1034,7 +1017,7 @@ def generate_presubmits_e2e():
             networking='cilium',
             tab_name='e2e-gce',
             always_run=False,
-            skip_override=r'\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|\[Driver:.nfs\]|Firewall|Dashboard|RuntimeClass|RuntimeHandler|kube-dns|run.a.Pod.requesting.a.RuntimeClass|should.set.TCP.CLOSE_WAIT|Services.*rejected.*endpoints', # pylint: disable=line-too-long
+            skip_regex=r'\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|\[Driver:.nfs\]|Firewall|Dashboard|RuntimeClass|RuntimeHandler|kube-dns|run.a.Pod.requesting.a.RuntimeClass|should.set.TCP.CLOSE_WAIT|Services.*rejected.*endpoints', # pylint: disable=line-too-long
             feature_flags=['GoogleCloudBucketACL'],
         ),
         # A special test for AWS Cloud-Controller-Manager
@@ -1073,7 +1056,7 @@ def generate_presubmits_e2e():
                 networking='calico',
                 tab_name='e2e-' + name_suffix,
                 always_run=True,
-                skip_override=skip_regex,
+                skip_regex=skip_regex+'|Invalid.AWS.KMS.key',
             )
         )
     return jobs

--- a/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
@@ -43,8 +43,7 @@ presubmits:
             --ginkgo-args="--debug" \
             --test-args="-test.timeout=60m -num-nodes=0" \
             --test-package-marker=stable-1.21.txt \
-            --parallel=25 \
-            --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|\[Driver:.nfs\]|Dashboard|RuntimeClass|RuntimeHandler|Invalid.AWS.KMS.key"
+            --parallel=25
         securityContext:
           privileged: true
         env:
@@ -109,8 +108,7 @@ presubmits:
             --ginkgo-args="--debug" \
             --test-args="-test.timeout=60m -num-nodes=0" \
             --test-package-marker=stable-1.21.txt \
-            --parallel=25 \
-            --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|\[Driver:.nfs\]|Dashboard|RuntimeClass|RuntimeHandler|Invalid.AWS.KMS.key"
+            --parallel=25
         securityContext:
           privileged: true
         env:
@@ -175,8 +173,8 @@ presubmits:
             --ginkgo-args="--debug" \
             --test-args="-test.timeout=60m -num-nodes=0" \
             --test-package-marker=stable-1.21.txt \
-            --parallel=25 \
-            --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|\[Driver:.nfs\]|Dashboard|RuntimeClass|RuntimeHandler|Multi-AZ|Invalid.AWS.KMS.key"
+            --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|\[Driver:.nfs\]|Dashboard|RuntimeClass|RuntimeHandler|Multi-AZ|Invalid.AWS.KMS.key" \
+            --parallel=25
         securityContext:
           privileged: true
         env:
@@ -242,8 +240,7 @@ presubmits:
             --ginkgo-args="--debug" \
             --test-args="-test.timeout=60m -num-nodes=0" \
             --test-package-marker=stable-1.21.txt \
-            --parallel=25 \
-            --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|\[Driver:.nfs\]|Dashboard|RuntimeClass|RuntimeHandler|Invalid.AWS.KMS.key"
+            --parallel=25
         securityContext:
           privileged: true
         env:
@@ -305,8 +302,8 @@ presubmits:
             --ginkgo-args="--debug" \
             --test-args="-test.timeout=60m -num-nodes=0" \
             --test-package-marker=stable-1.21.txt \
-            --parallel=25 \
-            --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|\[Driver:.nfs\]|Firewall|Dashboard|RuntimeClass|RuntimeHandler|kube-dns|run.a.Pod.requesting.a.RuntimeClass|should.set.TCP.CLOSE_WAIT|Services.*rejected.*endpoints"
+            --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|\[Driver:.nfs\]|Firewall|Dashboard|RuntimeClass|RuntimeHandler|kube-dns|run.a.Pod.requesting.a.RuntimeClass|should.set.TCP.CLOSE_WAIT|Services.*rejected.*endpoints" \
+            --parallel=25
         securityContext:
           privileged: true
         env:
@@ -372,8 +369,7 @@ presubmits:
             --ginkgo-args="--debug" \
             --test-args="-test.timeout=60m -num-nodes=0" \
             --test-package-marker=latest.txt \
-            --parallel=25 \
-            --skip-regex="None"
+            --parallel=25
         securityContext:
           privileged: true
         env:
@@ -440,8 +436,7 @@ presubmits:
             --ginkgo-args="--debug" \
             --test-args="-test.timeout=60m -num-nodes=0" \
             --test-package-marker=latest.txt \
-            --parallel=25 \
-            --skip-regex="None"
+            --parallel=25
         securityContext:
           privileged: true
         env:
@@ -508,8 +503,8 @@ presubmits:
             --ginkgo-args="--debug" \
             --test-args="-test.timeout=60m -num-nodes=0" \
             --test-package-marker=stable-1.21.txt \
-            --parallel=25 \
-            --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|\[Driver:.nfs\]|Dashboard|RuntimeClass|RuntimeHandler|Invalid.AWS.KMS.key"
+            --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|\[Driver:.nfs\]|Dashboard|RuntimeClass|RuntimeHandler|Invalid.AWS.KMS.key" \
+            --parallel=25
         securityContext:
           privileged: true
         env:

--- a/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
@@ -44,8 +44,7 @@ presubmits:
             --ginkgo-args="--debug" \
             --test-args="-test.timeout=60m -num-nodes=0" \
             --test-package-marker=stable.txt \
-            --parallel=25 \
-            --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|\[Driver:.nfs\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Invalid.AWS.KMS.key"
+            --parallel=25
         securityContext:
           privileged: true
         env:
@@ -112,8 +111,7 @@ presubmits:
             --ginkgo-args="--debug" \
             --test-args="-test.timeout=60m -num-nodes=0" \
             --test-package-marker=stable.txt \
-            --parallel=25 \
-            --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|\[Driver:.nfs\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Services.*rejected.*endpoints|external.IP.is.not.assigned.to.a.node|hostPort.but.different.hostIP|same.port.number.but.different.protocols|Invalid.AWS.KMS.key"
+            --parallel=25
         securityContext:
           privileged: true
         env:
@@ -180,8 +178,7 @@ presubmits:
             --ginkgo-args="--debug" \
             --test-args="-test.timeout=60m -num-nodes=0" \
             --test-package-marker=stable.txt \
-            --parallel=25 \
-            --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|\[Driver:.nfs\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Services.*rejected.*endpoints|external.IP.is.not.assigned.to.a.node|hostPort.but.different.hostIP|same.port.number.but.different.protocols|up\sand\sdown|headless|service-proxy-name|Invalid.AWS.KMS.key"
+            --parallel=25
         securityContext:
           privileged: true
         env:
@@ -248,8 +245,7 @@ presubmits:
             --ginkgo-args="--debug" \
             --test-args="-test.timeout=60m -num-nodes=0" \
             --test-package-marker=stable.txt \
-            --parallel=25 \
-            --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|\[Driver:.nfs\]|Dashboard|RuntimeClass|RuntimeHandler|should.set.TCP.CLOSE_WAIT|Services.*rejected.*endpoints|external.IP.is.not.assigned.to.a.node|hostPort.but.different.hostIP|same.port.number.but.different.protocols|Invalid.AWS.KMS.key"
+            --parallel=25
         securityContext:
           privileged: true
         env:
@@ -316,8 +312,7 @@ presubmits:
             --ginkgo-args="--debug" \
             --test-args="-test.timeout=60m -num-nodes=0" \
             --test-package-marker=stable.txt \
-            --parallel=25 \
-            --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|\[Driver:.nfs\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|up\sand\sdown|headless|service-proxy-name|Invalid.AWS.KMS.key"
+            --parallel=25
         securityContext:
           privileged: true
         env:
@@ -384,8 +379,7 @@ presubmits:
             --ginkgo-args="--debug" \
             --test-args="-test.timeout=60m -num-nodes=0" \
             --test-package-marker=stable.txt \
-            --parallel=25 \
-            --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|\[Driver:.nfs\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|load-balancer|hairpin|affinity\stimeout|service\.kubernetes\.io|CLOSE_WAIT|Invalid.AWS.KMS.key"
+            --parallel=25
         securityContext:
           privileged: true
         env:
@@ -452,8 +446,7 @@ presubmits:
             --ginkgo-args="--debug" \
             --test-args="-test.timeout=60m -num-nodes=0" \
             --test-package-marker=stable.txt \
-            --parallel=25 \
-            --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|\[Driver:.nfs\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Services.*rejected.*endpoints|external.IP.is.not.assigned.to.a.node|hostPort.but.different.hostIP|same.port.number.but.different.protocols|Invalid.AWS.KMS.key"
+            --parallel=25
         securityContext:
           privileged: true
         env:


### PR DESCRIPTION
We can't use it for release branch jobs (because the skip-regex logic hasnt been cherry-picked back to release-1.21 yet) as well as GCE jobs because it doesn't support GCE yet. Those will get migrated next when ready