### PR TITLE
Run pre-submitts on Windows e2e tests

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/generate-presubmits.sh
+++ b/config/jobs/kubernetes-sigs/sig-windows/generate-presubmits.sh
@@ -129,7 +129,7 @@ $(generate_presubmit_annotations ${branch} pull-kubernetes-e2e-aks-engine-window
   - name: pull-kubernetes-e2e-aks-engine-windows-containerd
     always_run: false
     optional: true
-    run_if_changed: 'azure.*\.go$|.*windows\.go$'
+    run_if_changed: 'azure.*\.go$|.*windows\.go$|test/e2e/windows/.*'
     decorate: true
     decoration_config:
       timeout: 3h

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.18-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.18-windows-presubmits.yaml
@@ -54,7 +54,7 @@ presubmits:
   - name: pull-kubernetes-e2e-aks-engine-windows-containerd
     always_run: false
     optional: true
-    run_if_changed: 'azure.*\.go$|.*windows\.go$'
+    run_if_changed: 'azure.*\.go$|.*windows\.go$|test/e2e/windows/.*'
     decorate: true
     decoration_config:
       timeout: 3h

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.19-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.19-windows-presubmits.yaml
@@ -54,7 +54,7 @@ presubmits:
   - name: pull-kubernetes-e2e-aks-engine-windows-containerd
     always_run: false
     optional: true
-    run_if_changed: 'azure.*\.go$|.*windows\.go$'
+    run_if_changed: 'azure.*\.go$|.*windows\.go$|test/e2e/windows/.*'
     decorate: true
     decoration_config:
       timeout: 3h

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.20-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.20-windows-presubmits.yaml
@@ -54,7 +54,7 @@ presubmits:
   - name: pull-kubernetes-e2e-aks-engine-windows-containerd
     always_run: false
     optional: true
-    run_if_changed: 'azure.*\.go$|.*windows\.go$'
+    run_if_changed: 'azure.*\.go$|.*windows\.go$|test/e2e/windows/.*'
     decorate: true
     decoration_config:
       timeout: 3h

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.21-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.21-windows-presubmits.yaml
@@ -55,7 +55,7 @@ presubmits:
   - name: pull-kubernetes-e2e-aks-engine-windows-containerd
     always_run: false
     optional: true
-    run_if_changed: 'azure.*\.go$|.*windows\.go$'
+    run_if_changed: 'azure.*\.go$|.*windows\.go$|test/e2e/windows/.*'
     decorate: true
     decoration_config:
       timeout: 3h

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
@@ -58,7 +58,7 @@ presubmits:
   - name: pull-kubernetes-e2e-aks-engine-windows-containerd
     always_run: false
     optional: true
-    run_if_changed: 'azure.*\.go$|.*windows\.go$'
+    run_if_changed: 'azure.*\.go$|.*windows\.go$|test/e2e/windows/.*'
     decorate: true
     decoration_config:
       timeout: 3h


### PR DESCRIPTION
Noticed in https://github.com/kubernetes/kubernetes/pull/103083 and https://github.com/kubernetes/kubernetes/pull/103371 the tests don't run automatically and they should.

/assign @chewong 
/sig windows