### PR TITLE
config/jobs: k8s-infra-prow deploy jobs report to slack

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-prow.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-prow.yaml
@@ -10,6 +10,7 @@ postsubmits:
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: wg-k8s-infra-prow
+      testgrid-tab-name: deploy-prow-build
       testgrid-alert-email: k8s-infra-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
     rerun_auth_config:
@@ -20,6 +21,15 @@ postsubmits:
       # proxy for test-infra-oncall
       - org: kubernetes
         slug: test-infra-admins
+    reporter_config:
+      slack:
+        channel: "prow-alerts"
+        job_states_to_report:
+        - success
+        - failure
+        - aborted
+        - error
+        report_template: 'Deploying k8s-infra-prow-build cluster: {{.Status.State}}. Commit: <{{.Spec.Refs.BaseLink}}|{{printf "%.7s" .Spec.Refs.BaseSHA}}> | <{{.Status.URL}}|Spyglass> | <https://testgrid.k8s.io/wg-k8s-infra-prow#deploy-prow-build|Testgrid> | <https://prow.k8s.io/?job={{.Spec.Job}}|Deck>'
     spec:
       serviceAccountName: prow-deployer
       containers:
@@ -36,6 +46,7 @@ postsubmits:
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: wg-k8s-infra-prow
+      testgrid-tab-name: deploy-prow-build-trusted
       testgrid-alert-email: k8s-infra-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
     rerun_auth_config:
@@ -52,3 +63,12 @@ postsubmits:
       - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
         command:
         - ./infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/deploy.sh
+    reporter_config:
+      slack:
+        channel: "prow-alerts"
+        job_states_to_report:
+        - success
+        - failure
+        - aborted
+        - error
+        report_template: 'Deploying k8s-infra-prow-build-trusted cluster: {{.Status.State}}. Commit: <{{.Spec.Refs.BaseLink}}|{{printf "%.7s" .Spec.Refs.BaseSHA}}> | <{{.Status.URL}}|Spyglass> | <https://testgrid.k8s.io/wg-k8s-infra-prow#deploy-prow-build-trusted|Testgrid> | <https://prow.k8s.io/?job={{.Spec.Job}}|Deck>'


### PR DESCRIPTION
Opting to use #prow-alerts instead of #k8s-infra-alerts since these jobs
are prow-specific. Now we can see deploys of the prow control plane and
its (community-owned) build clusters all in the same channel.