### PR TITLE
Kops - Increase job timeout for keypair rotation test

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -622,6 +622,7 @@ def generate_misc():
                    cloud="aws",
                    kops_channel="alpha",
                    runs_per_day=3,
+                   test_timeout_minutes=120,
                    scenario="keypair-rotation",
                    extra_dashboards=['kops-misc']),
 

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -1351,7 +1351,7 @@ periodics:
     preset-dind-enabled: "true"
   decorate: true
   decoration_config:
-    timeout: 90m
+    timeout: 150m
   extra_refs:
   - org: kubernetes
     repo: kops


### PR DESCRIPTION
Fixes https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-aws-keypair-rotation/1416835553650806784/build-log.txt

`{"component":"entrypoint","file":"prow/entrypoint/run.go:165","func":"k8s.io/test-infra/prow/entrypoint.Options.ExecuteProcess","level":"error","msg":"Process did not finish before 1h30m0s timeout","severity":"error","time":"2021-07-18T20:32:17Z"}`