### PR TITLE
config/jobs: shorten prow autobump slack msg

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -107,7 +107,7 @@ postsubmits:
         - failure
         - aborted
         - error
-        report_template: 'Deploying prow: {{.Status.State}}. <{{.Spec.Refs.BaseLink}}|Commit {{.Spec.Refs.BaseSHA}}> <{{.Status.URL}}|View logs> <https://testgrid.k8s.io/sig-testing-prow#deploy-prow|Job history on Testgrid>'
+        report_template: '{{.Status.State}}. Commit: <{{.Spec.Refs.BaseLink}}|{{printf "%.7s" .Spec.Refs.BaseSHA}}> | <{{.Status.URL}}|Spyglass> | <https://testgrid.k8s.io/sig-testing-prow#deploy-prow|Testgrid> | <https://prow.k8s.io/?job={{.Spec.Job}}|Deck>'
     spec:
       serviceAccountName: deployer
       containers:


### PR DESCRIPTION
Match the message format used for the build cluster deploy jobs

Current format:
<img width="845" alt="Screen Shot 2021-07-28 at 12 15 47 PM" src="https://user-images.githubusercontent.com/49258/127382460-4ed8977a-f2e7-4911-bc2a-055ce770aa64.png">

New format:
<img width="738" alt="Screen Shot 2021-07-28 at 12 15 14 PM" src="https://user-images.githubusercontent.com/49258/127382393-ab056965-0812-48e0-80ae-bdb360eab3a1.png">
