### PR TITLE
Remove restart kubelet flag from e2e lock contention

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -452,7 +452,7 @@ periodics:
           - --node-test-args=--kubelet-flags="--exit-on-lock-contention --lock-file=/var/run/kubelet.lock"
           - --node-tests=true
           - --provider=gce
-          - --test_args=--nodes=1 --focus="\[NodeFeature:LockContention\]" --restart-kubelet=false
+          - --test_args=--nodes=1 --focus="\[NodeFeature:LockContention\]"
         env:
           - name: GOPATH
             value: /go

--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -452,7 +452,7 @@ periodics:
           - --node-test-args=--kubelet-flags="--exit-on-lock-contention --lock-file=/var/run/kubelet.lock"
           - --node-tests=true
           - --provider=gce
-          - --test_args=--nodes=1 --focus="\[NodeFeature:LockContention\]"
+          - --test_args=--nodes=1 --focus="\[NodeFeature:LockContention\]" --skip=""
         env:
           - name: GOPATH
             value: /go


### PR DESCRIPTION
The flag `--restart-kubelet` was added to the test suite in https://github.com/kubernetes/kubernetes/pull/97028

However as it turns out, in order to test the exit on lock contention, it is not needed, hence removing the flag from the test job.

The corresponding PR for the e2e test is https://github.com/kubernetes/kubernetes/pull/103608.

Locally the test can be tested without requiring the `--restart-kubelet` flag
```
make test-e2e-node REMOTE=false TEST_ARGS="--kubelet-flags=\"--lock-file=/var/run/kubelet.lock --exit-on-lock-contention --v 4\"" FOCUS="\[NodeFeature:LockContention\]" SKIP="\[Flaky\]|\[Serial\]"
```


/cc @knabben @rata 