### PR TITLE
Trigger pull-cip-image-cip for every PR against CIP

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -144,8 +144,8 @@ presubmits:
     cluster: k8s-infra-prow-build
     decorate: true
     path_alias: "sigs.k8s.io/k8s-container-image-promoter"
-    # TODO(releng): Run unconditionally once the job runs successfully
-    always_run: false
+    skip_report: false
+    always_run: true
     spec:
       serviceAccountName: gcb-builder-releng-test
       containers:


### PR DESCRIPTION
This change will trigger the `pull-cip-image-cip` pre-submit for every PR. Since prior permissions issues have been resolved, this test triggers GCB based on the `cloudbuild.yaml` config. This runs the `make image-push` target, ensuring images can be built and pushed correctly.

cc: @listx @amwat @justaugustus @kubernetes-sigs/release-engineering