### PR TITLE
remove unused env variables in csi-secrets-store for azure preset

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-presets.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-presets.yaml
@@ -12,16 +12,6 @@ presets:
       secretKeyRef:
         name: azure-secrets-store-cred
         key: clientsecret
-  - name: RESOURCE_GROUP
-    valueFrom:
-      secretKeyRef:
-        name: azure-secrets-store-cred
-        key: resourcegroup
-  - name: SUBSCRIPTION_ID
-    valueFrom:
-      secretKeyRef:
-        name: azure-secrets-store-cred
-        key: subscriptionid
   - name: TENANT_ID
     valueFrom:
       secretKeyRef:


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

- Removes `RESOURCE_GROUP` and `SUBSCRIPTION_ID` env var which are never used in the azure e2e tests. 