### PR TITLE
Commenter: Replace \n with space as the former started to break searches

### DIFF
--- a/robots/commenter/main.go
+++ b/robots/commenter/main.go
@@ -116,6 +116,8 @@ func parseHTMLURL(url string) (string, string, int, error) {
 }
 
 func makeQuery(query string, includeArchived, includeClosed bool, minUpdated time.Duration) (string, error) {
+	// GitHub used to allow \n but changed it at some point to result in no results at all
+	query = strings.ReplaceAll(query, "\n", " ")
 	parts := []string{query}
 	if !includeArchived {
 		if strings.Contains(query, "archived:true") {
@@ -210,7 +212,6 @@ func makeCommenter(comment string, useTemplate bool) func(meta) (string, error) 
 }
 
 func run(c client, query, sort string, asc, random bool, commenter func(meta) (string, error), ceiling int) error {
-	log.Printf("Searching: %s", query)
 	issues, err := c.FindIssues(query, sort, asc)
 	if err != nil {
 		return fmt.Errorf("search failed: %v", err)

--- a/robots/commenter/main_test.go
+++ b/robots/commenter/main_test.go
@@ -133,6 +133,11 @@ func TestMakeQuery(t *testing.T) {
 			unexpected: []string{"%", "+"},
 		},
 		{
+			name:     "linebreaks are replaced by whitespaces",
+			query:    "label:foo\nlabel:bar",
+			expected: []string{"label:foo label:bar"},
+		},
+		{
 			name:   "include closed with is:open query errors",
 			query:  "hello is:open",
 			closed: true,


### PR DESCRIPTION
Noticed in openshift:
This query with \n doesn't return anything: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-retester/1416111565043666944
The same query but with spaces instead works: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-retester/1416112703218388992


This also breaks all the fejta-bot periodics like e.G. this one: https://github.com/kubernetes/test-infra/blob/e1bc1db4ac684f8b9a72ec895df1a10808add39b/config/jobs/kubernetes/test-infra/fejta-bot-periodics.yaml#L20-L30

/assign @chaodaiG 