### PR TITLE
Boskos: Update golang to 1.16

### DIFF
--- a/config/jobs/kubernetes-sigs/boskos/boskos-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/boskos/boskos-postsubmits.yaml
@@ -6,7 +6,7 @@ postsubmits:
       path_alias: sigs.k8s.io/boskos
       spec:
         containers:
-          - image: golang:1.15
+          - image: golang:1.16
             imagePullPolicy: Always
             command:
               - make

--- a/config/jobs/kubernetes-sigs/boskos/boskos-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/boskos/boskos-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
       path_alias: sigs.k8s.io/boskos
       spec:
         containers:
-          - image: golang:1.15
+          - image: golang:1.16
             imagePullPolicy: Always
             command:
               - make


### PR DESCRIPTION
Required to be able to bump its test-infra version in https://github.com/kubernetes-sigs/boskos/pull/95