### PR TITLE
AlertManager: Redirect AWS account alerts to a different Slack channel

### DIFF
--- a/config/prow/cluster/monitoring/alertmanager-prow_secret.yaml
+++ b/config/prow/cluster/monitoring/alertmanager-prow_secret.yaml
@@ -19,11 +19,17 @@ stringData:
       repeat_interval: 4h
       receiver: 'slack-warnings'
       routes:
+      - receiver: 'cluster-api-aws-alerts'
+        group_interval: 5m
+        repeat_interval: 2h
+        matchers:
+          - boskos_type = aws-account
       - receiver: 'slack-alerts'
         group_interval: 5m
         repeat_interval: 2h
-        match_re:
-          severity: 'critical|high'
+        matchers:
+          - severity =~ "critical|high"
+
 
     receivers:
     - name: 'slack-warnings'
@@ -39,6 +45,13 @@ stringData:
         api_url: '{{ api_url }}'
         icon_url: https://avatars3.githubusercontent.com/u/3380462
         text: '@test-infra-oncall {{ template "custom_slack_text" . }}'
+        link_names: true
+    - name: 'cluster-api-aws-alerts'
+      slack_configs:
+      - channel: '#cluster-api-aws-alerts'
+        api_url: '{{ api_url }}'
+        icon_url: https://avatars3.githubusercontent.com/u/3380462
+        text: '@aws-account-users {{ template "custom_slack_text" . }}'
         link_names: true
 
     templates:


### PR DESCRIPTION
Redirect AWS account alerts to a different Slack channel
Migrates configuration from deprecated `match_re` to `matchers` based on PromQL.

!!!!!!!
Note, I don't have access to AlertManager, so I'm not sure this is correct. Please be ready to revert if need be.
!!!!!!!

Signed-off-by: Naadir Jeewa <jeewan@vmware.com>
