### PR TITLE
k/autoscaler - Remove branch protection from gh-pages branch

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -173,7 +173,12 @@ branch-protection:
         autoscaler:
           required_status_checks:
             contexts:
-            - continuous-integration/travis-ci/pr
+            - test-and-verify
+            - Helm chart
+            - Helm Docs
+          branches:
+            gh-pages:
+              protect: false
         client-go:
           restrictions:
             users: []


### PR DESCRIPTION
Also switch the required status check from Travis to GHActions runs

We want to follow the example of other repositories such as cluster-proportional-autoscaler and remove branch protection to allow automatic publishing of new versions of helm charts. (See e.g. #22996)

The change in required status checks is due to us now having moved from Travis to Github Actions for the repository's CI. See e.g. https://github.com/kubernetes/autoscaler/pull/4225

cc: @mwielgus 