### PR TITLE
Crier: Don't error if pod got deleted by the time we add the finalizer

### DIFF
--- a/prow/crier/reporters/gcs/kubernetes/reporter_test.go
+++ b/prow/crier/reporters/gcs/kubernetes/reporter_test.go
@@ -128,6 +128,7 @@ type testResourceGetter struct {
 	events    []v1.Event
 	patchData string
 	patchType types.PatchType
+	patchErr  error
 }
 
 func (rg testResourceGetter) GetPod(_ context.Context, cluster, namespace, name string) (*v1.Pod, error) {
@@ -163,6 +164,9 @@ func (rg testResourceGetter) GetEvents(cluster, namespace string, pod *v1.Pod) (
 }
 
 func (rg testResourceGetter) PatchPod(ctx context.Context, cluster, namespace, name string, pt types.PatchType, data []byte) error {
+	if rg.patchErr != nil {
+		return rg.patchErr
+	}
 	if _, err := rg.GetPod(ctx, cluster, namespace, name); err != nil {
 		return err
 	}
@@ -184,6 +188,7 @@ func TestReportPodInfo(t *testing.T) {
 		pjPending               bool
 		pjState                 prowv1.ProwJobState
 		pod                     *v1.Pod
+		patchErr                error
 		events                  []v1.Event
 		dryRun                  bool
 		expectReport            bool
@@ -280,6 +285,19 @@ func TestReportPodInfo(t *testing.T) {
 			expectedPatch: `{"metadata":{"finalizers":null}}`,
 		},
 		{
+			name:   "Pod gets deleted between check and finalizer add request, error is swallowed",
+			pjName: "ba123965-4fd4-421f-8509-7590c129ab69",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ba123965-4fd4-421f-8509-7590c129ab69",
+					Namespace: "test-pods",
+					Labels:    map[string]string{"created-by-prow": "true"},
+				},
+			},
+			patchErr:     errors.New(`Pod "b2c94437-e0e2-11eb-a92c-0a580a801781" is invalid: metadata.finalizers: Forbidden: no new finalizers can be added if the object is being deleted, found new finalizers []string{"prow.x-k8s.io/gcsk8sreporter"}`),
+			expectReport: false,
+		},
+		{
 			name:       "Finalizer is removed from complete pod",
 			pjName:     "ba123965-4fd4-421f-8509-7590c129ab69",
 			pjPending:  false,
@@ -371,6 +389,7 @@ func TestReportPodInfo(t *testing.T) {
 				cluster:   "the-build-cluster",
 				pod:       tc.pod,
 				events:    tc.events,
+				patchErr:  tc.patchErr,
 				patchData: tc.expectedPatch,
 				patchType: types.MergePatchType,
 			}


### PR DESCRIPTION
It is not allowed to add a finalizer to a deleted resource. We already
check for that, however it occasionally still happens due to TOCTOU
racing.

Fixes https://github.com/kubernetes/test-infra/issues/22846