### PR TITLE
[releng] 1.22: Add 1.22 and remove 1.18 milestone_applier rules

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -321,10 +321,10 @@ milestone_applier:
     master: v1.22
   kubernetes/kubernetes:
     master: v1.22
+    release-1.22: v1.22
     release-1.21: v1.21
     release-1.20: v1.20
     release-1.19: v1.19
-    release-1.18: v1.18
   kubernetes/org:
     main: v1.22
   kubernetes/release:


### PR DESCRIPTION
This commit adds the 1.22 branch configuration and removes the 1.18 rule for the milestone_applier plugin.

Pending 1.22 branch cut:
/hold

/sig release
/area release-eng
/assign @saschagrunert @justaugustus @cpanato
/milestone v1.22
cc: @kubernetes/release-engineering

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>