### PR TITLE
ingress-nginx: enable require-matching-label

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -801,6 +801,10 @@ plugins:
     - require-matching-label
     - stage
 
+  kubernetes/ingress-nginx:
+    plugins:
+    - require-matching-label
+
   kubernetes/k8s.io:
     plugins:
     - milestone


### PR DESCRIPTION
Enable require-matching-label for k/ingress-nginx

/assign @rikatz @iamNoah1