### PR TITLE
Allow workload-identity scripts to use region

### DIFF
--- a/workload-identity/bind-service-accounts.sh
+++ b/workload-identity/bind-service-accounts.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 if [[ $# != 6 ]]; then
-  echo "Usage: $(basename "$0") <project> <zone> <cluster> <namespace> <name> <gcp-service-account>" >&2
+  echo "Usage: $(basename "$0") <project> <zone_or_region> <cluster> <namespace> <name> <gcp-service-account>" >&2
   exit 1
 fi
 
@@ -33,9 +33,9 @@ if ((${BASH_VERSINFO[0]}<4)) || ( ((${BASH_VERSINFO[0]}==4)) && ((${BASH_VERSINF
 fi
 
 project=$1
-zone=$2
+location=$2
 cluster=$3
-context="gke_${project}_${zone}_${cluster}"
+context="gke_${project}_${location}_${cluster}"
 namespace=$4
 name=$5
 gcp_service_account=$6

--- a/workload-identity/bind-service-accounts.sh
+++ b/workload-identity/bind-service-accounts.sh
@@ -33,9 +33,9 @@ if ((${BASH_VERSINFO[0]}<4)) || ( ((${BASH_VERSINFO[0]}==4)) && ((${BASH_VERSINF
 fi
 
 project=$1
-location=$2
+zone=$2
 cluster=$3
-context="gke_${project}_${location}_${cluster}"
+context="gke_${project}_${zone}_${cluster}"
 namespace=$4
 name=$5
 gcp_service_account=$6

--- a/workload-identity/enable-workload-identity.sh
+++ b/workload-identity/enable-workload-identity.sh
@@ -35,7 +35,7 @@ if ((${BASH_VERSINFO[0]}<4)) || ( ((${BASH_VERSINFO[0]}==4)) && ((${BASH_VERSINF
 fi
 
 project=$1
-location=$2
+zone=$2
 cluster=$3
 
 
@@ -47,7 +47,7 @@ call-gcloud() {
   (
     set -o xtrace
     # gcloud container accepts region or zone for either argument
-    gcloud beta container "$@" "--project=$project" "--zone=$location"
+    gcloud beta container "$@" "--project=$project" "--zone=$zone"
   )
 }
 

--- a/workload-identity/enable-workload-identity.sh
+++ b/workload-identity/enable-workload-identity.sh
@@ -21,7 +21,7 @@ set -o pipefail
 # Enables workload identity on a cluster
 
 if [[ $# != 3 ]]; then
-  echo "Usage: $(basename "$0") <project> <zone> <cluster>" >&2
+  echo "Usage: $(basename "$0") <project> <zone_or_region> <cluster>" >&2
   exit 1
 fi
 
@@ -35,7 +35,7 @@ if ((${BASH_VERSINFO[0]}<4)) || ( ((${BASH_VERSINFO[0]}==4)) && ((${BASH_VERSINF
 fi
 
 project=$1
-zone=$2
+location=$2
 cluster=$3
 
 
@@ -46,7 +46,8 @@ pool_metadata=GKE_METADATA
 call-gcloud() {
   (
     set -o xtrace
-    gcloud beta container "$@" "--project=$project" "--zone=$zone"
+    # gcloud container accepts region or zone for either argument
+    gcloud beta container "$@" "--project=$project" "--zone=$location"
   )
 }
 


### PR DESCRIPTION
Just a documentation change.

I verified the following `gcloud container` commands don't care if you
pass a region in to --zone:

clusters describe
node-pools list
clusters update

Additionally the "context" name also matched in my kube config.