### PR TITLE
Fix typo - update loop device count in the comment

### DIFF
--- a/config/prow/cluster/create-loop-devs_daemonset.yaml
+++ b/config/prow/cluster/create-loop-devs_daemonset.yaml
@@ -5,7 +5,7 @@
 # in a KIND cluster are started with a copy of /dev from the host and
 # loop devices created later on do not show up in that static /dev
 # (https://github.com/kubernetes-sigs/kind/issues/1248). Creating
-# "enough" (100 in this daemonset) in advance avoids running out of
+# "enough" (1000 in this daemonset) in advance avoids running out of
 # loop devices.
 apiVersion: apps/v1
 kind: DaemonSet


### PR DESCRIPTION
The count got updated via - https://github.com/kubernetes/test-infra/pull/18090 but missed updating the comment, hence this PR is for updating the count in the comment as well.

/cc @BenTheElder 