### PR TITLE
[wg-k8s-infra] Fix path of canary job

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/canaries/sig-scalability.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/canaries/sig-scalability.yaml
@@ -412,7 +412,7 @@ periodics:
       args:
       - -c
       - >-
-        cd /workspace/k8s.io/perf-tests/golang &&
+        cd /home/prow/go/src/k8s.io/perf-tests/golang &&
         make GCS_BUCKET=k8s-infra-scale-golang-builds
       # docker-in-docker needs privileged mode
       securityContext:


### PR DESCRIPTION
Followup of https://github.com/kubernetes/test-infra/pull/22966.

Fix wrong path for the make command.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>