### PR TITLE
Fix a bug to skip presubmit tests for WorkInProgress Gerrit changes correctly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/Azure/go-autorest/autorest/adal v0.9.5
 	github.com/GoogleCloudPlatform/testgrid v0.0.68
 	github.com/NYTimes/gziphandler v1.1.1
-	github.com/andygrunwald/go-gerrit v0.0.0-20190120104749-174420ebee6c
+	github.com/andygrunwald/go-gerrit v0.0.0-20210709065208-9d38b0be0268
 	github.com/andygrunwald/go-jira v1.13.0
 	github.com/aws/aws-sdk-go v1.31.12
 	github.com/bazelbuild/buildtools v0.0.0-20200922170545-10384511ce98

--- a/go.sum
+++ b/go.sum
@@ -228,8 +228,9 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNg
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/brotli v0.0.0-20190621154722-5f990b63d2d6 h1:bZ28Hqta7TFAK3Q08CMvv8y3/8ATaEqv2nGoc6yff6c=
 github.com/andybalholm/brotli v0.0.0-20190621154722-5f990b63d2d6/go.mod h1:+lx6/Aqd1kLJ1GQfkvOnaZ1WGmLpMpbprPuIOOZX30U=
-github.com/andygrunwald/go-gerrit v0.0.0-20190120104749-174420ebee6c h1:uUuUZipfD5nPl2L/i0I3N4iRKJcoO2CPjktaH/kP9gQ=
 github.com/andygrunwald/go-gerrit v0.0.0-20190120104749-174420ebee6c/go.mod h1:0iuRQp6WJ44ts+iihy5E/WlPqfg5RNeQxOmzRkxCdtk=
+github.com/andygrunwald/go-gerrit v0.0.0-20210709065208-9d38b0be0268 h1:7gokoTWteZhP1t2f0OzrFFXlyL8o0+b0r4ZaRV9PXOs=
+github.com/andygrunwald/go-gerrit v0.0.0-20210709065208-9d38b0be0268/go.mod h1:aqcjwEnmLLSalFNYR0p2ttnEXOVVRctIzsUMHbEcruU=
 github.com/andygrunwald/go-jira v1.13.0 h1:vvIImGgX32bHfoiyUwkNo+/YrPnRczNarvhLOncP6dE=
 github.com/andygrunwald/go-jira v1.13.0/go.mod h1:jYi4kFDbRPZTJdJOVJO4mpMMIwdB+rcZwSO58DzPd2I=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
@@ -837,8 +838,9 @@ github.com/google/go-licenses v0.0.0-20191112164736-212ea350c932/go.mod h1:16wa6
 github.com/google/go-licenses v0.0.0-20200227160636-0fa8c766a591 h1:eVR9gT5gBPTHXeyGAcA8OF/SKNUFFg+a0BJqfx4z5eE=
 github.com/google/go-licenses v0.0.0-20200227160636-0fa8c766a591/go.mod h1:JWeTIGPLQ9gF618ZOdlUitd1gRR/l99WOkHOlmR/UVA=
 github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
-github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/go-replayers/grpcreplay v0.1.0 h1:eNb1y9rZFmY4ax45uEEECSa8fsxGRU+8Bil52ASAwic=
 github.com/google/go-replayers/grpcreplay v0.1.0/go.mod h1:8Ig2Idjpr6gifRd6pNVggX6TC1Zw6Jx74AKp7QNH2QE=
 github.com/google/go-replayers/httpreplay v0.1.0 h1:AX7FUb4BjrrzNvblr/OlgwrmFiep6soj5K2QSDW7BGk=

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -287,9 +287,9 @@ func (c *Controller) processChange(logger logrus.FieldLogger, instance string, c
 		filters := []pjutil.Filter{
 			messageFilter(messages, failed, all, logger),
 		}
-		// Automatically trigger the Prow jobs if the revision is new and is not
-		// draft.
-		if revision.Created.Time.After(lastUpdate) && !revision.Draft {
+		// Automatically trigger the Prow jobs if the revision is new and the
+		// change is not in WorkInProgress.
+		if revision.Created.Time.After(lastUpdate) && !change.WorkInProgress {
 			filters = append(filters, pjutil.TestAllFilter())
 		}
 		toTrigger, err := pjutil.FilterPresubmits(pjutil.AggregateFilter(filters), listChangedFiles(change), change.Branch, presubmits, logger)

--- a/prow/gerrit/adapter/adapter_test.go
+++ b/prow/gerrit/adapter/adapter_test.go
@@ -358,14 +358,14 @@ func TestProcessChange(t *testing.T) {
 		expectedBaseSHA  string
 	}{
 		{
-			name: "no presubmit Prow jobs automatically triggered from draft revision",
+			name: "no presubmit Prow jobs automatically triggered from WorkInProgess change",
 			change: client.ChangeInfo{
 				CurrentRevision: "1",
 				Project:         "test-infra",
 				Status:          "NEW",
+				WorkInProgress:  true,
 				Revisions: map[string]gerrit.RevisionInfo{
 					"1": {
-						Draft:  true,
 						Number: 1001,
 					},
 				},
@@ -575,11 +575,12 @@ func TestProcessChange(t *testing.T) {
 			expectedBaseSHA: "abc",
 		},
 		{
-			name: "presubmit does not run when a file matches run_if_changed but the revision is draft",
+			name: "presubmit does not run when a file matches run_if_changed but the change is WorkInProgress",
 			change: client.ChangeInfo{
 				CurrentRevision: "1",
 				Project:         "test-infra",
 				Status:          "NEW",
+				WorkInProgress:  true,
 				Revisions: map[string]client.RevisionInfo{
 					"1": {
 						Files: map[string]client.FileInfo{
@@ -588,7 +589,6 @@ func TestProcessChange(t *testing.T) {
 							"important-code.go":    {},
 						},
 						Created: stampNow,
-						Draft:   true,
 					},
 				},
 			},
@@ -734,16 +734,16 @@ func TestProcessChange(t *testing.T) {
 			expectedBaseSHA: "abc",
 		},
 		{
-			name: "trigger always run job on test all even if revision is draft",
+			name: "trigger always run job on test all even if the change is WorkInProgress",
 			change: client.ChangeInfo{
 				CurrentRevision: "1",
 				Project:         "test-infra",
 				Branch:          "baz",
 				Status:          "NEW",
+				WorkInProgress:  true,
 				Revisions: map[string]client.RevisionInfo{
 					"1": {
 						Number: 1,
-						Draft:  true,
 					},
 				},
 				Messages: []gerrit.ChangeMessageInfo{

--- a/repos.bzl
+++ b/repos.bzl
@@ -128,8 +128,8 @@ def go_repositories():
         build_file_generation = "on",
         build_file_proto_mode = "disable",
         importpath = "github.com/andygrunwald/go-gerrit",
-        sum = "h1:uUuUZipfD5nPl2L/i0I3N4iRKJcoO2CPjktaH/kP9gQ=",
-        version = "v0.0.0-20190120104749-174420ebee6c",
+        sum = "h1:7gokoTWteZhP1t2f0OzrFFXlyL8o0+b0r4ZaRV9PXOs=",
+        version = "v0.0.0-20210709065208-9d38b0be0268",
     )
 
     go_repository(
@@ -1973,8 +1973,8 @@ def go_repositories():
         build_file_generation = "on",
         build_file_proto_mode = "disable",
         importpath = "github.com/google/go-querystring",
-        sum = "h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=",
-        version = "v1.0.0",
+        sum = "h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=",
+        version = "v1.1.0",
     )
 
     go_repository(


### PR DESCRIPTION
The `revision.Draft` field has been removed from the latest Gerrit API, `change.WorkInProgress` should be used instead.

To use the new field, we need to update github.com/andygrunwald/go-gerrit dependency to the latest.

/cc @cjwagner @chaodaiG 