### PR TITLE
Fix PR revision tooltip isn't shown on Prow Status page after redraw

### DIFF
--- a/prow/cmd/deck/static/prow/prow.ts
+++ b/prow/cmd/deck/static/prow/prow.ts
@@ -727,6 +727,9 @@ function redraw(fz: FuzzySearch, pushState: boolean = true): void {
         modal.style.display = "block";
         rerunCommand.innerHTML = "Rerunning that job requires GitHub login. Now that you're logged in, try again";
     }
+    // we need to upgrade DOM for new created dynamic elements
+    // see https://getmdl.io/started/index.html#dynamic
+    componentHandler.upgradeDom();
 }
 
 function createRerunCell(modal: HTMLElement, rerunElement: HTMLElement, prowjob: string): HTMLTableDataCellElement {

--- a/prow/cmd/deck/static/vendor.d.ts
+++ b/prow/cmd/deck/static/vendor.d.ts
@@ -10,6 +10,8 @@ interface Window {
 // Needed for mysterious reasons, otherwise ts doesn't understand this is a module
 declare module 'dialog-polyfill';
 
+declare var componentHandler: any;
+
 // Enough typing for the Material Design library to be usable.
 interface MaterialSnackbarOptionsNoAction {
   message: string;


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/test-infra/issues/22567 
Fixes: https://github.com/kubernetes/test-infra/issues/12081
FIxes: https://github.com/kubernetes/test-infra/issues/10605 



see https://getmdl.io/started/index.html#dynamic 

> Material Design Lite will automatically register and render all elements marked with MDL classes upon page load. However in the case where you are creating DOM elements dynamically you need to register new elements using the upgradeElement function

here we use [upgradeDom()](https://github.com/google/material-design-lite/blob/60f441a22ed98ed2c03f6179adf460d888bf459f/src/mdlComponentHandler.js#L38) to upgrade all DOM elements 

I test it locally, this fix works