### PR TITLE
config/jobs: slow down k8s-infra-ci-robot jobs

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-k8sio.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-k8sio.yaml
@@ -1,8 +1,6 @@
 periodics:
 - name: ci-k8sio-audit
-  # TODO(spiffxp): low interval for debugging / verification, remove and adjust cron when done
-  interval: 10m
-  # interval: 3h
+  interval: 2h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
   max_concurrency: 1

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-prow.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-prow.yaml
@@ -75,9 +75,8 @@ postsubmits:
 
 periodics:
 - name: ci-k8sio-autobump-prow-build-clusters
-  # TODO(spiffxp): low interval for debugging / verification, remove and adjust cron when done
-  interval: 10m
-  # cron: "30 17-22/5 * * 1-5"  # Run at 10:30 and 15:30 PST (17:05 UTC) Mon-Fri
+  # This is arbitrarily 3h earlier than test-infra-oncall's prow autobump job
+  cron: "30 14-19/5 * * 1-5"  # Run at 7:30 and 12:30 PST Mon-Fri
   cluster: k8s-infra-prow-build-trusted
   decorate: true
   max_concurrency: 1
@@ -105,6 +104,7 @@ periodics:
       - /app/prow/cmd/generic-autobumper/app.binary
       args:
       - --config=hack/autobump-config.yaml
+      # TODO(spiffxp): consider making this a skip-review thing...
       volumeMounts:
       - name: github
         mountPath: /etc/github-token


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1742
- Followup to: https://github.com/kubernetes/test-infra/pull/23048

The jobs were 10m intervals for debugging, but now that we've confirmed they work, let's use more realistic intervals:
- autobump prow build clusters 3h earlier than prow itself is autodeployed
- run audit every 2h (it was formerly 3h, but it takes about 90m, and more frequent updates could be useful)