### PR TITLE
Tide: Add option to display all queries in status

### DIFF
--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -168,6 +168,11 @@ type Tide struct {
 	// starting a new one requires to start new instances of all tests.
 	// Use '*' as key to set this globally. Defaults to true.
 	PrioritizeExistingBatchesMap map[string]bool `json:"prioritize_existing_batches,omitempty"`
+
+	// DisplayAllQueriesInStatus controls if Tide should mention all queries in the status it
+	// creates. The default is to only mention the one to which we are closest (Calculated
+	// by total number of requirements - fulfilled number of requirements).
+	DisplayAllQueriesInStatus bool `json:"display_all_tide_queries_in_status,omitempty"`
 }
 
 func (t *Tide) mergeFrom(additional *Tide) error {

--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -284,7 +284,12 @@ func (sc *statusController) expectedStatus(log *logrus.Entry, queryMap *config.Q
 		var minDiff string
 		for _, q := range queryMap.ForRepo(repo) {
 			diff, diffCount := requirementDiff(pr, &q, cc)
-			if minDiffCount == -1 || diffCount < minDiffCount {
+			if sc.config().Tide.DisplayAllQueriesInStatus {
+				if minDiff != "" {
+					minDiff = strings.TrimSuffix(minDiff, ".") + " OR"
+				}
+				minDiff += diff
+			} else if minDiffCount == -1 || diffCount < minDiffCount {
 				minDiffCount = diffCount
 				minDiff = diff
 			}


### PR DESCRIPTION
Currently, Tide will always only show one query in the status using a
heuristic. This can be confusing for ppl in the face of multiple
queries.

This change adds a config option to make Tide display all queries
instead.

/assign @petr-muller 