### PR TITLE
Adding new pre-submit 'pull-cip-verify-archives' to CIP

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -213,3 +213,28 @@ presubmits:
       testgrid-dashboards: sig-release-releng-presubmits
       testgrid-num-columns-recent: '30'
       testgrid-alert-email: release-managers+alerts@kubernetes.io
+  - name: pull-cip-verify-archives
+    decorate: true
+    path_alias: "sigs.k8s.io/k8s-container-image-promoter"
+    skip_report: false
+    always_run: true
+    labels:
+      preset-dind-enabled: "true"
+    branches:
+    - ^master$
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-releng/k8s-ci-builder:latest-default
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - make
+        - verify-archives
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+    annotations:
+      testgrid-dashboards: sig-release-releng-presubmits
+      testgrid-num-columns-recent: '30'
+      testgrid-alert-email: release-managers+alerts@kubernetes.io


### PR DESCRIPTION
This change adds a new pre-submit `pull-cip-verify-archives` to CIP, allowing golden-archives to be verified upon each PR. Since the `verify-archives.sh` script requires docker, we must enable **docker-in-docker** support for this job. The script itself is very simple and short, meaning it should not be a concern for running on every PR. Successful runs will result in the following of debugging output:

```
./hack/verify-archives.sh /home/tyler/Projects/k8s-container-image-promoter
gcr.io/k8s-staging-cip-test/golden-bar/bar:1.0
gcr.io/k8s-staging-cip-test/golden-foo/foo:1.0-linux_s390x
gcr.io/k8s-staging-cip-test/golden-foo/foo:NOTAG-0
gcr.io/k8s-staging-cip-test/golden-foo/foo:1.0-linux_amd64
```
These are the golden-archive images loaded from tarfile. Their contents are verified by this test, ensuring they are valid archives for testing.



Includes the intended behavior of #22827
Partially satisfies CIP issue: #326
Blocking CIP PR: #340
cc: @listx @amwat @justaugustus @kubernetes-sigs/release-engineering