### PR TITLE
prow/config.yaml: set merge_method for kubebuilder repos

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -610,8 +610,11 @@ tide:
     kubernetes-client/gen: squash
     kubernetes-sigs/cluster-api-provider-digitalocean: squash
     kubernetes-sigs/cluster-api-provider-ibmcloud: squash
+    kubernetes-sigs/controller-runtime: squash
+    kubernetes-sigs/controller-tools: squash
     kubernetes-sigs/krew-index: squash
     kubernetes-sigs/krew: squash
+    kubernetes-sigs/kubebuilder: squash
     kubernetes-sigs/kubespray: squash
     kubernetes-sigs/kui: rebase
     kubernetes-sigs/security-profiles-operator: rebase


### PR DESCRIPTION
kubebuilder, controller-runtime, and controller-tools
use "squash" commits for merging PRs. Adding this to
help avoid non-squash commits by default.

Signed-off-by: Joe Lanford <joe.lanford@gmail.com>