### PR TITLE
Kops - remove --skip-regex flag to use kubetest2-tester-kops' default

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -612,8 +612,7 @@ presubmits:
             --ginkgo-args="--debug" \
             --test-args="-test.timeout=60m -num-nodes=0" \
             --test-package-marker=latest.txt \
-            --parallel=25 \
-            --skip-regex="None"
+            --parallel=25
         securityContext:
           privileged: true
         env:


### PR DESCRIPTION
There was a bug in build_jobs.py that at one point generated `--skip-regex="None"`. This bug has been fixed and most jobs no longer set --skip-regex altogether, but this manually-managed job was likely copy/pasted from a job impacted by that bug.

ref: https://github.com/kubernetes/kops/pull/11895