### PR TITLE
robots/commenter: add --include-locked flag

### DIFF
--- a/robots/commenter/main_test.go
+++ b/robots/commenter/main_test.go
@@ -95,6 +95,7 @@ func TestMakeQuery(t *testing.T) {
 		query      string
 		archived   bool
 		closed     bool
+		locked     bool
 		dur        time.Duration
 		expected   []string
 		unexpected []string
@@ -107,18 +108,25 @@ func TestMakeQuery(t *testing.T) {
 			unexpected: []string{"updated:", "openhello", "worldis"},
 		},
 		{
-			name:       "basic closed",
-			query:      "hello world",
-			closed:     true,
-			expected:   []string{"hello world", "archived:false"},
-			unexpected: []string{"is:open"},
-		},
-		{
 			name:       "basic archived",
 			query:      "hello world",
 			archived:   true,
-			expected:   []string{"hello world", "is:open"},
+			expected:   []string{"hello world", "is:open", "is:unlocked"},
 			unexpected: []string{"archived:false"},
+		},
+		{
+			name:       "basic closed",
+			query:      "hello world",
+			closed:     true,
+			expected:   []string{"hello world", "archived:false", "is:unlocked"},
+			unexpected: []string{"is:open"},
+		},
+		{
+			name:       "basic locked",
+			query:      "hello world",
+			locked:     true,
+			expected:   []string{"hello world", "is:open", "archived:false"},
+			unexpected: []string{"is:unlocked"},
 		},
 		{
 			name:     "basic duration",
@@ -144,11 +152,6 @@ func TestMakeQuery(t *testing.T) {
 			err:    true,
 		},
 		{
-			name:  "is:closed without includeClosed",
-			query: "hello is:closed",
-			err:   true,
-		},
-		{
 			name:     "archived:false with include-archived errors",
 			query:    "hello archived:false",
 			archived: true,
@@ -159,10 +162,26 @@ func TestMakeQuery(t *testing.T) {
 			query: "hello archived:true",
 			err:   true,
 		},
+		{
+			name:  "is:closed without includeClosed errors",
+			query: "hello is:closed",
+			err:   true,
+		},
+		{
+			name:  "is:locked without includeLocked errors",
+			query: "hello is:locked",
+			err:   true,
+		},
+		{
+			name:   "is:unlocked with includeLocked errors",
+			query:  "hello is:unlocked",
+			locked: true,
+			err:    true,
+		},
 	}
 
 	for _, tc := range cases {
-		actual, err := makeQuery(tc.query, tc.archived, tc.closed, tc.dur)
+		actual, err := makeQuery(tc.query, tc.archived, tc.closed, tc.locked, tc.dur)
 		if err != nil && !tc.err {
 			t.Errorf("%s: unexpected error: %v", tc.name, err)
 		} else if err == nil && tc.err {


### PR DESCRIPTION
This fixes something I just happened to notice while verifying https://github.com/kubernetes/test-infra/pull/22997 as part of https://github.com/kubernetes/test-infra/issues/12296

https://testgrid.k8s.io/sig-contribex-k8s-triage-robot#stale - the job is commenting, but it's also failing because it's unable to comment on a locked issue, e.g. https://storage.googleapis.com/kubernetes-jenkins/logs/ci-k8s-triage-robot-stale/1419722568809582592/build-log.txt

In this case the issue is being used as an announcements issue, so they don't want contributors to be able to comment on it.

Rather than add `is:unlocked` to all of the queries, ignore locked issues by default.  This is the same thing we do with `--include-archived` and `--include-closed`.

Added equivalent test cases, reordered a bit so the order is consistently "archived, closed, locked"