### PR TITLE
Don't protect cluster-proportional-autoscaler gh-pages branch

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -452,6 +452,10 @@ branch-protection:
           required_status_checks:
             contexts:
             - lint
+        cluster-proportional-autoscaler:
+          branches:
+            gh-pages:
+              protect: false
         kube-batch:
           required_status_checks:
             contexts:


### PR DESCRIPTION
We want to use an action to publish an index.yaml file to the gh-pages branch for a Helm chart repository.  The branch being protected causes the action to fail.

https://github.com/kubernetes-sigs/cluster-proportional-autoscaler/runs/3136292276?check_suite_focus=true#step:4:32

This has been done for several other kubernetes-sigs repositories.  Here is an example of a previously merged PR doing the same thing:
https://github.com/kubernetes/test-infra/pull/20157