### PR TITLE
Add capz presubmit job for exp folder changes

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
           - name: GINKGO_FOCUS
             value: "Workload cluster creation"
           - name: GINKGO_SKIP
-            value: "Creating a GPU-enabled cluster|.*Windows.*|Creating a cluster that uses the external cloud provider"
+            value: "Creating a GPU-enabled cluster|.*Windows.*|.*AKS.*|Creating a cluster that uses the external cloud provider"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -131,6 +131,39 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-e2e-windows-main
+      testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+  - name: pull-cluster-api-provider-azure-e2e-exp
+    path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+    always_run: false
+    optional: true
+    decorate: true
+    run_if_changed: '^((exp)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
+    max_concurrency: 5
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+    branches:
+    # The script this job runs is not in all branches.
+    - ^master$
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210622-762366a-go-canary
+        command:
+        - "runner.sh"
+        - "./scripts/ci-e2e.sh"
+        env:
+          - name: GINKGO_FOCUS
+            value: ".*AKS.*"
+          - name: GINKGO_SKIP
+            value: ""
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+      testgrid-tab-name: capz-pr-e2e-exp-main
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-capi-e2e
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"


### PR DESCRIPTION
for cluster-api-provider-azure
 - Add a presubmit job for AKS related changes in exp/ folder and 
 - skip AKS test from main e2e job

https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/1483

/cc @CecileRobertMichon @alexeldeib 