### PR TITLE
Drop travis for kubernetes/utils

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -360,10 +360,6 @@ branch-protection:
             users: []
             teams:
             - stage-bots
-        utils:
-          required_status_checks:
-            contexts:
-            - continuous-integration/travis-ci
         website:
           protect: false # TODO(fejta): protect all branches soon
           branches:


### PR DESCRIPTION
Travis is gone from k/utils repository.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>