### PR TITLE
Allow GH teams to have overrides at the org level.

### DIFF
--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -1764,7 +1764,7 @@ func (b *Bugzilla) OptionsForRepo(org, repo string) map[string]BugzillaBranchOpt
 // Override holds options for the override plugin
 type Override struct {
 	AllowTopLevelOwners bool `json:"allow_top_level_owners,omitempty"`
-	// AllowedGitHubTeams is a map of repositories (eg "k/k") to list of GitHub team slugs,
+	// AllowedGitHubTeams is a map of orgs and/or repositories (eg "org" or "org/repo") to list of GitHub team slugs,
 	// members of which are allowed to override contexts
 	AllowedGitHubTeams map[string][]string `json:"allowed_github_teams,omitempty"`
 }

--- a/prow/plugins/override/override.go
+++ b/prow/plugins/override/override.go
@@ -179,7 +179,7 @@ func whoCanUse(overrideConfig plugins.Override, org, repo string) string {
 		repoRef := fmt.Sprintf("%s/%s", org, repo)
 		var allTeams []string
 		for r, allowedTeams := range overrideConfig.AllowedGitHubTeams {
-			if repoRef == "/" || r == repoRef {
+			if repoRef == "/" || r == repoRef || r == org {
 				allTeams = append(allTeams, fmt.Sprintf("%s: %s", r, strings.Join(allowedTeams, " ")))
 			}
 		}
@@ -244,7 +244,9 @@ func authorizedGitHubTeamMember(gc githubClient, log *logrus.Entry, teamSlugs ma
 		log.WithError(err).Warnf("invalid team slug(s)")
 	}
 
-	for _, slug := range teamSlugs[fmt.Sprintf("%s/%s", org, repo)] {
+	slugs := teamSlugs[fmt.Sprintf("%s/%s", org, repo)]
+	slugs = append(slugs, teamSlugs[org]...)
+	for _, slug := range slugs {
 		for _, team := range teams {
 			if team.Slug == slug {
 				members, err := gc.ListTeamMembers(org, team.ID, github.RoleAll)

--- a/prow/plugins/override/override_test.go
+++ b/prow/plugins/override/override_test.go
@@ -831,10 +831,11 @@ func TestWhoCanUse(t *testing.T) {
 		AllowedGitHubTeams: map[string][]string{
 			"org1/repo1": {"team-foo", "team-bar"},
 			"org2/repo2": {"team-bar"},
+			"org1":       {"team-foo-bar"},
 		},
 	}
 	expectedWho := "Repo administrators, and the following github teams:" +
-		"org1/repo1: team-foo team-bar."
+		"org1/repo1: team-foo team-bar, org1: team-foo-bar."
 
 	who := whoCanUse(override, "org1", "repo1")
 	if who != expectedWho {
@@ -873,6 +874,14 @@ func TestAuthorizedGitHubTeamMember(t *testing.T) {
 				"org/repo": {"team-foo"},
 			},
 			user: "member",
+		},
+		{
+			name: "members of specified teams are authorized to org",
+			slugs: map[string][]string{
+				fakeOrg: {"team-foo"},
+			},
+			user:     "user1",
+			expected: true,
 		},
 	}
 	log := logrus.WithField("plugin", pluginName)

--- a/prow/plugins/plugin-config-documented.yaml
+++ b/prow/plugins/plugin-config-documented.yaml
@@ -418,7 +418,7 @@ lgtm:
 milestone_applier:
     "": null
 override:
-    # AllowedGitHubTeams is a map of repositories (eg "k/k") to list of GitHub team slugs,
+    # AllowedGitHubTeams is a map of orgs and/or repositories (eg "org" or "org/repo") to list of GitHub team slugs,
     # members of which are allowed to override contexts
     allowed_github_teams:
         "": null


### PR DESCRIPTION
Resolves https://github.com/kubernetes/test-infra/issues/22673

Since the existing `AllowedGitHubTeams` field already contained `org/repo -> team` it seemed trivial enough to also allow it to contain `org -> team` rather than introducing a new field.