### PR TITLE
Block PRs in client-go except updates to README

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -196,6 +196,13 @@ blockades:
   blockregexps:
   - ^push-build.sh
   explanation: "Changes to push-build.sh will immediately affect the Kubernetes CI. This PR must be explicitly approved by SIG Release repo admins."
+- repos:
+  - kubernetes/client-go
+  blockregexps:
+  - .*
+  exceptionregexps:
+  - ^README\.md$
+  explanation: "We do not accept changes directly against this repository, unless the change is to the `README.md` itself. Please see `CONTRIBUTING.md` for information on where and how to contribute instead."
 
 blunderbuss:
   max_request_count: 2


### PR DESCRIPTION
We currently do not allow code to merge directly to the client-go
repo (except the main `README.md`) since it's published by the
publishing-bot. The `CONTRIBUTING.md` file mentions this info as well:
https://github.com/kubernetes/client-go/blob/master/CONTRIBUTING.md

To avoid accidental merges, we should explicitly
block PRs updates to non-README files by applying the
 `do-not-merge/blocked-paths` label.

Note that this is not an issue for other client-go repos since we
disable tide/automatic merging for those repos in the first place:
https://github.com/kubernetes/test-infra/blob/a2c4ac32a4bb360621d7d38278b5b065caa2f799/config/prow/config.yaml#L490-L521

The text for explanation matches the pull request template in client-go:
https://github.com/kubernetes/client-go/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Slack thread for context - https://kubernetes.slack.com/archives/C0EG7JC6T/p1624349678194100?thread_ts=1624347242.192800&cid=C0EG7JC6T

/sig api-machinery

/assign @sttts 
for lgtm (client-go approver)

/assign @dims 
for approving this PR