### PR TITLE
config/jobs: bump commenter jobs image

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
@@ -10,7 +10,7 @@ periodics:
     testgrid-tab-name: api-review-help
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20210726-be0ec6fec1
+    - image: gcr.io/k8s-prow/commenter:v20210727-b2b0794248n
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -57,7 +57,7 @@ periodics:
     testgrid-tab-name: cla
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20210726-be0ec6fec1
+    - image: gcr.io/k8s-prow/commenter:v20210727-b2b0794248
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -97,7 +97,7 @@ periodics:
     testgrid-tab-name: close
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20210726-be0ec6fec1
+    - image: gcr.io/k8s-prow/commenter:v20210727-b2b0794248
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -139,7 +139,7 @@ periodics:
     description: Automatically /retest for approved PRs that failed retesting
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20210726-be0ec6fec1
+    - image: gcr.io/k8s-prow/commenter:v20210727-b2b0794248
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -196,7 +196,7 @@ periodics:
     testgrid-tab-name: rotten
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20210726-be0ec6fec1
+    - image: gcr.io/k8s-prow/commenter:v20210727-b2b0794248
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -241,7 +241,7 @@ periodics:
     testgrid-tab-name: stale
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20210726-be0ec6fec1
+    - image: gcr.io/k8s-prow/commenter:v20210727-b2b0794248
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -287,7 +287,7 @@ periodics:
     description: Creates github issues based on data from various 'IssueSource's.
   spec:
     containers:
-    - image: gcr.io/k8s-prow/issue-creator:v20210726-be0ec6fec1
+    - image: gcr.io/k8s-prow/issue-creator:v20210727-b2b0794248
       command:
       - /app/robots/issue-creator/app.binary
       args:


### PR DESCRIPTION
This is to pickup https://github.com/kubernetes/test-infra/pull/23029

Which should get https://testgrid.k8s.io/sig-contribex-k8s-triage-robot#stale back to green