### PR TITLE
Fix vended id overflows

### DIFF
--- a/prow/cmd/deck/job_history.go
+++ b/prow/cmd/deck/job_history.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
 	pkgio "k8s.io/test-infra/prow/io"
@@ -365,7 +364,7 @@ func getBuildData(ctx context.Context, bucket storageBucket, dir string) (buildD
 		logrus.Debugf("failed to read finished.json (job might be unfinished): %v", err)
 	}
 
-	pj := prowapi.ProwJob{}
+	pj := prowv1.ProwJob{}
 	err = readJSON(ctx, bucket, path.Join(dir, prowv1.ProwJobFile), &pj)
 	if err != nil {
 		logrus.WithError(err).Debugf("failed to read %s", prowv1.ProwJobFile)

--- a/prow/cmd/deck/job_history.go
+++ b/prow/cmd/deck/job_history.go
@@ -50,7 +50,7 @@ const (
 	// https://github.com/kubernetes/test-infra/tree/master/gubernator#gcs-bucket-layout
 	logsPrefix     = gcs.NonPRLogs
 	spyglassPrefix = "/view"
-	emptyID        = int64(-1) // indicates no build id was specified
+	emptyID        = uint64(0) // indicates no build id was specified
 )
 
 var (
@@ -122,15 +122,15 @@ func (bucket blobStorageBucket) getStorageProvider() string {
 	return bucket.storageProvider
 }
 
-func readLatestBuild(ctx context.Context, bucket storageBucket, root string) (int64, error) {
+func readLatestBuild(ctx context.Context, bucket storageBucket, root string) (uint64, error) {
 	key := path.Join(root, latestBuildFile)
 	data, err := bucket.readObject(ctx, key)
 	if err != nil {
-		return -1, fmt.Errorf("failed to read %s: %w", key, err)
+		return 0, fmt.Errorf("failed to read %s: %w", key, err)
 	}
-	n, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
+	n, err := strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
 	if err != nil {
-		return -1, fmt.Errorf("failed to parse %s: %v", key, err)
+		return 0, fmt.Errorf("failed to parse %s: %v", key, err)
 	}
 	return n, nil
 }
@@ -236,13 +236,13 @@ func (bucket blobStorageBucket) listAll(ctx context.Context, prefix string) ([]s
 }
 
 // Gets all build ids for a job.
-func (bucket blobStorageBucket) listBuildIDs(ctx context.Context, root string) ([]int64, error) {
-	var ids []int64
+func (bucket blobStorageBucket) listBuildIDs(ctx context.Context, root string) ([]uint64, error) {
+	var ids []uint64
 	if strings.HasPrefix(root, logsPrefix) {
 		dirs, listErr := bucket.listSubDirs(ctx, root)
 		for _, dir := range dirs {
 			leaf := path.Base(dir)
-			i, err := strconv.ParseInt(leaf, 10, 64)
+			i, err := strconv.ParseUint(leaf, 10, 64)
 			if err == nil {
 				ids = append(ids, i)
 			} else {
@@ -257,11 +257,11 @@ func (bucket blobStorageBucket) listBuildIDs(ctx context.Context, root string) (
 		for _, key := range keys {
 			matches := linkRe.FindStringSubmatch(key)
 			if len(matches) == 2 {
-				i, err := strconv.ParseInt(matches[1], 10, 64)
+				i, err := strconv.ParseUint(matches[1], 10, 64)
 				if err == nil {
 					ids = append(ids, i)
 				} else {
-					logrus.Warningf("unrecognized file name (expected <int64>.txt): %s", key)
+					logrus.Warningf("unrecognized file name (expected <uint64>.txt): %s", key)
 				}
 			}
 		}
@@ -283,7 +283,7 @@ func (bucket blobStorageBucket) listBuildIDs(ctx context.Context, root string) (
 // * bucketName: kubernetes-jenkins
 // * root: pr-logs/directory/pull-capi
 // * buildID: 1245584383100850177
-func parseJobHistURL(url *url.URL) (storageProvider, bucketName, root string, buildID int64, err error) {
+func parseJobHistURL(url *url.URL) (storageProvider, bucketName, root string, buildID uint64, err error) {
 	buildID = emptyID
 	p := strings.TrimPrefix(url.Path, "/job-history/")
 	// examples for p:
@@ -315,7 +315,7 @@ func parseJobHistURL(url *url.URL) (storageProvider, bucketName, root string, bu
 	}
 
 	if idVals := url.Query()[idParam]; len(idVals) >= 1 && idVals[0] != "" {
-		buildID, err = strconv.ParseInt(idVals[0], 10, 64)
+		buildID, err = strconv.ParseUint(idVals[0], 10, 64)
 		if err != nil {
 			err = fmt.Errorf("invalid value for %s: %v", idParam, err)
 			return
@@ -329,12 +329,12 @@ func parseJobHistURL(url *url.URL) (storageProvider, bucketName, root string, bu
 	return
 }
 
-func linkID(url *url.URL, id int64) string {
+func linkID(url *url.URL, id uint64) string {
 	u := *url
 	q := u.Query()
 	var val string
 	if id != emptyID {
-		val = strconv.FormatInt(id, 10)
+		val = strconv.FormatUint(id, 10)
 	}
 	q.Set(idParam, val)
 	u.RawQuery = q.Encode()
@@ -399,8 +399,8 @@ func getBuildData(ctx context.Context, bucket storageBucket, dir string) (buildD
 
 // assumes a to be sorted in descending order
 // returns a subslice of a along with its indices (inclusive)
-func cropResults(a []int64, max int64) ([]int64, int, int) {
-	res := []int64{}
+func cropResults(a []uint64, max uint64) ([]uint64, int, int) {
+	res := []uint64{}
 	firstIndex := -1
 	lastIndex := 0
 	for i, v := range a {
@@ -419,11 +419,11 @@ func cropResults(a []int64, max int64) ([]int64, int, int) {
 }
 
 // golang <3
-type int64slice []int64
+type uint64slice []uint64
 
-func (a int64slice) Len() int           { return len(a) }
-func (a int64slice) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a int64slice) Less(i, j int) bool { return a[i] < a[j] }
+func (a uint64slice) Len() int           { return len(a) }
+func (a uint64slice) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a uint64slice) Less(i, j int) bool { return a[i] < a[j] }
 
 // Gets job history from the bucket specified in config.
 func getJobHistory(ctx context.Context, url *url.URL, cfg config.Getter, opener pkgio.Opener) (jobHistoryTemplate, error) {
@@ -458,7 +458,7 @@ func getJobHistory(ctx context.Context, url *url.URL, cfg config.Getter, opener 
 		return tmpl, fmt.Errorf("failed to get build ids: %v", err)
 	}
 
-	sort.Sort(sort.Reverse(int64slice(buildIDs)))
+	sort.Sort(sort.Reverse(uint64slice(buildIDs)))
 
 	// determine which results to display on this page
 	shownIDs, firstIndex, lastIndex := cropResults(buildIDs, top)
@@ -484,8 +484,8 @@ func getJobHistory(ctx context.Context, url *url.URL, cfg config.Getter, opener 
 	// concurrently fetch data for all of the builds to be shown
 	bch := make(chan buildData)
 	for i, buildID := range shownIDs {
-		go func(i int, buildID int64) {
-			id := strconv.FormatInt(buildID, 10)
+		go func(i int, buildID uint64) {
+			id := strconv.FormatUint(buildID, 10)
 			dir, err := bucket.getPath(ctx, root, id, "")
 			if err != nil {
 				if !pkgio.IsNotExist(err) {

--- a/prow/cmd/deck/job_history.go
+++ b/prow/cmd/deck/job_history.go
@@ -126,11 +126,11 @@ func readLatestBuild(ctx context.Context, bucket storageBucket, root string) (ui
 	key := path.Join(root, latestBuildFile)
 	data, err := bucket.readObject(ctx, key)
 	if err != nil {
-		return 0, fmt.Errorf("failed to read %s: %w", key, err)
+		return emptyID, fmt.Errorf("failed to read %s: %w", key, err)
 	}
 	n, err := strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("failed to parse %s: %v", key, err)
+		return emptyID, fmt.Errorf("failed to parse %s: %v", key, err)
 	}
 	return n, nil
 }

--- a/prow/cmd/deck/job_history.go
+++ b/prow/cmd/deck/job_history.go
@@ -320,7 +320,7 @@ func parseJobHistURL(url *url.URL) (storageProvider, bucketName, root string, bu
 			err = fmt.Errorf("invalid value for %s: %v", idParam, err)
 			return
 		}
-		if buildID < 0 {
+		if buildID < 1 {
 			err = fmt.Errorf("invalid value %s = %d", idParam, buildID)
 			return
 		}

--- a/prow/cmd/deck/job_history_test.go
+++ b/prow/cmd/deck/job_history_test.go
@@ -222,7 +222,7 @@ func TestLinkID(t *testing.T) {
 	}{
 		{
 			startAddr: "http://www.example.com/job-history/foo-bucket/logs/bar-e2e",
-			id:        0,
+			id:        emptyID,
 			expAddr:   "http://www.example.com/job-history/foo-bucket/logs/bar-e2e?buildId=",
 		},
 		{

--- a/prow/cmd/deck/job_history_test.go
+++ b/prow/cmd/deck/job_history_test.go
@@ -38,7 +38,7 @@ func TestJobHistURL(t *testing.T) {
 		storageProvider string
 		bktName         string
 		root            string
-		id              int64
+		id              uint64
 		expErr          bool
 	}{
 		{
@@ -156,7 +156,7 @@ func TestJobHistURL(t *testing.T) {
 	}
 }
 
-func eq(a, b []int64) bool {
+func eq(a, b []uint64) bool {
 	if len(a) != len(b) {
 		return false
 	}
@@ -170,37 +170,37 @@ func eq(a, b []int64) bool {
 
 func TestCropResults(t *testing.T) {
 	cases := []struct {
-		a   []int64
-		max int64
-		exp []int64
+		a   []uint64
+		max uint64
+		exp []uint64
 		p   int
 		q   int
 	}{
 		{
-			a:   []int64{},
+			a:   []uint64{},
 			max: 42,
-			exp: []int64{},
+			exp: []uint64{},
 			p:   -1,
 			q:   0,
 		},
 		{
-			a:   []int64{81, 27, 9, 3, 1},
+			a:   []uint64{81, 27, 9, 3, 1},
 			max: 100,
-			exp: []int64{81, 27, 9, 3, 1},
+			exp: []uint64{81, 27, 9, 3, 1},
 			p:   0,
 			q:   4,
 		},
 		{
-			a:   []int64{81, 27, 9, 3, 1},
+			a:   []uint64{81, 27, 9, 3, 1},
 			max: 50,
-			exp: []int64{27, 9, 3, 1},
+			exp: []uint64{27, 9, 3, 1},
 			p:   1,
 			q:   4,
 		},
 		{
-			a:   []int64{25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1},
+			a:   []uint64{25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1},
 			max: 23,
-			exp: []int64{23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4},
+			exp: []uint64{23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4},
 			p:   2,
 			q:   21,
 		},
@@ -217,12 +217,12 @@ func TestCropResults(t *testing.T) {
 func TestLinkID(t *testing.T) {
 	cases := []struct {
 		startAddr string
-		id        int64
+		id        uint64
 		expAddr   string
 	}{
 		{
 			startAddr: "http://www.example.com/job-history/foo-bucket/logs/bar-e2e",
-			id:        -1,
+			id:        0,
 			expAddr:   "http://www.example.com/job-history/foo-bucket/logs/bar-e2e?buildId=",
 		},
 		{

--- a/prow/cmd/deck/job_history_test.go
+++ b/prow/cmd/deck/job_history_test.go
@@ -407,7 +407,7 @@ func Test_getJobHistory(t *testing.T) {
 func TestListBuildIDsReturnsResultsOnError(t *testing.T) {
 	t.Run("logs-prefix", func(t *testing.T) {
 		bucket := blobStorageBucket{Opener: fakeOpener{iterator: fakeIterator{
-			result: io.ObjectAttributes{Name: "1327350934719696896", IsDir: true},
+			result: io.ObjectAttributes{Name: "13728953029057617923", IsDir: true},
 			err:    errors.New("some-err"),
 		}}}
 		ids, err := bucket.listBuildIDs(context.Background(), logsPrefix)
@@ -420,7 +420,7 @@ func TestListBuildIDsReturnsResultsOnError(t *testing.T) {
 	})
 	t.Run("no-prefix", func(t *testing.T) {
 		bucket := blobStorageBucket{Opener: fakeOpener{iterator: fakeIterator{
-			result: io.ObjectAttributes{Name: "/1327350934719696896.txt", IsDir: false},
+			result: io.ObjectAttributes{Name: "/13728953029057617923.txt", IsDir: false},
 			err:    errors.New("some-err"),
 		}}}
 		ids, err := bucket.listBuildIDs(context.Background(), "")


### PR DESCRIPTION
Ref. #22256
Ids in the `prow/cmd/deck` job history were overflowing so I switched out `int64` type with `uint64`. 🎉 

/sig testing
/cc @matthyx 
/kind bug
/area prow