### PR TITLE
Fix override tests

### DIFF
--- a/prow/plugins/override/override.go
+++ b/prow/plugins/override/override.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -183,6 +184,7 @@ func whoCanUse(overrideConfig plugins.Override, org, repo string) string {
 				allTeams = append(allTeams, fmt.Sprintf("%s: %s", r, strings.Join(allowedTeams, " ")))
 			}
 		}
+		sort.Strings(allTeams)
 		teams = ", and the following github teams:" + strings.Join(allTeams, ", ")
 	}
 


### PR DESCRIPTION
- Check expected comments exist between actual comments.
  `fakeClient`'s `CreateComment` function isn't under test, so ignore any
  failure in order to verify comments.
  Fix `comment for incorrect context` and `comment on get pr failure`
  tests.

- Sort `allTeams` on `whoCanUse` for consistent output.
