### PR TITLE
Replace U+2011 NON-BREAKING HYPHEN with regular hyphen in gerrit commit

### DIFF
--- a/prow/cmd/generic-autobumper/bumper/bumper.go
+++ b/prow/cmd/generic-autobumper/bumper/bumper.go
@@ -473,7 +473,8 @@ func MakeGitCommit(remote, remoteBranch, name, email string, stdout, stderr io.W
 }
 
 func makeGerritCommit(summary, commitTag, changeId string) string {
-	return fmt.Sprintf("%s\n\n[%s]\n\nChange-Id: %s", summary, commitTag, changeId)
+	//Gerrit commits do not recognize "&#x2011;" as NON-BREAKING HYPHEN, so just replace with a regular hyphen.
+	return fmt.Sprintf("%s\n\n[%s]\n\nChange-Id: %s", strings.ReplaceAll(summary, "&#x2011;", "-"), commitTag, changeId)
 }
 
 // GitCommitAndPush runs a sequence of git commands to commit.


### PR DESCRIPTION
Gerrit commits do not recognize "&#x2011;" as NON-BREAKING HYPHEN, so this change just replaces it with a regular hyphen.