### PR TITLE
Do not comment help message for Gerrit repos that are opt-out

### DIFF
--- a/prow/cmd/gerrit/main_test.go
+++ b/prow/cmd/gerrit/main_test.go
@@ -104,8 +104,9 @@ func TestFlags(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			expected := &options{
-				projects:         client.ProjectsFlag{},
-				lastSyncFallback: "gs://path",
+				projects:           client.ProjectsFlag{},
+				projectsOptOutHelp: client.ProjectsFlag{},
+				lastSyncFallback:   "gs://path",
 				config: configflagutil.ConfigOptions{
 					ConfigPathFlagName:                    "config-path",
 					JobConfigPathFlagName:                 "job-config-path",
@@ -115,15 +116,17 @@ func TestFlags(t *testing.T) {
 				dryRun:                 false,
 				instrumentationOptions: flagutil.DefaultInstrumentationOptions(),
 			}
-			expected.projects.Set("foo=bar")
+			expected.projects.Set("foo=bar,baz")
+			expected.projectsOptOutHelp.Set("foo=bar")
 			if tc.expected != nil {
 				tc.expected(expected)
 			}
 			argMap := map[string]string{
-				"--gerrit-projects":    "foo=bar",
-				"--last-sync-fallback": "gs://path",
-				"--config-path":        "yo",
-				"--dry-run":            "false",
+				"--gerrit-projects":              "foo=bar,baz",
+				"--gerrit-projects-opt-out-help": "foo=bar",
+				"--last-sync-fallback":           "gs://path",
+				"--config-path":                  "yo",
+				"--dry-run":                      "false",
 			}
 			for k, v := range tc.args {
 				argMap[k] = v

--- a/prow/gerrit/adapter/adapter_test.go
+++ b/prow/gerrit/adapter/adapter_test.go
@@ -1162,6 +1162,60 @@ func TestProcessChange(t *testing.T) {
 	}
 }
 
+func TestIsProjectExemptFromHelp(t *testing.T) {
+	var testcases = []struct {
+		name                   string
+		projectsExemptFromHelp map[string]sets.String
+		instance               string
+		project                string
+		expected               bool
+	}{
+		{
+			name:                   "no project is exempt",
+			projectsExemptFromHelp: map[string]sets.String{},
+			instance:               "foo",
+			project:                "bar",
+			expected:               false,
+		},
+		{
+			name: "the instance does not match",
+			projectsExemptFromHelp: map[string]sets.String{
+				"foo": sets.NewString("bar"),
+			},
+			instance: "fuz",
+			project:  "bar",
+			expected: false,
+		},
+		{
+			name: "the instance matches but the project does not",
+			projectsExemptFromHelp: map[string]sets.String{
+				"foo": sets.NewString("baz"),
+			},
+			instance: "fuz",
+			project:  "bar",
+			expected: false,
+		},
+		{
+			name: "the project is exempt",
+			projectsExemptFromHelp: map[string]sets.String{
+				"foo": sets.NewString("bar"),
+			},
+			instance: "foo",
+			project:  "bar",
+			expected: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isProjectOptOutHelp(tc.projectsExemptFromHelp, tc.instance, tc.project)
+			if got != tc.expected {
+				t.Errorf("expected %t for IsProjectExemptFromHelp but got %t", tc.expected, got)
+			}
+		})
+	}
+}
+
 func TestDeckLinkForPR(t *testing.T) {
 	tcs := []struct {
 		name         string


### PR DESCRIPTION
In https://github.com/kubernetes/test-infra/pull/22817 we added the feature to comment help message for running presubmit test, if it is requested from the Gerrit changes. However, for some repos that run their presubmit Prow jobs with multiple Prow instances, the comments could be confusing, so they want to opt-out from this feature.

This PR adds a flag to control the list of projects that want opt-out.

/cc @chaodaiG 