### PR TITLE
Prow auto deploy job tolerate one failure

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -902,7 +902,7 @@ periodics:
     testgrid-dashboards: sig-testing-prow
     testgrid-tab-name: autobump-prow-for-auto-deploy
     testgrid-alert-email: k8s-infra-oncall@google.com
-    testgrid-num-failures-to-alert: '1' # We want to know if this one fails even once. If this fails we do not auto-deploy
+    testgrid-num-failures-to-alert: '2' # This could fail when it runs right in the middle of prow push, tolerate it once
     description: runs autobumper to create/update a PR that bumps prow to the latest RC with label 'skip-review'
 - cron: "30 * * * 1-5"  # Bump don't label `skip-review`. Run at :30 past every hour Mon-Fri
   name: ci-test-infra-autobump-prow


### PR DESCRIPTION
It fails if it happens to run right in the middle of a prow push, because prow auto bump wants to ensure that all images are bumped to the same hash