### PR TITLE
config/tests: jobs should not use gs://kubernetes-release-pull

### DIFF
--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -1201,8 +1201,7 @@ func TestKubernetesProwJobsShouldUsePodUtils(t *testing.T) {
 	jobs := allStaticJobs()
 	for _, job := range jobs {
 		// Only consider Pods
-		// TODO(https://github.com/kubernetes/test-infra/issues/14343): remove kubeflow exemption when job configs migrated
-		if job.Spec == nil || strings.HasPrefix("kubeflow", job.Name) {
+		if job.Spec == nil {
 			continue
 		}
 		if !*job.Decorate {


### PR DESCRIPTION
Log policy violations rather than fail the test. Once migration away from
 this bucket is complete, the test can be switched to fail instead of log.

 Ideally though, this test would then be switched to a test that fails for
 _all_ job types if gs://kubernetes-release-pull shows up as a substring in
 _any_ argument.

 We could also remove it (possibly N months down the line).

Part of https://github.com/kubernetes/test-infra/issues/18789