### PR TITLE
Reflect that we are using the nightly build not 1.5 of containerd for Windows

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -700,7 +700,7 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs Windows alpha HostProcess tests (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 3h
-  name: ci-kubernetes-e2e-aks-engine-azure-master-windows-containerd-1-5
+  name: ci-kubernetes-e2e-aks-engine-azure-master-windows-containerd-nightly
   decorate: true
   decoration_config:
     timeout: 3h
@@ -741,7 +741,7 @@ periodics:
       - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
       - --aksengine-winZipBuildScript=$(WIN_BUILD)
       - --aksengine-orchestratorRelease=1.22
-      - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_1_5.json
+      - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_nightly.json
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
       # Specific test args
@@ -752,6 +752,6 @@ periodics:
   annotations:
     fork-per-release: "true"
     testgrid-dashboards: sig-windows-master-release
-    testgrid-tab-name: aks-engine-windows-containerd-1-5-master
+    testgrid-tab-name: aks-engine-windows-containerd-nightly
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
-    description: Runs Windows tests on a Kubernetes cluster running containerd provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
+    description: Runs Windows tests on a Kubernetes cluster running nightly builds of containerd and hcsshim provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud


### PR DESCRIPTION
updates for https://github.com/kubernetes-sigs/windows-testing/pull/276

/sig windows
/cc @marosset @chewong 

/hold
will release both PRs at same time to minimize failures