### PR TITLE
chore: no longer sync gcp-secrets-store-cred

### DIFF
--- a/config/prow/cluster/build_kubernetes-external-secrets_customresource.yaml
+++ b/config/prow/cluster/build_kubernetes-external-secrets_customresource.yaml
@@ -17,19 +17,6 @@ spec:
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
-  name: gcp-secrets-store-cred
-  namespace: test-pods
-spec:
-  backendType: gcpSecretsManager
-  projectId: secretmanager-csi-build
-  data:
-  - key: k8s-oss-prow
-    name: key.json
-    version: latest
----
-apiVersion: kubernetes-client.io/v1
-kind: ExternalSecret
-metadata:
   name: azure-secrets-store-cred
   namespace: test-pods
 spec:


### PR DESCRIPTION
This secret is no longer needed by the `secrets-store-csi-driver-e2e-gcp` test jobs as https://github.com/kubernetes/test-infra/pull/22944 migrated the job to use workload identity instead.