### PR TITLE
Kubernetes v1.22 Code Freeze

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -537,6 +537,7 @@ tide:
     - kubernetes/kubernetes
     excludedBranches:
     - master
+    - release-1.22
     labels:
     - lgtm
     - approved
@@ -558,6 +559,7 @@ tide:
     milestone: v1.22
     includedBranches:
     - master
+    - release-1.22
     labels:
     - lgtm
     - approved

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -535,6 +535,29 @@ tide:
     - needs-rebase
   - repos:
     - kubernetes/kubernetes
+    excludedBranches:
+    - master
+    labels:
+    - lgtm
+    - approved
+    - "cncf-cla: yes"
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/blocked-paths
+    - do-not-merge/cherry-pick-not-approved
+    - do-not-merge/hold
+    - do-not-merge/invalid-commit-message
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/needs-kind
+    - do-not-merge/needs-sig
+    - do-not-merge/release-note-label-needed
+    - do-not-merge/work-in-progress
+    - needs-rebase
+  - repos:
+    - kubernetes/kubernetes
+    milestone: v1.22
+    includedBranches:
+    - master
     labels:
     - lgtm
     - approved


### PR DESCRIPTION
This PR enables code freeze for `kubernetes/kubernetes` on the master branch.

/hold
This PR should only be merged after Thursday, July 8, 2021 18:00 PDT.

/sig release
/area release-eng

cc: @kubernetes/release-team-leads @kubernetes/release-engineering 