### PR TITLE
wg-k8s-infra: Adjust memory for scalability canary job

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/canaries/sig-scalability.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/canaries/sig-scalability.yaml
@@ -45,10 +45,10 @@ periodics:
       resources:
         requests:
           cpu: 6
-          memory: "48Gi"
+          memory: "32Gi"
         limits:
           cpu: 6
-          memory: "48Gi"
+          memory: "32Gi"
 
 - cron: '1 17 * * *' # Run daily at 9:01PST (17:01 UTC)
   name: ci-kubernetes-e2e-gce-scale-performance-canary


### PR DESCRIPTION
Set the memory limit and request of the job to make it runnable on build
cluster.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>