### PR TITLE
config/jobs: fix kubernetes deprecated build jobs

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -43,8 +43,8 @@ periodics:
       - --root=/go/src
       - --timeout=240
       - --scenario=kubernetes_build
-      - --release=kubernetes-release-dev
       - --
+      - --release=kubernetes-release-dev
       - --allow-dup
       - --extra-version-markers=k8s-master
       - --registry=gcr.io/kubernetes-ci-images

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -214,8 +214,8 @@ periodics:
       - --root=/go/src
       - --timeout=240
       - --scenario=kubernetes_build
-      - --release=kubernetes-release-dev
       - --
+      - --release=kubernetes-release-dev
       - --allow-dup
       - --extra-version-markers=k8s-stable3
       - --registry=gcr.io/kubernetes-ci-images

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
@@ -213,8 +213,8 @@ periodics:
       - --root=/go/src
       - --timeout=240
       - --scenario=kubernetes_build
-      - --release=kubernetes-release-dev
       - --
+      - --release=kubernetes-release-dev
       - --allow-dup
       - --extra-version-markers=k8s-stable2
       - --registry=gcr.io/kubernetes-ci-images

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.21.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.21.yaml
@@ -215,8 +215,8 @@ periodics:
       - --root=/go/src
       - --timeout=240
       - --scenario=kubernetes_build
-      - --release=kubernetes-release-dev
       - --
+      - --release=kubernetes-release-dev
       - --allow-dup
       - --extra-version-markers=k8s-stable1
       - --registry=gcr.io/kubernetes-ci-images


### PR DESCRIPTION
The `--release` parameter was being picked up bootstrap.py instead of
the scenario it was invoking.

This should resolve https://github.com/kubernetes/kubernetes/issues/103647 but I'm not using the fixes keyword so we can close it after we've seen successful job runs

This fixes a bug introduced in https://github.com/kubernetes/test-infra/pull/22840, specifically in https://github.com/kubernetes/test-infra/pull/22840/commits/cbd67f42667b7b46db147fa5bac3cc37dfe28f91