### PR TITLE
Fix triggering presubmit Prow jobs for Gerrit change if it's changed from draft to active

### DIFF
--- a/prow/gerrit/adapter/trigger.go
+++ b/prow/gerrit/adapter/trigger.go
@@ -66,7 +66,7 @@ func messageFilter(messages []string, failingContexts, allContexts sets.String, 
 	for _, message := range messages {
 		// If the Gerrit Change changed from draft to active state, trigger all
 		// presubmit Prow jobs.
-		if strings.TrimSpace(message) == client.ReadyForReviewMessage {
+		if strings.HasSuffix(message, client.ReadyForReviewMessageFixed) || strings.HasSuffix(message, client.ReadyForReviewMessageCustomizable) {
 			filters = append(filters, pjutil.TestAllFilter())
 			continue
 		}

--- a/prow/gerrit/adapter/trigger_test.go
+++ b/prow/gerrit/adapter/trigger_test.go
@@ -299,9 +299,32 @@ func TestMessageFilter(t *testing.T) {
 			},
 		},
 		{
-			name:     "draft->active triggers multiple",
-			messages: []string{client.ReadyForReviewMessage},
+			name:     "draft->active by clicking `MARK AS ACTIVE` triggers multiple",
+			messages: []string{client.ReadyForReviewMessageFixed},
 			all:      sets.NewString("foo", "bar"),
+			checks: []check{
+				{
+					job:             job("foo", nil),
+					shouldRun:       true,
+					forcedToRun:     false,
+					defaultBehavior: false,
+				},
+				{
+					job:             job("bar", nil),
+					shouldRun:       true,
+					forcedToRun:     false,
+					defaultBehavior: false,
+				},
+			},
+		},
+		{
+			name: "draft->active by clicking `SEND AND START REVIEW` triggers multiple",
+			messages: []string{`Patch Set 1:
+
+			(1 comment)
+			
+			` + client.ReadyForReviewMessageCustomizable},
+			all: sets.NewString("foo", "bar"),
 			checks: []check{
 				{
 					job:             job("foo", nil),

--- a/prow/gerrit/client/client.go
+++ b/prow/gerrit/client/client.go
@@ -51,9 +51,12 @@ const (
 	// New status indicates a Gerrit change is new (ie pending)
 	New = "NEW"
 
-	// ReadyForReviewMessage is the message for a Gerrit change if it's changed
-	// from Draft to Active
-	ReadyForReviewMessage = "Set Ready For Review"
+	// ReadyForReviewMessage are the messages for a Gerrit change if it's changed
+	// from Draft to Active.
+	// This message will be sent if users press the `MARK AS ACTIVE` button.
+	ReadyForReviewMessageFixed = "Set Ready For Review"
+	// This message will be sent if users press the `SEND AND START REVIEW` button.
+	ReadyForReviewMessageCustomizable = "This change is ready for review."
 )
 
 // ProjectsFlag is the flag type for gerrit projects when initializing a gerrit client


### PR DESCRIPTION
The reason for having this is there are two ways to change the Gerrit change from `draft` to `active`, and the messages are different, so we need to parse both messages in order to trigger presubmit Prow jobs correctly.

/cc @chaodaiG 