### PR TITLE
Update sig-release jobs to use new ci-images location

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -47,7 +47,7 @@ periodics:
       - --
       - --allow-dup
       - --extra-version-markers=k8s-master
-      - --registry=gcr.io/kubernetes-ci-images
+      - --registry=gcr.io/k8s-staging-ci-images
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -218,7 +218,7 @@ periodics:
       - --
       - --allow-dup
       - --extra-version-markers=k8s-stable3
-      - --registry=gcr.io/kubernetes-ci-images
+      - --registry=gcr.io/k8s-staging-ci-images
       image: gcr.io/k8s-testimages/bootstrap:v20210709-5168b64
       name: ""
       resources:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
@@ -217,7 +217,7 @@ periodics:
       - --
       - --allow-dup
       - --extra-version-markers=k8s-stable2
-      - --registry=gcr.io/kubernetes-ci-images
+      - --registry=gcr.io/k8s-staging-ci-images
       image: gcr.io/k8s-testimages/bootstrap:v20210709-5168b64
       name: ""
       resources:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.21.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.21.yaml
@@ -219,7 +219,7 @@ periodics:
       - --
       - --allow-dup
       - --extra-version-markers=k8s-stable1
-      - --registry=gcr.io/kubernetes-ci-images
+      - --registry=gcr.io/k8s-staging-ci-images
       image: gcr.io/k8s-testimages/bootstrap:v20210709-5168b64
       name: ""
       resources:


### PR DESCRIPTION
This PR updates the sig-release jobs that refer to `gcr.io/kubernetes-ci-images` to instead use the new `gcr.io/k8s-staging-ci-images` path.