### PR TITLE
Remove pr blocking test

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-0-6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-0-6.yaml
@@ -1,5 +1,5 @@
 periodics:
-- name: periodic-cluster-api-provider-aws-e2e-v1alpha3
+- name: periodic-cluster-api-provider-aws-e2e-release-0-6
   decorate: true
   decoration_config:
     timeout: 5h
@@ -34,10 +34,10 @@ periodics:
           memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
-    testgrid-tab-name: periodic-e2e-v1alpha3
+    testgrid-tab-name: periodic-e2e-release-0-6
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
-- name: periodic-cluster-api-provider-aws-capi-e2e-v1alpha3
+- name: periodic-cluster-api-provider-aws-capi-e2e-release-0-6
   decorate: true
   decoration_config:
     timeout: 5h
@@ -74,10 +74,10 @@ periodics:
             memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
-    testgrid-tab-name: periodic-capi-e2e-v1alpha3
+    testgrid-tab-name: periodic-capi-e2e-release-0-6
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
-- name: periodic-cluster-api-provider-aws-e2e-conformance-v1alpha3
+- name: periodic-cluster-api-provider-aws-e2e-conformance-release-0-6
   decorate: true
   decoration_config:
     timeout: 5h
@@ -112,10 +112,10 @@ periodics:
             memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
-    testgrid-tab-name: periodic-e2e-conformance-v1alpha3
+    testgrid-tab-name: periodic-conformance-release-0-6
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
-- name: periodic-cluster-api-provider-aws-e2e-conformance-v1alpha3-with-k8s-ci-artifacts
+- name: periodic-cluster-api-provider-aws-e2e-conformance-release-0-6-with-k8s-ci-artifacts
   max_concurrency: 1
   labels:
     preset-dind-enabled: "true"
@@ -167,6 +167,6 @@ periodics:
             cpu: 2
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws, sig-release-master-informing
-    testgrid-tab-name: capa-conformance-v1alpha3-k8s-master
+    testgrid-tab-name: periodic-conformance-release-0-6-k8s-main
     testgrid-num-columns-recent: '20'
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io, release-team@kubernetes.io

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
@@ -34,7 +34,7 @@ periodics:
           memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
-    testgrid-tab-name: periodic-e2e
+    testgrid-tab-name: periodic-e2e-main
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-provider-aws-capi-e2e
@@ -74,7 +74,7 @@ periodics:
             memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
-    testgrid-tab-name: periodic-capi-e2e
+    testgrid-tab-name: periodic-capi-e2e-main
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-provider-aws-e2e-conformance
@@ -112,7 +112,7 @@ periodics:
             memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
-    testgrid-tab-name: periodic-e2e-conformance
+    testgrid-tab-name: periodic-conformance-main
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-provider-aws-e2e-conformance-with-k8s-ci-artifacts
@@ -168,7 +168,7 @@ periodics:
     # TODO: Change back to once v1alpha4 is stable:
     # testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws, sig-release-master-informing
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
-    testgrid-tab-name: capa-conformance-k8s-main
+    testgrid-tab-name: periodic-conformance-main-k8s-main
     testgrid-num-columns-recent: '20'
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io, release-team@kubernetes.io
 - name: periodic-cluster-api-provider-aws-coverage
@@ -207,4 +207,4 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-tab-name: periodic-capa-test-coverage
+    testgrid-tab-name: periodic-test-coverage

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
@@ -34,7 +34,7 @@ postsubmits:
                 memory: "9Gi"
       annotations:
         testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
-        testgrid-tab-name: ci-e2e
+        testgrid-tab-name: postsubmit-e2e-main
         testgrid-num-columns-recent: '20'
         testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     - name: ci-cluster-api-provider-aws-e2e-conformance
@@ -71,6 +71,6 @@ postsubmits:
                 memory: "9Gi"
       annotations:
         testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
-        testgrid-tab-name: ci-e2e-conformance
+        testgrid-tab-name: postsubmit-conformance-main
         testgrid-num-columns-recent: '20'
         testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-0.6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-0.6.yaml
@@ -48,7 +48,7 @@ presubmits:
         - "verify"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
-      testgrid-tab-name: verify-release-0-6
+      testgrid-tab-name: pr-verify-release-0-6
   # conformance test
   - name: pull-cluster-api-provider-aws-e2e-conformance-release-0-6
     branches:
@@ -142,7 +142,7 @@ presubmits:
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
-      testgrid-tab-name: pr-conformance-k8s-master-release-0-6
+      testgrid-tab-name: pr-conformance-release-0-6-k8s-main
       testgrid-num-columns-recent: '20'
   - name: pull-cluster-api-provider-aws-e2e-release-0-6
     branches:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
         - "verify"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
-      testgrid-tab-name: verify
+      testgrid-tab-name: pr-verify
   # conformance test
   - name: pull-cluster-api-provider-aws-e2e-conformance
     branches:
@@ -142,7 +142,7 @@ presubmits:
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
-      testgrid-tab-name: pr-conformance-k8s-master
+      testgrid-tab-name: pr-conformance-main-k8s-main
       testgrid-num-columns-recent: '20'
   - name: pull-cluster-api-provider-aws-e2e-blocking
     branches:
@@ -150,7 +150,7 @@ presubmits:
       - ^main$
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|exp|feature|hack|pkg|test|util)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
-    optional: false
+    optional: true
     decorate: true
     decoration_config:
       timeout: 5h
@@ -182,7 +182,7 @@ presubmits:
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
-      testgrid-tab-name: pr-blocking-e2e
+      testgrid-tab-name: pr-quick-e2e-main
       testgrid-num-columns-recent: '20'
   - name: pull-cluster-api-provider-aws-e2e
     branches:
@@ -221,7 +221,7 @@ presubmits:
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
-      testgrid-tab-name: pr-e2e
+      testgrid-tab-name: pr-e2e-main
       testgrid-num-columns-recent: '20'
   - name: pull-cluster-api-provider-aws-e2e-eks
     branches:
@@ -260,5 +260,5 @@ presubmits:
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
-      testgrid-tab-name: pr-e2e-eks
+      testgrid-tab-name: pr-e2e-eks-main
       testgrid-num-columns-recent: '20'


### PR DESCRIPTION
Remove PR blocking test due to test-infra AWS resource limitations.
Instead add a quick e2e test that can be run optionally on the PRs.

+ Some renaming in the tests.

cc @richardcase @randomvariable 