### PR TITLE
Set the DynamicKubeletConfig feature gate to true for the memory manager

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -341,7 +341,7 @@ periodics:
           - --gcp-project-type=node-e2e-project
           - --gcp-zone=us-west1-b
           - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial-cpu-manager.yaml
-          - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
+          - --node-test-args=--feature-gates=DynamicKubeletConfig=true --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
           - --node-tests=true
           - --provider=gce
           - --test_args=--nodes=1 --focus="\[Feature:MemoryManager\]"


### PR DESCRIPTION
DynamicKubeletConfig is dead; the feature is being removed instead of promoted due to poor maintenance, support, and adoption. As of 1.22, it will be deprecated and the feature gate disabled-by-default (it was enabled-by-default in 1.21).

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>