### PR TITLE
Update CAPG jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-release-0-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-release-0-3.yaml
@@ -1,5 +1,5 @@
 periodics:
-- name: periodic-cluster-api-provider-gcp-make-conformance-v1alpha3
+- name: periodic-cluster-api-provider-gcp-conformance-v1alpha3
   labels:
     preset-service-account: "true"
     preset-bazel-scratch-dir: "true"
@@ -47,7 +47,7 @@ periodics:
     testgrid-tab-name: capg-conformance-v1alpha3-release-0-3
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
-- name: periodic-cluster-api-provider-gcp-make-conformance-v1alpha3-k8s-ci-artifacts
+- name: periodic-cluster-api-provider-gcp-conformance-v1alpha3-k8s-ci-artifacts
   labels:
     preset-service-account: "true"
     preset-bazel-scratch-dir: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics.yaml
@@ -57,10 +57,6 @@ periodics:
     repo: cluster-api-provider-gcp
     base_ref: main
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
-  - org: kubernetes-sigs
-    repo: image-builder
-    base_ref: master
-    path_alias: "sigs.k8s.io/image-builder"
   - org: kubernetes
     repo: kubernetes
     base_ref: release-1.19

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
@@ -79,11 +79,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 3h
-    extra_refs:
-    - org: kubernetes-sigs
-      repo: image-builder
-      base_ref: master
-      path_alias: "sigs.k8s.io/image-builder"
     spec:
       containers:
         - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-master
@@ -107,7 +102,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-e2e-test
   # conformance test against kubernetes master branch with `kind` + cluster-api-provider-gcp
-  - name: pull-cluster-api-provider-gcp-make-conformance
+  - name: pull-cluster-api-provider-gcp-conformance-ci-artifacts
     labels:
       preset-service-account: "true"
       preset-bazel-scratch-dir: "true"
@@ -141,6 +136,48 @@ presubmits:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"
             - "--use-ci-artifacts"
+          # we need privileged mode in order to do docker in docker
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              # these are both a bit below peak usage during build
+              # this is mostly for building kubernetes
+              memory: "9000Mi"
+              # during the tests more like 3-20m is used
+              cpu: 2000m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
+      testgrid-tab-name: pr-conformance-ci-artifacts
+  - name: pull-cluster-api-provider-gcp-conformance
+    labels:
+      preset-service-account: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
+    branches:
+    - ^main$
+    always_run: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 3h
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: release-1.19
+      path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-master
+          env:
+            - name: "BOSKOS_HOST"
+              value: "boskos.test-pods.svc.cluster.local"
+          command:
+            - "runner.sh"
+            - "./scripts/ci-conformance.sh"
           # we need privileged mode in order to do docker in docker
           securityContext:
             privileged: true


### PR DESCRIPTION
Now we don't need to build the node images every time, so we can remove the image-builder dependency

the only job we need to keep is the conformance that uses ci artifacts because the nightly job does not build that image, and then for the presubmits adding two conformance tests one with ci-artifacts and another without.

Related PR in CAPG: https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/400

/assign @dims 