### PR TITLE
Add new label for security assessments

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -29,6 +29,7 @@
 - [Labels that apply to kubernetes/org, only for issues](#labels-that-apply-to-kubernetesorg-only-for-issues)
 - [Labels that apply to kubernetes/release, for both issues and PRs](#labels-that-apply-to-kubernetesrelease-for-both-issues-and-prs)
 - [Labels that apply to kubernetes/sig-release, for both issues and PRs](#labels-that-apply-to-kubernetessig-release-for-both-issues-and-prs)
+- [Labels that apply to kubernetes/sig-security, for both issues and PRs](#labels-that-apply-to-kubernetessig-security-for-both-issues-and-prs)
 - [Labels that apply to kubernetes/test-infra, for both issues and PRs](#labels-that-apply-to-kubernetestest-infra-for-both-issues-and-prs)
 - [Labels that apply to kubernetes/test-infra, only for PRs](#labels-that-apply-to-kubernetestest-infra-only-for-prs)
 - [Labels that apply to kubernetes/website, for both issues and PRs](#labels-that-apply-to-kuberneteswebsite-for-both-issues-and-prs)
@@ -412,6 +413,12 @@ larger set of contributors to apply/remove them.
 | <a id="area/release-eng" href="#area/release-eng">`area/release-eng`</a> | Issues or PRs related to the Release Engineering subproject <br><br> This was previously `area/release-infra`, | label | |
 | <a id="area/release-eng/security" href="#area/release-eng/security">`area/release-eng/security`</a> | Issues or PRs related to release engineering security| label | |
 | <a id="area/release-team" href="#area/release-team">`area/release-team`</a> | Issues or PRs related to the release-team subproject| label | |
+
+## Labels that apply to kubernetes/sig-security, for both issues and PRs
+
+| Name | Description | Added By | Prow Plugin |
+| ---- | ----------- | -------- | --- |
+| <a id="area/security-assessment" href="#area/security-assessment">`area/security-assessment`</a> | Issues or PRs related to security assessment of sub-projects| anyone | |
 
 ## Labels that apply to kubernetes/test-infra, for both issues and PRs
 

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -1212,6 +1212,13 @@ repos:
         name: area/release-team
         target: both
         addedBy: label
+  kubernetes/sig-security:
+    labels:
+      - color: 0052cc
+        description: Issues or PRs related to security assessment of sub-projects
+        name: area/security-assessment
+        target: both
+        addedBy: anyone
   kubernetes/test-infra:
     labels:
       - color: 0052cc


### PR DESCRIPTION
- Kubernetes SIG Security is undertaking a partnership to
perform a self-assessment of sub projects that request it
- This label will help in identifying such requests and
will be an auto-assigned label for a github issue template

/sig security

Related: https://github.com/kubernetes/community/issues/5921