### PR TITLE
Drop go report card from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # test-infra
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/kubernetes/test-infra)](https://goreportcard.com/report/github.com/kubernetes/test-infra)
 [![GoDoc](https://godoc.org/github.com/kubernetes/test-infra?status.svg)](https://godoc.org/github.com/kubernetes/test-infra)
 [![Build status](https://prow.k8s.io/badge.svg?jobs=post-test-infra-bazel)](https://testgrid.k8s.io/sig-testing-misc#post-bazel)
 


### PR DESCRIPTION
This repo does not build without bazel so the report cared is permanently an F, displaying it clearly isn't dong any good.

We can always add it back if we wish the repo to work with plain `go build` again in the future.