### PR TITLE
add upgrade periodic test for csi-secrets-store release-0.1

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -573,6 +573,7 @@ postsubmits:
       github_users:
       - aramase
       - ritazh
+
 periodics:
 - interval: 24h
   name: periodic-secrets-store-csi-driver-image-scan
@@ -605,8 +606,7 @@ periodics:
     testgrid-alert-email: kubernetes-secrets-store-csi-driver@googlegroups.com
     description: "Run vulnerability scans for Secrets Store CSI driver images."
     testgrid-num-columns-recent: '30'
-
-- interval: 24h
+- interval: 12h
   name: periodic-secrets-store-csi-driver-upgrade-test-azure
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-release-0.1-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-release-0.1-config.yaml
@@ -1,0 +1,37 @@
+periodics:
+- interval: 12h
+  name: periodic-secrets-store-csi-driver-upgrade-test-azure-release-0-1
+  decorate: true
+  decoration_config:
+    timeout: 30m
+  labels:
+    # this is required because we want to run kind in docker
+    preset-dind-enabled: "true"
+    # this is required to make CNI installation to succeed for kind
+    preset-kind-volume-mounts: "true"
+    # sets up the azure keyvault parameters used for testing
+    preset-azure-secrets-store-creds: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: secrets-store-csi-driver
+    base_ref: release-0.1
+    path_alias: sigs.k8s.io/secrets-store-csi-driver
+  spec:
+    containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210715-521d667-master
+        command:
+          - runner.sh
+        args:
+        - bash
+        - -c
+        - >-
+          HELM_CHART_DIR=$(ls -h charts/*.tgz | sort --version-sort --field-separator=- --key=5 | tail -n 1) make e2e-bootstrap e2e-helm-deploy-release e2e-azure && HELM_CHART_DIR=manifest_staging/charts/secrets-store-csi-driver make e2e-helm-upgrade e2e-azure
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+  annotations:
+    testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-periodic
+    testgrid-tab-name: secrets-store-csi-driver-upgrade-test-azure-release-0-1
+    testgrid-alert-email: kubernetes-secrets-store-csi-driver@googlegroups.com
+    description: "Run driver upgrade test with azure provider for Secrets Store CSI driver."
+    testgrid-num-columns-recent: '30'


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

- Adds upgrade periodic test for release-0.1 branch.
- Updates the periodic test frequency to 12h to get more test runs per day.