### PR TITLE
pull-security-profiles-operator-test-e2e: switch `/var/log` to `/var/log/audit`

### DIFF
--- a/config/jobs/kubernetes-sigs/security-profiles-operator/seccomp-operator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/security-profiles-operator/seccomp-operator-presubmits.yaml
@@ -90,10 +90,10 @@ presubmits:
         - hack/pull-security-profiles-operator-test-e2e
         volumeMounts:
         - name: varlog
-          mountPath: /var/log
+          mountPath: /var/log/audit
           readOnly: true
       volumes:
       - name: varlog
         hostPath:
-          path: /var/log
+          path: /var/log/audit
           type: Directory


### PR DESCRIPTION
We cannot read-only mount /var/log without breaking docker in docker.
Switch to `/var/log/audit` since auditd seems to be installed on the
nodes.

Follow-up of https://github.com/kubernetes/test-infra/pull/22821