### PR TITLE
pull-security-profiles-operator-test-e2e: add `hostPID` and `/var/log volume`

### DIFF
--- a/config/jobs/kubernetes-sigs/security-profiles-operator/seccomp-operator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/security-profiles-operator/seccomp-operator-presubmits.yaml
@@ -72,6 +72,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       hostNetwork: true
+      hostPID: true
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210622-762366a-master
         securityContext:
@@ -87,3 +88,12 @@ presubmits:
         - runner.sh
         args:
         - hack/pull-security-profiles-operator-test-e2e
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+          readOnly: true
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+          type: Directory


### PR DESCRIPTION
We need to test a feature within the security-profiles-operator which
requires us to read `/var/log/syslog` or `/var/log/audit/audit.log` as
well as tracking the container process by its cgroup (via
`/proc/$PID/cgroup`). This means we require:

- `hostPID` to be able to read the process cgroup of the running
  container
- mounting `/var/log` to read `/var/log/syslog`

I assume that the prow machines run Debian 10, which does not ship
auditd per default but the syslog daemon.
