### PR TITLE
fix missing watch permissions for horologium in starter Prow config

### DIFF
--- a/config/prow/cluster/starter-gcs.yaml
+++ b/config/prow/cluster/starter-gcs.yaml
@@ -727,6 +727,7 @@ rules:
     verbs:
       - create
       - list
+      - watch
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/prow/cluster/starter-s3.yaml
+++ b/config/prow/cluster/starter-s3.yaml
@@ -725,6 +725,7 @@ rules:
     verbs:
       - create
       - list
+      - watch
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
#21760 introduced the requirement for the `WATCH` permission, but forgot to update the 2 starter configs.