### PR TITLE
kubekins-e2e/krte: Build go-canary variant using go1.17rc1

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -9,7 +9,7 @@ variants:
     UPGRADE_DOCKER: 'true'
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.16.6
+    GO_VERSION: 1.17rc1
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
Tracking issues: https://github.com/kubernetes/release/issues/2169

Signed-off-by: Stephen Augustus <foo@auggie.dev>