### PR TITLE
Make prow-controller-manager optionally publish build cluster status to cloud storage.

### DIFF
--- a/prow/cmd/prow-controller-manager/BUILD.bazel
+++ b/prow/cmd/prow-controller-manager/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//prow/flagutil:go_default_library",
         "//prow/flagutil/config:go_default_library",
         "//prow/interrupts:go_default_library",
+        "//prow/io:go_default_library",
         "//prow/logrusutil:go_default_library",
         "//prow/metrics:go_default_library",
         "//prow/pjutil/pprof:go_default_library",

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -533,6 +533,11 @@ type Plank struct {
 	// JobURLPrefixDisableAppendStorageProvider disables that the storageProvider is
 	// automatically appended to the JobURLPrefix
 	JobURLPrefixDisableAppendStorageProvider bool `json:"jobURLPrefixDisableAppendStorageProvider,omitempty"`
+
+	// BuildClusterStatusFile is an optional field used to specify the blob storage location
+	// to publish cluster status information.
+	// e.g. gs://my-bucket/cluster-status.json
+	BuildClusterStatusFile string `json:"build_cluster_status_file,omitempty"`
 }
 
 // DefaultDecorationConfigEntry contains a DecorationConfig and a set of

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -509,6 +509,11 @@ owners_dir_denylist:
     repos:
         "": null
 plank:
+    # BuildClusterStatusFile is an optional field used to specify the blob storage location
+    # to publish cluster status information.
+    # e.g. gs://my-bucket/cluster-status.json
+    build_cluster_status_file: ' '
+
     # DefaultDecorationConfigEntries holds the default decoration config for specific values.
     # Each entry in the slice specifies Repo and Cluster regexp filter fields to
     # match against jobs and a corresponding DecorationConfig. All entries that

--- a/prow/plank/BUILD.bazel
+++ b/prow/plank/BUILD.bazel
@@ -17,6 +17,7 @@ go_test(
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
+        "//prow/io:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/pjutil:go_default_library",
         "@com_github_go_test_deep//:go_default_library",
@@ -56,7 +57,9 @@ go_library(
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
+        "//prow/crier/reporters/gcs/internal/util:go_default_library",
         "//prow/crier/reporters/gcs/kubernetes/api:go_default_library",
+        "//prow/io:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/pjutil:go_default_library",
         "//prow/pod-utils/decorate:go_default_library",

--- a/prow/plank/controller_test.go
+++ b/prow/plank/controller_test.go
@@ -1854,7 +1854,7 @@ func TestMaxConcurrencyWithNewlyTriggeredJobs(t *testing.T) {
 				&indexingClient{
 					Client:     fakeProwJobClient,
 					indexFuncs: map[string]ctrlruntimeclient.IndexerFunc{prowJobIndexName: prowJobIndexer("prowjobs")},
-				}, nil, newFakeConfigAgent(t, 0).Config, "")
+				}, nil, newFakeConfigAgent(t, 0).Config, nil, "")
 			r.buildClients = buildClients
 			for _, job := range test.PJs {
 				request := reconcile.Request{NamespacedName: types.NamespacedName{


### PR DESCRIPTION
This is the first component of the solution for https://github.com/kubernetes/test-infra/issues/23027.  This will allow `checkconfig` to lookup the clusters (and their status) that Prow has credentials for without accessing the credential secret itself.

Please let me know if this looks reasonable, then I'll add some unit tests.
/assign @chaodaiG 