### PR TITLE
Tide: Finish apps auth support

### DIFF
--- a/prow/tide/BUILD.bazel
+++ b/prow/tide/BUILD.bazel
@@ -66,6 +66,7 @@ go_test(
         "//prow/tide/history:go_default_library",
         "@com_github_go_test_deep//:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
+        "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
         "@com_github_google_gofuzz//:go_default_library",
         "@com_github_shurcool_githubv4//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/prow/tide/blockers/BUILD.bazel
+++ b/prow/tide/blockers/BUILD.bazel
@@ -8,6 +8,8 @@ go_library(
     deps = [
         "@com_github_shurcool_githubv4//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/errors:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
     ],
 )
 
@@ -16,6 +18,8 @@ go_test(
     srcs = ["blockers_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "@com_github_google_go_cmp//cmp:go_default_library",
+        "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
         "@com_github_shurcool_githubv4//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",

--- a/prow/tide/blockers/blockers.go
+++ b/prow/tide/blockers/blockers.go
@@ -22,10 +22,13 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	githubql "github.com/shurcooL/githubv4"
 	"github.com/sirupsen/logrus"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 var (
@@ -70,16 +73,53 @@ func (b Blockers) GetApplicable(org, repo, branch string) []Blocker {
 }
 
 // FindAll finds issues with label in the specified orgs/repos that should block tide.
-func FindAll(ghc githubClient, log *logrus.Entry, label, orgRepoTokens string) (Blockers, error) {
+func FindAll(ghc githubClient, log *logrus.Entry, label string, orgRepoTokensByOrg map[string]string, splitQueryByOrg bool) (Blockers, error) {
+	queries := map[string]sets.String{}
+	for org, query := range orgRepoTokensByOrg {
+		if splitQueryByOrg {
+			queries[org] = sets.NewString(blockerQuery(label, query)...)
+		} else {
+			if queries[""] == nil {
+				queries[""] = sets.String{}
+			}
+			queries[""].Insert(blockerQuery(label, query)...)
+		}
+	}
+
+	var issues []Issue
+	var errs []error
+	var lock sync.Mutex
+	var wg sync.WaitGroup
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
-	issues, err := search(
-		ctx,
-		ghc,
-		log,
-		blockerQuery(label, orgRepoTokens),
-	)
-	if err != nil {
+	for org, query := range queries {
+		org, query := org, strings.Join(query.List(), " ")
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+			result, err := search(
+				ctx,
+				ghc,
+				org,
+				log,
+				query,
+			)
+			lock.Lock()
+			defer lock.Unlock()
+			if err != nil {
+				errs = append(errs, err)
+				return
+			}
+			issues = append(issues, result...)
+
+		}()
+
+	}
+	wg.Wait()
+
+	if err := utilerrors.NewAggregate(errs); err != nil {
 		return Blockers{}, fmt.Errorf("error searching for blocker issues: %v", err)
 	}
 
@@ -119,14 +159,12 @@ func fromIssues(issues []Issue, log *logrus.Entry) Blockers {
 	return res
 }
 
-func blockerQuery(label, orgRepoTokens string) string {
-	tokens := []string{
+func blockerQuery(label, orgRepoTokens string) []string {
+	return append([]string{
 		"is:issue",
 		"state:open",
 		fmt.Sprintf("label:\"%s\"", label),
-		orgRepoTokens,
-	}
-	return strings.Join(tokens, " ")
+	}, strings.Split(orgRepoTokens, " ")...)
 }
 
 func parseBranches(str string) []string {
@@ -137,7 +175,7 @@ func parseBranches(str string) []string {
 	return res
 }
 
-func search(ctx context.Context, ghc githubClient, log *logrus.Entry, q string) ([]Issue, error) {
+func search(ctx context.Context, ghc githubClient, githubOrg string, log *logrus.Entry, q string) ([]Issue, error) {
 	requestStart := time.Now()
 	var ret []Issue
 	vars := map[string]interface{}{
@@ -148,8 +186,7 @@ func search(ctx context.Context, ghc githubClient, log *logrus.Entry, q string) 
 	var remaining int
 	for {
 		sq := searchQuery{}
-		// TODO alvaroaleman: Add github apps support
-		if err := ghc.QueryWithGitHubAppsSupport(ctx, &sq, vars, ""); err != nil {
+		if err := ghc.QueryWithGitHubAppsSupport(ctx, &sq, vars, githubOrg); err != nil {
 			return nil, err
 		}
 		totalCost += int(sq.RateLimit.Cost)
@@ -162,9 +199,13 @@ func search(ctx context.Context, ghc githubClient, log *logrus.Entry, q string) 
 		}
 		vars["searchCursor"] = githubql.NewString(sq.Search.PageInfo.EndCursor)
 	}
-	log.WithField(
-		"duration", time.Since(requestStart).String(),
-	).Debugf("Search for blocker query \"%s\" cost %d point(s). %d remaining.", q, totalCost, remaining)
+	log.WithFields(logrus.Fields{
+		"duration":       time.Since(requestStart).String(),
+		"pr_found_count": len(ret),
+		"query":          q,
+		"cost":           totalCost,
+		"remaining":      remaining,
+	}).Debug("Search for blocker query")
 	return ret, nil
 }
 


### PR DESCRIPTION
Ref https://github.com/kubernetes/test-infra/issues/10423

This change finishes the GitHub apps support in Tide by also adding it to the status controller and the merge blocker code. The sync controller already got support in https://github.com/kubernetes/test-infra/pull/20575.

It makes the two split their v4 queries by org if and only if apps auth is enabled. If not, behavior will remain unchanged.