### PR TITLE
run CAPI/CAPV/CAPA/CAPZ jobs with kubekins-e2e 1.21

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
@@ -17,7 +17,7 @@ periodics:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
       command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -58,7 +58,7 @@ periodics:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
       command:
         - "runner.sh"
         - "./scripts/ci-e2e-eks.sh"
@@ -96,7 +96,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         command:
           - "runner.sh"
           - "./scripts/ci-conformance.sh"
@@ -148,7 +148,7 @@ periodics:
       path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         env:
           - name: BOSKOS_HOST
             value: "boskos.test-pods.svc.cluster.local"
@@ -191,7 +191,7 @@ periodics:
       path_alias: k8s.io/test-infra
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         command:
           - runner.sh
           - bash

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
@@ -17,7 +17,7 @@ postsubmits:
         preset-aws-credential: "true"
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
             command:
               - "runner.sh"
               - "./scripts/ci-e2e.sh"
@@ -57,7 +57,7 @@ postsubmits:
         preset-aws-credential: "true"
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
             command:
               - "runner.sh"
               - "./scripts/ci-e2e-eks.sh"
@@ -97,7 +97,7 @@ postsubmits:
         preset-aws-credential: "true"
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
             command:
               - "runner.sh"
               - "./scripts/ci-conformance.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -24,7 +24,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -41,7 +41,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         command:
         - "make"
         - "verify"
@@ -80,7 +80,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
           command:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"
@@ -123,7 +123,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
           command:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"
@@ -164,7 +164,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
           command:
             - "runner.sh"
             - "./scripts/ci-e2e.sh"
@@ -208,7 +208,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
           command:
             - "runner.sh"
             - "./scripts/ci-e2e.sh"
@@ -247,7 +247,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
           command:
             - "runner.sh"
             - "./scripts/ci-e2e-eks.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
@@ -15,7 +15,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         command:
         - "runner.sh"
         - "./scripts/ci-conformance.sh"
@@ -47,7 +47,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         command:
         - "runner.sh"
         - "./scripts/ci-conformance.sh"
@@ -83,7 +83,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
       command:
       - "runner.sh"
       - "./scripts/ci-e2e.sh"
@@ -112,7 +112,7 @@ periodics:
       path_alias: k8s.io/test-infra
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
       command:
       - runner.sh
       - bash
@@ -149,7 +149,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
       command:
       - "runner.sh"
       - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-postsubmits.yaml
@@ -14,7 +14,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -27,7 +27,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -51,7 +51,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -83,7 +83,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -116,7 +116,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -149,7 +149,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -183,7 +183,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -210,7 +210,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         command:
         - "runner.sh"
         - "make"
@@ -238,7 +238,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         command:
         - "runner.sh"
         - "./scripts/ci-conformance.sh"
@@ -270,7 +270,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         command:
         - "runner.sh"
         - "./scripts/ci-conformance.sh"
@@ -308,7 +308,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
           command:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"
@@ -341,7 +341,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
           command:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"
@@ -377,7 +377,7 @@ presubmits:
       - command:
         - runner.sh
         - ./scripts/ci-apidiff.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-apidiff-main
@@ -396,7 +396,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         command:
         - runner.sh
         - bash

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-ci.yaml
@@ -13,7 +13,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
       command:
       - runner.sh
       args:
@@ -51,7 +51,7 @@ postsubmits:
     max_concurrency: 1
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         resources:
           requests:
             cpu: "1000m"
@@ -82,7 +82,7 @@ postsubmits:
     max_concurrency: 1
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         resources:
           requests:
             cpu: "1000m"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -78,7 +78,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         command:
         - hack/check-lint.sh
     annotations:
@@ -133,7 +133,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         command:
         - hack/verify-crds.sh
     annotations:
@@ -149,7 +149,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         resources:
           requests:
             cpu: "500m"
@@ -177,7 +177,7 @@ presubmits:
     max_concurrency: 3
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
@@ -17,7 +17,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
       args:
         - runner.sh
         - "./scripts/ci-e2e.sh"
@@ -61,7 +61,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
       args:
         - runner.sh
         - "./scripts/ci-e2e.sh"
@@ -105,7 +105,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
       args:
         - runner.sh
         - "./scripts/ci-e2e.sh"
@@ -149,7 +149,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
       args:
         - runner.sh
         - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -11,7 +11,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
       command:
       - "./scripts/ci-test.sh"
       resources:
@@ -35,7 +35,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -63,7 +63,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
       command:
       - "runner.sh"
       - "make"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -12,7 +12,7 @@ presubmits:
     - ^operator-0.4$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         command:
         - runner.sh
         - ./scripts/ci-build.sh
@@ -39,7 +39,7 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         resources:
           requests:
             cpu: 7300m
@@ -62,7 +62,7 @@ presubmits:
       - command:
         - runner.sh
         - ./scripts/ci-apidiff.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-apidiff-main
@@ -78,7 +78,7 @@ presubmits:
     - ^operator-0.4$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         command:
         - "runner.sh"
         - ./scripts/ci-verify.sh
@@ -100,7 +100,7 @@ presubmits:
     - ^operator-0.4$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         args:
         - runner.sh
         - ./scripts/ci-test.sh
@@ -122,7 +122,7 @@ presubmits:
     run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|errors|exp|feature|hack|scripts|test|third_party|util)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -151,7 +151,7 @@ presubmits:
     run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|errors|exp|feature|hack|scripts|test|third_party|util)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -186,7 +186,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -223,7 +223,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-go-canary
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.21
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

This PR moves CAPI/CAPV/CAPA/CAPZ jobs from the kubekins go-canary to the 1.21 image which ensures we're building with Go 1.16.x.
More details in https://github.com/kubernetes-sigs/cluster-api/issues/4954 how the go-canary image with go 1.17 rc1 lead to problems

Fixes https://github.com/kubernetes-sigs/cluster-api/issues/4954

CAPI:
/cc @CecileRobertMichon  @vincepri @fabriziopandini 
CAPV: 
/cc @yastij @randomvariable 
CAPA:
/cc @richardcase @randomvariable @sedefsavas 
CAPZ:
/cc @CecileRobertMichon  @nader-ziada 

Feel free to cc other folks, I'm not entirely sure who to cc for each provider.
