### PR TITLE
Remove omitempty from job_state_to_report

### DIFF
--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -288,7 +288,7 @@ type ReporterConfig struct {
 type SlackReporterConfig struct {
 	Host              string         `json:"host,omitempty"`
 	Channel           string         `json:"channel,omitempty"`
-	JobStatesToReport []ProwJobState `json:"job_states_to_report,omitempty"`
+	JobStatesToReport []ProwJobState `json:"job_states_to_report"`
 	ReportTemplate    string         `json:"report_template,omitempty"`
 }
 

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -22,9 +22,12 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	coreapi "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
 
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 )
@@ -68,6 +71,59 @@ func TestMain(m *testing.M) {
 	c = conf
 
 	os.Exit(m.Run())
+}
+
+func TestReporterConfigRoundtrip(t *testing.T) {
+	tests := []struct {
+		content    string
+		expectedPJ JobBase
+	}{
+		{
+			content: `name: abc
+reporter_config:
+  slack:
+    job_states_to_report: []`,
+			expectedPJ: JobBase{
+				Name: "abc",
+				ReporterConfig: &prowapi.ReporterConfig{
+					Slack: &prowapi.SlackReporterConfig{
+						JobStatesToReport: []prowapi.ProwJobState{},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run("a", func(t *testing.T) {
+			// Unmarshal straight should pass
+			var pj JobBase
+			if err := yaml.Unmarshal([]byte(tc.content), &pj); err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tc.expectedPJ, pj); diff != "" {
+				t.Fatal("Failed unmarshal straight:\n\n", diff)
+			}
+
+			// Marshal (roundtrip)
+			marshalFromUnmarshal, err := yaml.Marshal(pj)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tc.content, strings.TrimSpace(string(marshalFromUnmarshal))); diff != "" {
+				t.Fatal("Failed marshal back to original: \n\n", diff)
+			}
+
+			// Unmarshal again (roundtrip)
+			var secondPj JobBase
+			if err := yaml.Unmarshal([]byte(marshalFromUnmarshal), &secondPj); err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tc.expectedPJ, secondPj); diff != "" {
+				t.Fatal("Failed restore:\n\n", diff)
+			}
+		})
+	}
 }
 
 func TestPresubmits(t *testing.T) {


### PR DESCRIPTION
As discussed in https://github.com/kubernetes/test-infra/issues/22888, it's intended behavior that omitempty treats empty slice as nil, which makes it not possible to differentiate nil from empty slice. While we need this for allowing overriding global default with empty slice, removing omitempty from job_state_to_report