### PR TITLE
Add e2e lock contention job

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -418,3 +418,33 @@ periodics:
     testgrid-tab-name: kubelet-serial-gce-e2e-graceful-node-shutdown
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: Executes graceful node shutdown e2e node tests
+
+- name: ci-kubernetes-node-kubelet-lock-contention
+  interval: 4h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-master
+        args:
+          - --repo=k8s.io/kubernetes=master
+          - --timeout=240
+          - --root=/go/src
+          - --scenario=kubernetes_e2e
+          - --
+          - --deployment=node
+          - --gcp-project-type=node-e2e-project
+          - --gcp-zone=us-west1-b
+          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
+          - --node-test-args=--kubelet-flags="--exit-on-lock-contention --lock-file=/var/run/kubelet.lock"
+          - --node-tests=true
+          - --provider=gce
+          - --test_args=--nodes=1 --focus="\[NodeFeature:LockContention\]" --restart-kubelet=false
+        env:
+          - name: GOPATH
+            value: /go
+  annotations:
+    testgrid-dashboards: sig-node-kubelet
+    testgrid-tab-name: kubelet-gce-e2e-lock-contention
+    description: "Contains disruptive tests for the Lock Contention feature."


### PR DESCRIPTION
This PR adds a new job `ci-kubernetes-node-kubelet-lock-contention`
to the test suite.

This test is created due to the want of `--lock-file` and
`--exit-on-lock-contention` be moved as flags and into the Kubelet
configuration file rather than be dropped.

Adds a new tab in TestGrid named `kubelet-gce-e2e-lock-contention`
running tests focused on `NodeFeature:LockContention`.

This PR  is created to supercede #20106 

Requesting creator of the original PR #20106 @knabben to advise on further steps on his PR. Could #20106 be closed in favor of this ?

Requesting @ike-ma @SergeyKanzhelev , the reviewers of the original PR to please review this. 

@ike-ma I've addressed your https://github.com/kubernetes/test-infra/pull/20106#discussion_r617114498 and for this  https://github.com/kubernetes/test-infra/pull/20106#discussion_r617125341, I'd like to let you know that https://github.com/kubernetes/kubernetes/pull/97028 is now merged which was a pre-requisite for this PR to get merged.

cc: @rata 

Signed-off-by: Imran Pochi <imran@kinvolk.io>