### PR TITLE
Add support for EasyCLA

### DIFF
--- a/prow/plugins/cla/BUILD.bazel
+++ b/prow/plugins/cla/BUILD.bazel
@@ -14,6 +14,7 @@ go_test(
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",
         "//prow/labels:go_default_library",
+        "//prow/plugins:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )

--- a/prow/plugins/cla/cla.go
+++ b/prow/plugins/cla/cla.go
@@ -95,7 +95,7 @@ func handleStatusEvent(pc plugins.Agent, se github.StatusEvent) error {
 	return handle(pc.GitHubClient, pc.Logger, se, pc.PluginConfig.CLAConfig)
 }
 
-// 1. Check that the status event received from the webhook is for the CNCF-CLA. The valid values are cla/linuxfoundation and EasyCLA.
+// 1. Check that the status event received from the webhook is for the CNCF-CLA.
 // 2. Use the github search API to search for the PRs which match the commit hash corresponding to the status event.
 // 3. For each issue that matches, check that the PR's HEAD commit hash against the commit hash for which the status
 //    was received. This is because we only care about the status associated with the last (latest) commit in a PR.
@@ -239,8 +239,7 @@ func handleComment(gc gitHubClient, log *logrus.Entry, e *github.GenericCommentE
 	}
 
 	for _, status := range combined.Statuses {
-
-		// Valid status values are cla/linuxfoundation and EasyCLA
+		// Only consider "cla/linuxfoundation" or "EasyCLA" status
 		if contains(cc.CLAContextNames, status.Context) {
 
 			// Success state implies that the cla exists, so label should be cncf-cla:yes.
@@ -277,9 +276,6 @@ func handleComment(gc gitHubClient, log *logrus.Entry, e *github.GenericCommentE
 					}
 				}
 			}
-
-			// No need to consider other contexts once you find the one you need.
-			break
 		}
 	}
 	return nil

--- a/prow/plugins/cla/cla.go
+++ b/prow/plugins/cla/cla.go
@@ -95,7 +95,7 @@ func handleStatusEvent(pc plugins.Agent, se github.StatusEvent) error {
 	return handle(pc.GitHubClient, pc.Logger, se, pc.PluginConfig.CLAConfig)
 }
 
-// 1. Check that the status event received from the webhook is for the CNCF-CLA.
+// 1. Check that the status event received from the webhook is for the CNCF-CLA. The valid values are cla/linuxfoundation and EasyCLA.
 // 2. Use the github search API to search for the PRs which match the commit hash corresponding to the status event.
 // 3. For each issue that matches, check that the PR's HEAD commit hash against the commit hash for which the status
 //    was received. This is because we only care about the status associated with the last (latest) commit in a PR.
@@ -240,7 +240,7 @@ func handleComment(gc gitHubClient, log *logrus.Entry, e *github.GenericCommentE
 
 	for _, status := range combined.Statuses {
 
-		// Only consider "cla/linuxfoundation" status.
+		// Valid status values are cla/linuxfoundation and EasyCLA
 		if contains(cc.CLAContextNames, status.Context) {
 
 			// Success state implies that the cla exists, so label should be cncf-cla:yes.

--- a/prow/plugins/cla/cla.go
+++ b/prow/plugins/cla/cla.go
@@ -33,7 +33,6 @@ import (
 
 const (
 	pluginName             = "cla"
-	claContextName         = "cla/linuxfoundation"
 	cncfclaNotFoundMessage = `Thanks for your pull request. Before we can look at your pull request, you'll need to sign a Contributor License Agreement (CLA).
 
 :memo: **Please follow instructions at <https://git.k8s.io/community/CLA.md#the-contributor-license-agreement> to sign the CLA.**
@@ -58,12 +57,19 @@ It may take a couple minutes for the CLA signature to be fully registered; after
 )
 
 var (
-	checkCLARe = regexp.MustCompile(`(?mi)^/check-cla\s*$`)
+	checkCLARe     = regexp.MustCompile(`(?mi)^/check-cla\s*$`)
+	claContextName string
 )
 
 func init() {
 	plugins.RegisterStatusEventHandler(pluginName, handleStatusEvent, helpProvider)
 	plugins.RegisterGenericCommentHandler(pluginName, handleCommentEvent, helpProvider)
+	config := &plugins.Configuration{}
+	if config.EasyCLAEnabled {
+		claContextName = "cla/easy-cla"
+	} else {
+		claContextName = "cla/linuxfoundation"
+	}
 }
 
 func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {

--- a/prow/plugins/cla/cla_test.go
+++ b/prow/plugins/cla/cla_test.go
@@ -332,6 +332,54 @@ func TestCheckCLA(t *testing.T) {
 
 			removedLabel: fmt.Sprintf("/#3:%s", labels.ClaYes),
 		},
+		{
+			name:       "cla/easy-cla status adds the cla-no label and removes cla-yes label when its state is \"failure\"",
+			context:    "cla/easy-cla",
+			state:      "failure",
+			issueState: "open",
+			SHA:        "sha",
+			action:     "created",
+			body:       "/check-cla",
+			pullRequests: []github.PullRequest{
+				{Number: 3, Head: github.PullRequestBranch{SHA: "sha"}},
+			},
+			hasCLAYes: true,
+
+			addedLabel:   fmt.Sprintf("/#3:%s", labels.ClaNo),
+			removedLabel: fmt.Sprintf("/#3:%s", labels.ClaYes),
+		},
+		{
+			name:       "cla/easy-cla status retains the cla-yes label and removes cla-no label when its state is \"success\"",
+			context:    "cla/easy-cla",
+			state:      "success",
+			issueState: "open",
+			SHA:        "sha",
+			action:     "created",
+			body:       "/check-cla",
+			pullRequests: []github.PullRequest{
+				{Number: 3, Head: github.PullRequestBranch{SHA: "sha"}},
+			},
+			hasCLANo:  true,
+			hasCLAYes: true,
+
+			removedLabel: fmt.Sprintf("/#3:%s", labels.ClaNo),
+		},
+		{
+			name:       "cla/easy-cla status retains the cla-no label and removes cla-yes label when its state is \"failure\"",
+			context:    "cla/easy-cla",
+			state:      "failure",
+			issueState: "open",
+			SHA:        "sha",
+			action:     "created",
+			body:       "/check-cla",
+			pullRequests: []github.PullRequest{
+				{Number: 3, Head: github.PullRequestBranch{SHA: "sha"}},
+			},
+			hasCLANo:  true,
+			hasCLAYes: true,
+
+			removedLabel: fmt.Sprintf("/#3:%s", labels.ClaYes),
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/prow/plugins/cla/cla_test.go
+++ b/prow/plugins/cla/cla_test.go
@@ -211,8 +211,7 @@ func TestCLALabels(t *testing.T) {
 func TestCheckCLA(t *testing.T) {
 	var testcases = []struct {
 		name         string
-		context      string
-		state        string
+		contexts     map[string]string
 		issueState   string
 		SHA          string
 		action       string
@@ -225,9 +224,10 @@ func TestCheckCLA(t *testing.T) {
 		removedLabel string
 	}{
 		{
-			name:       "ignore non cla/linuxfoundation context",
-			context:    "random/context",
-			state:      "success",
+			name: "ignore non cla/linuxfoundation context",
+			contexts: map[string]string{
+				"random/context": "success",
+			},
 			issueState: "open",
 			SHA:        "sha",
 			action:     "created",
@@ -238,8 +238,9 @@ func TestCheckCLA(t *testing.T) {
 		},
 		{
 			name:       "ignore non open PRs",
-			context:    "cla/linuxfoundation",
-			state:      "success",
+			contexts: map[string]string{
+				"cla/linuxfoundation": "success",
+			},
 			issueState: "closed",
 			SHA:        "sha",
 			action:     "created",
@@ -250,8 +251,9 @@ func TestCheckCLA(t *testing.T) {
 		},
 		{
 			name:       "ignore non /check-cla comments",
-			context:    "cla/linuxfoundation",
-			state:      "success",
+			contexts: map[string]string{
+				"cla/linuxfoundation": "success",
+			},
 			issueState: "open",
 			SHA:        "sha",
 			action:     "created",
@@ -262,8 +264,9 @@ func TestCheckCLA(t *testing.T) {
 		},
 		{
 			name:       "do nothing on when status state is \"pending\"",
-			context:    "cla/linuxfoundation",
-			state:      "pending",
+			contexts: map[string]string{
+				"cla/linuxfoundation": "pending",
+			},
 			issueState: "open",
 			SHA:        "sha",
 			action:     "created",
@@ -273,9 +276,10 @@ func TestCheckCLA(t *testing.T) {
 			},
 		},
 		{
-			name:       "cla/linuxfoundation status adds the cla-yes label when its state is \"success\"",
-			context:    "cla/linuxfoundation",
-			state:      "success",
+			name:       "EasyCLA status adds the cla-yes label when its state is \"success\"",
+			contexts: map[string]string{
+				"EasyCLA": "success",
+			},
 			issueState: "open",
 			SHA:        "sha",
 			action:     "created",
@@ -287,9 +291,10 @@ func TestCheckCLA(t *testing.T) {
 			addedLabel: fmt.Sprintf("/#3:%s", labels.ClaYes),
 		},
 		{
-			name:       "cla/linuxfoundation status adds the cla-yes label and removes cla-no label when its state is \"success\"",
-			context:    "cla/linuxfoundation",
-			state:      "success",
+			name:       "EasyCLA status adds the cla-yes label and removes cla-no label when its state is \"success\"",
+			contexts: map[string]string{
+				"EasyCLA": "success",
+			},
 			issueState: "open",
 			SHA:        "sha",
 			action:     "created",
@@ -304,8 +309,9 @@ func TestCheckCLA(t *testing.T) {
 		},
 		{
 			name:       "cla/linuxfoundation status adds the cla-no label when its state is \"failure\"",
-			context:    "cla/linuxfoundation",
-			state:      "failure",
+			contexts: map[string]string{
+				"cla/linuxfoundation": "failure",
+			},
 			issueState: "open",
 			SHA:        "sha",
 			action:     "created",
@@ -317,9 +323,10 @@ func TestCheckCLA(t *testing.T) {
 			addedLabel: fmt.Sprintf("/#3:%s", labels.ClaNo),
 		},
 		{
-			name:       "cla/linuxfoundation status adds the cla-no label and removes cla-yes label when its state is \"failure\"",
-			context:    "cla/linuxfoundation",
-			state:      "failure",
+			name:       "EasyCLA status adds the cla-no label and removes cla-yes label when its state is \"failure\"",
+			contexts: map[string]string{
+				"EasyCLA": "failure",
+			},
 			issueState: "open",
 			SHA:        "sha",
 			action:     "created",
@@ -334,8 +341,9 @@ func TestCheckCLA(t *testing.T) {
 		},
 		{
 			name:       "cla/linuxfoundation status retains the cla-yes label and removes cla-no label when its state is \"success\"",
-			context:    "cla/linuxfoundation",
-			state:      "success",
+			contexts: map[string]string{
+				"cla/linuxfoundation": "success",
+			},
 			issueState: "open",
 			SHA:        "sha",
 			action:     "created",
@@ -350,8 +358,9 @@ func TestCheckCLA(t *testing.T) {
 		},
 		{
 			name:       "cla/linuxfoundation status retains the cla-no label and removes cla-yes label when its state is \"failure\"",
-			context:    "cla/linuxfoundation",
-			state:      "failure",
+			contexts: map[string]string{
+				"cla/linuxfoundation": "failure",
+			},
 			issueState: "open",
 			SHA:        "sha",
 			action:     "created",
@@ -365,9 +374,11 @@ func TestCheckCLA(t *testing.T) {
 			removedLabel: fmt.Sprintf("/#3:%s", labels.ClaYes),
 		},
 		{
-			name:       "EasyCLA status retains the cla-no label and removes cla-yes label when its state is \"failure\"",
-			context:    "EasyCLA",
-			state:      "failure",
+			name:       "cla/linuxfoundation status retains the cla-no label and removes cla-yes label when its state is \"failure\"",
+			contexts: map[string]string{
+				"cla/linuxfoundation": "failure",
+				"EasyCLA": "success",
+			},
 			issueState: "open",
 			SHA:        "sha",
 			action:     "created",
@@ -381,9 +392,11 @@ func TestCheckCLA(t *testing.T) {
 			removedLabel: fmt.Sprintf("/#3:%s", labels.ClaYes),
 		},
 		{
-			name:       "EasyCLA status retains the cla-yes label and removes cla-no label when its state is \"success\"",
-			context:    "EasyCLA",
-			state:      "success",
+			name:       "cla/linuxfoundation status retains the cla-yes label and removes cla-no label when its state is \"success\"",
+			contexts: map[string]string{
+				"EasyCLA": "failure",
+				"cla/linuxfoundation": "success",
+			},
 			issueState: "open",
 			SHA:        "sha",
 			action:     "created",
@@ -396,6 +409,7 @@ func TestCheckCLA(t *testing.T) {
 
 			removedLabel: fmt.Sprintf("/#3:%s", labels.ClaNo),
 		},
+
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -415,11 +429,17 @@ func TestCheckCLA(t *testing.T) {
 			cc := plugins.CLAConfig{
 				CLAContextNames: []string{"cla/linuxfoundation", "EasyCLA"},
 			}
+			var statuses []github.Status
+			for context, state := range tc.contexts {
+				statuses = append(statuses, github.Status{
+					State:   state,
+					Context: context,
+				})
+			}
+
 			fc.CombinedStatuses = map[string]*github.CombinedStatus{
 				tc.SHA: {
-					Statuses: []github.Status{
-						{State: tc.state, Context: tc.context},
-					},
+					Statuses: statuses,
 				},
 			}
 			if tc.hasCLAYes {

--- a/prow/plugins/cla/cla_test.go
+++ b/prow/plugins/cla/cla_test.go
@@ -30,16 +30,16 @@ import (
 
 func TestCLALabels(t *testing.T) {
 	var testcases = []struct {
-		name          string
-		context       string
-		state         string
+		name           string
+		context        string
+		state          string
 		easyCLAEnabled bool
-		statusSHA     string
-		issues        []github.Issue
-		pullRequests  []github.PullRequest
-		labels        []string
-		addedLabels   []string
-		removedLabels []string
+		statusSHA      string
+		issues         []github.Issue
+		pullRequests   []github.PullRequest
+		labels         []string
+		addedLabels    []string
+		removedLabels  []string
 	}{
 		{
 			name:          "unrecognized status context has no effect",
@@ -142,11 +142,11 @@ func TestCLALabels(t *testing.T) {
 			removedLabels: []string{fmt.Sprintf("/#3:%s", labels.ClaYes)},
 		},
 		{
-			name:      "cla/linuxfoundation status failure removes \"cncf-cla: yes\" label",
-			context:   "cla/easy-cla",
-			state:     "failure",
+			name:           "cla/linuxfoundation status failure removes \"cncf-cla: yes\" label",
+			context:        "cla/easy-cla",
+			state:          "failure",
 			easyCLAEnabled: true,
-			statusSHA: "a",
+			statusSHA:      "a",
 			issues: []github.Issue{
 				{Number: 3, State: "open", Labels: []github.Label{{Name: labels.ClaYes}}},
 			},
@@ -199,17 +199,17 @@ func TestCLALabels(t *testing.T) {
 
 func TestCheckCLA(t *testing.T) {
 	var testcases = []struct {
-		name         string
-		context      string
+		name           string
+		context        string
 		easyCLAEnabled bool
-		state        string
-		issueState   string
-		SHA          string
-		action       string
-		body         string
-		pullRequests []github.PullRequest
-		hasCLAYes    bool
-		hasCLANo     bool
+		state          string
+		issueState     string
+		SHA            string
+		action         string
+		body           string
+		pullRequests   []github.PullRequest
+		hasCLAYes      bool
+		hasCLANo       bool
 
 		addedLabel   string
 		removedLabel string
@@ -355,14 +355,14 @@ func TestCheckCLA(t *testing.T) {
 			removedLabel: fmt.Sprintf("/#3:%s", labels.ClaYes),
 		},
 		{
-			name:       "cla/easy-cla status retains the cla-no label and removes cla-yes label when its state is \"failure\"",
-			context:    "cla/easy-cla",
+			name:           "cla/easy-cla status retains the cla-no label and removes cla-yes label when its state is \"failure\"",
+			context:        "cla/easy-cla",
 			easyCLAEnabled: true,
-			state:      "failure",
-			issueState: "open",
-			SHA:        "sha",
-			action:     "created",
-			body:       "/check-cla",
+			state:          "failure",
+			issueState:     "open",
+			SHA:            "sha",
+			action:         "created",
+			body:           "/check-cla",
 			pullRequests: []github.PullRequest{
 				{Number: 3, Head: github.PullRequestBranch{SHA: "sha"}},
 			},

--- a/prow/plugins/cla/cla_test.go
+++ b/prow/plugins/cla/cla_test.go
@@ -237,7 +237,7 @@ func TestCheckCLA(t *testing.T) {
 			},
 		},
 		{
-			name:       "ignore non open PRs",
+			name: "ignore non open PRs",
 			contexts: map[string]string{
 				"cla/linuxfoundation": "success",
 			},
@@ -250,7 +250,7 @@ func TestCheckCLA(t *testing.T) {
 			},
 		},
 		{
-			name:       "ignore non /check-cla comments",
+			name: "ignore non /check-cla comments",
 			contexts: map[string]string{
 				"cla/linuxfoundation": "success",
 			},
@@ -263,7 +263,7 @@ func TestCheckCLA(t *testing.T) {
 			},
 		},
 		{
-			name:       "do nothing on when status state is \"pending\"",
+			name: "do nothing on when status state is \"pending\"",
 			contexts: map[string]string{
 				"cla/linuxfoundation": "pending",
 			},
@@ -276,7 +276,7 @@ func TestCheckCLA(t *testing.T) {
 			},
 		},
 		{
-			name:       "EasyCLA status adds the cla-yes label when its state is \"success\"",
+			name: "EasyCLA status adds the cla-yes label when its state is \"success\"",
 			contexts: map[string]string{
 				"EasyCLA": "success",
 			},
@@ -291,7 +291,7 @@ func TestCheckCLA(t *testing.T) {
 			addedLabel: fmt.Sprintf("/#3:%s", labels.ClaYes),
 		},
 		{
-			name:       "EasyCLA status adds the cla-yes label and removes cla-no label when its state is \"success\"",
+			name: "EasyCLA status adds the cla-yes label and removes cla-no label when its state is \"success\"",
 			contexts: map[string]string{
 				"EasyCLA": "success",
 			},
@@ -308,7 +308,7 @@ func TestCheckCLA(t *testing.T) {
 			removedLabel: fmt.Sprintf("/#3:%s", labels.ClaNo),
 		},
 		{
-			name:       "cla/linuxfoundation status adds the cla-no label when its state is \"failure\"",
+			name: "cla/linuxfoundation status adds the cla-no label when its state is \"failure\"",
 			contexts: map[string]string{
 				"cla/linuxfoundation": "failure",
 			},
@@ -323,7 +323,7 @@ func TestCheckCLA(t *testing.T) {
 			addedLabel: fmt.Sprintf("/#3:%s", labels.ClaNo),
 		},
 		{
-			name:       "EasyCLA status adds the cla-no label and removes cla-yes label when its state is \"failure\"",
+			name: "EasyCLA status adds the cla-no label and removes cla-yes label when its state is \"failure\"",
 			contexts: map[string]string{
 				"EasyCLA": "failure",
 			},
@@ -340,7 +340,7 @@ func TestCheckCLA(t *testing.T) {
 			removedLabel: fmt.Sprintf("/#3:%s", labels.ClaYes),
 		},
 		{
-			name:       "cla/linuxfoundation status retains the cla-yes label and removes cla-no label when its state is \"success\"",
+			name: "cla/linuxfoundation status retains the cla-yes label and removes cla-no label when its state is \"success\"",
 			contexts: map[string]string{
 				"cla/linuxfoundation": "success",
 			},
@@ -357,7 +357,7 @@ func TestCheckCLA(t *testing.T) {
 			removedLabel: fmt.Sprintf("/#3:%s", labels.ClaNo),
 		},
 		{
-			name:       "cla/linuxfoundation status retains the cla-no label and removes cla-yes label when its state is \"failure\"",
+			name: "cla/linuxfoundation status retains the cla-no label and removes cla-yes label when its state is \"failure\"",
 			contexts: map[string]string{
 				"cla/linuxfoundation": "failure",
 			},
@@ -374,10 +374,10 @@ func TestCheckCLA(t *testing.T) {
 			removedLabel: fmt.Sprintf("/#3:%s", labels.ClaYes),
 		},
 		{
-			name:       "cla/linuxfoundation status retains the cla-no label and removes cla-yes label when its state is \"failure\"",
+			name: "cla/linuxfoundation status retains the cla-no label and removes cla-yes label when its state is \"failure\"",
 			contexts: map[string]string{
 				"cla/linuxfoundation": "failure",
-				"EasyCLA": "success",
+				"EasyCLA":             "success",
 			},
 			issueState: "open",
 			SHA:        "sha",
@@ -392,9 +392,9 @@ func TestCheckCLA(t *testing.T) {
 			removedLabel: fmt.Sprintf("/#3:%s", labels.ClaYes),
 		},
 		{
-			name:       "cla/linuxfoundation status retains the cla-yes label and removes cla-no label when its state is \"success\"",
+			name: "cla/linuxfoundation status retains the cla-yes label and removes cla-no label when its state is \"success\"",
 			contexts: map[string]string{
-				"EasyCLA": "failure",
+				"EasyCLA":             "failure",
 				"cla/linuxfoundation": "success",
 			},
 			issueState: "open",
@@ -409,7 +409,6 @@ func TestCheckCLA(t *testing.T) {
 
 			removedLabel: fmt.Sprintf("/#3:%s", labels.ClaNo),
 		},
-
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -90,6 +90,7 @@ type Configuration struct {
 	Welcome              []Welcome                    `json:"welcome,omitempty"`
 	Override             Override                     `json:"override,omitempty"`
 	Help                 Help                         `json:"help,omitempty"`
+	EasyCLAEnabled       bool                         `json:"easy_cla_enabled,omitempty"`
 }
 
 type Help struct {

--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -991,6 +991,9 @@ func (c *Configuration) setDefaults() {
 			c.RequireMatchingLabel[i].GracePeriod = "5s"
 		}
 	}
+	if len(c.CLAConfig.CLAContextNames) == 0 {
+		c.CLAConfig.CLAContextNames = []string{"cla/linuxfoundation"}
+	}
 }
 
 // validatePluginsDupes will return an error if there are duplicated plugins.

--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -90,7 +90,7 @@ type Configuration struct {
 	Welcome              []Welcome                    `json:"welcome,omitempty"`
 	Override             Override                     `json:"override,omitempty"`
 	Help                 Help                         `json:"help,omitempty"`
-	EasyCLAEnabled       bool                         `json:"easy_cla_enabled,omitempty"`
+	CLAConfig            CLAConfig                    `json:"cla_config,omitempty"`
 }
 
 type Help struct {
@@ -481,6 +481,11 @@ type ConfigUpdater struct {
 	// If GZIP is true then files will be gzipped before insertion into
 	// their corresponding configmap
 	GZIP bool `json:"gzip"`
+}
+
+// CLAConfig contains the list of available context names
+type CLAConfig struct {
+	CLAContextNames []string `json:"cla_context_names,omitempty"`
 }
 
 type configUpdatedWithoutUnmarshaler ConfigUpdater

--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -485,6 +485,11 @@ type ConfigUpdater struct {
 
 // CLAConfig contains the list of available context names
 type CLAConfig struct {
+	// CLAContextNames is the list of status contexts to check to decide the
+	// CLA status of pull requests.  When any status in this list fails, the
+	// "cncf-cla: no" GitHub label is applied.  When any status in this list
+	// passes, the "cncf-cla: yes" GitHub label is applied. The last status in
+	// the list has priority.  Defaults to ["cla/linuxfoundation"]
 	CLAContextNames []string `json:"cla_context_names,omitempty"`
 }
 

--- a/prow/plugins/plugin-config-documented.yaml
+++ b/prow/plugins/plugin-config-documented.yaml
@@ -317,6 +317,11 @@ cherry_pick_unapproved:
     # `do-not-merge/cherry-pick-not-approved` label.
     comment: ' '
 cla_config:
+    # CLAContextNames is the list of status contexts to check to decide the
+    # CLA status of pull requests. When any status in this list fails, the
+    # "cncf-cla: no" GitHub label is applied. When any status in this list
+    # passes, the "cncf-cla: yes" GitHub label is applied. The last status in
+    # the list has priority. Defaults to ["cla/linuxfoundation"]
     cla_context_names:
       - ""
 config_updater:

--- a/prow/plugins/plugin-config-documented.yaml
+++ b/prow/plugins/plugin-config-documented.yaml
@@ -316,6 +316,9 @@ cherry_pick_unapproved:
     # Comment is the comment added by the plugin while adding the
     # `do-not-merge/cherry-pick-not-approved` label.
     comment: ' '
+cla_config:
+    cla_context_names:
+      - ""
 config_updater:
     # ClusterGroups is a map of ClusterGroups that can be used as a target
     # in the map config.

--- a/prow/plugins/plugins_test.go
+++ b/prow/plugins/plugins_test.go
@@ -278,6 +278,9 @@ func TestLoad(t *testing.T) {
 			Help: Help{
 				HelpGuidelinesURL: "https://git.k8s.io/community/contributors/guide/help-wanted.md",
 			},
+			CLAConfig: CLAConfig{
+				CLAContextNames: []string{"cla/linuxfoundation"},
+			},
 		}
 		for _, modify := range m {
 			modify(cfg)


### PR DESCRIPTION
Added a new field `EasyCLAEnabled` in the plugins config and based on
this field, if set will assign the `claContextName` to `cla/easy-cla`, else
default to `cla/linuxfoundation`

Fixes #22721 