### PR TITLE
Prow pubsub: allow restricting clusters for project

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -161,6 +161,10 @@ type ProwConfig struct {
 	// Pub/Sub Subscriptions that we want to listen to
 	PubSubSubscriptions PubsubSubscriptions `json:"pubsub_subscriptions,omitempty"`
 
+	// PubSubTriggers defines Pub/Sub Subscriptions that we want to listen to,
+	// can be used to restrict build cluster on a topic
+	PubSubTriggers PubSubTriggers `json:"pubsub_triggers,omitempty"`
+
 	// GitHubOptions allows users to control how prow applications display GitHub website links.
 	GitHubOptions GitHubOptions `json:"github,omitempty"`
 
@@ -1008,8 +1012,18 @@ func (rac RerunAuthConfigs) GetRerunAuthConfig(refs *prowapi.Refs) prowapi.Rerun
 	return rac["*"]
 }
 
-// PubSubSubscriptions maps GCP projects to a list of Topics.
+// PubsubSubscriptions maps GCP projects to a list of Topics
 type PubsubSubscriptions map[string][]string
+
+// PubSubTriggers contains pubsub configurations
+type PubSubTriggers []PubSubTrigger
+
+// PubSubTrigger contain pubsub configuration for a single project
+type PubSubTrigger struct {
+	Project         string   `json:"project"`
+	Topics          []string `json:"topics"`
+	AllowedClusters []string `json:"allowed_clusters"`
+}
 
 // GitHubOptions allows users to control how prow applications display GitHub website links.
 type GitHubOptions struct {
@@ -1274,6 +1288,20 @@ func loadConfig(prowConfig, jobConfig string, additionalProwConfigDirs []string,
 	// Respect `"*": []`, which disabled default global cluster
 	if nc.InRepoConfig.AllowedClusters["*"] == nil {
 		nc.InRepoConfig.AllowedClusters["*"] = []string{kube.DefaultClusterAlias}
+	}
+
+	// merge pubsub configs
+	if nc.PubSubSubscriptions != nil {
+		if nc.PubSubTriggers != nil {
+			return nil, errors.New("pubsub_subscriptions and pubsub_triggers are mutually exclusive")
+		}
+		for proj, topics := range nc.PubSubSubscriptions {
+			nc.PubSubTriggers = append(nc.PubSubTriggers, PubSubTrigger{
+				Project:         proj,
+				Topics:          topics,
+				AllowedClusters: []string{"*"},
+			})
+		}
 	}
 
 	// TODO(krzyzacy): temporary allow empty jobconfig

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -2440,6 +2440,27 @@ in_repo_config:
 			},
 		},
 		{
+			name: "PubSubSubscriptions set but not PubSubTriggers",
+			prowConfig: `
+pubsub_subscriptions:
+  projA:
+  - topicB
+  - topicC
+`,
+			verify: func(c *Config) error {
+				if diff := cmp.Diff(c.PubSubTriggers, PubSubTriggers([]PubSubTrigger{
+					{
+						Project:         "projA",
+						Topics:          []string{"topicB", "topicC"},
+						AllowedClusters: []string{"*"},
+					},
+				})); diff != "" {
+					return fmt.Errorf("want(-), got(+): \n%s", diff)
+				}
+				return nil
+			},
+		},
+		{
 			name:               "Version file sets the version",
 			versionFileContent: "some-git-sha",
 			verify: func(c *Config) error {

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -912,6 +912,16 @@ pubsub_subscriptions:
     "": null
 
 
+# PubSubTriggers defines Pub/Sub Subscriptions that we want to listen to,
+# can be used to restrict build cluster on a topic
+pubsub_triggers:
+  - allowed_clusters:
+      - ""
+    project: ' '
+    topics:
+      - ""
+
+
 # PushGateway is a prometheus push gateway.
 push_gateway:
     # Endpoint is the location of the prometheus pushgateway

--- a/prow/pubsub/subscriber/subscriber.go
+++ b/prow/pubsub/subscriber/subscriber.go
@@ -175,7 +175,7 @@ func extractFromAttribute(attrs map[string]string, key string) (string, error) {
 	return value, nil
 }
 
-func (s *Subscriber) handleMessage(msg messageInterface, subscription string) error {
+func (s *Subscriber) handleMessage(msg messageInterface, subscription string, allowedClusters []string) error {
 	l := logrus.WithFields(logrus.Fields{
 		"pubsub-subscription": subscription,
 		"pubsub-id":           msg.getID()})
@@ -201,14 +201,14 @@ func (s *Subscriber) handleMessage(msg messageInterface, subscription string) er
 		s.Metrics.ErrorCounter.With(prometheus.Labels{subscriptionLabel: subscription})
 		return fmt.Errorf("unsupported event type: %s", eType)
 	}
-	if err = s.handleProwJob(l, jh, msg, subscription); err != nil {
+	if err = s.handleProwJob(l, jh, msg, subscription, allowedClusters); err != nil {
 		l.WithError(err).Error("failed to create Prow Job")
 		s.Metrics.ErrorCounter.With(prometheus.Labels{subscriptionLabel: subscription})
 	}
 	return err
 }
 
-func (s *Subscriber) handleProwJob(l *logrus.Entry, jh jobHandler, msg messageInterface, subscription string) error {
+func (s *Subscriber) handleProwJob(l *logrus.Entry, jh jobHandler, msg messageInterface, subscription string, allowedClusters []string) error {
 
 	var pe ProwJobEvent
 	var prowJob prowapi.ProwJob
@@ -236,6 +236,22 @@ func (s *Subscriber) handleProwJob(l *logrus.Entry, jh jobHandler, msg messageIn
 	}
 	if prowJobSpec == nil {
 		return fmt.Errorf("failed getting prowjob spec") // This should not happen
+	}
+
+	// deny job that runs on not allowed cluster
+	var clusterIsAllowed bool
+	for _, allowedCluster := range allowedClusters {
+		if allowedCluster == "*" || allowedCluster == prowJobSpec.Cluster {
+			clusterIsAllowed = true
+			break
+		}
+	}
+	if !clusterIsAllowed {
+		err := fmt.Errorf("cluster %s is not allowed. Can be fixed by defining this cluster under pubsub_triggers -> allowed_clusters", prowJobSpec.Cluster)
+		l.WithField("cluster", prowJobSpec.Cluster).Warn("cluster not allowed")
+		prowJob = pjutil.NewProwJob(*prowJobSpec, nil, pe.Annotations)
+		reportProwJobFailure(&prowJob, err)
+		return err
 	}
 
 	// Adds / Updates Labels from prow job event


### PR DESCRIPTION
Added a new prow config field while still keeps backward compatible