### PR TITLE
Fix konnectivity agent test logs export.

### DIFF
--- a/logexporter/cluster/log-dump.sh
+++ b/logexporter/cluster/log-dump.sh
@@ -42,7 +42,7 @@ readonly node_ssh_supported_providers="gce gke aws"
 readonly gcloud_supported_providers="gce gke"
 
 readonly master_logfiles="kube-apiserver.log kube-apiserver-audit.log kube-scheduler.log kube-controller-manager.log etcd.log etcd-events.log glbc.log cluster-autoscaler.log kube-addon-manager.log konnectivity-server.log fluentd.log kubelet.cov"
-readonly node_logfiles="kube-proxy.log konnectivity-agent.log fluentd.log node-problem-detector.log kubelet.cov"
+readonly node_logfiles="kube-proxy.log containers/konnectivity-agent-*.log fluentd.log node-problem-detector.log kubelet.cov"
 readonly node_systemd_services="node-problem-detector"
 readonly hollow_node_logfiles="kubelet-hollow-node-*.log kubeproxy-hollow-node-*.log npd-hollow-node-*.log"
 readonly aws_logfiles="cloud-init-output.log"


### PR DESCRIPTION
I made a mistake in https://github.com/kubernetes/test-infra/pull/22781

Since this is a daemonset there is a name suffix (for example, at https://storage.googleapis.com/kubernetes-jenkins/logs/ci-gcp-compute-persistent-disk-csi-driver-stable-k8s-master-migration/1412724970550726656/artifacts/e2e-test-prow-minion-group-69q0/kubelet.log we see: "kube-system/konnectivity-agent-2mdrf").
