### PR TITLE
Fix alertmanager config to not use 'matchers' field.

### DIFF
--- a/config/prow/cluster/monitoring/alertmanager-prow_secret.yaml
+++ b/config/prow/cluster/monitoring/alertmanager-prow_secret.yaml
@@ -22,13 +22,13 @@ stringData:
       - receiver: 'cluster-api-aws-alerts'
         group_interval: 5m
         repeat_interval: 2h
-        matchers:
-          - boskos_type = aws-account
+        match:
+          boskos_type: aws-account
       - receiver: 'slack-alerts'
         group_interval: 5m
         repeat_interval: 2h
-        matchers:
-          - severity =~ "critical|high"
+        match_re:
+          severity: 'critical|high'
 
 
     receivers:


### PR DESCRIPTION
Switching to `matchers` in https://github.com/kubernetes/test-infra/pull/22828 broke the config.
Also for debugging in the future, note that it appears that prometheus-operator manages an intermediate generated secret that is consumed by alertmanager. Invalid configs cause errors in prometheus-operator logs, not alertmanager's, and the generated config that is actually used won't be updated.

I've fixed the secret in the cluster already and the config seems to have loaded properly now.
/assign @randomvariable 