### PR TITLE
Handle webhooks from unrecognized org/repos as warnings, not errors.

### DIFF
--- a/prow/github/hmac.go
+++ b/prow/github/hmac.go
@@ -21,7 +21,7 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -62,7 +62,7 @@ func ValidatePayload(payload []byte, sig string, tokenGenerator func() []byte) b
 	}
 	hmacs, err := extractHMACs(orgRepo, tokenGenerator)
 	if err != nil {
-		logrus.WithError(err).Error("couldn't unmarshal the hmac secret")
+		logrus.WithError(err).Warning("failed to get an appropriate hmac secret")
 		return false
 	}
 
@@ -115,7 +115,7 @@ func extractHMACs(orgRepo string, tokenGenerator func() []byte) ([][]byte, error
 	if val, ok := repoToTokenMap["*"]; ok {
 		return extractTokens(val), nil
 	}
-	return nil, errors.New("invalid content in secret file, global token doesn't exist")
+	return nil, fmt.Errorf("no hmac is configured for the org/repo %q and no legacy global token is configured", orgRepo)
 }
 
 // extractTokens return tokens for any given level of tree.


### PR DESCRIPTION
Fixes: https://github.com/GoogleCloudPlatform/oss-test-infra/issues/990

I think this is expected behavior if we receive a webhook from an org or repo that we haven't registered an HMAC for so I'm lowering this to a warning level error and including the org/repo in question in the error message.  If it is possible for webhooks to be sent without an associated org/repo then that could also explain this error and may mean that Prow instances have to provide a global token. (Hopefully this is not the case or that type of webhook can be ignored since that would reduce security.)

/assign @chizhg 