### PR TITLE
Fix broken base images link in /prow/cmd README

### DIFF
--- a/prow/cmd/README.md
+++ b/prow/cmd/README.md
@@ -44,4 +44,4 @@ These are small tools that are automatically added to ProwJob pods for jobs that
 
 ## Base Images
 
-The container images in [`images`](/prow/cmd/images) are used as base images for Prow components.
+The container images in [`images`](/images) are used as base images for Prow components.


### PR DESCRIPTION
Resolves https://github.com/kubernetes/test-infra/issues/22987

The images definition were moved under https://github.com/kubernetes/test-infra/tree/master/images
as part of  https://github.com/kubernetes/test-infra/pull/17809 .