### PR TITLE
Generic autobumper tells more detail when images are not bumped consi…

### DIFF
--- a/prow/cmd/generic-autobumper/main.go
+++ b/prow/cmd/generic-autobumper/main.go
@@ -434,7 +434,7 @@ func getVersionsAndCheckConsistency(prefixes []prefix, images map[string]string)
 			if strings.HasPrefix(k, prefix.Prefix) {
 				found, ok := consistencyChecker[prefix.Prefix]
 				if ok && (found != v) && prefix.ConsistentImages {
-					return nil, fmt.Errorf("%q was supposed to be bumped consistntly but was not", prefix.Name)
+					return nil, fmt.Errorf("%s:%s not bumped consistently for prefix %s(%s), expected version: %s", k, v, prefix.Prefix, prefix.Name, found)
 				} else if !ok {
 					consistencyChecker[prefix.Prefix] = v
 				}


### PR DESCRIPTION
…stently

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-test-infra-autobump-prow/1411059717203038208

logs:
```
time="2021-07-02T20:31:02Z" level=fatal msg="failed to run the bumper tool" error="process function 0: \"Prow\" was supposed to be bumped consistntly but was not"
```
which is not super helpful for debugging