### PR TITLE
Testgrid - Add OpenShift 4.9 Single-Node Serial periodics to OpenShift Single-Node dashboard

### DIFF
--- a/config/testgrids/openshift/single-node.yaml
+++ b/config/testgrids/openshift/single-node.yaml
@@ -1,6 +1,33 @@
 dashboards:
 - name: redhat-single-node
   dashboard_tab:
+  - name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-single-node-serial
+    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-single-node-serial
+    base_options: width=10
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    file_bug_template:
+      options:
+      - key: classification
+        value: Red Hat
+      - key: product
+        value: OpenShift Container Platform
+      - key: cf_internal_whiteboard
+        value: buildcop
+      - key: short_desc
+        value: 'test: <test-name>'
+      - key: cf_environment
+        value: 'test: <test-name>'
+      - key: comment
+        value: 'test: <test-name> failed, see job: <test-url>'
+      url: https://bugzilla.redhat.com/enter_bug.cgi
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
   - name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-single-node
     test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-single-node
     base_options: width=10


### PR DESCRIPTION
Previously only 4.9 non-serial period tests were present https://github.com/kubernetes/test-infra/pull/22592

Periodic job was added to OpenShift CI in this PR: https://github.com/openshift/release/pull/19878