### PR TITLE
chore: use external secrets for gcp secrets-csi

### DIFF
--- a/config/prow/cluster/build_kubernetes-external-secrets_customresource.yaml
+++ b/config/prow/cluster/build_kubernetes-external-secrets_customresource.yaml
@@ -13,3 +13,16 @@ spec:
   - key: azure-cred
     name: credentials
     version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: gcp-secrets-store-cred
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: secretmanager-csi-build
+  data:
+  - key: key.json
+    name: k8s-oss-prow
+    version: latest


### PR DESCRIPTION
An identity is needed for the gcp provider testing in https://github.com/kubernetes-sigs/secrets-store-csi-driver

Previously this has been stored by running:
```
kubectl create secret generic -n test-pods gcp-secrets-store-cred --from-file=key.json
```

Every 6 months. This will now auto sync `projects/secretmanager-csi-build/secrets/k8s-oss-prow` to `gcp-secrets-store-cred`.

Rotation of the secret is still manual process.

Addresses:
https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/507
https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/640