### PR TITLE
drop days of results to 1 for unit job

### DIFF
--- a/config/jobs/kubernetes/sig-testing/make-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/make-test.yaml
@@ -71,7 +71,7 @@ periodics:
       fork-per-release: "true"
       testgrid-num-failures-to-alert: '3'
       testgrid-alert-stale-results-hours: '24'
-      testgrid-days-of-results: '7'
+      testgrid-days-of-results: '1'
       testgrid-create-test-group: 'true'
       testgrid-dashboards: sig-release-master-blocking
       testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com


### PR DESCRIPTION
it's still not loading, presumably due to too much data, if it doesn't load after this, altering this particular config is not going to be a solution period.
https://github.com/kubernetes/test-infra/issues/22744#issuecomment-873179127