### PR TITLE
Add docker-in-docker to pull-cip-verify

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -200,15 +200,22 @@ presubmits:
     path_alias: "sigs.k8s.io/k8s-container-image-promoter"
     skip_report: false
     always_run: true
+    labels:
+      preset-dind-enabled: "true"
     branches:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210622-762366a-master
         imagePullPolicy: Always
         command:
+        - runner.sh
+        args:
         - make
         - verify
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
     annotations:
       testgrid-dashboards: sig-release-releng-presubmits
       testgrid-num-columns-recent: '30'


### PR DESCRIPTION
This change adds docker-in-docker support to the `pull-cip-verify` pre-submit, allowing the `verify-archives` target to run.
Partially satisfies CIP issue: [#326](https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/326)
Blocking CIP PR: [#340](https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/340)

cc: @listx @amwat @justaugustus