### PR TITLE
Update Metal3 prow reference link

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -85,7 +85,7 @@ Prow is used by the following organizations and projects:
 - [Knative](https://prow.knative.dev/)
 - [Jetstack](https://prow.build-infra.jetstack.net/)
 - [Kyma](https://status.build.kyma-project.io/)
-- [Metal³](https://prow.apps.ci.metal3.io/)
+- [Metal³](https://prow.apps.test.metal3.io/)
 - [Prometheus](http://prombench.prometheus.io/)
 - [Caicloud](https://github.com/caicloud)
 - [Kubeflow](https://github.com/kubeflow)


### PR DESCRIPTION
[Metal3](https://github.com/metal3-io/) project prow setup has been [upgraded](https://github.com/metal3-io/project-infra/pull/182/files#diff-a7ce615e7d212a0ab9aabafc3570ccadc3a6a246f9e5004382659496fdba7649R17) recently and prow dashboard has been moved from `https://prow.apps.ci.metal3.io/`  to [https://prow.apps.test.metal3.io/](https://prow.apps.test.metal3.io/). 
This PR updates the reference link to correct prow dashboard of the Metal3 project. 