### PR TITLE
Fix path of image-builder ova-ci script

### DIFF
--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-ova-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-ova-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
           - image: gcr.io/k8s-testimages/kubekins-e2e:v20210622-762366a-master
             args:
               - runner.sh
-              - "./images/capi/packer/ova/scripts/ci-ova.sh"
+              - "./images/capi/scripts/ci-ova.sh"
             resources:
               requests:
                 cpu: "1000m"


### PR DESCRIPTION
image-builder ci scripts were consolidated to a new location. 
This fixes the path for OVA ci script. 

/assign @codenrhoden 