### PR TITLE
Update prow.svc.ci links to be prow.ci

### DIFF
--- a/config/testgrids/openshift/dedicated.yaml
+++ b/config/testgrids/openshift/dedicated.yaml
@@ -210,7 +210,7 @@ dashboards:
     test_group_name: osde2e-stage-aws-conformance-default
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -221,7 +221,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -230,7 +230,7 @@ dashboards:
     test_group_name: osde2e-int-aws-e2e-upgrade-to-latest-z
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -241,7 +241,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -250,7 +250,7 @@ dashboards:
     test_group_name: osde2e-int-aws-e2e-osd-default-plus-one-nightly
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -261,7 +261,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -270,7 +270,7 @@ dashboards:
     test_group_name: osde2e-int-aws-e2e-upgrade-to-latest-y
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -281,7 +281,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -290,7 +290,7 @@ dashboards:
     test_group_name: osde2e-int-aws-e2e-osd-default-plus-two-nightly
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -301,7 +301,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -310,7 +310,7 @@ dashboards:
     test_group_name: osde2e-prod-aws-e2e-default
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -321,7 +321,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -330,7 +330,7 @@ dashboards:
     test_group_name: osde2e-prod-aws-informing-default
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -341,7 +341,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -350,7 +350,7 @@ dashboards:
     test_group_name: osde2e-stage-aws-informing-default
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -361,7 +361,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -370,7 +370,7 @@ dashboards:
     test_group_name: osde2e-prod-aws-e2e-upgrade-to-latest
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -381,7 +381,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -390,7 +390,7 @@ dashboards:
     test_group_name: osde2e-prod-aws-e2e-upgrade-prod-minus-one-to-next
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -401,7 +401,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -410,7 +410,7 @@ dashboards:
     test_group_name: osde2e-prod-aws-e2e-upgrade-prod-minus-two-to-next
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -421,7 +421,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -430,7 +430,7 @@ dashboards:
     test_group_name: osde2e-prod-aws-e2e-upgrade-prod-minus-three-to-next
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -441,7 +441,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -450,7 +450,7 @@ dashboards:
     test_group_name: osde2e-prod-aws-e2e-upgrade-prod-minus-four-to-next
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -461,7 +461,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -470,7 +470,7 @@ dashboards:
     test_group_name: osde2e-prod-aws-e2e-upgrade-prod-plus-one-to-latest
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -481,7 +481,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -490,7 +490,7 @@ dashboards:
     test_group_name: osde2e-prod-aws-e2e-middle-imageset
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -501,7 +501,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -510,7 +510,7 @@ dashboards:
     test_group_name: osde2e-prod-aws-e2e-next
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -521,7 +521,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -530,7 +530,7 @@ dashboards:
     test_group_name: osde2e-prod-aws-informing-next
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -541,7 +541,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -550,7 +550,7 @@ dashboards:
     test_group_name: osde2e-stage-aws-informing-next
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -561,7 +561,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -570,7 +570,7 @@ dashboards:
     test_group_name: osde2e-prod-aws-e2e-oldest-imageset
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -581,7 +581,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -590,7 +590,7 @@ dashboards:
     test_group_name: osde2e-stage-aws-e2e-default
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -601,7 +601,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -610,7 +610,7 @@ dashboards:
     test_group_name: osde2e-stage-aws-e2e-upgrade-to-latest-z
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -621,7 +621,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -630,7 +630,7 @@ dashboards:
     test_group_name: osde2e-stage-aws-e2e-upgrade-to-latest
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -641,7 +641,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -650,7 +650,7 @@ dashboards:
     test_group_name: osde2e-stage-aws-e2e-middle-imageset
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -661,7 +661,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -670,7 +670,7 @@ dashboards:
     test_group_name: osde2e-stage-aws-e2e-next-z
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -681,7 +681,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -690,7 +690,7 @@ dashboards:
     test_group_name: osde2e-stage-aws-e2e-next-y
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -701,7 +701,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -710,7 +710,7 @@ dashboards:
     test_group_name: osde2e-stage-aws-e2e-oldest-imageset
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -721,7 +721,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -730,7 +730,7 @@ dashboards:
     test_group_name: osde2e-int-gcp-e2e-upgrade-to-latest-z
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -741,7 +741,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -750,7 +750,7 @@ dashboards:
     test_group_name: osde2e-int-gcp-e2e-osd-default-plus-one-nightly
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -761,7 +761,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -770,7 +770,7 @@ dashboards:
     test_group_name: osde2e-int-gcp-e2e-upgrade-to-latest-y
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -781,7 +781,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -790,7 +790,7 @@ dashboards:
     test_group_name: osde2e-int-gcp-e2e-osd-default-plus-two-nightly
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -801,7 +801,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -810,7 +810,7 @@ dashboards:
     test_group_name: osde2e-int-moa-e2e-osd-default-plus-one-nightly
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -821,7 +821,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -830,7 +830,7 @@ dashboards:
     test_group_name: osde2e-int-moa-e2e-osd-default-plus-two-nightly
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -841,7 +841,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -850,7 +850,7 @@ dashboards:
     test_group_name: osde2e-stage-gcp-e2e-default
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -861,7 +861,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -870,7 +870,7 @@ dashboards:
     test_group_name: osde2e-stage-gcp-e2e-upgrade-to-latest
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -881,7 +881,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -890,7 +890,7 @@ dashboards:
     test_group_name: osde2e-stage-gcp-e2e-upgrade-to-latest-z
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -901,7 +901,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -910,7 +910,7 @@ dashboards:
     test_group_name: osde2e-stage-gcp-e2e-next-y
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -921,7 +921,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -930,7 +930,7 @@ dashboards:
     test_group_name: osde2e-stage-gcp-e2e-next-z
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -941,7 +941,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -950,7 +950,7 @@ dashboards:
     test_group_name: osde2e-stage-moa-e2e-default
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -961,7 +961,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -970,7 +970,7 @@ dashboards:
     test_group_name: osde2e-stage-moa-e2e-next-y
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -981,7 +981,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -990,7 +990,7 @@ dashboards:
     test_group_name: osde2e-stage-moa-e2e-next-z
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -1001,7 +1001,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -1010,7 +1010,7 @@ dashboards:
     test_group_name: osde2e-prod-gcp-e2e-default
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -1021,7 +1021,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -1030,7 +1030,7 @@ dashboards:
     test_group_name: osde2e-prod-gcp-e2e-upgrade-to-next-y
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -1041,7 +1041,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -1050,7 +1050,7 @@ dashboards:
     test_group_name: osde2e-prod-gcp-e2e-upgrade-to-next-z
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -1061,7 +1061,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -1070,7 +1070,7 @@ dashboards:
     test_group_name: osde2e-prod-gcp-e2e-next
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -1081,7 +1081,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -1090,7 +1090,7 @@ dashboards:
     test_group_name: osde2e-prod-moa-e2e-default
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -1101,7 +1101,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
@@ -1110,7 +1110,7 @@ dashboards:
     test_group_name: osde2e-prod-moa-e2e-next
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     file_bug_template: # The URL template to visit when filing a bug
       url: https://github.com/openshift/osde2e/issues/new
       options:
@@ -1121,7 +1121,7 @@ dashboards:
     open_bug_template: # The URL template to visit when visiting an associated bug
       url: https://github.com/openshift/osde2e/issues/
     results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>

--- a/prow/README.md
+++ b/prow/README.md
@@ -79,7 +79,7 @@ To see common Prow usage and interactions flow, see the pull request interaction
 Prow is used by the following organizations and projects:
 - [Kubernetes](https://prow.k8s.io)
   - This includes [kubernetes](https://github.com/kubernetes), [kubernetes-client](https://github.com/kubernetes-client), [kubernetes-csi](https://github.com/kubernetes-csi), and [kubernetes-sigs](https://github.com/kubernetes-sigs).
-- [OpenShift](https://prow.svc.ci.openshift.org/)
+- [OpenShift](https://prow.ci.openshift.org/)
   - This includes [openshift](https://github.com/openshift), [openshift-s2i](https://github.com/openshift-s2i), [operator-framework](https://github.com/operator-framework), and some repos in [containers](https://github.com/containers) and [heketi](https://github.com/heketi).
 - [Istio](https://prow.istio.io/)
 - [Knative](https://prow.knative.dev/)


### PR DESCRIPTION
https://prow.svc.ci.openshift.org has been moved to https://prow.ci.openshift.org/ :) 