### PR TITLE
Fix yaml syntax in skip_if_only_changed documentation

### DIFF
--- a/prow/jobs.md
+++ b/prow/jobs.md
@@ -194,7 +194,7 @@ presubmits:
   org/repo:
   - name: compile-job
     always_run: false
-    run_if_changed: "(\.[ch]|^Makefile)$"
+    run_if_changed: "(\\.[ch]|^Makefile)$"
     ...
 ```
 
@@ -207,7 +207,7 @@ presubmits:
   org/repo:
   - name: compile-job
     always_run: false
-    skip_if_only_changed: "^docs/|\.(md|adoc)$|^(README|LICENSE)$"
+    skip_if_only_changed: "^docs/|\\.(md|adoc)$|^(README|LICENSE)$"
 ```
 
 Both of the above examples would trigger on a pull request containing


### PR DESCRIPTION
If a yaml string is surrounded by single quotes, then it can contain literal backslashes. However if, as in this case, it is [surrounded by double quotes](https://yaml.org/spec/1.2/spec.html#id2787109) then backslash is an escape character and literal backslashes must themselves be escaped.