### PR TITLE
Add a rerun button to Spyglass

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -1081,37 +1081,41 @@ lensesLoop:
 	}
 
 	var viewBuf bytes.Buffer
-	type lensesTemplate struct {
-		Lenses        map[int]spyglass.LensConfig
-		LensIndexes   []int
-		Source        string
-		LensArtifacts map[int][]string
-		JobHistLink   string
-		ProwJobLink   string
-		ArtifactsLink string
-		PRHistLink    string
-		Announcement  template.HTML
-		TestgridLink  string
-		JobName       string
-		BuildID       string
-		PRLink        string
-		ExtraLinks    []spyglass.ExtraLink
+	type spyglassTemplate struct {
+		Lenses          map[int]spyglass.LensConfig
+		LensIndexes     []int
+		Source          string
+		LensArtifacts   map[int][]string
+		JobHistLink     string
+		ProwJobLink     string
+		ArtifactsLink   string
+		PRHistLink      string
+		Announcement    template.HTML
+		TestgridLink    string
+		JobName         string
+		BuildID         string
+		PRLink          string
+		ExtraLinks      []spyglass.ExtraLink
+		ReRunCreatesJob bool
+		ProwJobName     string
 	}
-	lTmpl := lensesTemplate{
-		Lenses:        ls,
-		LensIndexes:   lensIndexes,
-		Source:        src,
-		LensArtifacts: lensCache,
-		JobHistLink:   jobHistLink,
-		ProwJobLink:   prowJobLink,
-		ArtifactsLink: artifactsLink,
-		PRHistLink:    prHistLink,
-		Announcement:  template.HTML(announcement),
-		TestgridLink:  tgLink,
-		JobName:       jobName,
-		BuildID:       buildID,
-		PRLink:        prLink,
-		ExtraLinks:    extraLinks,
+	sTmpl := spyglassTemplate{
+		Lenses:          ls,
+		LensIndexes:     lensIndexes,
+		Source:          src,
+		LensArtifacts:   lensCache,
+		JobHistLink:     jobHistLink,
+		ProwJobLink:     prowJobLink,
+		ArtifactsLink:   artifactsLink,
+		PRHistLink:      prHistLink,
+		Announcement:    template.HTML(announcement),
+		TestgridLink:    tgLink,
+		JobName:         jobName,
+		BuildID:         buildID,
+		PRLink:          prLink,
+		ExtraLinks:      extraLinks,
+		ReRunCreatesJob: o.rerunCreatesJob,
+		ProwJobName:     prowJobName,
 	}
 	t := template.New("spyglass.html")
 
@@ -1123,7 +1127,7 @@ lensesLoop:
 		return "", fmt.Errorf("error parsing template: %v", err)
 	}
 
-	if err = t.Execute(&viewBuf, lTmpl); err != nil {
+	if err = t.Execute(&viewBuf, sTmpl); err != nil {
 		return "", fmt.Errorf("error rendering template: %v", err)
 	}
 	renderElapsed := time.Since(renderStart)

--- a/prow/cmd/deck/static/BUILD.bazel
+++ b/prow/cmd/deck/static/BUILD.bazel
@@ -9,9 +9,10 @@ ts_library(
 
 ts_library(
     name = "common",
-    srcs = glob(["common/*.ts"]),
+    srcs = glob(["common/*.ts"]) + ["vendor.d.ts"],
     deps = [
         ":api",
+        "@npm//@types/gtag.js",
         "@npm//moment",
     ],
 )
@@ -165,6 +166,7 @@ ts_library(
     name = "spyglass",
     srcs = ["spyglass/spyglass.ts"],
     deps = [
+        ":common",
         ":spyglass_common",
     ],
 )

--- a/prow/cmd/deck/static/common/common.ts
+++ b/prow/cmd/deck/static/common/common.ts
@@ -1,5 +1,6 @@
 import moment from "moment";
 import {ProwJobState, Pull} from "../api/prow";
+import {relativeURL} from "./urls";
 
 // This file likes namespaces, so stick with it for now.
 /* tslint:disable:no-namespace */
@@ -218,4 +219,83 @@ export function getCookieByName(name: string): string {
     }
   }
   return "";
+}
+
+export function createRerunProwJobIcon(modal: HTMLElement, rerunElement: HTMLElement, prowjob: string, rerunCreatesJob: boolean, csrfToken: string): HTMLElement {
+  const url = `${location.protocol}//${location.host}/rerun?prowjob=${prowjob}`;
+  const i = icon.create("refresh", "Show instructions for rerunning this job");
+
+  // we actually want to know whether the "access-token-session" cookie exists, but we can't always
+  // access it from the frontend. "github_login" should be set whenever "access-token-session" is
+  i.onclick = () => {
+    modal.style.display = "block";
+    rerunElement.innerHTML = `kubectl create -f "<a href="${url}">${url}</a>"`;
+    const copyButton = document.createElement('a');
+    copyButton.className = "mdl-button mdl-js-button mdl-button--icon";
+    copyButton.onclick = () => copyToClipboardWithToast(`kubectl create -f "${url}"`);
+    copyButton.innerHTML = "<i class='material-icons state triggered' style='color: gray'>file_copy</i>";
+    rerunElement.appendChild(copyButton);
+    if (rerunCreatesJob) {
+        const runButton = document.createElement('a');
+        runButton.innerHTML = "<button class='mdl-button mdl-js-button'>Rerun</button>";
+        runButton.onclick = async () => {
+            gtag("event", "rerun", {
+                event_category: "engagement",
+                transport_type: "beacon",
+            });
+            const result = await fetch(url, {
+                headers: {
+                    "Content-type": "application/x-www-form-urlencoded; charset=UTF-8",
+                    "X-CSRF-Token": csrfToken,
+                },
+                method: 'post',
+            });
+            const data = await result.text();
+            if (result.status === 401) {
+                window.location.href = window.location.origin + `/github-login?dest=${relativeURL({rerun: "gh_redirect"})}`;
+            } else {
+                rerunElement.innerHTML = data;
+            }
+        };
+        rerunElement.appendChild(runButton);
+    }
+  };
+
+  return i;
+}
+
+function copyToClipboardWithToast(text: string): void {
+  copyToClipboard(text);
+
+  const toast = document.getElementById("toast") as SnackbarElement<HTMLDivElement>;
+  toast.MaterialSnackbar.showSnackbar({message: "Copied to clipboard"});
+}
+
+// copyToClipboard is from https://stackoverflow.com/a/33928558
+// Copies a string to the clipboard. Must be called from within an
+// event handler such as click. May return false if it failed, but
+// this is not always possible. Browser support for Chrome 43+,
+// Firefox 42+, Safari 10+, Edge and IE 10+.
+// IE: The clipboard feature may be disabled by an administrator. By
+// default a prompt is shown the first time the clipboard is
+// used (per session).
+function copyToClipboard(text: string) {
+  if (window.clipboardData && window.clipboardData.setData) {
+      // IE specific code path to prevent textarea being shown while dialog is visible.
+      return window.clipboardData.setData("Text", text);
+  } else if (document.queryCommandSupported && document.queryCommandSupported("copy")) {
+      const textarea = document.createElement("textarea");
+      textarea.textContent = text;
+      textarea.style.position = "fixed";  // Prevent scrolling to bottom of page in MS Edge.
+      document.body.appendChild(textarea);
+      textarea.select();
+      try {
+          return document.execCommand("copy");  // Security exception may be thrown by some browsers.
+      } catch (ex) {
+          console.warn("Copy to clipboard failed.", ex);
+          return false;
+      } finally {
+          document.body.removeChild(textarea);
+      }
+  }
 }

--- a/prow/cmd/deck/static/prow/prow.ts
+++ b/prow/cmd/deck/static/prow/prow.ts
@@ -1,7 +1,7 @@
 import moment from "moment";
 import {ProwJob, ProwJobList, ProwJobState, ProwJobType, Pull} from "../api/prow";
-import {cell, icon} from "../common/common";
-import {getParameterByName, relativeURL} from "../common/urls";
+import {cell, createRerunProwJobIcon, icon} from "../common/common";
+import {getParameterByName} from "../common/urls";
 import {FuzzySearch} from './fuzzy-search';
 import {JobHistogram, JobSample} from './histogram';
 
@@ -733,46 +733,8 @@ function redraw(fz: FuzzySearch, pushState: boolean = true): void {
 }
 
 function createRerunCell(modal: HTMLElement, rerunElement: HTMLElement, prowjob: string): HTMLTableDataCellElement {
-    const url = `${location.protocol}//${location.host}/rerun?prowjob=${prowjob}`;
     const c = document.createElement("td");
-    const i = icon.create("refresh", "Show instructions for rerunning this job");
-
-    // we actually want to know whether the "access-token-session" cookie exists, but we can't always
-    // access it from the frontend. "github_login" should be set whenever "access-token-session" is
-    i.onclick = () => {
-        modal.style.display = "block";
-        rerunElement.innerHTML = `kubectl create -f "<a href="${url}">${url}</a>"`;
-        const copyButton = document.createElement('a');
-        copyButton.className = "mdl-button mdl-js-button mdl-button--icon";
-        copyButton.onclick = () => copyToClipboardWithToast(`kubectl create -f "${url}"`);
-        copyButton.innerHTML = "<i class='material-icons state triggered' style='color: gray'>file_copy</i>";
-        rerunElement.appendChild(copyButton);
-        if (rerunCreatesJob) {
-            const runButton = document.createElement('a');
-            runButton.innerHTML = "<button class='mdl-button mdl-js-button'>Rerun</button>";
-            runButton.onclick = async () => {
-                gtag("event", "rerun", {
-                    event_category: "engagement",
-                    transport_type: "beacon",
-                });
-                const result = await fetch(url, {
-                    headers: {
-                        "Content-type": "application/x-www-form-urlencoded; charset=UTF-8",
-                        "X-CSRF-Token": csrfToken,
-                    },
-                    method: 'post',
-                });
-                const data = await result.text();
-                if (result.status === 401) {
-                    window.location.href = window.location.origin + `/github-login?dest=${relativeURL({rerun: "gh_redirect"})}`;
-                } else {
-                    rerunElement.innerHTML = data;
-                }
-            };
-            rerunElement.appendChild(runButton);
-        }
-    };
-    c.appendChild(i);
+    c.appendChild(createRerunProwJobIcon(modal, rerunElement, prowjob, rerunCreatesJob, csrfToken));
     c.classList.add("icon-cell");
     return c;
 }
@@ -784,42 +746,6 @@ function createViewJobCell(prowjob: string): HTMLTableDataCellElement {
     c.classList.add("icon-cell");
     c.appendChild(i);
     return c;
-}
-
-// copyToClipboard is from https://stackoverflow.com/a/33928558
-// Copies a string to the clipboard. Must be called from within an
-// event handler such as click. May return false if it failed, but
-// this is not always possible. Browser support for Chrome 43+,
-// Firefox 42+, Safari 10+, Edge and IE 10+.
-// IE: The clipboard feature may be disabled by an administrator. By
-// default a prompt is shown the first time the clipboard is
-// used (per session).
-function copyToClipboard(text: string) {
-    if (window.clipboardData && window.clipboardData.setData) {
-        // IE specific code path to prevent textarea being shown while dialog is visible.
-        return window.clipboardData.setData("Text", text);
-    } else if (document.queryCommandSupported && document.queryCommandSupported("copy")) {
-        const textarea = document.createElement("textarea");
-        textarea.textContent = text;
-        textarea.style.position = "fixed";  // Prevent scrolling to bottom of page in MS Edge.
-        document.body.appendChild(textarea);
-        textarea.select();
-        try {
-            return document.execCommand("copy");  // Security exception may be thrown by some browsers.
-        } catch (ex) {
-            console.warn("Copy to clipboard failed.", ex);
-            return false;
-        } finally {
-            document.body.removeChild(textarea);
-        }
-    }
-}
-
-function copyToClipboardWithToast(text: string): void {
-    copyToClipboard(text);
-
-    const toast = document.getElementById("toast") as SnackbarElement<HTMLDivElement>;
-    toast.MaterialSnackbar.showSnackbar({message: "Copied to clipboard"});
 }
 
 function batchRevisionCell(build: ProwJob): HTMLTableDataCellElement {

--- a/prow/cmd/deck/static/spyglass/spyglass.ts
+++ b/prow/cmd/deck/static/spyglass/spyglass.ts
@@ -1,9 +1,13 @@
+import {createRerunProwJobIcon} from "../common/common";
+import {getParameterByName} from "../common/urls";
 import {isTransitMessage, serialiseHashes} from "./common";
 
 declare const src: string;
 declare const lensArtifacts: {[index: string]: string[]};
 declare const lensIndexes: number[];
 declare const csrfToken: string;
+declare const rerunCreatesJob: boolean;
+declare const prowJobName: string;
 
 // Loads views for this job
 function loadLenses(): void {
@@ -160,4 +164,32 @@ window.addEventListener('hashchange', (e) => {
 // We can't use DOMContentLoaded here or we end up with a bunch of flickering. This appears to be MDL's fault.
 window.addEventListener('load', () => {
     loadLenses();
+    handleRerunButton();
 });
+
+function handleRerunButton() {
+  // In case prowJob is unavailable, the rerun button shouldn't be shown
+  if (!prowJobName) {
+    return;
+  }
+
+  const rerunStatus = getParameterByName("rerun");
+  const modal = document.getElementById('rerun')!;
+  const rerunCommand = document.getElementById('rerun-content')!;
+  window.onclick = (event: any) => {
+      if (event.target === modal) {
+          modal.style.display = "none";
+      }
+  };
+
+  const r = document.getElementById("header-title")!;
+  const c = document.createElement("div");
+  c.appendChild(createRerunProwJobIcon(modal, rerunCommand, prowJobName, rerunCreatesJob, csrfToken));
+  c.classList.add("icon-cell");
+  r.appendChild(c);
+
+  if (rerunStatus === "gh_redirect") {
+    modal.style.display = "block";
+    rerunCommand.innerHTML = "Rerunning that job requires GitHub login. Now that you're logged in, try again";
+  }
+}

--- a/prow/cmd/deck/static/style.css
+++ b/prow/cmd/deck/static/style.css
@@ -327,6 +327,7 @@ i.state {
     border: 1px solid #888;
     width: 80%;
     text-align: center;
+    color: #444;
 }
 
 #queries li {

--- a/prow/cmd/deck/template/base.html
+++ b/prow/cmd/deck/template/base.html
@@ -43,7 +43,7 @@
 <div id="alert-container"></div>
 <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
   <header class="mdl-layout__header"{{if branding.HeaderColor}} style="background-color: {{branding.HeaderColor}};"{{end}}>
-    <div class="mdl-layout__header-row">
+    <div id="header-title" class="mdl-layout__header-row">
       <a href="/"
          class="logo"><img src="{{or branding.Logo $defaultLogo}}" alt="kubernetes logo" class="logo"/></a>
       <span class="mdl-layout-title header-title">{{block "pageTitle" .Arguments}}{{template "title" .}}{{end}}</span>

--- a/prow/cmd/deck/template/spyglass.html
+++ b/prow/cmd/deck/template/spyglass.html
@@ -5,6 +5,8 @@
   var src = {{.Source}};
   var lensArtifacts = {{.LensArtifacts}};
   var lensIndexes = {{.LensIndexes}};
+  var rerunCreatesJob = {{.ReRunCreatesJob}};
+  var prowJobName = {{.ProwJobName}};
 </script>
 <script type="text/javascript" src="/static/spyglass_bundle.min.js"></script>
 <link rel="stylesheet" type="text/css" href="/static/spyglass/spyglass.css">
@@ -47,3 +49,7 @@
 {{end}}
 
 {{template "page" (settings mobileUnfriendly darkMode "spyglass" .)}}
+
+<div id="rerun">
+  <div id="rerun-content"></div>
+</div>


### PR DESCRIPTION
Resolves #14226

The `createRerunProwJobIcon` creating a rerun button is moved
from the deck module into the common package.

Setting the color of the text in `rerun-content` box as gray to
preserve consistency since it is currently handled on higher levels.

Add `handleRerunButton` function when loading spyglass page.
The function would call `createRerunProwJobIcon` same as the deck page.
The rerun button won't be shown in case the prowJob is unavailable.

Add `ReRunCreateJob` boolean option and `ProwJobName` to the
spyglass template to be used for the rerun command.

Rename `lensesTemplate` struct to `spyglassTemplate` since it includes more
than just lens data.


![Screenshot from 2021-06-26 21-58-26](https://user-images.githubusercontent.com/29873449/123523036-ce216e00-d6c9-11eb-9ddc-107ea7291e43.png)

/cc @cjwagner @alvaroaleman
