### PR TITLE
config/testgrids: cleanup sig-testing config

### DIFF
--- a/config/jobs/kubernetes/repo-infra/repo-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/repo-infra/repo-infra-presubmits.yaml
@@ -14,5 +14,5 @@ presubmits:
         - ./presubmit.sh
         imagePullPolicy: Always
     annotations:
-      testgrid-dashboards: presubmits-test-infra
+      testgrid-dashboards: sig-release-releng-presubmits
       testgrid-tab-name: repo-infra

--- a/config/testgrids/kubernetes/presubmits/config.yaml
+++ b/config/testgrids/kubernetes/presubmits/config.yaml
@@ -173,3 +173,4 @@ dashboards:
 - name: presubmits-misc
 - name: presubmits-node-problem-detector
 - name: presubmits-poseidon
+- name: presubmits-test-infra

--- a/config/testgrids/kubernetes/sig-testing/sig-testing.yaml
+++ b/config/testgrids/kubernetes/sig-testing/sig-testing.yaml
@@ -10,29 +10,29 @@ test_groups:
 dashboard_groups:
 - name: sig-testing
   dashboard_names:
-  - sig-testing-misc
+  - sig-testing-boskos
   - sig-testing-canaries
   - sig-testing-e2e-framework
+  - sig-testing-images
   - sig-testing-kind
   - sig-testing-kubetest2
   - sig-testing-maintenance
+  - sig-testing-misc
   - sig-testing-prow
-  - sig-testing-images
-  - sig-testing-boskos
 
 # Dashboards
 
 dashboards:
-- name: sig-testing-misc
+- name: sig-testing-boskos
 - name: sig-testing-canaries
   dashboard_tab:
   - name: ci-kubernetes-coverage-unit
     test_group_name: ci-kubernetes-coverage-unit
     base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
 - name: sig-testing-e2e-framework
+- name: sig-testing-images
 - name: sig-testing-kind
 - name: sig-testing-kubetest2
 - name: sig-testing-maintenance
+- name: sig-testing-misc
 - name: sig-testing-prow
-- name: sig-testing-images
-- name: sig-testing-boskos

--- a/config/testgrids/kubernetes/sig-testing/test-infra.yaml
+++ b/config/testgrids/kubernetes/sig-testing/test-infra.yaml
@@ -1,2 +1,0 @@
-dashboards:
-  - name: presubmits-test-infra


### PR DESCRIPTION
Specifically:

- drop the unused test-infra group
- move the repo-infro presubmit to sig-release-releng-presubmits
- alphabetize sig-testing groups