### PR TITLE
Support reporting batch jobs

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1800,9 +1800,8 @@ func parseProwConfig(c *Config) error {
 	}
 
 	// validate entries are valid job types
-	// Currently only presubmit and postsubmit can be reported to github
 	for _, t := range c.GitHubReporter.JobTypesToReport {
-		if t != prowapi.PresubmitJob && t != prowapi.PostsubmitJob {
+		if t != prowapi.PresubmitJob && t != prowapi.PostsubmitJob && t != prowapi.BatchJob {
 			return fmt.Errorf("invalid job_types_to_report: %v", t)
 		}
 	}

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -2827,7 +2827,7 @@ func TestValidGitHubReportType(t *testing.T) {
 github_reporter:
   job_types_to_report:
   - presubmit
-  - batch
+  - periodic
 `,
 			expectError: true,
 		},
@@ -2838,8 +2838,9 @@ github_reporter:
   job_types_to_report:
   - presubmit
   - postsubmit
+  - batch
 `,
-			expectTypes: []prowapi.ProwJobType{prowapi.PresubmitJob, prowapi.PostsubmitJob},
+			expectTypes: []prowapi.ProwJobType{prowapi.PresubmitJob, prowapi.PostsubmitJob, prowapi.BatchJob},
 		},
 	}
 


### PR DESCRIPTION
In order to improve transparency and make users be more exposed to failures.
This would allow a PR owner to be able to watch failures related to his PR from its PR view.

Otherwise, in the case of repeated batch intervals, a green PR could be shown as "stuck" for hours. (unless going to tide dashboard to understand what's going on with it)