### PR TITLE
Branchprotector: Update status contexts if there is at least one optional job

### DIFF
--- a/prow/cmd/branchprotector/request.go
+++ b/prow/cmd/branchprotector/request.go
@@ -58,7 +58,7 @@ func makeBool(val *bool) bool {
 // makeChecks renders a ContextPolicy into the corresponding GitHub api object.
 //
 // Returns nil when input policy is nil.
-// Otherwise returns non-nil Contexts (empty if unset) and Strict iff Strict is true
+// Otherwise returns non-nil Contexts (empty if unset) and Strict if Strict is true
 func makeChecks(cp *branchprotection.ContextPolicy) *github.RequiredStatusChecks {
 	if cp == nil {
 		return nil

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -2683,7 +2683,7 @@ func (pc *ProwConfig) HasConfigFor() (global bool, orgs sets.String, repos sets.
 }
 
 func (pc *ProwConfig) hasGlobalConfig() bool {
-	if pc.BranchProtection.ProtectTested != nil || pc.BranchProtection.AllowDisabledPolicies != nil || pc.BranchProtection.AllowDisabledJobPolicies != nil || isPolicySet(pc.BranchProtection.Policy) {
+	if pc.BranchProtection.ProtectTested != nil || pc.BranchProtection.AllowDisabledPolicies != nil || pc.BranchProtection.AllowDisabledJobPolicies != nil || pc.BranchProtection.ProtectReposWithOptionalJobs != nil || isPolicySet(pc.BranchProtection.Policy) {
 		return true
 	}
 	emptyReference := &ProwConfig{

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -211,6 +211,10 @@ branch-protection:
     # branch protection config.
     protect-tested-repos: false
 
+    # ProtectReposWithOptionalJobs will make the Branchprotector manage required status
+    # contexts on repositories that only have optional jobs (default: false)
+    protect_repos_with_optional_jobs: false
+
     # RequiredLinearHistory enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch.
     required_linear_history: false
 


### PR DESCRIPTION
Currently, the branchprotector will ignore repos that do not have
mandatory jobs, unless the repo has an explicit config.
This leads to orphaned required status contexts on GitHub if all jobs on
a repo are made optional.

This change will make the branchprotector always update the required
status contexts if there is at least one job, optional or not.

Note that this changes behavior that was deliberate (i.E. we tested for). I can not see any downside to this other than that it might cost us a bit more tokens. If there is any other downside I missed, please do tell :)

/cc @petr-muller @cjwagner 