### PR TITLE
cloud-provider-azure: make capz test required

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -260,7 +260,6 @@ presubmits:
       testgrid-num-columns-recent: '30'
   - name: pull-cloud-provider-azure-e2e-ccm-capz
     always_run: true
-    optional: true
     decorate: true
     decoration_config:
       timeout: 3h


### PR DESCRIPTION
CAPZ presubmit has been running for 2 months now on https://github.com/kubernetes-sigs/cloud-provider-azure PRs (job history: https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-cloud-provider-azure-e2e-ccm-capz). This PR makes the presubmit required.

/assign @feiskyer @chewong @andyzhangx @nilo19 