### PR TITLE
Align job history with tide history view

### DIFF
--- a/prow/cmd/deck/job_history.go
+++ b/prow/cmd/deck/job_history.go
@@ -67,7 +67,7 @@ type buildData struct {
 	Duration     time.Duration
 	Result       string
 	commitHash   string
-	Pull         *prowv1.Pull
+	Pulls        []prowv1.Pull
 }
 
 // storageBucket is an abstraction for unit testing
@@ -370,8 +370,8 @@ func getBuildData(ctx context.Context, bucket storageBucket, dir string) (buildD
 	if err != nil {
 		logrus.WithError(err).Debugf("failed to read %s", prowv1.ProwJobFile)
 	} else {
-		if pj.Spec.Refs != nil && len(pj.Spec.Refs.Pulls) > 0 {
-			b.Pull = &pj.Spec.Refs.Pulls[0]
+		if pj.Spec.Refs != nil {
+			b.Pulls = pj.Spec.Refs.Pulls
 		}
 	}
 
@@ -457,6 +457,7 @@ func getJobHistory(ctx context.Context, url *url.URL, cfg config.Getter, opener 
 	if err != nil && !errors.Is(err, context.DeadlineExceeded) {
 		return tmpl, fmt.Errorf("failed to get build ids: %v", err)
 	}
+
 	sort.Sort(sort.Reverse(int64slice(buildIDs)))
 
 	// determine which results to display on this page

--- a/prow/cmd/deck/static/BUILD.bazel
+++ b/prow/cmd/deck/static/BUILD.bazel
@@ -208,6 +208,7 @@ ts_library(
     srcs = glob(["job-history/*.ts"]),
     deps = [
         ":common",
+        "@npm//moment",
     ],
 )
 

--- a/prow/cmd/deck/static/common/common.ts
+++ b/prow/cmd/deck/static/common/common.ts
@@ -21,11 +21,7 @@ export namespace cell {
     main.textContent = when.format(isADayOld ? 'MMM DD HH:mm:ss' : 'HH:mm:ss');
     main.id = tid;
 
-    const tip = document.createElement("div");
-    tip.textContent = when.format('MMM DD YYYY, HH:mm:ss [UTC]ZZ');
-    tip.setAttribute("data-mdl-for", tid);
-    tip.classList.add("mdl-tooltip", "mdl-tooltip--large");
-
+    const tip = tooltip.forElem(tid, document.createTextNode(when.format('MMM DD YYYY, HH:mm:ss [UTC]ZZ')));
     const c = document.createElement("td");
     c.appendChild(main);
     c.appendChild(tip);
@@ -298,4 +294,27 @@ function copyToClipboard(text: string) {
           document.body.removeChild(textarea);
       }
   }
+}
+
+export function formatDuration(seconds: number): string {
+  const parts: string[] = [];
+  if (seconds >= 3600) {
+      const hours = Math.floor(seconds / 3600);
+      parts.push(String(hours));
+      parts.push('h');
+      seconds = seconds % 3600;
+  }
+  if (seconds >= 60) {
+      const minutes = Math.floor(seconds / 60);
+      if (minutes > 0) {
+          parts.push(String(minutes));
+          parts.push('m');
+          seconds = seconds % 60;
+      }
+  }
+  if (seconds >= 0) {
+      parts.push(String(seconds));
+      parts.push('s');
+  }
+  return parts.join('');
 }

--- a/prow/cmd/deck/static/job-history/job-history.ts
+++ b/prow/cmd/deck/static/job-history/job-history.ts
@@ -1,14 +1,46 @@
-import {tooltip} from '../common/common';
+import moment from "moment";
+import {cell, formatDuration} from '../common/common';
+
+declare const allBuilds: any;
 
 window.onload = (): void => {
-  const rows = document.getElementsByClassName("build-row");
+  const tbody = document.getElementById("history-table-body")!;
 
-  for (const row of rows) {
-    const title = row.getAttribute("data-title");
-    if (title != null) {
-      const tip = tooltip.forElem(row.id, document.createTextNode(title));
-      tip.classList.add("mdl-tooltip--right");
-      row.appendChild(tip);
+  for (const build of allBuilds) {
+    const tr = document.createElement("tr");
+
+    let className = "";
+    switch (build.Result) {
+      case "SUCCESS":
+        className = "run-success";
+        break;
+      case "FAILURE":
+        className = "run-failure";
+        break;
+      default:
+        className = "run-pending";
     }
+    tr.classList.add(className);
+
+    tr.appendChild(cell.link(build.ID, build.SpyglassLink));
+
+    if (build.Pulls) {
+      for (const pull of build.Pulls) {
+        tr.appendChild(cell.prRevision("bla", pull));
+      }
+    } else {
+      tr.appendChild(cell.text(""));
+    }
+
+    const started = Date.parse(build.Started) / 1000;
+    tr.appendChild(cell.time(build.ID, moment.unix(started)));
+    tr.appendChild(cell.text(formatDuration(build.Duration / 1000000000 ))); // convert from ns to s.
+    tr.appendChild(cell.text(build.Result));
+
+    for (const child of tr.children) {
+      child.classList.add("mdl-data-table__cell--non-numeric");
+    }
+
+    tbody.appendChild(tr);
   }
 };

--- a/prow/cmd/deck/static/prow/prow.ts
+++ b/prow/cmd/deck/static/prow/prow.ts
@@ -1,6 +1,6 @@
 import moment from "moment";
 import {ProwJob, ProwJobList, ProwJobState, ProwJobType, Pull} from "../api/prow";
-import {cell, createRerunProwJobIcon, icon} from "../common/common";
+import {cell, createRerunProwJobIcon, formatDuration, icon} from "../common/common";
 import {getParameterByName} from "../common/urls";
 import {FuzzySearch} from './fuzzy-search';
 import {JobHistogram, JobSample} from './histogram';
@@ -803,51 +803,6 @@ function stateToAdj(state: ProwJobState): string {
         default:
             return state;
     }
-}
-
-function parseDuration(duration: string): number {
-    if (duration.length === 0) {
-        return 0;
-    }
-    let seconds = 0;
-    let multiple = 0;
-    for (let i = duration.length; i >= 0; i--) {
-        const ch = duration[i];
-        if (ch === 's') {
-            multiple = 1;
-        } else if (ch === 'm') {
-            multiple = 60;
-        } else if (ch === 'h') {
-            multiple = 60 * 60;
-        } else if (ch >= '0' && ch <= '9') {
-            seconds += Number(ch) * multiple;
-            multiple *= 10;
-        }
-    }
-    return seconds;
-}
-
-function formatDuration(seconds: number): string {
-    const parts: string[] = [];
-    if (seconds >= 3600) {
-        const hours = Math.floor(seconds / 3600);
-        parts.push(String(hours));
-        parts.push('h');
-        seconds = seconds % 3600;
-    }
-    if (seconds >= 60) {
-        const minutes = Math.floor(seconds / 60);
-        if (minutes > 0) {
-            parts.push(String(minutes));
-            parts.push('m');
-            seconds = seconds % 60;
-        }
-    }
-    if (seconds > 0) {
-        parts.push(String(seconds));
-        parts.push('s');
-    }
-    return parts.join('');
 }
 
 function drawJobHistogram(total: number, jobHistogram: JobHistogram, start: number, end: number, maximum: number): void {

--- a/prow/cmd/deck/template/job-history.html
+++ b/prow/cmd/deck/template/job-history.html
@@ -1,6 +1,10 @@
 {{define "title"}}Job History: {{.Name}}{{end}}
 {{define "scripts"}}
 <script type="text/javascript" src="/static/job_history_bundle.min.js"></script>
+<script type="text/javascript">
+  var allBuilds = {{.Builds}};
+</script>
+
 <style>
   .run-success {
     background-color: rgba(0, 255, 0, 0.3);
@@ -13,33 +17,20 @@
   }
 </style>
 {{end}}
+
 {{define "content"}}
 <div class="table-container">
   <table id="history-table" class="mdl-data-table mdl-js-data-table mdl-shadow--2dp" style="max-width: 1000px">
     <thead>
     <tr>
       <th class="mdl-data-table__cell--non-numeric">Build</th>
+      <th class="mdl-data-table__cell--non-numeric">Revision</th>
       <th class="mdl-data-table__cell--non-numeric">Started</th>
       <th class="mdl-data-table__cell--non-numeric">Duration</th>
       <th class="mdl-data-table__cell--non-numeric">Result</th>
     </tr>
     </thead>
-    <tbody>
-      {{range .Builds}}
-      <tr id="build-{{.ID}}"
-        class="build-row {{if eq .Result "SUCCESS"}}run-success{{else if eq .Result "FAILURE"}}run-failure{{else}}run-pending{{end}}"
-        {{if .Pull}} data-title="{{.Pull.Title}}" {{end}}
-        >
-        <td class="mdl-data-table__cell--non-numeric">
-          {{if .SpyglassLink}}<a href="{{.SpyglassLink}}">{{.ID}}</a>
-          {{else}}{{.ID}}{{end}}
-          {{if .Pull}}(#<a href={{.Pull.Link}}>{{.Pull.Number}}</a> by <a href={{.Pull.AuthorLink}}>{{.Pull.Author}}){{end}}
-        </td>
-        <td class="mdl-data-table__cell--non-numeric">{{.Started}}</td>
-        <td class="mdl-data-table__cell--non-numeric">{{.Duration}}</td>
-        <td class="mdl-data-table__cell--non-numeric">{{.Result}}</td>
-      </tr>
-      {{end}}
+    <tbody id="history-table-body">
     </tbody>
   </table>
   <table style="max-width: 1000px">


### PR DESCRIPTION
- Move formatDuration to common package

Remove `parseDuration` as it isn't used.
Align `cell.time` tooltip with `prRevision`.


- Move job history builds rendering to typescript module

Add a `Revision` column and align with tide history and deck PR revision view.
`Started` column time display is aligned with the tide history view.
Now it would show a tooltip when hovering over it, and use the same TZ
Support multiple pulls for batch jobs.

![Screenshot from 2021-07-01 20-15-03](https://user-images.githubusercontent.com/29873449/124164443-4fea1080-daa9-11eb-8764-4c45ba9cbf4a.png)

