### PR TITLE
bump bootstrap image references

### DIFF
--- a/config/jobs/cadvisor/cadvisor.yaml
+++ b/config/jobs/cadvisor/cadvisor.yaml
@@ -57,7 +57,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20210707-0f9c540
+    - image: gcr.io/k8s-testimages/bootstrap:v20210709-5168b64
       args:
       - --repo=github.com/google/cadvisor
       - --root=/go/src

--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20210707-0f9c540
+      - image: gcr.io/k8s-testimages/bootstrap:v20210709-5168b64
         command:
         - runner.sh
         args:
@@ -36,7 +36,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20210707-0f9c540
+    - image: gcr.io/k8s-testimages/bootstrap:v20210709-5168b64
       args:
       - --repo=k8s.io/kubernetes
       - --repo=k8s.io/release

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -219,7 +219,7 @@ periodics:
       - --allow-dup
       - --extra-version-markers=k8s-stable3
       - --registry=gcr.io/kubernetes-ci-images
-      image: gcr.io/k8s-testimages/bootstrap:v20210707-0f9c540
+      image: gcr.io/k8s-testimages/bootstrap:v20210709-5168b64
       name: ""
       resources:
         limits:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
@@ -218,7 +218,7 @@ periodics:
       - --allow-dup
       - --extra-version-markers=k8s-stable2
       - --registry=gcr.io/kubernetes-ci-images
-      image: gcr.io/k8s-testimages/bootstrap:v20210707-0f9c540
+      image: gcr.io/k8s-testimages/bootstrap:v20210709-5168b64
       name: ""
       resources:
         limits:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.21.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.21.yaml
@@ -220,7 +220,7 @@ periodics:
       - --allow-dup
       - --extra-version-markers=k8s-stable1
       - --registry=gcr.io/kubernetes-ci-images
-      image: gcr.io/k8s-testimages/bootstrap:v20210707-0f9c540
+      image: gcr.io/k8s-testimages/bootstrap:v20210709-5168b64
       name: ""
       resources:
         limits:

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
@@ -34,7 +34,7 @@ periodics:
     testgrid-tab-name: build-and-push-k8s-at-golang-tip
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20210707-0f9c540
+    - image: gcr.io/k8s-testimages/bootstrap:v20210709-5168b64
       command:
       - runner.sh
       - /workspace/scenarios/execute.py

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -616,7 +616,7 @@ presubmits:
       testgrid-tab-name: pull-perf-tests-util-images
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20210707-0f9c540
+      - image: gcr.io/k8s-testimages/bootstrap:v20210709-5168b64
         command:
         - runner.sh
         - /workspace/scenarios/execute.py

--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -17,7 +17,7 @@
 
 ARG OLD_BAZEL_VERSION
 FROM launcher.gcr.io/google/bazel:${OLD_BAZEL_VERSION} as old
-FROM gcr.io/k8s-testimages/bootstrap:v20210707-0f9c540
+FROM gcr.io/k8s-testimages/bootstrap:v20210709-5168b64
 
 # hint to kubetest that it is in CI
 ENV KUBETEST_IN_DOCKER="true"


### PR DESCRIPTION
Bump boostrap image references to pick up changes built as a result of https://github.com/kubernetes/test-infra/pull/22840

Split into two commits for ease of revert:
- first commit bumps the image as used in config/jobs
- second commit will build new kubekins-e2e images

This will be followed by another PR to bump kubekins