### PR TITLE
chore: correct gcp-secrets-store-cred paths

### DIFF
--- a/config/prow/cluster/build_kubernetes-external-secrets_customresource.yaml
+++ b/config/prow/cluster/build_kubernetes-external-secrets_customresource.yaml
@@ -23,6 +23,6 @@ spec:
   backendType: gcpSecretsManager
   projectId: secretmanager-csi-build
   data:
-  - key: key.json
-    name: k8s-oss-prow
+  - key: k8s-oss-prow
+    name: key.json
     version: latest


### PR DESCRIPTION
From the docs I had these backwards: https://github.com/kubernetes/test-infra/blob/master/prow/prow_secrets.md#usage-prow-clients

```
  - key: <my-gsm-secret-name>     # name of the GCP secret
    name: <my-kubernetes-secret-name>   # key name in the k8s secret
```

Intent is to load `projects/secretmanager-csi-build/secrets/k8s-oss-prow/versions/latest` to K8s secret `test-pods/gcp-secrets-store-cred` at key `key.json`