### PR TITLE
images/bootstrap: build multi-archs amd64 & arm64

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -72,9 +72,13 @@ RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.ta
         --bash-completion=false \
         --path-update=false \
         --usage-reporting=false && \
-    gcloud components install alpha beta kubectl && \
+    gcloud components install alpha beta && \
     gcloud info | tee /workspace/gcloud-info.txt
 
+# gcloud not provide kubectl arm64 binary
+ARG TARGETARCH
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${TARGETARCH:-amd64}/kubectl" && \
+    chmod +x ./kubectl && mv ./kubectl /usr/local/bin/kubectl
 
 #
 # BEGIN: DOCKER IN DOCKER SETUP
@@ -93,10 +97,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 # Add the Docker apt-repository
+ARG TARGETARCH
 RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg \
     | apt-key add - && \
     add-apt-repository \
-    "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \
+    "deb [arch=${TARGETARCH:-amd64}] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \
     $(lsb_release -cs) stable"
 
 # Install Docker

--- a/images/bootstrap/cloudbuild.yaml
+++ b/images/bootstrap/cloudbuild.yaml
@@ -1,20 +1,22 @@
 steps:
   - name: busybox
     args: ['cp', '-r', 'scenarios', './images/bootstrap/scenarios']
-  - name: gcr.io/cloud-builders/docker
+  - name: gcr.io/k8s-testimages/gcb-docker-gcloud
+    entrypoint: /buildx-entrypoint
     args:
-    - build
-    - --tag=gcr.io/$PROJECT_ID/bootstrap:$_GIT_TAG
-    - --build-arg=IMAGE_ARG=gcr.io/$PROJECT_ID/bootstrap:$_GIT_TAG
-    - .
+      - build
+      - --tag=gcr.io/$PROJECT_ID/bootstrap:$_GIT_TAG
+      - --platform=linux/amd64,linux/arm64/v8
+      - --push
+      - .
     dir: images/bootstrap
-  - name: gcr.io/cloud-builders/docker
+  - name: gcr.io/k8s-testimages/gcb-docker-gcloud
+    entrypoint: gcloud
     args:
-    - tag
-    - gcr.io/$PROJECT_ID/bootstrap:$_GIT_TAG
-    - gcr.io/$PROJECT_ID/bootstrap:latest
+      - container
+      - images
+      - add-tag
+      - gcr.io/$PROJECT_ID/bootstrap:$_GIT_TAG
+      - gcr.io/$PROJECT_ID/bootstrap:latest
 substitutions:
   _GIT_TAG: '12345'
-images:
-  - 'gcr.io/$PROJECT_ID/bootstrap:$_GIT_TAG'
-  - 'gcr.io/$PROJECT_ID/bootstrap:latest'


### PR DESCRIPTION
changes here could make people use `docker buildx build` to build multi-arch images

example images: https://github.com/orgs/querycap/packages?repo_name=k8s-prow-images

rel: https://github.com/kubernetes/test-infra/issues/16588