### PR TITLE
releng: Point 1.22 jobs to kubekins-e2e:v20210721-2b77449-1.22

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml
@@ -23,7 +23,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
       name: ""
       resources:
         limits:
@@ -63,7 +63,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
       name: ""
       resources:
         limits:
@@ -109,7 +109,7 @@ periodics:
         value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|should.provide.basic.identity|\[NodeFeature:PodReadinessGate\]
       - name: PARALLEL
         value: "true"
-      image: gcr.io/k8s-testimages/krte:v20210715-521d667-1.22
+      image: gcr.io/k8s-testimages/krte:v20210721-2b77449-1.22
       name: ""
       resources:
         limits:
@@ -150,7 +150,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
       name: ""
       resources:
         limits:
@@ -187,7 +187,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
       name: ""
       resources:
         limits:
@@ -335,7 +335,7 @@ periodics:
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
       name: ""
       resources:
         limits:
@@ -416,7 +416,7 @@ periodics:
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
       name: ""
       resources:
         limits:
@@ -455,7 +455,7 @@ periodics:
       env:
       - name: SHORT
         value: --short=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
       name: ""
       resources:
         limits:
@@ -487,7 +487,7 @@ periodics:
     - command:
       - make
       - test
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
       name: ""
       resources:
         limits:
@@ -529,7 +529,7 @@ periodics:
         value: release-1.22
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
       imagePullPolicy: Always
       name: ""
       resources:
@@ -590,7 +590,7 @@ periodics:
         value: win2019
       - name: PREPULL_YAML
         value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
       name: ""
       resources: {}
 - annotations:
@@ -645,7 +645,7 @@ periodics:
         value: "true"
       - name: PREPULL_YAML
         value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
       name: ""
       resources: {}
 - annotations:
@@ -700,7 +700,7 @@ periodics:
         value: "true"
       - name: PREPULL_YAML
         value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
       name: ""
       resources: {}
 - annotations:
@@ -763,7 +763,7 @@ periodics:
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
       name: ""
       resources:
         limits:
@@ -812,7 +812,7 @@ periodics:
         value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|should.provide.basic.identity|\[NodeFeature:PodReadinessGate\]
       - name: PARALLEL
         value: "true"
-      image: gcr.io/k8s-testimages/krte:v20210715-521d667-1.22
+      image: gcr.io/k8s-testimages/krte:v20210721-2b77449-1.22
       name: ""
       resources:
         limits:
@@ -862,7 +862,7 @@ periodics:
         value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|should.provide.basic.identity|\[NodeFeature:PodReadinessGate\]
       - name: PARALLEL
         value: "true"
-      image: gcr.io/k8s-testimages/krte:v20210715-521d667-1.22
+      image: gcr.io/k8s-testimages/krte:v20210721-2b77449-1.22
       name: ""
       resources:
         limits:
@@ -923,7 +923,7 @@ periodics:
       command:
       - runner.sh
       - kubetest
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
       name: ""
       resources: {}
       securityContext:
@@ -978,7 +978,7 @@ periodics:
       command:
       - runner.sh
       - kubetest
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
       name: ""
       resources: {}
       securityContext:
@@ -1029,7 +1029,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
         name: ""
         resources:
           requests:
@@ -1070,7 +1070,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
         name: ""
         resources:
           limits:
@@ -1119,7 +1119,7 @@ presubmits:
         env:
         - name: BOOTSTRAP_FETCH_TEST_INFRA
           value: "true"
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
         name: ""
         resources:
           limits:
@@ -1170,7 +1170,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
         name: ""
         resources:
           requests:
@@ -1222,7 +1222,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
         name: ""
         resources:
           limits:
@@ -1277,7 +1277,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
         name: ""
         resources:
           limits:
@@ -1325,7 +1325,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
         name: ""
         resources:
           requests:
@@ -1362,7 +1362,7 @@ presubmits:
           value: release-1.22
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
         imagePullPolicy: IfNotPresent
         name: ""
         resources:
@@ -1408,7 +1408,7 @@ presubmits:
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
         name: ""
         resources:
           limits:
@@ -1452,7 +1452,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
         name: ""
         resources:
           requests:
@@ -1491,7 +1491,7 @@ presubmits:
         - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/image-config.yaml
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
         name: ""
         resources:
           limits:
@@ -1559,7 +1559,7 @@ presubmits:
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
         name: ""
         resources:
           limits:
@@ -1636,7 +1636,7 @@ presubmits:
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
         name: ""
         resources:
           limits:
@@ -1676,7 +1676,7 @@ presubmits:
           value: ipv6
         - name: PARALLEL
           value: "true"
-        image: gcr.io/k8s-testimages/krte:v20210715-521d667-1.22
+        image: gcr.io/k8s-testimages/krte:v20210721-2b77449-1.22
         name: ""
         resources:
           requests:
@@ -1705,7 +1705,7 @@ presubmits:
         env:
         - name: WHAT
           value: external-dependencies-version vendor vendor-licenses
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
         name: main
         resources:
           limits:
@@ -1767,7 +1767,7 @@ presubmits:
         env:
         - name: WHAT
           value: generated-files-remake
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
         name: main
         resources:
           limits:
@@ -1793,7 +1793,7 @@ presubmits:
         - ./hack/jenkins/test-dockerized.sh
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
         name: ""
         resources:
           limits:
@@ -1862,7 +1862,7 @@ presubmits:
           value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|NFS|nfs|inline.execution.and.attach|should.be.rejected.when.no.endpoints.exist
         - name: PARALLEL
           value: "true"
-        image: gcr.io/k8s-testimages/krte:v20210715-521d667-1.22
+        image: gcr.io/k8s-testimages/krte:v20210721-2b77449-1.22
         name: ""
         resources:
           limits:
@@ -1906,7 +1906,7 @@ presubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/k8s-testimages/krte:v20210715-521d667-1.22
+        image: gcr.io/k8s-testimages/krte:v20210721-2b77449-1.22
         name: ""
         resources:
           limits:
@@ -1944,7 +1944,7 @@ presubmits:
           value: "true"
         - name: PARALLEL
           value: "true"
-        image: gcr.io/k8s-testimages/krte:v20210715-521d667-1.22
+        image: gcr.io/k8s-testimages/krte:v20210721-2b77449-1.22
         name: ""
         resources:
           limits:
@@ -1970,7 +1970,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
         name: ""
         resources:
           limits:
@@ -1998,7 +1998,7 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck typecheck-providerless typecheck-dockerless
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
         name: main
         resources:
           limits:
@@ -2035,7 +2035,7 @@ presubmits:
           value: release-1.22
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-1.22
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
         imagePullPolicy: Always
         name: ""
         resources:


### PR DESCRIPTION
The generated jobs for the 1.22 picked the previous kubekins image
which do not have a 1.22 variant. This PR points them to
`gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22`
to fix them before the general version bump.

/cc @kubernetes/release-engineering 
/priority critical-urgent

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>