### PR TITLE
image-builder: make OVA job optional

### DIFF
--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-ova-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-ova-presubmits.yaml
@@ -7,6 +7,7 @@ presubmits:
         preset-cluster-api-provider-vsphere-e2e-config: "true"
         preset-cloud-provider-vsphere-e2e-config: "true"
       decorate: true
+      optional: true
       decoration_config:
         timeout: 1h
       run_if_changed: 'images/capi/(Makefile|ansible\.cfg)|images/capi/ansible/.*|images/capi/scripts/ci-ova\.sh|images/capi/packer/(config|goss|ova)/.*|images/capi/hack/ensure-(ansible|packer|goss).*'


### PR DESCRIPTION
make OVA job optional, need to update the job secrets.

slack 🧵 https://kubernetes.slack.com/archives/C01E0Q35A8J/p1626725388053700

/assign @CecileRobertMichon @codenrhoden 