### PR TITLE
fix  pull-kubernetes-e2e-gce-ubuntu

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -239,6 +239,8 @@ presubmits:
         - --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu
         - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2004-focal-v20200423
         - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
+        - --env=KUBE_CONTAINER_RUNTIME=docker
+        - --env=ENABLE_POD_SECURITY_POLICY=true
         - --extract=local
         - --gcp-master-image=ubuntu
         - --gcp-node-image=ubuntu


### PR DESCRIPTION
It should match the periodic job configuration
https://github.com/kubernetes/test-infra/blob/920847bfec1154e1382293df9a06fa0da05a091d/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml#L468-L499

The periodic job has an open isseu https://github.com/kubernetes/kubernetes/issues/103708, but we can't know if the fix works until it merges.

Right now ithe job doesn't work, it fails during the installation
process because it is missing some components.

Fixes: https://github.com/kubernetes/kubernetes/issues/103738