### PR TITLE
Use --container-runtime=containerd for cloud-provider-gcp-e2e-full

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -103,4 +103,4 @@ presubmits:
           go get sigs.k8s.io/kubetest2@latest;
           go get sigs.k8s.io/kubetest2/kubetest2-gce@latest;
           go get sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
-          kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo -- --test-package-version=v1.21.0 --parallel=30 --test-args='--minStartupPods=8' --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
+          kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo -- --test-package-version=v1.21.0 --parallel=30 --test-args='--minStartupPods=8 --container-runtime=containerd' --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'


### PR DESCRIPTION
This PR passes the correct container runtime argument to the ginkgo invocation for cloud-provider-gcp, fixing a couple E2E tests where that ends up used. A similar usage of the argument can be seen [here](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/kops/kops-periodics-distros.yaml#L34).