### PR TITLE
Fix post-test-infra-push-prow regex to not match on bump prs

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -171,7 +171,7 @@ postsubmits:
   - name: post-test-infra-push-prow
     cluster: test-infra-trusted
     # Runs on more than just the Prow dir to include some additional images that we publish to gcr.io/k8s-prow.
-    run_if_changed: '^(WORKSPACE|load.bzl|repos.bzl|containers.bzl|prow|ghproxy|label_sync/.+\.go|robots/commenter|robots/pr-creator|robots/issue-creator|testgrid/cmd|gcsweb)'
+    run_if_changed: '^(WORKSPACE|load.bzl|repos.bzl|containers.bzl|(prow((?!\/test\/)))|ghproxy|label_sync/.+\.go|robots/commenter|robots/pr-creator|robots/issue-creator|testgrid/cmd|gcsweb)'
     decorate: true
     branches:
     - ^master$


### PR DESCRIPTION
Bump prs bump the file
`prow/test/integration/prow/cluster/deck_deployment.yaml` which is
currently matched by the regex, so a bump will cause a build, will cause
an automatic bump etc.

Avoid this by just matching things in prow that are not followed by
/test/.

/assign @chaodaiG 