### PR TITLE
containerd: 1.5.2 -> 1.5.4

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -282,7 +282,7 @@ presubmits:
             - --build=quick
             - --cluster=
             - --env=KUBE_CONTAINER_RUNTIME=containerd
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.2
+            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.4
             - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc95
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -342,7 +342,7 @@ presubmits:
             - --build=quick
             - --cluster=
             - --env=KUBE_CONTAINER_RUNTIME=containerd
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.2
+            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.4
             - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc95
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -517,7 +517,7 @@ periodics:
           - --
           - --check-leaked-resources
           - --env=KUBE_CONTAINER_RUNTIME=containerd
-          - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.2
+          - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.4
           - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc95
           - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
           - --env=CONTAINER_RUNTIME_TEST_HANDLER=true

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -36,7 +36,7 @@ presubmits:
         - --extract=local
         - --env=ALLOW_PRIVILEGED=true
         - --env=KUBE_CONTAINER_RUNTIME=containerd
-        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.2
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.4
         - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc95
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -102,7 +102,7 @@ presubmits:
         - --env=NETWORK_POLICY_PROVIDER=calico
         - --env=KUBE_CONTAINER_RUNTIME=containerd
         - --env=KUBE_FEATURE_GATES=NetworkPolicyEndPort=true
-        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.2
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.4
         - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc95
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -654,7 +654,7 @@ periodics:
       - --env=NETWORK_POLICY_PROVIDER=calico
       - --env=KUBE_CONTAINER_RUNTIME=containerd
       - --env=KUBE_FEATURE_GATES=NetworkPolicyEndPort=true
-      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.2
+      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.4
       - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc95
       - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
       - --env=CONTAINER_RUNTIME_TEST_HANDLER=true


### PR DESCRIPTION
Bumping images to containerd v1.5.4

### Upstream Release Notes
#### v1.5.4
https://github.com/containerd/containerd/releases/tag/v1.5.4

- CVE Patch for CVE-2021-32760

#### v1.5.3
https://github.com/containerd/containerd/releases/tag/v1.5.3

- Update runc binary to 1.0.0
- Send pod UID to CNI plugins as K8S_POD_UID
- Fix invalid validation error checking
- Fix error on image pull resume 
- Fix User Agent sent to registry authentication server
- Fix symlink resolution for disk mounts on Windows


