### PR TITLE
secrets-store-csi-driver: gcp use workload identity instead of secret

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -230,9 +230,8 @@ presubmits:
       preset-dind-enabled: "true"
       # this is required to make CNI installation to succeed for kind
       preset-kind-volume-mounts: "true"
-      # sets up the gcp parameters used for testing
-      preset-gcp-secrets-store-creds: "true"
     spec:
+      serviceAccountName: secrets-store-csi-driver-gcp
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-master
         command:
@@ -392,9 +391,8 @@ presubmits:
       preset-dind-enabled: "true"
       # this is required to make CNI installation to succeed for kind
       preset-kind-volume-mounts: "true"
-      # sets up the gcp parameters used for testing
-      preset-gcp-secrets-store-creds: "true"
     spec:
+      serviceAccountName: secrets-store-csi-driver-gcp
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-master
         command:
@@ -500,9 +498,8 @@ postsubmits:
       preset-dind-enabled: "true"
       # this is required to make CNI installation to succeed for kind
       preset-kind-volume-mounts: "true"
-      # sets up the gcp parameters used for testing
-      preset-gcp-secrets-store-creds: "true"
     spec:
+      serviceAccountName: secrets-store-csi-driver-gcp
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-master
         command:

--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-presets.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-presets.yaml
@@ -27,11 +27,3 @@ presets:
       secretKeyRef:
         name: azure-secrets-store-cred
         key: tenantid
-- labels:
-    preset-gcp-secrets-store-creds: "true"
-  env:
-  - name: GCP_SA_JSON
-    valueFrom:
-      secretKeyRef:
-        name: gcp-secrets-store-cred
-        key: key.json

--- a/config/prow/cluster/build_serviceaccounts.yaml
+++ b/config/prow/cluster/build_serviceaccounts.yaml
@@ -44,4 +44,13 @@ metadata:
   name: kubernetes-external-secrets-sa
   namespace: default
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    # Used by the gcp provider tests for secrets-store-csi-driver
+    iam.gke.io/gcp-service-account: k8s-csi-test@secretmanager-csi-build.iam.gserviceaccount.com
+  name: secrets-store-csi-driver-gcp
+  namespace: test-pods
+---
 # TODO(fejta): any other service accounts


### PR DESCRIPTION
Alternative to [ExternalSecret](https://github.com/kubernetes/test-infra/pull/22943) syncing, using workload identity for the secrets-store-csi-driver gcp integration tests:


Requires:
* https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/pull/130
* https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/641

I've verified that the GCP provider process in the test cases currently runs as the user `serviceAccount:k8s-prow-builds.svc.id.goog[test-pods/default]`. Switching the pod to a different SA and granting:

`serviceAccount:k8s-prow-builds.svc.id.goog[test-pods/secrets-store-csi-driver-gcp]` permission to act as `k8s-csi-test@secretmanager-csi-build.iam.gserviceaccount.com` will allow the test cases to use workload identity instead of exported SA + sync'd secret.