### PR TITLE
releng: Use `releng-ci` go1.16 image variant for CIP verify tests

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -204,7 +204,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.15
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
         imagePullPolicy: Always
         command:
         - make


### PR DESCRIPTION
Companion PR for https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/337.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @puerco @saschagrunert @cpanato 
cc: @kubernetes/release-engineering 