### PR TITLE
Trigger: Add /retest-required that excludes optional jobs

### DIFF
--- a/prow/github/report/report.go
+++ b/prow/github/report/report.go
@@ -272,7 +272,7 @@ func createComment(reportTemplate *template.Template, pj prowapi.ProwJob, entrie
 		}
 	}
 	lines := []string{
-		fmt.Sprintf("@%s: The following test%s **failed**, say `/retest` to rerun all failed tests:", pj.Spec.Refs.Pulls[0].Author, plural),
+		fmt.Sprintf("@%s: The following test%s **failed**, say `/retest` to rerun all failed tests or `/retest-required` to rerun all mandatory failed tests:", pj.Spec.Refs.Pulls[0].Author, plural),
 		"",
 		"Test name | Commit | Details | Rerun command",
 		"--- | --- | --- | ---",

--- a/prow/pjutil/filter_test.go
+++ b/prow/pjutil/filter_test.go
@@ -19,10 +19,11 @@ package pjutil
 import (
 	"errors"
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/test-infra/prow/github"
 	"reflect"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/github"
 
 	"github.com/sirupsen/logrus"
 
@@ -637,6 +638,58 @@ func TestPresubmitFilter(t *testing.T) {
 				},
 			},
 			expected: [][]bool{{false, false, false}, {false, false, false}, {true, false, true}, {true, false, true}, {true, false, false}},
+		},
+		{
+			name: "retest command selects for errored or failed contexts unless they are optional",
+			body: "/retest-required",
+			org:  "org",
+			repo: "repo",
+			ref:  "ref",
+			presubmits: []config.Presubmit{
+				{
+					JobBase: config.JobBase{
+						Name: "successful-job",
+					},
+					Reporter: config.Reporter{
+						Context: "existing-successful",
+					},
+				},
+				{
+					JobBase: config.JobBase{
+						Name: "pending-job",
+					},
+					Reporter: config.Reporter{
+						Context: "existing-pending",
+					},
+				},
+				{
+					JobBase: config.JobBase{
+						Name: "failure-job",
+					},
+					Reporter: config.Reporter{
+						Context: "existing-failure",
+					},
+					Optional: true,
+				},
+				{
+					JobBase: config.JobBase{
+						Name: "error-job",
+					},
+					Reporter: config.Reporter{
+						Context: "existing-error",
+					},
+				},
+				{
+					JobBase: config.JobBase{
+						Name: "missing-always-runs",
+					},
+					Reporter: config.Reporter{
+						Context: "missing-always-runs",
+					},
+					AlwaysRun: true,
+				},
+			},
+			expected: [][]bool{{false, false, false}, {false, false, false}, {true, false, false}, {true, false, true}, {true, false, false}},
 		},
 		{
 			name: "explicit test command filters for jobs that match",

--- a/prow/plugins/trigger/generic-comment.go
+++ b/prow/plugins/trigger/generic-comment.go
@@ -57,6 +57,7 @@ func handleGenericComment(c Client, trigger plugins.Trigger, gc github.GenericCo
 
 	// Skip comments not germane to this plugin
 	if !pjutil.RetestRe.MatchString(gc.Body) &&
+		!pjutil.RetestRequiredRe.MatchString(gc.Body) &&
 		!pjutil.OkToTestRe.MatchString(gc.Body) &&
 		!pjutil.TestAllRe.MatchString(gc.Body) &&
 		!pjutil.MayNeedHelpComment(gc.Body) {

--- a/prow/plugins/trigger/generic-comment_test.go
+++ b/prow/plugins/trigger/generic-comment_test.go
@@ -476,6 +476,95 @@ func TestHandleGenericComment(t *testing.T) {
 			StartsExactly: "pull-jub",
 		},
 		{
+			name:   "Retest triggers failed job",
+			Author: "trusted-member",
+			Body:   "/retest",
+			State:  "open",
+			IsPR:   true,
+			Presubmits: map[string][]config.Presubmit{
+				"org/repo": {
+					{
+						JobBase: config.JobBase{
+							Name: "jib",
+						},
+						Reporter: config.Reporter{
+							Context: "pull-jib",
+						},
+						Trigger:      `(?m)^/test (?:.*? )?jib(?: .*?)?$`,
+						RerunCommand: `/test jib`,
+					},
+				},
+			},
+			ShouldBuild: true,
+		},
+		{
+			name:   "Retest triggers failed job that is optional",
+			Author: "trusted-member",
+			Body:   "/retest",
+			State:  "open",
+			IsPR:   true,
+			Presubmits: map[string][]config.Presubmit{
+				"org/repo": {
+					{
+						JobBase: config.JobBase{
+							Name: "jib",
+						},
+						Reporter: config.Reporter{
+							Context: "pull-jib",
+						},
+						Trigger:      `(?m)^/test (?:.*? )?jib(?: .*?)?$`,
+						RerunCommand: `/test jib`,
+						Optional:     true,
+					},
+				},
+			},
+			ShouldBuild: true,
+		},
+		{
+			name:   "Retest-Required doesn't triggers failed job",
+			Author: "trusted-member",
+			Body:   "/retest-required",
+			State:  "open",
+			IsPR:   true,
+			Presubmits: map[string][]config.Presubmit{
+				"org/repo": {
+					{
+						JobBase: config.JobBase{
+							Name: "jib",
+						},
+						Reporter: config.Reporter{
+							Context: "pull-jib",
+						},
+						Trigger:      `(?m)^/test (?:.*? )?jib(?: .*?)?$`,
+						RerunCommand: `/test jib`,
+					},
+				},
+			},
+			ShouldBuild: true,
+		},
+		{
+			name:   "Retest-Required doesn't trigger failed job that is optional",
+			Author: "trusted-member",
+			Body:   "/retest-required",
+			State:  "open",
+			IsPR:   true,
+			Presubmits: map[string][]config.Presubmit{
+				"org/repo": {
+					{
+						JobBase: config.JobBase{
+							Name: "jib",
+						},
+						Reporter: config.Reporter{
+							Context: "pull-jib",
+						},
+						Trigger:      `(?m)^/test (?:.*? )?jib(?: .*?)?$`,
+						RerunCommand: `/test jib`,
+						Optional:     true,
+					},
+				},
+			},
+		},
+		{
 			name:   "Retest of run_if_changed job that failed. Changes do not require the job",
 			Author: "trusted-member",
 			Body:   "/retest",


### PR DESCRIPTION
This is primarily useful for automated re-triggering. This explicitly adds a new command to not surprise ppl.