### PR TITLE
Lint for exported loop var pointers and fix occurences

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,7 @@ linters:
   - ineffassign
   - staticcheck
   - gosimple
+  - exportloopref
   disable-all: true
 
 issues:

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -1157,6 +1157,9 @@ func handleArtifactView(o options, sg *spyglass.Spyglass, cfg config.Getter) htt
 		var lens *config.LensFileConfig
 		for _, configLens := range cfg().Deck.Spyglass.Lenses {
 			if configLens.Lens.Name == lensName {
+
+				// Directly followed by break, so this is ok
+				// nolint: exportloopref
 				lens = &configLens
 				break
 			}

--- a/prow/plugins/bugzilla/bugzilla_test.go
+++ b/prow/plugins/bugzilla/bugzilla_test.go
@@ -1759,6 +1759,7 @@ Instructions for interacting with me using PR comments are available [here](http
 				gc.IssueLabelsExisting = append(gc.IssueLabelsExisting, fmt.Sprintf("%s/%s#%d:%s", e.org, e.repo, e.number, label))
 			}
 			for _, pr := range testCase.prs {
+				pr := pr
 				gc.PullRequests[pr.Number] = &pr
 			}
 			bc := bugzilla.Fake{

--- a/prow/plugins/cla/cla_test.go
+++ b/prow/plugins/cla/cla_test.go
@@ -144,11 +144,13 @@ func TestCLALabels(t *testing.T) {
 	for _, tc := range testcases {
 		pullRequests := make(map[int]*github.PullRequest)
 		for _, pr := range tc.pullRequests {
+			pr := pr
 			pullRequests[pr.Number] = &pr
 		}
 
 		issues := make(map[int]*github.Issue)
 		for _, issue := range tc.issues {
+			issue := issue
 			issues[issue.Number] = &issue
 		}
 
@@ -337,6 +339,7 @@ func TestCheckCLA(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			pullRequests := make(map[int]*github.PullRequest)
 			for _, pr := range tc.pullRequests {
+				pr := pr
 				pullRequests[pr.Number] = &pr
 			}
 			fc := fakegithub.NewFakeClient()

--- a/prow/pubsub/subscriber/subscriber.go
+++ b/prow/pubsub/subscriber/subscriber.go
@@ -155,6 +155,8 @@ func (peh *periodicJobHandler) getProwJobSpec(cfg prowCfgClient, pe ProwJobEvent
 	// https://github.com/kubernetes/test-infra/issues/21729 is done?
 	for _, job := range cfg.AllPeriodics() {
 		if job.Name == pe.Name {
+			// Directly followed by break, so this is ok
+			// nolint: exportloopref
 			periodicJob = &job
 			break
 		}
@@ -268,6 +270,7 @@ func (poh *postsubmitJobHandler) getProwJobSpec(cfg prowCfgClient, pe ProwJobEve
 	}
 
 	for _, job := range postsubmits {
+		job := job
 		if !job.CouldRun(branch) { // filter out jobs that are not branch matching
 			continue
 		}

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -1887,6 +1887,7 @@ func testTakeAction(clients localgit.Clients, t *testing.T) {
 					t.Errorf("prowjob %q didn't have expected namespace %q but %q", pj.Name, pjNamespace, pj.Namespace)
 				}
 				if pj.Spec.Type == prowapi.BatchJob {
+					pj := pj
 					batchJobs = append(batchJobs, &pj)
 				}
 			}


### PR DESCRIPTION
Finds issues like https://github.com/kubernetes/test-infra/pull/22926 (and did in fact find another issue in the same file).

Only drawback is that it complains when such a construct is followed by `break`, even though that is valid.

/assign @chaodaiG 