### PR TITLE
Add presubmit for building container image

### DIFF
--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
@@ -125,3 +125,29 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-image-builder
       testgrid-tab-name: pr-goss-populate
+  - name: pull-container-image-build
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    always_run: false
+    optional: true
+    decorate: true
+    path_alias: sigs.k8s.io/image-builder
+    max_concurrency: 5
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-master
+          args:
+            - runner.sh
+            - "./images/capi/scripts/ci-container-image.sh"
+          resources:
+            requests:
+              cpu: "4000m"
+              memory: "6Gi"
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["NET_ADMIN"]
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-image-builder
+      testgrid-tab-name: pr-container-image-build


### PR DESCRIPTION
This job tests to make sure that the container image can be built
successfully.

Leaving as optional for right now. Will add `run_if_changed` logic later on after making sure test works as planned.

/assign @CecileRobertMichon 
depends on https://github.com/kubernetes-sigs/image-builder/pull/651
FYI @kkeshavamurthy 