### PR TITLE
images/gcb-docker-gcloud: use docker buildx v0.6.0

### DIFF
--- a/images/gcb-docker-gcloud/Dockerfile
+++ b/images/gcb-docker-gcloud/Dockerfile
@@ -44,7 +44,7 @@ RUN echo http://dl-cdn.alpinelinux.org/alpine/latest-stable/community >> /etc/ap
 # Install docker Buildx for fast docker builds
 ENV HOME=/root
 RUN mkdir -p  $HOME/.docker/cli-plugins \
-    && curl -fsSL "https://github.com/docker/buildx/releases/download/v0.4.1/buildx-v0.4.1.linux-amd64" --output $HOME/.docker/cli-plugins/docker-buildx \
+    && curl -fsSL "https://github.com/docker/buildx/releases/download/v0.6.0/buildx-v0.6.0.linux-amd64" --output $HOME/.docker/cli-plugins/docker-buildx \
     && chmod a+x $HOME/.docker/cli-plugins/docker-buildx
 
 # Copy qemu static binaries.


### PR DESCRIPTION
Hoping this addresses https://github.com/kubernetes/test-infra/issues/20884

According to the upstream issue(s) this should include the fix we're looking for