### PR TITLE
prow: allow popups in html lens

### DIFF
--- a/prow/spyglass/lenses/html/template.html
+++ b/prow/spyglass/lenses/html/template.html
@@ -13,7 +13,7 @@
     {{/* Do _not_ hide this by default, that will break inner javascript that dynamically resizes. Hiding post-render is ok, so we hide on first resize request */}}
     <tr class="initial" id="{{$title}}-tr">
       <td colspan="2" style="border: 0px; padding: 0px;">
-        <iframe srcdoc="{{$content}}" title="{{$title}}" sandbox="allow-scripts" id="{{$title}}" width="100%" scrolling="no"></iframe>
+        <iframe srcdoc="{{$content}}" title="{{$title}}" sandbox="allow-scripts allow-popups" id="{{$title}}" width="100%" scrolling="no"></iframe>
       </td>
     </tr>
     {{end}}

--- a/prow/spyglass/lenses/html/testdata/TestRenderBody_Simple.yaml
+++ b/prow/spyglass/lenses/html/testdata/TestRenderBody_Simple.yaml
@@ -21,7 +21,7 @@ window.addEventListener(&quot;load&quot;, function(){
     var config = { attributes: true, childList: true, characterData: true, subtree:true}; // PT2
     observer.observe(window.document, config);                                            // PT3
 });
-</script>" title="file.html" sandbox="allow-scripts" id="file.html" width="100%" scrolling="no"></iframe>
+</script>" title="file.html" sandbox="allow-scripts allow-popups" id="file.html" width="100%" scrolling="no"></iframe>
       </td>
     </tr>
     

--- a/prow/spyglass/lenses/html/testdata/TestRenderBody_With_quotes.yaml
+++ b/prow/spyglass/lenses/html/testdata/TestRenderBody_With_quotes.yaml
@@ -21,7 +21,7 @@ window.addEventListener(&quot;load&quot;, function(){
     var config = { attributes: true, childList: true, characterData: true, subtree:true}; // PT2
     observer.observe(window.document, config);                                            // PT3
 });
-</script>" title="file.html" sandbox="allow-scripts" id="file.html" width="100%" scrolling="no"></iframe>
+</script>" title="file.html" sandbox="allow-scripts allow-popups" id="file.html" width="100%" scrolling="no"></iframe>
       </td>
     </tr>
     


### PR DESCRIPTION
I have a file that's included by the html lens that has external links,
but without having the `allow-popups`[1] permission in the sandbox, the
links can only open in the tiny iframe.

[1] https://www.w3schools.com/tags/att_iframe_sandbox.asp