### PR TITLE
update csi-secrets-store build branch to release

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-csi-secrets-store.yaml
+++ b/config/jobs/image-pushing/k8s-staging-csi-secrets-store.yaml
@@ -16,7 +16,7 @@ postsubmits:
       # job makes sense on every branch (unless it's setting a `latest` tag it
       # probably does).
       branches:
-        - ^master$
+        - ^release-v$
       spec:
         serviceAccountName: gcb-builder
         containers:


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

- Removing `master` branch from build trigger so we don't build master anymore. The builds will be from release branches only. 