### PR TITLE
capg/image-builder: update job interval to run once a day

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/image-builder/image-builder-periodics.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/image-builder/image-builder-periodics.yaml
@@ -1,7 +1,7 @@
 periodics:
 - name: periodic-image-builder-gcp-all-nightly
   cluster: k8s-infra-prow-build-trusted
-  interval: 2h
+  interval: 24h
   decorate: true
   extra_refs:
   - org: kubernetes-sigs


### PR DESCRIPTION
Now the debugging phase is over we can move this job to run once a day!

also we are using the node images produced here in the CAPG CI 🎉 

/assign @dims 