### PR TITLE
Drop explicit repo-root from pull-kubernetes-e2e-gce-kubetest2

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -139,7 +139,6 @@ presubmits:
         - kubetest2
         - gce
         - -v=2
-        - --repo-root=$(PWD)
         - --legacy-mode # indicate that we are using kubernetes/kubernetes as opposed to kubernetes/cloud-provider-gcp
         - --build
         - --up


### PR DESCRIPTION
Quoting this correctly seems to be having issues. Drop it altogether, kubetest2 will default to $PWD anyway.

follow up to: https://github.com/kubernetes/test-infra/pull/22863
ref: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/92316/pull-kubernetes-e2e-gce-kubetest2/1414701760827625472

/cc @BenTheElder @spiffxp 