### PR TITLE
docs: update "Life of a Prow Job"

### DIFF
--- a/prow/life_of_a_prow_job.md
+++ b/prow/life_of_a_prow_job.md
@@ -1,36 +1,57 @@
 # Life of a Prow Job
 
-I comment `/test all` on a Pull Request (PR). In response, GitHub posts my comment to Prow, via [a webhook](https://developer.github.com/webhooks/). See examples for webhook payloads [here](https://github.com/kubernetes/test-infra/tree/c8829eef589a044126289cb5b4dc8e85db3ea22f/prow/cmd/phony/examples).
+NOTE: This document uses [5df7636b83cab54e248e550a31dbf1e4731197a6][prow-repo-sync-point] (July 21, 2021) as a reference point for all code links.
 
-Prow's Kubernetes cluster uses an [ingress resource](https://kubernetes.io/docs/concepts/services-networking/ingress/) for terminating TLS, and routing traffic to the hook [service resource](https://kubernetes.io/docs/concepts/services-networking/service/). [This document](https://github.com/kubernetes/test-infra/blob/c8829eef589a044126289cb5b4dc8e85db3ea22f/prow/cluster/ingress.yaml) describes the configuration for the ingress resource. The ingress resource sends traffic to the "hook" service. [This document](https://github.com/kubernetes/test-infra/blob/c8829eef589a044126289cb5b4dc8e85db3ea22f/prow/cluster/hook_service.yaml) describes the configuration for the "hook" service.
+Let's pretend a user comments `/test all` on a Pull Request (PR).
+In response, GitHub posts this comment to Prow via a [webhook][github-webhook].
+See [examples for webhook payloads][sample-github-webhook-payloads].
 
-The "hook" service routes traffic to the "hook" application. [This deployment resource](https://github.com/kubernetes/test-infra/blob/c8829eef589a044126289cb5b4dc8e85db3ea22f/prow/cluster/hook_deployment.yaml) defines the pods that "hook" is comprised of.
+Prow's Kubernetes cluster uses an [ingress resource][ingress-resource] for terminating TLS, and routes traffic to the **hook** [service resource][service-resource], finally sending the traffic to the **hook** application, which is defined as a [deployment][deployment-controller]:
 
-The pods for "hook" run [the "Hook" executable](https://github.com/kubernetes/test-infra/blob/42d4af367a2312d8facbb92f9669f7356d8b13f4/prow/cmd/hook/main.go#L95). "hook" listens for incoming http requests and translates them to "GitHub event objects". Afterwards, "hook" broadcasts these events to Prow Plugins. In the case of my `/test all` comment, "hook" builds an ["Issue Comment Event"](https://github.com/kubernetes/test-infra/blob/c8829eef589a044126289cb5b4dc8e85db3ea22f/prow/github/types.go#L116-L121).
+* [This document][ingress-yaml] describes the configuration for the ingress resource.
+* [This document][hook-service-yaml] describes the configuration for the **hook** service.
+* [This document][hook-deployment-yaml] defines the pods for the  **hook** application.
 
-Prow plugins receive 2 objects: 1) a GitHub event object, and 2) a ["client agent object"](https://github.com/kubernetes/test-infra/blob/42d4af367a2312d8facbb92f9669f7356d8b13f4/prow/plugins/plugins.go#L199). The Client agent object contains 7 clients: GitHub, Prow jobs, Kubernetes, Git, Slack, Owners, and Bugzilla. These 7 clients are initialized by "hook", during start-up. This is what "client agent objects" look like:
+The pods for **hook** run [the **hook** executable][hook-main].
+**hook** listens for incoming HTTP requests and translates them to "GitHub event objects".
+For example, in the case of the `/test all` comment from above, **hook** builds an [`GenericCommentEvent`][github-GenericommentEvent].
+Afterwards, **hook** broadcasts these events to Prow Plugins.
 
-```go
-type ClientAgent struct {
-	GitHubClient     github.Client
-	ProwJobClient    prowv1.ProwJobInterface
-	KubernetesClient kubernetes.Interface
-	GitClient        *git.Client
-	SlackClient      *slack.Client
-	OwnersClient     *repoowners.Client
-	BugzillaClient   bugzilla.Client
-}
-```
+Prow Plugins receive 2 objects:
 
-"hook" [multiplexes events](https://github.com/kubernetes/test-infra/blob/c8829eef589a044126289cb5b4dc8e85db3ea22f/prow/cmd/hook/server.go#L40) by looking at "X-GitHub-Event", a custom http header. Afterwards, a [PluginAgent object](https://github.com/kubernetes/test-infra/blob/c8829eef589a044126289cb5b4dc8e85db3ea22f/prow/plugins/plugins.go#L86), initialized [during Hook's startup](https://github.com/kubernetes/test-infra/blob/c8829eef589a044126289cb5b4dc8e85db3ea22f/prow/cmd/hook/main.go#L128), selects plugins to handle events. See [events.go](https://github.com/kubernetes/test-infra/blob/c8829eef589a044126289cb5b4dc8e85db3ea22f/prow/cmd/hook/events.go#L17) for more details, and check [plugins.yaml](https://github.com/kubernetes/test-infra/blob/c8829eef589a044126289cb5b4dc8e85db3ea22f/prow/plugins.yaml) for a list of plugins per repo.
+1) a GitHub event object, and
+2) a [`ClientAgent`][plugins-ClientAgent] object.
 
-"hook" delivers an event that represents my `/test all` comment to the [Trigger plugin](https://github.com/kubernetes/test-infra/tree/c8829eef589a044126289cb5b4dc8e85db3ea22f/prow/plugins/trigger). The Trigger plugin validates the PR before running tests. One such validation is, for instance, that the author is a member of the organization or that the PR is labeled `ok-to-test`. The function called [`handleGenericCommentEvent` (implemented by `handleGenericComment`)](https://github.com/kubernetes/test-infra/blob/99b91b56b097e39d70cb1ae82c0b1cb57d98ac48/prow/plugins/trigger/generic-comment.go#L32) describes Trigger's logic.
+The `ClientAgent` object contains the following clients:
 
-Finally, `handleGenericComment` determines *presubmit* jobs to run. The list of jobs supplied by the `Config` object, in the `PluginClient` object, will be used to find suitable jobs.
+- GitHub client
+- Prow job client
+- Kubernetes client
+- BuildClusterCoreV1 clients
+- Git client
+- Slack client
+- Owners client
+- Bugzilla client
+- Jira client
 
-Next, the trigger plugin talks to the Kubernetes API server and creates a [ProwJob Custom Resource](https://github.com/kubernetes/test-infra/blob/c8829eef589a044126289cb5b4dc8e85db3ea22f/prow/kube/prowjob.go#L50-L83) with the information from the issue comment.
+These clients are initialized by **hook**, during start-up.
 
-Pod details aside, the resulting Prow job looks like this:
+**hook** [handles events][hook-ServeHTTP] by looking at [`X-GitHub-Event`][github-ValidateWebhook], a custom HTTP header.
+Afterwards, a [`ConfigAgent` object][plugins-ConfigAgent], initialized [during **hook**'s startup][hook-initialize-configAgent], selects plugins to handle events.
+See [githubeventserver.go][githubeventserver-handleEvent] for more details, and check [plugins.yaml][plugins-yaml] for a list of plugins per repo.
+
+Going back to the example, **hook** delivers an event that represents the `/test all` comment to the [Trigger plugin][prow-plugins-trigger].
+The Trigger plugin validates the PR before running tests.
+One such validation is, for instance, that the author is a member of the organization or that the PR is labeled `ok-to-test`.
+The function called [`handleGenericComment`][trigger-handleGenericComment] describes Trigger's logic.
+
+If all conditions are met (`ok-to-test`, the comment is not a bot comment, etc.), `handleGenericComment` [determines][trigger-FilterPresubmits] which *presubmit* jobs to run.
+The initial list of presubmit jobs to run (before being filtered down to those that qualify for this particular comment), is retrieved with [`getPresubmits`][trigger-handleGenericComment-getPresubmits].
+
+Next, for each presubmit we want to run, the **trigger** plugin talks to the Kubernetes API server and creates a [`ProwJob`][api-ProwJob] with the information from the PR comment.
+The `ProwJob` is primarily composed of the [`Spec`][api-ProwJobSpec] and [`Status`][api-ProwJobStatus] objects.
+
+Pod details aside, a sample ProwJob might look like this:
 
 ```yaml
 apiVersion: prow.k8s.io/v1
@@ -58,8 +79,65 @@ status:
   state: triggered
 ```
 
-On ProwJob or Pod changes, `cmd/plank` runs [`Reconcile`](https://github.com/kubernetes/test-infra/blob/a94e7c78b4dd3e2a288f2d74aaac6839bd7e5bc4/prow/plank/reconciler.go#L175). `Reconcile` is the current `plank` entry point that manages the Prow Job Life cycle.
+[**prow-controller-manager**][prow-controller-manager] runs ProwJobs by launching them by creating a new Kubernetes pod.
+It knows how to schedule new ProwJobs onto the cluster, responding to changes in the ProwJob or cluster health.
 
-When the Prow job ends, the `syncKubernetesJob` method updates the ProwJob status to success and sets the status line on GitHub to success. The status update makes a green check-mark show up on the PR.
+When the ProwJob finishes (the containers in the pod have finished running), **prow-controller-manager** updates the ProwJob.
+[**crier**][crier] reports back the status of the ProwJob back to the various external services like GitHub (e.g., as a green check-mark on the PR where the original `/test all` comment was made).
 
-A day later, [`cmd/sinker`](https://github.com/kubernetes/test-infra/blob/c8829eef589a044126289cb5b4dc8e85db3ea22f/prow/cmd/sinker/main.go#L58-L92) notices that the job and pod are a day old and deletes them from the Kubernetes API server.
+A day later, [**sinker**][sinker] notices that the job and pod are a day old and [deletes them][sinker-clean] from the Kubernetes API server.
+
+Here is a summary of the above:
+
+1. User types in `/test all` as a comment into a GitHub PR.
+1. GitHub sends a webhook (HTTP request) to Prow, to the `prow.k8s.io/hook` endpoint.
+1. The request gets intercepted by the [ingress][ingress-yaml].
+1. The ingress routes the request to the **hook** [service][hook-service-yaml].
+1. The **hook** service in turn routes traffic to the **hook** *application*, defined as a [deployment][hook-deployment-yaml].
+1. The container routes traffic to the **hook** [binary][hook-main] inside it.
+1. **hook** binary [parses and validates the HTTP request][hook-ServeHTTP-ValidateWebhook] and [creates a GitHub event object][hook-ServeHTTP-demuxEvent].
+1. **hook** binary sends the GitHub event object (in this case [`GenericCommentEvent`][github-GenericCommentEvent]) to [`handleGenericCommentEvent`][hook-handleGenericComment].
+1. `handleGenericCommentEvent` sends the data to be handled by the [`handleEvent`][githubeventserver-handleEvent].
+1. The data in the comment gets sent from **hook** to one of its many plugins, one of which is **trigger**. (The pattern is that **hook** constructs objects to be consumed by various plugins.)
+1. **trigger** determines which presubmit jobs to run (because it sees the `/test` command in `/test all`).
+1. **trigger** creates a ProwJob object!
+1. **prow-controller-manager** creates a pod to start the ProwJob.
+1. When the ProwJob's pod finishes, **prow-controller-manager** updates the ProwJob.
+1. **crier** sees the updated ProwJob status and reports back to the GitHub PR (creating a new comment).
+1. **sinker** cleans up the old pod from above and deletes it from the Kubernetes API server.
+
+[github-webhook]: https://developer.github.com/webhooks/
+
+[deployment-controller]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
+[ingress-resource]:      https://kubernetes.io/docs/concepts/services-networking/ingress/
+[service-resource]:      https://kubernetes.io/docs/concepts/services-networking/service/
+
+[api-ProwJobSpec]:               https://pkg.go.dev/k8s.io/test-infra@v0.0.0-20210721232751-5df7636b83ca/prow/apis/prowjobs/v1#ProwJobSpec
+[api-ProwJobStatus]:             https://pkg.go.dev/k8s.io/test-infra@v0.0.0-20210721232751-5df7636b83ca/prow/apis/prowjobs/v1#ProwJobStatus
+[api-ProwJob]:                   https://pkg.go.dev/k8s.io/test-infra@v0.0.0-20210721232751-5df7636b83ca/prow/apis/prowjobs/v1#ProwJob
+[crier]:                         https://pkg.go.dev/k8s.io/test-infra@v0.0.0-20210721232751-5df7636b83ca/prow/cmd/crier
+[github-GenericCommentEvent]:    https://pkg.go.dev/k8s.io/test-infra@v0.0.0-20210721232751-5df7636b83ca/prow/github#GenericCommentEvent
+[github-ValidateWebhook]:        https://pkg.go.dev/k8s.io/test-infra@v0.0.0-20210721232751-5df7636b83ca/prow/github#ValidateWebhook
+[plugins-ClientAgent]:           https://pkg.go.dev/k8s.io/test-infra@v0.0.0-20210721232751-5df7636b83ca/prow/plugins#ClientAgent
+[plugins-ConfigAgent]:           https://pkg.go.dev/k8s.io/test-infra@v0.0.0-20210721232751-5df7636b83ca/prow/plugins#ConfigAgent
+[prow-controller-manager]:       https://pkg.go.dev/k8s.io/test-infra@v0.0.0-20210721232751-5df7636b83ca/prow/cmd/prow-controller-manager
+[sinker]:                        https://pkg.go.dev/k8s.io/test-infra@v0.0.0-20210721232751-5df7636b83ca/prow/cmd/sinker
+
+[prow-repo-sync-point]:                       https://github.com/kubernetes/test-infra/tree/5df7636b83cab54e248e550a31dbf1e4731197a6
+[githubeventserver-handleEvent]:              https://github.com/kubernetes/test-infra/blob/5df7636b83cab54e248e550a31dbf1e4731197a6/prow/githubeventserver/githubeventserver.go#L202
+[hook-ServeHTTP]:                             https://github.com/kubernetes/test-infra/blob/5df7636b83cab54e248e550a31dbf1e4731197a6/prow/hook/server.go#L57
+[hook-ServeHTTP-ValidateWebhook]:             https://github.com/kubernetes/test-infra/blob/5df7636b83cab54e248e550a31dbf1e4731197a6/prow/hook/server.go#L58
+[hook-ServeHTTP-demuxEvent]:                  https://github.com/kubernetes/test-infra/blob/5df7636b83cab54e248e550a31dbf1e4731197a6/prow/hook/server.go#L72
+[hook-handleGenericComment]:                  https://github.com/kubernetes/test-infra/blob/5df7636b83cab54e248e550a31dbf1e4731197a6/prow/hook/events.go#L424
+[hook-deployment-yaml]:                       https://github.com/kubernetes/test-infra/blob/5df7636b83cab54e248e550a31dbf1e4731197a6/config/prow/cluster/hook_deployment.yaml
+[hook-initialize-configAgent]:                https://github.com/kubernetes/test-infra/blob/5df7636b83cab54e248e550a31dbf1e4731197a6/prow/cmd/hook/main.go#L107
+[hook-main]:                                  https://github.com/kubernetes/test-infra/blob/5df7636b83cab54e248e550a31dbf1e4731197a6/prow/cmd/hook/main.go#L99
+[hook-service-yaml]:                          https://github.com/kubernetes/test-infra/blob/5df7636b83cab54e248e550a31dbf1e4731197a6/config/prow/cluster/hook_service.yaml
+[ingress-yaml]:                               https://github.com/kubernetes/test-infra/blob/5df7636b83cab54e248e550a31dbf1e4731197a6/config/prow/cluster/tls-ing_ingress.yaml
+[plugins-yaml]:                               https://github.com/kubernetes/test-infra/blob/5df7636b83cab54e248e550a31dbf1e4731197a6/config/prow/plugins.yaml
+[prow-plugins-trigger]:                       https://github.com/kubernetes/test-infra/tree/5df7636b83cab54e248e550a31dbf1e4731197a6/prow/plugins/trigger
+[sample-github-webhook-payloads]:             https://github.com/kubernetes/test-infra/tree/5df7636b83cab54e248e550a31dbf1e4731197a6/prow/cmd/phony/examples
+[sinker-clean]:                               https://github.com/kubernetes/test-infra/blob/5df7636b83cab54e248e550a31dbf1e4731197a6/prow/cmd/sinker/main.go#L289
+[trigger-FilterPresubmits]:                   https://github.com/kubernetes/test-infra/blob/5df7636b83cab54e248e550a31dbf1e4731197a6/prow/plugins/trigger/generic-comment.go#L147-L162
+[trigger-handleGenericComment-getPresubmits]: https://github.com/kubernetes/test-infra/blob/5df7636b83cab54e248e550a31dbf1e4731197a6/prow/plugins/trigger/generic-comment.go#L56
+[trigger-handleGenericComment]:               https://github.com/kubernetes/test-infra/blob/5df7636b83cab54e248e550a31dbf1e4731197a6/prow/plugins/trigger/generic-comment.go#L32


### PR DESCRIPTION
This cleans up this doc and brings all links up to date to
5df7636b83cab54e248e550a31dbf1e4731197a6. We prefer to link to the
generated Go docs where applicable, to encourage codebase exploration
for the reader.

We also use link references to make the code easier to edit in the future.

I was also going to hard-line-wrap the text to fit within 80 chars, but refrained from doing so just in case that is not the expected style in this repo. Please take a look and spot any errors, thanks!

/cc @fejta 