### PR TITLE
Enable OVA CI for image-builder

### DIFF
--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-ova-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-ova-presubmits.yaml
@@ -6,11 +6,12 @@ presubmits:
         preset-kind-volume-mounts: "true"
         preset-cluster-api-provider-vsphere-e2e-config: "true"
         preset-cloud-provider-vsphere-e2e-config: "true"
-      always_run: false
-      optional: true
       decorate: true
+      decoration_config:
+        timeout: 1h
+      run_if_changed: 'images/capi/(Makefile|ansible\.cfg)|images/capi/ansible/.*|images/capi/scripts/ci-ova\.sh|images/capi/packer/(config|goss|ova)/.*|images/capi/hack/ensure-(ansible|packer|goss).*'
       path_alias: sigs.k8s.io/image-builder
-      max_concurrency: 5
+      max_concurrency: 3
       spec:
         containers:
           - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-master

--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
@@ -4,7 +4,7 @@ presubmits:
     labels:
       preset-azure-cred: "true"
     decorate: true
-    run_if_changed: 'images/capi/.*'
+    run_if_changed: 'images/capi/(Makefile|ansible\.cfg)|images/capi/ansible/.*|images/capi/scripts/ci-azure-e2e\.sh|images/capi/packer/(config|goss|azure)/.*|images/capi/hack/ensure-(ansible|packer|jq|azure-cli|goss).*'
     decoration_config:
       timeout: 1h
     max_concurrency: 5


### PR DESCRIPTION
With the addition of https://github.com/kubernetes-sigs/image-builder/pull/425, we now have working CI for Azure and OVAs. This PR enables the OVA CI by default, and changes the logic of when to run the presubmits to the following conditions:

 - Makefile
 - Ansible config file or any Ansible roles
 - provider specific CI script
 - Default configurations
 - GOSS config
 - provider specific Packer builder
 - hack/ensure-* scripts that are called by provider's 'make deps'

This makes it to where something like changing the Azure packer config doesn't run the OVA CI and vice versa. Howevever, any changes to anything common between the two will run both.

/assign @CecileRobertMichon 