### PR TITLE
[releng] 1.22: Update kubekins-e2e variants.yaml with 1.22 config

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -26,6 +26,12 @@ variants:
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
+  '1.22':
+    CONFIG: '1.22'
+    GO_VERSION: 1.16.6
+    K8S_RELEASE: latest-1.22
+    BAZEL_VERSION: 3.4.1
+    OLD_BAZEL_VERSION: 2.2.0
   '1.21':
     CONFIG: '1.21'
     GO_VERSION: 1.16.6


### PR DESCRIPTION
Add 1.22 configuration to kubekins-e2e variants.yaml

Pending branch cut:
/hold

/sig release
/milestone v1.22
/area release-eng
/assign @justaugustus @saschagrunert @cpanato
cc: @kubernetes/release-engineering

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>