### PR TITLE
custom-metrics-apiserver: bump golang to 1.16

### DIFF
--- a/config/jobs/kubernetes-sigs/custom-metrics-apiserver/custom-metrics-apiserver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/custom-metrics-apiserver/custom-metrics-apiserver-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     path_alias: sigs.k8s.io/custom-metrics-apiserver
     spec:
       containers:
-      - image: golang:1.15
+      - image: golang:1.16
         command:
         - make
         args:
@@ -20,7 +20,7 @@ presubmits:
     path_alias: sigs.k8s.io/custom-metrics-apiserver
     spec:
       containers:
-      - image: golang:1.15
+      - image: golang:1.16
         command:
         - make
         args:
@@ -34,7 +34,7 @@ presubmits:
     path_alias: sigs.k8s.io/custom-metrics-apiserver
     spec:
       containers:
-      - image: golang:1.15
+      - image: golang:1.16
         command:
         - make
         args:


### PR DESCRIPTION
Ref: https://github.com/kubernetes-sigs/custom-metrics-apiserver/pull/90

/cc @s-urbaniak @serathius 