### PR TITLE
releng: Invoke wrapper script for `pull-cip-verify-archives` job

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -227,8 +227,7 @@ presubmits:
       - image: gcr.io/k8s-staging-releng/k8s-ci-builder:latest-default
         imagePullPolicy: Always
         command:
-        - runner.sh
-        args:
+        - wrapper.sh
         - make
         - verify-archives
         # docker-in-docker needs privileged mode


### PR DESCRIPTION
Follow-up to https://github.com/kubernetes/test-infra/pull/22837, which should allow the new job to start passing.

Example failure: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_k8s-container-image-promoter/344/pull-cip-verify-archives/1413579592232341504

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @puerco @saschagrunert @cpanato 
cc: @kubernetes/release-engineering 