### PR TITLE
Prow sub: fix a runtime npe

### DIFF
--- a/prow/pubsub/subscriber/subscriber.go
+++ b/prow/pubsub/subscriber/subscriber.go
@@ -373,6 +373,9 @@ func (s *Subscriber) handleProwJob(l *logrus.Entry, jh jobHandler, msg messageIn
 	}
 
 	// Adds / Updates Labels from prow job event
+	if labels == nil { // Could be nil if the job doesn't have label
+		labels = make(map[string]string)
+	}
 	for k, v := range pe.Labels {
 		labels[k] = v
 	}


### PR DESCRIPTION
Previously this was developed for jobs that all have labels, so it never happened. As this function being used by more job types, such as presubmit and postsubmit, there are cases where labels are nil