### PR TITLE
chore: use external secrets for azure secrets-store-csi

### DIFF
--- a/config/prow/cluster/build_kubernetes-external-secrets_customresource.yaml
+++ b/config/prow/cluster/build_kubernetes-external-secrets_customresource.yaml
@@ -26,3 +26,22 @@ spec:
   - key: key.json
     name: k8s-oss-prow
     version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: azure-secrets-store-cred
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: kubernetes-upstream
+  data:
+  - key: azure-secrets-store-cred
+    name: credentials
+    version: latest
+  kvVersion: 2
+  template:
+    data:
+      clientid: <%= JSON.parse(data.credentials).clientid %>
+      clientsecret: <%= JSON.parse(data.credentials).clientsecret %>
+      tenantid: <%= JSON.parse(data.credentials).tenantid %>


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

The secret `azure-secrets-store-cred` has been added to `kubernetes-upstream`. The value is in json format.

```json
{
    "clientid": "<b64 encoded client id>",
    "clientsecret": "<b64 encoded client secret>",
    "tenantid": "<b64 encoded tenant id>",
    "keyvaultname": "<b64 encoded keyvault name>",
    "keyversion": "<b64 encoded key1 key version>"
}
```


fixes https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/507
- The gcp creds have been moved to use external-secrets as part of https://github.com/kubernetes/test-infra/pull/22943
- This PR is the last step for the issue