### PR TITLE
don't run test with ENABLE_POD_SECURITY_POLICY

### DIFF
--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -95,7 +95,6 @@ periodics:
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
-      - --env=ENABLE_POD_SECURITY_POLICY=true
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-master

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -7,10 +7,6 @@ presets:
 - labels:
     preset-pull-kubernetes-e2e-gce: "true"
   env:
-  # Enable the PodSecurityPolicy in tests.
-  # TODO: Enable this by default in the test environment.
-  - name: ENABLE_POD_SECURITY_POLICY
-    value: "true"
   - name: CREATE_CUSTOM_NETWORK
     value: "true"
 
@@ -240,7 +236,6 @@ presubmits:
         - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2004-focal-v20200423
         - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
         - --env=KUBE_CONTAINER_RUNTIME=docker
-        - --env=ENABLE_POD_SECURITY_POLICY=true
         - --extract=local
         - --gcp-master-image=ubuntu
         - --gcp-node-image=ubuntu
@@ -290,7 +285,6 @@ presubmits:
             - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.2
             - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc95
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
-            - --env=ENABLE_POD_SECURITY_POLICY=true
             - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
             - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
             - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-2004-focal-v20200423
@@ -351,7 +345,6 @@ presubmits:
             - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.2
             - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc95
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
-            - --env=ENABLE_POD_SECURITY_POLICY=true
             - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
             - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
             - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-2004-focal-v20200423
@@ -438,7 +431,6 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
-      - --env=ENABLE_POD_SECURITY_POLICY=true
       - --extract=ci/latest-fast
       - --extract-ci-bucket=k8s-release-dev
       - --gcp-master-image=gci
@@ -478,7 +470,6 @@ periodics:
           - --scenario=kubernetes_e2e
           - --
           - --check-leaked-resources
-          - --env=ENABLE_POD_SECURITY_POLICY=true
           - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
           - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-2004-focal-v20200423
           - --env=KUBE_GCE_MASTER_PROJECT=ubuntu-os-cloud
@@ -529,7 +520,6 @@ periodics:
           - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.2
           - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc95
           - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
-          - --env=ENABLE_POD_SECURITY_POLICY=true
           - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
           - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
           - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-2004-focal-v20200423
@@ -644,7 +634,6 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
-      - --env=ENABLE_POD_SECURITY_POLICY=true
       - --extract=ci/latest
       - --gcp-master-image=gci
       - --gcp-node-image=gci
@@ -902,7 +891,6 @@ periodics:
       - --
       - --down=false
       - --env=DOCKER_TEST_LOG_LEVEL=--log-level=warn
-      - --env=ENABLE_POD_SECURITY_POLICY=true
       - --extract=ci/k8s-stable1
       - --gcp-node-image=gci
       - --gcp-project=k8s-jkns-gci-gce-soak-1-4

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -121,7 +121,6 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
-      - --env=ENABLE_POD_SECURITY_POLICY=true
       - --extract=ci/latest
       - --gcp-node-image=gci
       - --gcp-nodes=4
@@ -388,7 +387,6 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
-      - --env=ENABLE_POD_SECURITY_POLICY=true
       - --extract=ci/latest
       - --gcp-node-image=gci
       - --gcp-nodes=4
@@ -748,7 +746,6 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
-      - --env=ENABLE_POD_SECURITY_POLICY=true
       - --extract=ci/latest
       - --gcp-node-image=gci
       - --gcp-nodes=4

--- a/config/jobs/kubernetes/sig-node/sig-node-config.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-config.yaml
@@ -14,7 +14,6 @@ periodics:
       - --check-leaked-resources
       - --env=KUBE_CONTAINER_RUNTIME=containerd
       - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
-      - --env=ENABLE_POD_SECURITY_POLICY=true
       - --extract=ci/latest
       - --gcp-master-image=gci
       - --gcp-node-image=gci

--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -94,7 +94,6 @@ periodics:
       - |
         shopt -s globstar
         ../test-infra/scenarios/kubernetes_e2e.py \
-          --env=ENABLE_POD_SECURITY_POLICY=true \
           --build=quick \
           --dump-before-and-after \
           --extract=local \

--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -138,7 +138,6 @@ periodics:
       - --check-leaked-resources
       - --check-version-skew=false
       - --cluster=canary-e2e
-      - --env=ENABLE_POD_SECURITY_POLICY=true
       - --extract=ci/k8s-stable1
       - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging

--- a/config/jobs/kubernetes/wg-k8s-infra/canaries/sig-node-containerd.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/canaries/sig-node-containerd.yaml
@@ -106,7 +106,6 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
-      - --env=ENABLE_POD_SECURITY_POLICY=true
       - --extract=ci/latest
       - --gcp-node-image=gci
       - --gcp-nodes=4
@@ -404,7 +403,6 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
-      - --env=ENABLE_POD_SECURITY_POLICY=true
       - --extract=ci/latest
       - --gcp-node-image=gci
       - --gcp-nodes=4
@@ -797,7 +795,6 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
-      - --env=ENABLE_POD_SECURITY_POLICY=true
       - --extract=ci/latest
       - --gcp-node-image=gci
       - --gcp-nodes=4

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -46,7 +46,6 @@ jobs:
     releaseBlocking: true
   ci-kubernetes-e2e-gce-cos-k8sbeta-default:
     args:
-    - --env=ENABLE_POD_SECURITY_POLICY=true
     - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
     interval: 1h
     sigOwners: [sig-cloud-provider-gcp]


### PR DESCRIPTION
Quoting from Jordan Liggitt
" PodSecurityPolicy is optional and deprecated.
We shouldn't be enabling it in new jobs.
No e2e or addon should fail if it's not enabled."

Remove the ENABLE_POD_SECURITY_POLICY=true option
from all jobs that run against master branch

/assign @liggitt @dims @spiffxp @BenTheElder @tallclair 