### PR TITLE
Phaino use grace and timeout from job

### DIFF
--- a/prow/cmd/phaino/BUILD.bazel
+++ b/prow/cmd/phaino/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
     ],
 )

--- a/prow/cmd/phaino/local.go
+++ b/prow/cmd/phaino/local.go
@@ -554,7 +554,7 @@ func getTimeout(optionsTimeout time.Duration, prowJobTimeout time.Duration) time
 	if prowJobTimeout > 0 {
 		return prowJobTimeout
 	}
-	return optionsTimeout
+	return defaultTimeout
 }
 
 func getMinimumGracePeriod(minimum time.Duration, optionsGracePeriod time.Duration, prowJobGracePeriod time.Duration, log *logrus.Entry) (gracePeriod time.Duration) {

--- a/prow/cmd/phaino/local.go
+++ b/prow/cmd/phaino/local.go
@@ -523,7 +523,7 @@ func (opts *options) convertJob(ctx context.Context, log *logrus.Entry, pj prowa
 		// cancelled
 	}
 
-	grace := getMinimumGracePeriod(time.Second, pj, opts, log)
+	grace := getMinimumGracePeriod(minimumGracePeriod, pj.Spec.DecorationConfig.GracePeriod.Duration, opts.grace, log)
 	log = log.WithFields(logrus.Fields{
 		"grace":     grace,
 		"interrupt": ctx.Err(),
@@ -557,13 +557,14 @@ func getTimeout(optionsTimeout time.Duration, prowJobTimeout time.Duration) time
 	return optionsTimeout
 }
 
-func getMinimumGracePeriod(minimum time.Duration, pj prowapi.ProwJob, opts *options, log *logrus.Entry) time.Duration {
-	if pj.Spec.DecorationConfig.GracePeriod.Duration >= minimum {
-		return pj.Spec.DecorationConfig.GracePeriod.Duration
+func getMinimumGracePeriod(minimum time.Duration, prowJobGracePeriod time.Duration, optionsGracePeriod time.Duration, log *logrus.Entry) (gracePeriod time.Duration) {
+	gracePeriod = prowJobGracePeriod
+	if optionsGracePeriod != defaultGracePeriod {
+		gracePeriod = optionsGracePeriod
 	}
-	if opts.grace >= minimum {
-		return opts.grace
+	if gracePeriod < minimum {
+		gracePeriod = minimum
+		log.WithField("grace", gracePeriod).Info("Increasing grace period to the minimum", gracePeriod)
 	}
-	log.WithField("grace", opts.grace).Info("Increasing grace period to the minimum", minimum)
-	return minimum
+	return gracePeriod
 }

--- a/prow/cmd/phaino/local.go
+++ b/prow/cmd/phaino/local.go
@@ -523,7 +523,7 @@ func (opts *options) convertJob(ctx context.Context, log *logrus.Entry, pj prowa
 		// cancelled
 	}
 
-	grace := getMinimumGracePeriod(minimumGracePeriod, pj.Spec.DecorationConfig.GracePeriod.Duration, opts.grace, log)
+	grace := getMinimumGracePeriod(minimumGracePeriod, opts.grace, pj.Spec.DecorationConfig.GracePeriod.Duration, log)
 	log = log.WithFields(logrus.Fields{
 		"grace":     grace,
 		"interrupt": ctx.Err(),
@@ -557,7 +557,7 @@ func getTimeout(optionsTimeout time.Duration, prowJobTimeout time.Duration) time
 	return optionsTimeout
 }
 
-func getMinimumGracePeriod(minimum time.Duration, prowJobGracePeriod time.Duration, optionsGracePeriod time.Duration, log *logrus.Entry) (gracePeriod time.Duration) {
+func getMinimumGracePeriod(minimum time.Duration, optionsGracePeriod time.Duration, prowJobGracePeriod time.Duration, log *logrus.Entry) (gracePeriod time.Duration) {
 	gracePeriod = prowJobGracePeriod
 	if optionsGracePeriod != defaultGracePeriod {
 		gracePeriod = optionsGracePeriod

--- a/prow/cmd/phaino/local.go
+++ b/prow/cmd/phaino/local.go
@@ -523,7 +523,7 @@ func (opts *options) convertJob(ctx context.Context, log *logrus.Entry, pj prowa
 		// cancelled
 	}
 
-	grace := getGracePeriod(pj, opts, log)
+	grace := getMinimumGracePeriod(time.Second, pj, opts, log)
 	log = log.WithFields(logrus.Fields{
 		"grace":     grace,
 		"interrupt": ctx.Err(),
@@ -557,13 +557,13 @@ func getTimeout(pj prowapi.ProwJob, opts *options) time.Duration {
 	return time.Duration(0)
 }
 
-func getGracePeriod(pj prowapi.ProwJob, opts *options, log *logrus.Entry) time.Duration {
-	if pj.Spec.DecorationConfig.GracePeriod.Duration >= time.Second {
+func getMinimumGracePeriod(minimum time.Duration, pj prowapi.ProwJob, opts *options, log *logrus.Entry) time.Duration {
+	if pj.Spec.DecorationConfig.GracePeriod.Duration >= minimum {
 		return pj.Spec.DecorationConfig.GracePeriod.Duration
 	}
-	if opts.grace >= time.Second {
+	if opts.grace >= minimum {
 		return opts.grace
 	}
-	log.WithField("grace", opts.grace).Info("Increasing grace period to the 1s minimum")
-	return time.Second
+	log.WithField("grace", opts.grace).Info("Increasing grace period to the %v minimum", minimum)
+	return minimum
 }

--- a/prow/cmd/phaino/local_test.go
+++ b/prow/cmd/phaino/local_test.go
@@ -588,7 +588,7 @@ func TestGetMinimumGracePeriod(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			gracePeriod := getMinimumGracePeriod(1*time.Second, tc.prowJobGracePeriod, tc.optsGracePeriod, logrus.NewEntry(logrus.StandardLogger()))
+			gracePeriod := getMinimumGracePeriod(1*time.Second, tc.optsGracePeriod, tc.prowJobGracePeriod, logrus.NewEntry(logrus.StandardLogger()))
 			if tc.expected != gracePeriod {
 				t.Errorf("getMinimumGracePeriod has wrong result! expected: %v , actual: %v", tc.expected, gracePeriod)
 			}

--- a/prow/cmd/phaino/local_test.go
+++ b/prow/cmd/phaino/local_test.go
@@ -555,34 +555,34 @@ func TestGetTimeout(t *testing.T) {
 
 func TestGetMinimumGracePeriod(t *testing.T) {
 	cases := []struct {
-		name     string
-		prowJobGracePeriod  time.Duration
-		optsGracePeriod       time.Duration
-		expected time.Duration
+		name               string
+		prowJobGracePeriod time.Duration
+		optsGracePeriod    time.Duration
+		expected           time.Duration
 	}{
 		{
-			name: "prowJob has defined grace of 30s, while option has default value -> prowjob grace overrides default",
+			name:               "prowJob has defined grace of 30s, while option has default value -> prowjob grace overrides default",
 			prowJobGracePeriod: 30 * time.Second,
-			optsGracePeriod: defaultGracePeriod,
-			expected: 30 * time.Second,
+			optsGracePeriod:    defaultGracePeriod,
+			expected:           30 * time.Second,
 		},
 		{
-			name: "prowJob has defined grace of 30s, while options grace is non default -> options overrides prowjob grace",
+			name:               "prowJob has defined grace of 30s, while options grace is non default -> options overrides prowjob grace",
 			prowJobGracePeriod: 30 * time.Second,
-			optsGracePeriod: 5 * time.Second,
-			expected: 5 * time.Second,
+			optsGracePeriod:    5 * time.Second,
+			expected:           5 * time.Second,
 		},
 		{
-			name: "prowJob has defined grace of 30s, while options has less than 1s -> minimum value of 1s",
+			name:               "prowJob has defined grace of 30s, while options has less than 1s -> minimum value of 1s",
 			prowJobGracePeriod: 30 * time.Second,
-			optsGracePeriod: 999 * time.Millisecond,
-			expected: 1 * time.Second,
+			optsGracePeriod:    999 * time.Millisecond,
+			expected:           1 * time.Second,
 		},
 		{
-			name: "prowJob has defined grace of < 1s, while option has default value -> minimum value of 1s",
+			name:               "prowJob has defined grace of < 1s, while option has default value -> minimum value of 1s",
 			prowJobGracePeriod: 999 * time.Millisecond,
-			optsGracePeriod: defaultGracePeriod,
-			expected: 1 * time.Second,
+			optsGracePeriod:    defaultGracePeriod,
+			expected:           1 * time.Second,
 		},
 	}
 

--- a/prow/cmd/phaino/main.go
+++ b/prow/cmd/phaino/main.go
@@ -37,7 +37,11 @@ import (
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 )
 
-const defaultTimeout = time.Hour
+const (
+	defaultTimeout     = time.Hour
+	defaultGracePeriod = 10 * time.Second
+	minimumGracePeriod = time.Second
+)
 
 type options struct {
 	keepGoing     bool
@@ -68,7 +72,7 @@ func gatherOptions() options {
 	fs.BoolVar(&o.priv, "privileged", false, "Allow privileged local runs")
 	fs.DurationVar(&o.timeout, "timeout", defaultTimeout, "Maximum duration for each job (0 for unlimited)")
 	fs.DurationVar(&o.totalTimeout, "total-timeout", 0, "Maximum duration for all jobs (0 for unlimited)")
-	fs.DurationVar(&o.grace, "grace", 10*time.Second, "Terminate timed out jobs after this grace period (1s minimum)")
+	fs.DurationVar(&o.grace, "grace", defaultGracePeriod, "Terminate timed out jobs after this grace period (1s minimum)")
 	fs.StringVar(&o.gopath, "gopath", "", "The path that is used in the container. "+
 		"Default is /home/prow/go/src, need to be changed if the repository depends on absolute code mount path it's is set to a different value in the container.")
 	fs.StringVar(&o.codeMountPath, "code-mount-path", "", "The GOPATH that is used in the container. "+

--- a/prow/cmd/phaino/main.go
+++ b/prow/cmd/phaino/main.go
@@ -37,6 +37,8 @@ import (
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 )
 
+const defaultTimeout = time.Hour
+
 type options struct {
 	keepGoing     bool
 	printCmd      bool
@@ -64,7 +66,7 @@ func gatherOptions() options {
 	fs.BoolVar(&o.keepGoing, "keep-going", false, "Continue running jobs after one fails if set")
 	fs.BoolVar(&o.printCmd, "print", false, "Just print the command it would run")
 	fs.BoolVar(&o.priv, "privileged", false, "Allow privileged local runs")
-	fs.DurationVar(&o.timeout, "timeout", time.Hour, "Maximum duration for each job (0 for unlimited)")
+	fs.DurationVar(&o.timeout, "timeout", defaultTimeout, "Maximum duration for each job (0 for unlimited)")
 	fs.DurationVar(&o.totalTimeout, "total-timeout", 0, "Maximum duration for all jobs (0 for unlimited)")
 	fs.DurationVar(&o.grace, "grace", 10*time.Second, "Terminate timed out jobs after this grace period (1s minimum)")
 	fs.StringVar(&o.gopath, "gopath", "", "The path that is used in the container. "+


### PR DESCRIPTION
When executing a prow job using phaino, use the values for grace period and timeout from the prow job spec. If there is nothing configured it uses the option values as a fallback.