### PR TITLE
Add a title tooltip for builds on job history view

### DIFF
--- a/prow/cmd/deck/static/BUILD.bazel
+++ b/prow/cmd/deck/static/BUILD.bazel
@@ -201,6 +201,22 @@ rollup_bundle(
     ],
 )
 
+ts_library(
+    name = "job_history",
+    srcs = glob(["job-history/*.ts"]),
+    deps = [
+        ":common",
+    ],
+)
+
+rollup_bundle(
+    name = "job_history_bundle",
+    entry_point = ":job-history/job-history.ts",
+    deps = [
+        ":job_history",
+    ],
+)
+
 test_suite(
     name = "unit_tests",
     tests = [
@@ -233,6 +249,7 @@ filegroup(
     name = "all-scripts",
     srcs = [
         ":command_help_bundle.min",
+        ":job_history_bundle.min",
         ":plugin_help_bundle.min",
         ":pr_bundle.min",
         ":prow_bundle.min",

--- a/prow/cmd/deck/static/common/common.ts
+++ b/prow/cmd/deck/static/common/common.ts
@@ -158,7 +158,7 @@ export namespace cell {
 }
 
 export namespace tooltip {
-  export function forElem(elemID: string, tipElem: Node): Node {
+  export function forElem(elemID: string, tipElem: Node): HTMLElement {
     const tip = document.createElement("div");
     tip.appendChild(tipElem);
     tip.setAttribute("data-mdl-for", elemID);

--- a/prow/cmd/deck/static/job-history/job-history.ts
+++ b/prow/cmd/deck/static/job-history/job-history.ts
@@ -1,0 +1,14 @@
+import {tooltip} from '../common/common';
+
+window.onload = (): void => {
+  const rows = document.getElementsByClassName("build-row");
+
+  for (const row of rows) {
+    const title = row.getAttribute("data-title");
+    if (title != null) {
+      const tip = tooltip.forElem(row.id, document.createTextNode(title));
+      tip.classList.add("mdl-tooltip--right");
+      row.appendChild(tip);
+    }
+  }
+};

--- a/prow/cmd/deck/template/job-history.html
+++ b/prow/cmd/deck/template/job-history.html
@@ -1,5 +1,6 @@
 {{define "title"}}Job History: {{.Name}}{{end}}
 {{define "scripts"}}
+<script type="text/javascript" src="/static/job_history_bundle.min.js"></script>
 <style>
   .run-success {
     background-color: rgba(0, 255, 0, 0.3);
@@ -25,7 +26,10 @@
     </thead>
     <tbody>
       {{range .Builds}}
-      <tr class= {{if eq .Result "SUCCESS"}}"run-success"{{else if eq .Result "FAILURE"}}"run-failure"{{else}}"run-pending"{{end}}>
+      <tr id="build-{{.ID}}"
+        class="build-row {{if eq .Result "SUCCESS"}}run-success{{else if eq .Result "FAILURE"}}run-failure{{else}}run-pending{{end}}"
+        {{if .Pull}} data-title="{{.Pull.Title}}" {{end}}
+        >
         <td class="mdl-data-table__cell--non-numeric">
           {{if .SpyglassLink}}<a href="{{.SpyglassLink}}">{{.ID}}</a>
           {{else}}{{.ID}}{{end}}


### PR DESCRIPTION
Add a job-history.ts module that goes over the build rows and adds a
tooltip with the build title to them.

![Screenshot from 2021-06-29 09-45-44](https://user-images.githubusercontent.com/29873449/124025697-72245580-d9f9-11eb-8963-96cd1f7bba9d.png)
