### PR TITLE
Bump kubekins-e2e 1.16 variants to golang 1.16.6

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.16.5
+    GO_VERSION: 1.16.6
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
@@ -9,7 +9,7 @@ variants:
     UPGRADE_DOCKER: 'true'
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.16.5
+    GO_VERSION: 1.16.6
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
@@ -22,13 +22,13 @@ variants:
     KIND_VERSION: 0.10.0
   master:
     CONFIG: master
-    GO_VERSION: 1.16.5
+    GO_VERSION: 1.16.6
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.21':
     CONFIG: '1.21'
-    GO_VERSION: 1.16.5
+    GO_VERSION: 1.16.6
     K8S_RELEASE: stable-1.21
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION

Tracking issue: https://github.com/kubernetes/release/issues/2157

This PR updates the kubekins-e2e variants to 1.16.6.
Only the 1.16 variants are modified pending cherry-picks of 1.15.14

/assign @xmudrii @Verolop @cpanato  @justaugustus
cc: @kubernetes/release-engineering


Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>