### PR TITLE
Add OpenShift Serverless mesh test to testgrid

### DIFF
--- a/config/testgrids/openshift/serverless.yaml
+++ b/config/testgrids/openshift/serverless.yaml
@@ -154,6 +154,31 @@ dashboards:
     code_search_path: https://github.com/openshift-knative/serverless-operator/search
     code_search_url_template:
       url: https://github.com/openshift-knative/serverless-operator/compare/<start-custom-0>...<end-custom-0>
+  - name: main-continuous-4.7-mesh
+    test_group_name: periodic-ci-openshift-knative-serverless-operator-main-4.7-e2e-mesh-ocp-47-continuous
+    base_options: width=14
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    file_bug_template:
+      options:
+      - key: classification
+        value: Red Hat
+      - key: product
+        value: Openshift Serverless
+      - key: short_desc
+        value: 'test: <test-name>'
+      - key: cf_environment
+        value: 'test: <test-name>'
+      - key: comment
+        value: 'test: <test-name> failed, see job: <test-url>'
+      url: https://bugzilla.redhat.com/enter_bug.cgi
+    open_bug_template:
+      url: https://github.com/openshift-knative/serverless-operator/issues/
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    code_search_path: https://github.com/openshift-knative/serverless-operator/search
+    code_search_url_template:
+      url: https://github.com/openshift-knative/serverless-operator/compare/<start-custom-0>...<end-custom-0>
   - name: main-continuous-upgrade-4.7
     test_group_name: periodic-ci-openshift-knative-serverless-operator-main-4.7-upgrade-tests-aws-ocp-47-continuous
     base_options: width=14
@@ -251,6 +276,9 @@ test_groups:
 - days_of_results: 14
   gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.7-azure-e2e-azure-ocp-47-continuous
   name: periodic-ci-openshift-knative-serverless-operator-main-4.7-azure-e2e-azure-ocp-47-continuous
+- days_of_results: 14
+  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.7-e2e-mesh-ocp-47-continuous
+  name: periodic-ci-openshift-knative-serverless-operator-main-4.7-e2e-mesh-ocp-47-continuous
 - days_of_results: 14
   gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.7-upgrade-tests-aws-ocp-47-continuous
   name: periodic-ci-openshift-knative-serverless-operator-main-4.7-upgrade-tests-aws-ocp-47-continuous


### PR DESCRIPTION
This patch adds the [serverless mesh test](https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.7-e2e-mesh-ocp-47-continuous) to testgrid.

/cc @stevekuznetsov @markusthoemmes 