### PR TITLE
Kops - extract templates and helper fns into their own files

### DIFF
--- a/config/jobs/kubernetes/kops/Makefile
+++ b/config/jobs/kubernetes/kops/Makefile
@@ -14,4 +14,4 @@
 
 .PHONY: generate
 generate:
-	python3 build_jobs.py
+	PYTHONPATH=. python3 build_jobs.py

--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -14,326 +14,23 @@
 
 import math
 import json
-import zlib
 import yaml
 
-import boto3 # pylint: disable=import-error
 import jinja2 # pylint: disable=import-error
 
-periodic_template = """
-- name: {{job_name}}
-  cron: '{{cron}}'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: {{job_timeout}}
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \\
-          -v 2 \\
-          --up --down \\
-          --cloud-provider=aws \\
-          --create-args="{{create_args}}" \\
-          {%- if kops_feature_flags %}
-          --env=KOPS_FEATURE_FLAGS={{kops_feature_flags}} \\
-          {%- endif %}
-          --kops-version-marker={{kops_deploy_url}} \\
-          {%- if publish_version_marker %}
-          --publish-version-marker={{publish_version_marker}} \\
-          {%- endif %}
-          --kubernetes-version={{k8s_deploy_url}} \\
-          {%- if terraform_version %}
-          --terraform-version={{terraform_version}} \\
-          {%- endif %}
-          {%- if validation_wait %}
-          --validation-wait={{validation_wait}} \\
-          {%- endif %}
-          --test=kops \\
-          -- \\
-          --ginkgo-args="--debug" \\
-          --test-args="-test.timeout={{test_timeout}} -num-nodes=0" \\
-          {%- if test_package_bucket %}
-          --test-package-bucket={{test_package_bucket}} \\
-          {%- endif %}
-          {%- if test_package_dir %}
-          --test-package-dir={{test_package_dir}} \\
-          {%- endif %}
-          --test-package-marker={{marker}} \\
-          {%- if focus_regex %}
-          --focus-regex="{{focus_regex}}" \\
-          {%- endif %}
-          {%- if skip_regex %}
-          --skip-regex="{{skip_regex}}" \\
-          {%- endif %}
-          --parallel={{test_parallelism}}
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: {{kops_ssh_user}}
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210622-762366a-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "2"
-          memory: 3Gi
-"""
-
-presubmit_template = """
-  - name: {{job_name}}
-    branches:
-    - {{branch}}
-    {%- if run_if_changed %}
-    run_if_changed: '{{run_if_changed}}'
-    {%- endif %}
-    always_run: {{always_run}}
-    skip_report: {{skip_report}}
-    labels:
-      {%- if cloud == "aws" %}
-      preset-service-account: "true"
-      preset-aws-ssh: "true"
-      preset-aws-credential: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-dind-enabled: "true"
-      {%- else %}
-      preset-k8s-ssh: "true"
-      {%- endif %}
-    decorate: true
-    decoration_config:
-      timeout: {{job_timeout}}
-    path_alias: k8s.io/kops
-    spec:
-      {%- if cloud == "gce" %}
-      serviceAccountName: k8s-kops-test
-      {%- endif %}
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210622-762366a-master
-        imagePullPolicy: Always
-        command:
-        - runner.sh
-        args:
-        - bash
-        - -c
-        - |
-            make test-e2e-install
-            kubetest2 kops \\
-            -v 2 \\
-            --up --build --down \\
-            --cloud-provider={{cloud}} \\
-            --create-args="{{create_args}}" \\
-            {%- if kops_feature_flags %}
-            --env=KOPS_FEATURE_FLAGS={{kops_feature_flags}} \\
-            {%- endif %}
-            --kubernetes-version={{k8s_deploy_url}} \\
-            --kops-binary-path=/home/prow/go/src/k8s.io/kops/bazel-bin/cmd/kops/linux-amd64/kops \\
-            {%- if terraform_version %}
-            --terraform-version={{terraform_version}} \\
-            {%- endif %}
-            --test=kops \\
-            -- \\
-            --ginkgo-args="--debug" \\
-            --test-args="-test.timeout={{test_timeout}} -num-nodes=0" \\
-            {%- if test_package_bucket %}
-            --test-package-bucket={{test_package_bucket}} \\
-            {%- endif %}
-            {%- if test_package_dir %}
-            --test-package-dir={{test_package_dir}} \\
-            {%- endif %}
-            --test-package-marker={{marker}} \\
-            {%- if focus_regex %}
-            --focus-regex="{{focus_regex}}" \\
-            {%- endif %}
-            {%- if skip_regex %}
-            --skip-regex="{{skip_regex}}" \\
-            {%- endif %}
-            --parallel={{test_parallelism}}
-        securityContext:
-          privileged: true
-        env:
-        - name: KUBE_SSH_KEY_PATH
-          value: {{kops_ssh_key_path}}
-        - name: KUBE_SSH_USER
-          value: {{kops_ssh_user}}
-        - name: GOPATH
-          value: /home/prow/go
-        resources:
-          requests:
-            cpu: "2"
-            memory: "6Gi"
-"""
-
-# We support rapid focus on a few tests of high concern
-# This should be used for temporary tests we are evaluating,
-# and ideally linked to a bug, and removed once the bug is fixed
-run_hourly = [
-]
-
-run_daily = [
-    'kops-grid-scenario-service-account-iam',
-    'kops-grid-scenario-arm64',
-    'kops-grid-scenario-serial-test-for-timeout',
-    'kops-grid-scenario-terraform',
-]
+from helpers import ( # pylint: disable=import-error, no-name-in-module
+    build_cron,
+    create_args,
+    distro_images,
+    distros_ssh_user,
+    k8s_version_info,
+    should_skip_newer_k8s,
+)
 
 # These are job tab names of unsupported grid combinations
 skip_jobs = [
 ]
 
-def simple_hash(s):
-    # & 0xffffffff avoids python2/python3 compatibility
-    return zlib.crc32(s.encode()) & 0xffffffff
-
-def build_cron(key, runs_per_day):
-    runs_per_week = 0
-    minute = simple_hash("minutes:" + key) % 60
-    hour = simple_hash("hours:" + key) % 24
-    day_of_week = simple_hash("day_of_week:" + key) % 7
-
-    if runs_per_day > 0:
-        hour_denominator = 24 / runs_per_day
-        hour_offset = simple_hash("hours:" + key) % hour_denominator
-        return "%d %d-23/%d * * *" % (minute, hour_offset, hour_denominator), (runs_per_day * 7)
-
-    # run Ubuntu 20.04 (Focal) jobs more frequently
-    if "u2004" in key:
-        runs_per_week += 7
-        return "%d %d * * *" % (minute, hour), runs_per_week
-
-    # run hotlist jobs more frequently
-    if key in run_hourly:
-        runs_per_week += 24 * 7
-        return "%d * * * *" % (minute), runs_per_week
-
-    if key in run_daily:
-        runs_per_week += 7
-        return "%d %d * * *" % (minute, hour), runs_per_week
-
-    runs_per_week += 1
-    return "%d %d * * %d" % (minute, hour, day_of_week), runs_per_week
-
-def replace_or_remove_line(s, pattern, new_str):
-    keep = []
-    for line in s.split('\n'):
-        if pattern in line:
-            if new_str:
-                line = line.replace(pattern, new_str)
-                keep.append(line)
-        else:
-            keep.append(line)
-    return '\n'.join(keep)
-
-def should_skip_newer_k8s(k8s_version, kops_version):
-    if kops_version is None:
-        return False
-    if k8s_version is None:
-        return True
-    return float(k8s_version) > float(kops_version)
-
-def k8s_version_info(k8s_version):
-    test_package_bucket = ''
-    test_package_dir = ''
-    if k8s_version == 'latest':
-        marker = 'latest.txt'
-        k8s_deploy_url = "https://storage.googleapis.com/kubernetes-release/release/latest.txt"
-    elif k8s_version == 'ci':
-        marker = 'latest.txt'
-        k8s_deploy_url = "https://storage.googleapis.com/kubernetes-release-dev/ci/latest.txt"
-        test_package_bucket = 'kubernetes-release-dev'
-        test_package_dir = 'ci'
-    elif k8s_version == 'stable':
-        marker = 'stable.txt'
-        k8s_deploy_url = "https://storage.googleapis.com/kubernetes-release/release/stable.txt"
-    elif k8s_version:
-        marker = f"stable-{k8s_version}.txt"
-        k8s_deploy_url = f"https://storage.googleapis.com/kubernetes-release/release/stable-{k8s_version}.txt" # pylint: disable=line-too-long
-    else:
-        raise Exception('missing required k8s_version')
-    return marker, k8s_deploy_url, test_package_bucket, test_package_dir
-
-def create_args(kops_channel, networking, container_runtime, extra_flags, kops_image):
-    args = f"--channel={kops_channel} --networking=" + networking
-    if container_runtime:
-        args += f" --container-runtime={container_runtime}"
-
-    if kops_image:
-        image_overridden = False
-        if extra_flags:
-            for arg in extra_flags:
-                if "--image=" in arg:
-                    image_overridden = True
-                args = args + " " + arg
-        if not image_overridden:
-            args = f"--image='{kops_image}' {args}"
-    return args.strip()
-
-def latest_aws_image(owner, name):
-    client = boto3.client('ec2', region_name='us-east-1')
-    response = client.describe_images(
-        Owners=[owner],
-        Filters=[
-            {
-                'Name': 'name',
-                'Values': [
-                    name,
-                ],
-            },
-        ],
-    )
-    images = {}
-    for image in response['Images']:
-        images[image['CreationDate']] = image['ImageLocation']
-    return images[sorted(images, reverse=True)[0]]
-
-distro_images = {
-    'amzn2': latest_aws_image('137112412989', 'amzn2-ami-hvm-*-x86_64-gp2'),
-    'centos7': latest_aws_image('125523088429', 'CentOS 7.*x86_64'),
-    'centos8': latest_aws_image('125523088429', 'CentOS 8.*x86_64'),
-    'deb9': latest_aws_image('379101102735', 'debian-stretch-hvm-x86_64-gp2-*'),
-    'deb10': latest_aws_image('136693071363', 'debian-10-amd64-*'),
-    'flatcar': latest_aws_image('075585003325', 'Flatcar-stable-*-hvm'),
-    'rhel7': latest_aws_image('309956199498', 'RHEL-7.*_HVM_*-x86_64-0-Hourly2-GP2'),
-    'rhel8': latest_aws_image('309956199498', 'RHEL-8.*_HVM-*-x86_64-0-Hourly2-GP2'),
-    'u1804': latest_aws_image('099720109477', 'ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*'), # pylint: disable=line-too-long
-    'u2004': latest_aws_image('099720109477', 'ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*'), # pylint: disable=line-too-long
-    'u2004arm64': latest_aws_image('099720109477', 'ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-*'), # pylint: disable=line-too-long
-    'u2010': latest_aws_image('099720109477', 'ubuntu/images/hvm-ssd/ubuntu-groovy-20.10-amd64-server-*'), # pylint: disable=line-too-long
-    'u2104': latest_aws_image('099720109477', 'ubuntu/images/hvm-ssd/ubuntu-hirsute-21.04-amd64-server-*'), # pylint: disable=line-too-long
-}
-
-distros_ssh_user = {
-    'amzn2': 'ec2-user',
-    'centos7': 'centos',
-    'centos8': 'centos',
-    'deb9': 'admin',
-    'deb10': 'admin',
-    'flatcar': 'core',
-    'rhel7': 'ec2-user',
-    'rhel8': 'ec2-user',
-    'u1804': 'ubuntu',
-    'u2004': 'ubuntu',
-    'u2004arm64': 'ubuntu',
-    'u2010': 'ubuntu',
-    'u2104': 'ubuntu',
-}
 
 ##############
 # Build Test #
@@ -405,7 +102,8 @@ def build_test(cloud='aws',
 
     cron, runs_per_week = build_cron(tab, runs_per_day)
 
-    tmpl = jinja2.Template(periodic_template)
+    loader = jinja2.FileSystemLoader(searchpath="./templates")
+    tmpl = jinja2.Environment(loader=loader).get_template("periodic.yaml.jinja")
     job = tmpl.render(
         job_name=job_name,
         cron=cron,
@@ -506,7 +204,8 @@ def presubmit_test(branch='master',
     marker, k8s_deploy_url, test_package_bucket, test_package_dir = k8s_version_info(k8s_version)
     args = create_args(kops_channel, networking, container_runtime, extra_flags, kops_image)
 
-    tmpl = jinja2.Template(presubmit_template)
+    loader = jinja2.FileSystemLoader(searchpath="./templates")
+    tmpl = jinja2.Environment(loader=loader).get_template("presubmit.yaml.jinja")
     job = tmpl.render(
         job_name=name,
         branch=branch,

--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -31,6 +31,7 @@ from helpers import ( # pylint: disable=import-error, no-name-in-module
 skip_jobs = [
 ]
 
+image = "gcr.io/k8s-testimages/kubekins-e2e:v20210622-762366a-master"
 
 ##############
 # Build Test #
@@ -123,6 +124,7 @@ def build_test(cloud='aws',
         focus_regex=focus_regex,
         publish_version_marker=publish_version_marker,
         validation_wait=validation_wait,
+        image=image,
     )
 
     spec = {
@@ -226,6 +228,7 @@ def presubmit_test(branch='master',
         run_if_changed=run_if_changed,
         skip_report='true' if skip_report else 'false',
         always_run='true' if always_run else 'false',
+        image=image,
     )
 
     spec = {

--- a/config/jobs/kubernetes/kops/helpers.py
+++ b/config/jobs/kubernetes/kops/helpers.py
@@ -1,0 +1,167 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import zlib
+
+import boto3 # pylint: disable=import-error
+
+# We support rapid focus on a few tests of high concern
+# This should be used for temporary tests we are evaluating,
+# and ideally linked to a bug, and removed once the bug is fixed
+run_hourly = [
+]
+
+run_daily = [
+    'kops-grid-scenario-service-account-iam',
+    'kops-grid-scenario-arm64',
+    'kops-grid-scenario-serial-test-for-timeout',
+    'kops-grid-scenario-terraform',
+]
+
+def simple_hash(s):
+    # & 0xffffffff avoids python2/python3 compatibility
+    return zlib.crc32(s.encode()) & 0xffffffff
+
+def build_cron(key, runs_per_day):
+    runs_per_week = 0
+    minute = simple_hash("minutes:" + key) % 60
+    hour = simple_hash("hours:" + key) % 24
+    day_of_week = simple_hash("day_of_week:" + key) % 7
+
+    if runs_per_day > 0:
+        hour_denominator = 24 / runs_per_day
+        hour_offset = simple_hash("hours:" + key) % hour_denominator
+        return "%d %d-23/%d * * *" % (minute, hour_offset, hour_denominator), (runs_per_day * 7)
+
+    # run Ubuntu 20.04 (Focal) jobs more frequently
+    if "u2004" in key:
+        runs_per_week += 7
+        return "%d %d * * *" % (minute, hour), runs_per_week
+
+    # run hotlist jobs more frequently
+    if key in run_hourly:
+        runs_per_week += 24 * 7
+        return "%d * * * *" % (minute), runs_per_week
+
+    if key in run_daily:
+        runs_per_week += 7
+        return "%d %d * * *" % (minute, hour), runs_per_week
+
+    runs_per_week += 1
+    return "%d %d * * %d" % (minute, hour, day_of_week), runs_per_week
+
+def replace_or_remove_line(s, pattern, new_str):
+    keep = []
+    for line in s.split('\n'):
+        if pattern in line:
+            if new_str:
+                line = line.replace(pattern, new_str)
+                keep.append(line)
+        else:
+            keep.append(line)
+    return '\n'.join(keep)
+
+def should_skip_newer_k8s(k8s_version, kops_version):
+    if kops_version is None:
+        return False
+    if k8s_version is None:
+        return True
+    return float(k8s_version) > float(kops_version)
+
+def k8s_version_info(k8s_version):
+    test_package_bucket = ''
+    test_package_dir = ''
+    if k8s_version == 'latest':
+        marker = 'latest.txt'
+        k8s_deploy_url = "https://storage.googleapis.com/kubernetes-release/release/latest.txt"
+    elif k8s_version == 'ci':
+        marker = 'latest.txt'
+        k8s_deploy_url = "https://storage.googleapis.com/kubernetes-release-dev/ci/latest.txt"
+        test_package_bucket = 'kubernetes-release-dev'
+        test_package_dir = 'ci'
+    elif k8s_version == 'stable':
+        marker = 'stable.txt'
+        k8s_deploy_url = "https://storage.googleapis.com/kubernetes-release/release/stable.txt"
+    elif k8s_version:
+        marker = f"stable-{k8s_version}.txt"
+        k8s_deploy_url = f"https://storage.googleapis.com/kubernetes-release/release/stable-{k8s_version}.txt" # pylint: disable=line-too-long
+    else:
+        raise Exception('missing required k8s_version')
+    return marker, k8s_deploy_url, test_package_bucket, test_package_dir
+
+def create_args(kops_channel, networking, container_runtime, extra_flags, kops_image):
+    args = f"--channel={kops_channel} --networking=" + networking
+    if container_runtime:
+        args += f" --container-runtime={container_runtime}"
+
+    if kops_image:
+        image_overridden = False
+        if extra_flags:
+            for arg in extra_flags:
+                if "--image=" in arg:
+                    image_overridden = True
+                args = args + " " + arg
+        if not image_overridden:
+            args = f"--image='{kops_image}' {args}"
+    return args.strip()
+
+def latest_aws_image(owner, name):
+    client = boto3.client('ec2', region_name='us-east-1')
+    response = client.describe_images(
+        Owners=[owner],
+        Filters=[
+            {
+                'Name': 'name',
+                'Values': [
+                    name,
+                ],
+            },
+        ],
+    )
+    images = {}
+    for image in response['Images']:
+        images[image['CreationDate']] = image['ImageLocation']
+    return images[sorted(images, reverse=True)[0]]
+
+distro_images = {
+    'amzn2': latest_aws_image('137112412989', 'amzn2-ami-hvm-*-x86_64-gp2'),
+    'centos7': latest_aws_image('125523088429', 'CentOS 7.*x86_64'),
+    'centos8': latest_aws_image('125523088429', 'CentOS 8.*x86_64'),
+    'deb9': latest_aws_image('379101102735', 'debian-stretch-hvm-x86_64-gp2-*'),
+    'deb10': latest_aws_image('136693071363', 'debian-10-amd64-*'),
+    'flatcar': latest_aws_image('075585003325', 'Flatcar-stable-*-hvm'),
+    'rhel7': latest_aws_image('309956199498', 'RHEL-7.*_HVM_*-x86_64-0-Hourly2-GP2'),
+    'rhel8': latest_aws_image('309956199498', 'RHEL-8.*_HVM-*-x86_64-0-Hourly2-GP2'),
+    'u1804': latest_aws_image('099720109477', 'ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*'), # pylint: disable=line-too-long
+    'u2004': latest_aws_image('099720109477', 'ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*'), # pylint: disable=line-too-long
+    'u2004arm64': latest_aws_image('099720109477', 'ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-*'), # pylint: disable=line-too-long
+    'u2010': latest_aws_image('099720109477', 'ubuntu/images/hvm-ssd/ubuntu-groovy-20.10-amd64-server-*'), # pylint: disable=line-too-long
+    'u2104': latest_aws_image('099720109477', 'ubuntu/images/hvm-ssd/ubuntu-hirsute-21.04-amd64-server-*'), # pylint: disable=line-too-long
+}
+
+distros_ssh_user = {
+    'amzn2': 'ec2-user',
+    'centos7': 'centos',
+    'centos8': 'centos',
+    'deb9': 'admin',
+    'deb10': 'admin',
+    'flatcar': 'core',
+    'rhel7': 'ec2-user',
+    'rhel8': 'ec2-user',
+    'u1804': 'ubuntu',
+    'u2004': 'ubuntu',
+    'u2004arm64': 'ubuntu',
+    'u2010': 'ubuntu',
+    'u2104': 'ubuntu',
+}

--- a/config/jobs/kubernetes/kops/templates/periodic.yaml.jinja
+++ b/config/jobs/kubernetes/kops/templates/periodic.yaml.jinja
@@ -1,0 +1,75 @@
+
+- name: {{job_name}}
+  cron: '{{cron}}'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: {{job_timeout}}
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="{{create_args}}" \
+          {%- if kops_feature_flags %}
+          --env=KOPS_FEATURE_FLAGS={{kops_feature_flags}} \
+          {%- endif %}
+          --kops-version-marker={{kops_deploy_url}} \
+          {%- if publish_version_marker %}
+          --publish-version-marker={{publish_version_marker}} \
+          {%- endif %}
+          --kubernetes-version={{k8s_deploy_url}} \
+          {%- if terraform_version %}
+          --terraform-version={{terraform_version}} \
+          {%- endif %}
+          {%- if validation_wait %}
+          --validation-wait={{validation_wait}} \
+          {%- endif %}
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout={{test_timeout}} -num-nodes=0" \
+          {%- if test_package_bucket %}
+          --test-package-bucket={{test_package_bucket}} \
+          {%- endif %}
+          {%- if test_package_dir %}
+          --test-package-dir={{test_package_dir}} \
+          {%- endif %}
+          --test-package-marker={{marker}} \
+          {%- if focus_regex %}
+          --focus-regex="{{focus_regex}}" \
+          {%- endif %}
+          {%- if skip_regex %}
+          --skip-regex="{{skip_regex}}" \
+          {%- endif %}
+          --parallel={{test_parallelism}}
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: {{kops_ssh_user}}
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210622-762366a-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi

--- a/config/jobs/kubernetes/kops/templates/periodic.yaml.jinja
+++ b/config/jobs/kubernetes/kops/templates/periodic.yaml.jinja
@@ -65,7 +65,7 @@
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: {{kops_ssh_user}}
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210622-762366a-master
+      image: {{image}}
       imagePullPolicy: Always
       resources:
         limits:

--- a/config/jobs/kubernetes/kops/templates/presubmit.yaml.jinja
+++ b/config/jobs/kubernetes/kops/templates/presubmit.yaml.jinja
@@ -1,0 +1,82 @@
+
+  - name: {{job_name}}
+    branches:
+    - {{branch}}
+    {%- if run_if_changed %}
+    run_if_changed: '{{run_if_changed}}'
+    {%- endif %}
+    always_run: {{always_run}}
+    skip_report: {{skip_report}}
+    labels:
+      {%- if cloud == "aws" %}
+      preset-service-account: "true"
+      preset-aws-ssh: "true"
+      preset-aws-credential: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+      {%- else %}
+      preset-k8s-ssh: "true"
+      {%- endif %}
+    decorate: true
+    decoration_config:
+      timeout: {{job_timeout}}
+    path_alias: k8s.io/kops
+    spec:
+      {%- if cloud == "gce" %}
+      serviceAccountName: k8s-kops-test
+      {%- endif %}
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210622-762366a-master
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - bash
+        - -c
+        - |
+            make test-e2e-install
+            kubetest2 kops \
+            -v 2 \
+            --up --build --down \
+            --cloud-provider={{cloud}} \
+            --create-args="{{create_args}}" \
+            {%- if kops_feature_flags %}
+            --env=KOPS_FEATURE_FLAGS={{kops_feature_flags}} \
+            {%- endif %}
+            --kubernetes-version={{k8s_deploy_url}} \
+            --kops-binary-path=/home/prow/go/src/k8s.io/kops/bazel-bin/cmd/kops/linux-amd64/kops \
+            {%- if terraform_version %}
+            --terraform-version={{terraform_version}} \
+            {%- endif %}
+            --test=kops \
+            -- \
+            --ginkgo-args="--debug" \
+            --test-args="-test.timeout={{test_timeout}} -num-nodes=0" \
+            {%- if test_package_bucket %}
+            --test-package-bucket={{test_package_bucket}} \
+            {%- endif %}
+            {%- if test_package_dir %}
+            --test-package-dir={{test_package_dir}} \
+            {%- endif %}
+            --test-package-marker={{marker}} \
+            {%- if focus_regex %}
+            --focus-regex="{{focus_regex}}" \
+            {%- endif %}
+            {%- if skip_regex %}
+            --skip-regex="{{skip_regex}}" \
+            {%- endif %}
+            --parallel={{test_parallelism}}
+        securityContext:
+          privileged: true
+        env:
+        - name: KUBE_SSH_KEY_PATH
+          value: {{kops_ssh_key_path}}
+        - name: KUBE_SSH_USER
+          value: {{kops_ssh_user}}
+        - name: GOPATH
+          value: /home/prow/go
+        resources:
+          requests:
+            cpu: "2"
+            memory: "6Gi"

--- a/config/jobs/kubernetes/kops/templates/presubmit.yaml.jinja
+++ b/config/jobs/kubernetes/kops/templates/presubmit.yaml.jinja
@@ -27,7 +27,7 @@
       serviceAccountName: k8s-kops-test
       {%- endif %}
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210622-762366a-master
+      - image: {{image}}
         imagePullPolicy: Always
         command:
         - runner.sh


### PR DESCRIPTION
build_jobs.py has grown long enough. I'm disabling the import pylint check that is incompatible with the `PYTHONPATH=.` required to break the single python file apart into multiple. I also extracted the job jinja templates into their own files which should help IDEs.

/cc @hakman