### PR TITLE
azure: use kubekins-e2e master instead of release branches

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/azure/generate.sh
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/generate.sh
@@ -38,7 +38,7 @@ EOF
 }
 
 # we need to define the full image URL so it can be autobumped
-tmp="gcr.io/k8s-testimages/kubekins-e2e:v20210707-0f9c540-master"
+tmp="gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-master"
 kubekins_e2e_image="${tmp/\-master/}"
 
 for release in "$@"; do
@@ -81,7 +81,7 @@ presubmits:
         path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-        - image: ${kubekins_e2e_image}-${release}
+        - image: ${kubekins_e2e_image}-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -126,7 +126,7 @@ $(generate_presubmit_annotations ${branch} pull-kubernetes-e2e-capz-azure-disk)
         path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-        - image: ${kubekins_e2e_image}-${release}
+        - image: ${kubekins_e2e_image}-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -173,7 +173,7 @@ $(generate_presubmit_annotations ${branch} pull-kubernetes-e2e-capz-azure-disk-v
         path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-        - image: ${kubekins_e2e_image}-${release}
+        - image: ${kubekins_e2e_image}-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -219,7 +219,7 @@ $(generate_presubmit_annotations ${branch} pull-kubernetes-e2e-capz-azure-file)
         path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-        - image: ${kubekins_e2e_image}-${release}
+        - image: ${kubekins_e2e_image}-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -263,7 +263,7 @@ $(generate_presubmit_annotations ${branch} pull-kubernetes-e2e-capz-azure-file-v
       workdir: true
     spec:
       containers:
-      - image: ${kubekins_e2e_image}-${release}
+      - image: ${kubekins_e2e_image}-master
         command:
         - runner.sh
         - ./scripts/ci-conformance.sh
@@ -301,7 +301,7 @@ $(generate_presubmit_annotations ${branch} pull-kubernetes-e2e-capz-conformance)
       workdir: true
     spec:
       containers:
-      - image: ${kubekins_e2e_image}-${release}
+      - image: ${kubekins_e2e_image}-master
         command:
         - runner.sh
         - ./scripts/ci-conformance.sh

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.18.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.18.yaml
@@ -26,7 +26,7 @@ presubmits:
         path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-1.18
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -71,7 +71,7 @@ presubmits:
         path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-1.18
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -118,7 +118,7 @@ presubmits:
         path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-1.18
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -164,7 +164,7 @@ presubmits:
         path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-1.18
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -208,7 +208,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-master
         command:
         - runner.sh
         - ./scripts/ci-conformance.sh
@@ -246,7 +246,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-master
         command:
         - runner.sh
         - ./scripts/ci-conformance.sh

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.19.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.19.yaml
@@ -26,7 +26,7 @@ presubmits:
         path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-1.19
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -71,7 +71,7 @@ presubmits:
         path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-1.19
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -118,7 +118,7 @@ presubmits:
         path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-1.19
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -164,7 +164,7 @@ presubmits:
         path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-1.19
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -208,7 +208,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-1.19
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-master
         command:
         - runner.sh
         - ./scripts/ci-conformance.sh
@@ -246,7 +246,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-1.19
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-master
         command:
         - runner.sh
         - ./scripts/ci-conformance.sh

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.20.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.20.yaml
@@ -26,7 +26,7 @@ presubmits:
         path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-1.20
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -71,7 +71,7 @@ presubmits:
         path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-1.20
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -118,7 +118,7 @@ presubmits:
         path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-1.20
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -164,7 +164,7 @@ presubmits:
         path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-1.20
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -208,7 +208,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-1.20
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-master
         command:
         - runner.sh
         - ./scripts/ci-conformance.sh
@@ -246,7 +246,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-1.20
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-master
         command:
         - runner.sh
         - ./scripts/ci-conformance.sh

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.21.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.21.yaml
@@ -26,7 +26,7 @@ presubmits:
         path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-1.21
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -71,7 +71,7 @@ presubmits:
         path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-1.21
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -118,7 +118,7 @@ presubmits:
         path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-1.21
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -164,7 +164,7 @@ presubmits:
         path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-1.21
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -208,7 +208,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-1.21
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-master
         command:
         - runner.sh
         - ./scripts/ci-conformance.sh
@@ -246,7 +246,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-1.21
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210709-09116fb-master
         command:
         - runner.sh
         - ./scripts/ci-conformance.sh


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

Fixes the following test failure in https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/103600/pull-kubernetes-e2e-capz-conformance/1414616018080239616:

```
Detected go version: go version go1.15.13 linux/amd64.
Kubernetes requires go1.16.0 or greater.
Please install go1.16.0 or later.
```

Fixes https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/1513

/assign @CecileRobertMichon 