### PR TITLE
Explicit empty http cookiefile config can override default

### DIFF
--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -367,7 +367,7 @@ type DecorationConfig struct {
 	SkipCloning *bool `json:"skip_cloning,omitempty"`
 	// CookieFileSecret is the name of a kubernetes secret that contains
 	// a git http.cookiefile, which should be used during the cloning process.
-	CookiefileSecret string `json:"cookiefile_secret,omitempty"`
+	CookiefileSecret *string `json:"cookiefile_secret,omitempty"`
 	// OauthTokenSecret is a Kubernetes secret that contains the OAuth token,
 	// which is going to be used for fetching a private repository.
 	OauthTokenSecret *OauthTokenSecret `json:"oauth_token_secret,omitempty"`
@@ -532,7 +532,7 @@ func (d *DecorationConfig) ApplyDefault(def *DecorationConfig) *DecorationConfig
 	if merged.SkipCloning == nil {
 		merged.SkipCloning = def.SkipCloning
 	}
-	if merged.CookiefileSecret == "" {
+	if merged.CookiefileSecret == nil {
 		merged.CookiefileSecret = def.CookiefileSecret
 	}
 	if merged.OauthTokenSecret == nil {

--- a/prow/apis/prowjobs/v1/zz_generated.deepcopy.go
+++ b/prow/apis/prowjobs/v1/zz_generated.deepcopy.go
@@ -122,6 +122,11 @@ func (in *DecorationConfig) DeepCopyInto(out *DecorationConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.CookiefileSecret != nil {
+		in, out := &in.CookiefileSecret, &out.CookiefileSecret
+		*out = new(string)
+		**out = **in
+	}
 	if in.OauthTokenSecret != nil {
 		in, out := &in.OauthTokenSecret, &out.OauthTokenSecret
 		*out = new(OauthTokenSecret)

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -557,7 +557,7 @@ plank:
 
             # CookieFileSecret is the name of a kubernetes secret that contains
             # a git http.cookiefile, which should be used during the cloning process.
-            cookiefile_secret: ' '
+            cookiefile_secret: ""
 
             # DefaultServiceAccountName is the name of the Kubernetes service account
             # that should be used by the pod if one is not specified in the podspec.
@@ -734,7 +734,7 @@ plank:
 
             # CookieFileSecret is the name of a kubernetes secret that contains
             # a git http.cookiefile, which should be used during the cloning process.
-            cookiefile_secret: ' '
+            cookiefile_secret: ""
 
             # DefaultServiceAccountName is the name of the Kubernetes service account
             # that should be used by the pod if one is not specified in the podspec.

--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -426,8 +426,8 @@ func CloneRefs(pj prowapi.ProwJob, codeMount, logMount coreapi.VolumeMount) (*co
 	var cloneArgs []string
 	var cookiefilePath string
 
-	if cp := pj.Spec.DecorationConfig.CookiefileSecret; cp != "" {
-		v, vm, vp := cookiefileVolume(cp)
+	if cp := pj.Spec.DecorationConfig.CookiefileSecret; cp != nil && *cp != "" {
+		v, vm, vp := cookiefileVolume(*cp)
 		cloneMounts = append(cloneMounts, vm)
 		cloneVolumes = append(cloneVolumes, v)
 		cookiefilePath = vp


### PR DESCRIPTION
This is needed in cases where majority of org/repo/cluster requires http cookiefile set, instead of explicitly add them in all, providing a way for the exceptions to be able to override default with empty string