### PR TITLE
config/jobs: use k8s-infra-ci-robot for k8s-infra PR-creating jobs

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-k8sio.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-k8sio.yaml
@@ -1,6 +1,8 @@
 periodics:
 - name: ci-k8sio-audit
-  interval: 3h
+  # TODO(spiffxp): low interval for debugging / verification, remove and adjust cron when done
+  interval: 10m
+  # interval: 3h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
   max_concurrency: 1
@@ -32,7 +34,7 @@ periodics:
     volumes:
     - name: github
       secret:
-        secretName: cncf-ci-github-token
+        secretName: k8s-infra-ci-robot-github-token
 
 postsubmits:
   kubernetes/k8s.io:

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-k8sio.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-k8sio.yaml
@@ -36,6 +36,46 @@ periodics:
       secret:
         secretName: k8s-infra-ci-robot-github-token
 
+- name: ci-k8sio-autobump-prow-build-clusters
+  # TODO(spiffxp): low interval for debugging / verification, remove and adjust cron when done
+  interval: 10m
+  # cron: "30 17-22/5 * * 1-5"  # Run at 10:30 and 15:30 PST (17:05 UTC) Mon-Fri
+  cluster: k8s-infra-prow-build-trusted
+  decorate: true
+  max_concurrency: 1
+  extra_refs:
+  - org: kubernetes
+    repo: k8s.io
+    base_ref: main
+  annotations:
+    testgrid-dashboards: wg-k8s-infra-k8sio
+    testgrid-alert-email: k8s-infra-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: '1'
+    description: runs autobumper to create/update a PR that updates prow build cluster component images
+  rerun_auth_config:
+    github_team_slugs:
+    # proxy for wg-k8s-infra-oncall
+    - org: kubernetes
+      slug: wg-k8s-infra-leads
+    # proxy for test-infra-oncall
+    - org: kubernetes
+      slug: test-infra-admins
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/generic-autobumper:v20210727-e0795bc861
+      command:
+      - /app/prow/cmd/generic-autobumper/app.binary
+      args:
+      - --config=hack/autobump-config.yaml
+      volumeMounts:
+      - name: github
+        mountPath: /etc/github-token
+        readOnly: true
+    volumes:
+    - name: github
+      secret:
+        secretName: oauth-token
+
 postsubmits:
   kubernetes/k8s.io:
   - name: post-k8sio-dns-update


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1742
- Depends on: https://github.com/kubernetes/k8s.io/pull/2403

The main intent of this is to add an autobump job, but now that we have access to k8s-infra-ci-robot, let's switch the audit job to use it as well.

The jobs have short intervals for debugging and will be set back to longer intervals once verified as working.

Kept as separate commits in case we want to revert.