### PR TITLE
Reset git in case the depstat utility made some changes to go.mod/sum

### DIFF
--- a/config/jobs/kubernetes/sig-arch/kubernetes-depstat.yaml
+++ b/config/jobs/kubernetes/sig-arch/kubernetes-depstat.yaml
@@ -27,7 +27,8 @@ presubmits:
           popd
 
           depstat stats --json > "${WORKDIR}/stats.json"
-          git checkout -b base "${PULL_BASE_SHA}";
+          git reset --hard HEAD
+          git checkout -b base "${PULL_BASE_SHA}"
           depstat stats --json > "${WORKDIR}/stats-base.json"
           diff -s -u --ignore-all-space "${WORKDIR}"/stats-base.json "${WORKDIR}"/stats.json || true
     annotations:


### PR DESCRIPTION
Occasionally, depstat has a side effect of modifying go.mod/sum and we end up in a situation like this:
https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/103586/check-dependency-stats/1413333438345252864/build-log.txt

So add a defensive `git reset`

```
/logs/artifacts /home/prow/go/src/k8s.io/kubernetes
go: downloading github.com/kubernetes-sigs/depstat v0.5.3
go: downloading github.com/spf13/cobra v1.1.1
go: downloading github.com/spf13/pflag v1.0.5
/home/prow/go/src/k8s.io/kubernetes
error: Your local changes to the following files would be overwritten by checkout:
	go.mod
Please commit your changes or stash them before you switch branches.
Aborting
```

Signed-off-by: Davanum Srinivas <davanum@gmail.com>