### PR TITLE
remove google-unit dashboard

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -144,7 +144,7 @@ periodics:
     github_team_ids:
       - 2241179 # release-managers
   annotations:
-    testgrid-dashboards: sig-release-master-blocking, google-unit
+    testgrid-dashboards: sig-release-master-blocking
     testgrid-tab-name: build-master-fast
     testgrid-alert-email: release-team@kubernetes.io
     description: 'Ends up running: make quick-release'

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -432,7 +432,7 @@ periodics:
   - 'perfDashBuildsCount: 500'
 - annotations:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
-    testgrid-dashboards: sig-release-1.18-informing, google-unit
+    testgrid-dashboards: sig-release-1.18-informing
     testgrid-tab-name: bazel-build-1.18
   decorate: true
   extra_refs:
@@ -476,7 +476,7 @@ periodics:
           memory: 12Gi
 - annotations:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
-    testgrid-dashboards: sig-release-1.18-blocking, google-unit
+    testgrid-dashboards: sig-release-1.18-blocking
     testgrid-tab-name: bazel-test-1.18
   cluster: k8s-infra-prow-build
   decorate: true
@@ -517,7 +517,7 @@ periodics:
     fork-per-release-generic-suffix: "true"
     fork-per-release-periodic-interval: ""
     testgrid-alert-email: release-team@kubernetes.io
-    testgrid-dashboards: sig-release-1.18-blocking, google-unit
+    testgrid-dashboards: sig-release-1.18-blocking
     testgrid-tab-name: integration-1.18
   cluster: k8s-infra-prow-build
   decorate: true
@@ -552,7 +552,7 @@ periodics:
     fork-per-release-generic-suffix: "true"
     fork-per-release-periodic-interval: ""
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com, release-managers+alerts@kubernetes.io
-    testgrid-dashboards: sig-release-1.18-blocking, google-unit
+    testgrid-dashboards: sig-release-1.18-blocking
     testgrid-tab-name: verify-1.18
   cluster: k8s-infra-prow-build
   decorate: true
@@ -738,7 +738,7 @@ periodics:
 postsubmits:
   kubernetes/kubernetes:
   - annotations:
-      testgrid-dashboards: google-unit, sig-release-job-config-errors
+      testgrid-dashboards: sig-release-job-config-errors
     branches:
     - release-1.18
     labels:
@@ -770,7 +770,7 @@ postsubmits:
             memory: 6Gi
   - annotations:
       testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
-      testgrid-dashboards: sig-release-1.18-informing, google-unit
+      testgrid-dashboards: sig-release-1.18-informing
     branches:
     - release-1.18
     decorate: true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -382,7 +382,7 @@ periodics:
   - 'perfDashBuildsCount: 500'
 - annotations:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
-    testgrid-dashboards: sig-release-1.19-informing, google-unit
+    testgrid-dashboards: sig-release-1.19-informing
     testgrid-tab-name: bazel-build-1.19
   decorate: true
   extra_refs:
@@ -426,7 +426,7 @@ periodics:
           memory: 12Gi
 - annotations:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
-    testgrid-dashboards: sig-release-1.19-blocking, google-unit
+    testgrid-dashboards: sig-release-1.19-blocking
     testgrid-tab-name: bazel-test-1.19
   cluster: k8s-infra-prow-build
   decorate: true
@@ -467,7 +467,7 @@ periodics:
     fork-per-release-generic-suffix: "true"
     fork-per-release-periodic-interval: 24h
     testgrid-alert-email: release-team@kubernetes.io
-    testgrid-dashboards: sig-release-1.19-blocking, google-unit
+    testgrid-dashboards: sig-release-1.19-blocking
     testgrid-tab-name: integration-1.19
   cluster: k8s-infra-prow-build
   decorate: true
@@ -502,7 +502,7 @@ periodics:
     fork-per-release-generic-suffix: "true"
     fork-per-release-periodic-interval: 24h
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com, release-managers+alerts@kubernetes.io
-    testgrid-dashboards: sig-release-1.19-blocking, google-unit
+    testgrid-dashboards: sig-release-1.19-blocking
     testgrid-tab-name: verify-1.19
   cluster: k8s-infra-prow-build
   decorate: true
@@ -688,7 +688,7 @@ periodics:
 postsubmits:
   kubernetes/kubernetes:
   - annotations:
-      testgrid-dashboards: google-unit, sig-release-job-config-errors
+      testgrid-dashboards: sig-release-job-config-errors
     branches:
     - release-1.19
     labels:
@@ -720,7 +720,7 @@ postsubmits:
             memory: 6Gi
   - annotations:
       testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
-      testgrid-dashboards: sig-release-1.19-informing, google-unit
+      testgrid-dashboards: sig-release-1.19-informing
     branches:
     - release-1.19
     decorate: true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
@@ -379,7 +379,7 @@ periodics:
   - 'perfDashBuildsCount: 500'
 - annotations:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
-    testgrid-dashboards: sig-release-1.20-informing, google-unit
+    testgrid-dashboards: sig-release-1.20-informing
     testgrid-tab-name: bazel-build-1.20
   decorate: true
   extra_refs:
@@ -423,7 +423,7 @@ periodics:
           memory: 12Gi
 - annotations:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
-    testgrid-dashboards: sig-release-1.20-blocking, google-unit
+    testgrid-dashboards: sig-release-1.20-blocking
     testgrid-tab-name: bazel-test-1.20
   cluster: k8s-infra-prow-build
   decorate: true
@@ -463,7 +463,7 @@ periodics:
 - annotations:
     fork-per-release-periodic-interval: 6h 24h
     testgrid-alert-email: release-team@kubernetes.io
-    testgrid-dashboards: sig-release-1.20-blocking, google-unit
+    testgrid-dashboards: sig-release-1.20-blocking
     testgrid-tab-name: integration-1.20
   cluster: k8s-infra-prow-build
   decorate: true
@@ -500,7 +500,7 @@ periodics:
 - annotations:
     fork-per-release-periodic-interval: 6h 24h
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com, release-managers+alerts@kubernetes.io
-    testgrid-dashboards: sig-release-1.20-blocking, google-unit
+    testgrid-dashboards: sig-release-1.20-blocking
     testgrid-tab-name: verify-1.20
   cluster: k8s-infra-prow-build
   decorate: true
@@ -687,7 +687,7 @@ periodics:
 postsubmits:
   kubernetes/kubernetes:
   - annotations:
-      testgrid-dashboards: google-unit, sig-release-job-config-errors
+      testgrid-dashboards: sig-release-job-config-errors
     branches:
     - release-1.20
     labels:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.21.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.21.yaml
@@ -424,7 +424,7 @@ periodics:
 - annotations:
     fork-per-release-periodic-interval: 2h 6h 24h
     testgrid-alert-email: release-team@kubernetes.io
-    testgrid-dashboards: sig-release-1.21-blocking, google-unit
+    testgrid-dashboards: sig-release-1.21-blocking
     testgrid-tab-name: integration-1.21
   cluster: k8s-infra-prow-build
   decorate: true
@@ -492,7 +492,7 @@ periodics:
 - annotations:
     fork-per-release-periodic-interval: 2h 6h 24h
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com, release-managers+alerts@kubernetes.io
-    testgrid-dashboards: sig-release-1.21-blocking, google-unit
+    testgrid-dashboards: sig-release-1.21-blocking
     testgrid-tab-name: verify-1.21
   cluster: k8s-infra-prow-build
   decorate: true

--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -83,7 +83,7 @@ periodics:
   annotations:
     fork-per-release: "true"
     fork-per-release-periodic-interval: 2h 2h 6h 24h
-    testgrid-dashboards: sig-release-master-blocking, google-unit
+    testgrid-dashboards: sig-release-master-blocking
     testgrid-tab-name: integration-master
     testgrid-alert-email: release-team@kubernetes.io
     description: "Ends up running: make test-cmd test-integration"

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -106,7 +106,7 @@ periodics:
   annotations:
     fork-per-release: "true"
     fork-per-release-periodic-interval: 2h 2h 6h 24h
-    testgrid-dashboards: sig-release-master-blocking, google-unit
+    testgrid-dashboards: sig-release-master-blocking
     testgrid-tab-name: verify-master
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com, release-managers+alerts@kubernetes.io
     description: "Ends up running: make verify"

--- a/config/testgrids/config.yaml
+++ b/config/testgrids/config.yaml
@@ -229,7 +229,6 @@ dashboards:
       - key: body
         value: <test-url>
 - name: google-soak
-- name: google-unit
 - name: google-windows
 
 - name: sig-auth-gce
@@ -274,7 +273,6 @@ dashboard_groups:
   - google-osconfig
   - google-rules_k8s
   - google-soak
-  - google-unit
   - google-windows
 
 


### PR DESCRIPTION
I have no idea why this was ever a thing, these unit tests are not "google"

Assuming this goes in, there are more of these to cleanup, which I will take up.