### PR TITLE
Commenter: Re-add query logging

### DIFF
--- a/robots/commenter/main.go
+++ b/robots/commenter/main.go
@@ -212,6 +212,7 @@ func makeCommenter(comment string, useTemplate bool) func(meta) (string, error) 
 }
 
 func run(c client, query, sort string, asc, random bool, commenter func(meta) (string, error), ceiling int) error {
+	log.Printf("Searching: %s", query)
 	issues, err := c.FindIssues(query, sort, asc)
 	if err != nil {
 		return fmt.Errorf("search failed: %v", err)


### PR DESCRIPTION
I accidentally removed this in
https://github.com/kubernetes/test-infra/pull/22922/files#diff-4ab84a2dd77572b4207a001a0e0747104a89dec523b4db6d2908e4f7eca5d863L213

/cc @chaodaiG 