### PR TITLE
Override: Support test names

### DIFF
--- a/prow/plugins/override/override.go
+++ b/prow/plugins/override/override.go
@@ -334,15 +334,32 @@ func handle(oc overrideClient, log *logrus.Entry, e *github.GenericCommentEvent,
 		return oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, resp))
 	}
 
+	baseSHAGetter := shaGetterFactory(oc, org, repo, pr.Base.Ref)
+	presubmits, err := oc.presubmits(org, repo, baseSHAGetter, sha)
+	if err != nil {
+		msg := "Failed to get presubmits"
+		log.WithError(err).Error(msg)
+		return oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, msg))
+	}
+
 	contexts := sets.NewString()
 	for _, status := range statuses {
 		if status.State == github.StatusSuccess {
 			continue
 		}
+
 		contexts.Insert(status.Context)
+
+		for _, job := range presubmits {
+			if job.Context == status.Context {
+				contexts.Insert(job.Name)
+				break
+			}
+		}
 	}
+
 	if unknown := overrides.Difference(contexts); unknown.Len() > 0 {
-		resp := fmt.Sprintf(`/override requires a failed status context to operate on.
+		resp := fmt.Sprintf(`/override requires a failed status context or a job name to operate on.
 The following unknown contexts were given:
 %s
 
@@ -363,19 +380,14 @@ Only the following contexts were expected:
 		oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, msg))
 	}()
 
-	baseSHAGetter := shaGetterFactory(oc, org, repo, pr.Base.Ref)
-	presubmits, err := oc.presubmits(org, repo, baseSHAGetter, sha)
-	if err != nil {
-		msg := "Failed to get presubmits"
-		log.WithError(err).Error(msg)
-		return oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, msg))
-	}
 	for _, status := range statuses {
-		if status.State == github.StatusSuccess || !overrides.Has(status.Context) {
+		pre := presubmitForContext(presubmits, status.Context)
+
+		if status.State == github.StatusSuccess || !(overrides.Has(status.Context) || pre != nil && overrides.Has(pre.Name)) {
 			continue
 		}
-		// First create the overridden prow result if necessary
-		pre := presubmitForContext(presubmits, status.Context)
+
+		// Create the overridden prow result if necessary
 		if pre != nil {
 			baseSHA, err := baseSHAGetter()
 			if err != nil {


### PR DESCRIPTION
Resolves #21556

 `/override <token>`
Will search:

- job names
- contexts on the PR
