### PR TITLE
labels: overhaul kubernetes/k8s.io labels

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -323,20 +323,33 @@ larger set of contributors to apply/remove them.
 
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
-| <a id="area/access" href="#area/access">`area/access`</a> | Issues or PRs related to defining who has access to what (e.g. IAM, RBAC, google groups)| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="area/access" href="#area/access">`area/access`</a> | Define who has access to what via IAM bindings, role bindings, policy, etc.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="area/apps" href="#area/apps">`area/apps`</a> | Application management, code in apps/ <br><br> This was previously `area/cluster-infra`, | anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="area/apps/cert-manager" href="#area/apps/cert-manager">`area/apps/cert-manager`</a> | cert-manager, code in apps/cert-manager/ <br><br> This was previously `area/infra/cert-manager`, | anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="area/apps/gcsweb" href="#area/apps/gcsweb">`area/apps/gcsweb`</a> | gcsweb.k8s.io, code in apps/gcsweb/| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="area/apps/k8s-io" href="#area/apps/k8s-io">`area/apps/k8s-io`</a> | k8s.io redirector, code in apps/k8s-io/| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="area/apps/kubernetes-external-secrets" href="#area/apps/kubernetes-external-secrets">`area/apps/kubernetes-external-secrets`</a> | kubernetes-external-secrets, code in apps/kubernetes-external-secrets/| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="area/apps/perfdash" href="#area/apps/perfdash">`area/apps/perfdash`</a> | perfdash.k8s.io, code in apps/perdash/| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="area/apps/prow" href="#area/apps/prow">`area/apps/prow`</a> | k8s-infra-prow.k8s.io, code in apps/prow/| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="area/apps/publishing-bot" href="#area/apps/publishing-bot">`area/apps/publishing-bot`</a> | publishing-bot, code in apps/publishing-bot/ <br><br> This was previously `area/infra/publishing-bot`, | anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="area/apps/sippy" href="#area/apps/sippy">`area/apps/sippy`</a> | sippy.k8s.io, code in apps/sippy/| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="area/apps/slack-infra" href="#area/apps/slack-infra">`area/apps/slack-infra`</a> | slack.k8s.io, slack-infra, code in apps/slack-infra| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="area/apps/triageparty-release" href="#area/apps/triageparty-release">`area/apps/triageparty-release`</a> | release.triage.k8s.io, triage-party, code in apps/triageparty-release| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="area/artifacts" href="#area/artifacts">`area/artifacts`</a> | Issues or PRs related to the hosting of release artifacts for subprojects| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="area/audit" href="#area/audit">`area/audit`</a> | Audit of project resources, audit followup issues, code in audit/ <br><br> This was previously `area/infra/auditing`, | anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="area/bash" href="#area/bash">`area/bash`</a> | Bash scripts, testing them, writing less of them, code in infra/gcp/| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="area/billing" href="#area/billing">`area/billing`</a> | Issues or PRs related to billing| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
-| <a id="area/cluster-infra" href="#area/cluster-infra">`area/cluster-infra`</a> | Issue or PRs related to project infra that runs on a cluster| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
-| <a id="area/cluster-mgmt" href="#area/cluster-mgmt">`area/cluster-mgmt`</a> | Issues or PRs related to managing k8s clusters to run k8s-infra| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
-| <a id="area/dns" href="#area/dns">`area/dns`</a> | Issues or PRs related to DNS records| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
-| <a id="area/infra/auditing" href="#area/infra/auditing">`area/infra/auditing`</a> | Issues or PRs related to auditing for the Kubernetes project infrastructure| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
-| <a id="area/infra/cert-manager" href="#area/infra/cert-manager">`area/infra/cert-manager`</a> | Issues or PRs related to Cert Manager| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
-| <a id="area/infra/monitoring" href="#area/infra/monitoring">`area/infra/monitoring`</a> | Issues or PRs related to monitoring of the Kubernetes project infrastructure| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
-| <a id="area/infra/publishing-bot" href="#area/infra/publishing-bot">`area/infra/publishing-bot`</a> | Issues or PRs related to Publishing bot| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
-| <a id="area/infra/reliability" href="#area/infra/reliability">`area/infra/reliability`</a> | Issues or PR related to reliability of the Kubernetes project infrastructure| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
-| <a id="area/infra/terraform" href="#area/infra/terraform">`area/infra/terraform`</a> | Issues or PR related to Terraform usage| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
-| <a id="area/prow" href="#area/prow">`area/prow`</a> | Issues or PR related to prow, build clusters, migrating jobs| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="area/cluster-mgmt" href="#area/cluster-mgmt">`area/cluster-mgmt`</a> | REMOVING. This will be deleted after 2021-08-04 00:00:00 +0000 UTC <br><br> Issues or PRs related to managing k8s clusters to run k8s-infra| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="area/dns" href="#area/dns">`area/dns`</a> | DNS records for k8s.io, kubernetes.io, k8s.dev, etc., code in dns/| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="area/groups" href="#area/groups">`area/groups`</a> | Google Groups management, code in groups/| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="area/infra" href="#area/infra">`area/infra`</a> | Infrastructure management, infrastructure design, code in infra/ <br><br> This was previously `area/cluster-infra`, | anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="area/infra/monitoring" href="#area/infra/monitoring">`area/infra/monitoring`</a> | REMOVING. This will be deleted after 2021-08-04 00:00:00 +0000 UTC <br><br> Issues or PRs related to monitoring of the Kubernetes project infrastructure| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="area/infra/reliability" href="#area/infra/reliability">`area/infra/reliability`</a> | REMOVING. This will be deleted after 2021-08-04 00:00:00 +0000 UTC <br><br> Issues or PR related to reliability of the Kubernetes project infrastructure| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="area/k8s.gcr.io" href="#area/k8s.gcr.io">`area/k8s.gcr.io`</a> | Code in k8s.gcr.io/| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="area/policy" href="#area/policy">`area/policy`</a> | Crafting policy, policy decisions, code in policy/| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="area/prow" href="#area/prow">`area/prow`</a> | Setting up or working with prow in general, prow.k8s.io, prow build clusters| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="area/release-eng" href="#area/release-eng">`area/release-eng`</a> | Issues or PRs related to the Release Engineering subproject| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="area/terraform" href="#area/terraform">`area/terraform`</a> | Terraform modules, testing them, writing more of them, code in infra/gcp/clusters/ <br><br> This was previously `area/infra/terraform`, | anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 
 ## Labels that apply to kubernetes/kubernetes, for both issues and PRs
 

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -882,8 +882,80 @@ repos:
   kubernetes/k8s.io:
     labels:
       - color: 0052cc
-        description: Issues or PRs related to defining who has access to what (e.g. IAM, RBAC, google groups)
+        description: Define who has access to what via IAM bindings, role bindings, policy, etc.
         name: area/access
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: 0052cc
+        description: Application management, code in apps/
+        name: area/apps
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: area/cluster-infra
+      - color: 0052cc
+        description: cert-manager, code in apps/cert-manager/
+        name: area/apps/cert-manager
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: area/infra/cert-manager
+      - color: 0052cc
+        description: gcsweb.k8s.io, code in apps/gcsweb/
+        name: area/apps/gcsweb
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: 0052cc
+        description: k8s.io redirector, code in apps/k8s-io/
+        name: area/apps/k8s-io
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: 0052cc
+        description: kubernetes-external-secrets, code in apps/kubernetes-external-secrets/
+        name: area/apps/kubernetes-external-secrets
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: 0052cc
+        description: perfdash.k8s.io, code in apps/perdash/
+        name: area/apps/perfdash
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: 0052cc
+        description: k8s-infra-prow.k8s.io, code in apps/prow/
+        name: area/apps/prow
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: 0052cc
+        description: publishing-bot, code in apps/publishing-bot/
+        name: area/apps/publishing-bot
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: area/infra/publishing-bot
+      - color: 0052cc
+        description: sippy.k8s.io, code in apps/sippy/
+        name: area/apps/sippy
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: 0052cc
+        description: slack.k8s.io, slack-infra, code in apps/slack-infra
+        name: area/apps/slack-infra
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: 0052cc
+        description: release.triage.k8s.io, triage-party, code in apps/triageparty-release
+        name: area/apps/triageparty-release
         target: both
         prowPlugin: label
         addedBy: anyone
@@ -894,14 +966,22 @@ repos:
         prowPlugin: label
         addedBy: anyone
       - color: 0052cc
-        description: Issues or PRs related to billing
-        name: area/billing
+        description: Audit of project resources, audit followup issues, code in audit/
+        name: area/audit
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: area/infra/auditing
+      - color: 0052cc
+        description: Bash scripts, testing them, writing less of them, code in infra/gcp/
+        name: area/bash
         target: both
         prowPlugin: label
         addedBy: anyone
       - color: 0052cc
-        description: Issue or PRs related to project infra that runs on a cluster
-        name: area/cluster-infra
+        description: Issues or PRs related to billing
+        name: area/billing
         target: both
         prowPlugin: label
         addedBy: anyone
@@ -911,50 +991,55 @@ repos:
         target: both
         prowPlugin: label
         addedBy: anyone
+        deleteAfter: "2021-08-04T00:00:00Z"
       - color: 0052cc
-        description: Issues or PRs related to DNS records
+        description: DNS records for k8s.io, kubernetes.io, k8s.dev, etc., code in dns/
         name: area/dns
         target: both
         prowPlugin: label
         addedBy: anyone
       - color: 0052cc
-        description: Issues or PRs related to auditing for the Kubernetes project infrastructure
-        name: area/infra/auditing
+        description: Code in k8s.gcr.io/
+        name: area/k8s.gcr.io
         target: both
         prowPlugin: label
         addedBy: anyone
       - color: 0052cc
-        description: Issues or PRs related to Cert Manager
-        name: area/infra/cert-manager
+        description: Google Groups management, code in groups/
+        name: area/groups
         target: both
         prowPlugin: label
         addedBy: anyone
+      - color: 0052cc
+        description: Infrastructure management, infrastructure design, code in infra/
+        name: area/infra
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: area/cluster-infra
       - color: 0052cc
         description: Issues or PRs related to monitoring of the Kubernetes project infrastructure
         name: area/infra/monitoring
         target: both
         prowPlugin: label
         addedBy: anyone
-      - color: 0052cc
-        description: Issues or PRs related to Publishing bot
-        name: area/infra/publishing-bot
-        target: both
-        prowPlugin: label
-        addedBy: anyone
+        deleteAfter: "2021-08-04T00:00:00Z"
       - color: 0052cc
         description: Issues or PR related to reliability of the Kubernetes project infrastructure
         name: area/infra/reliability
         target: both
         prowPlugin: label
         addedBy: anyone
+        deleteAfter: "2021-08-04T00:00:00Z"
       - color: 0052cc
-        description: Issues or PR related to Terraform usage
-        name: area/infra/terraform
+        description: Crafting policy, policy decisions, code in policy/
+        name: area/policy
         target: both
         prowPlugin: label
         addedBy: anyone
       - color: 0052cc
-        description: Issues or PR related to prow, build clusters, migrating jobs
+        description: Setting up or working with prow in general, prow.k8s.io, prow build clusters
         name: area/prow
         target: both
         prowPlugin: label
@@ -965,6 +1050,14 @@ repos:
         target: both
         prowPlugin: label
         addedBy: anyone
+      - color: 0052cc
+        description: Terraform modules, testing them, writing more of them, code in infra/gcp/clusters/
+        name: area/terraform
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: area/infra/terraform
   kubernetes/kubernetes:
     labels:
       - color: 0052cc


### PR DESCRIPTION
Related:
- Implements https://github.com/kubernetes/k8s.io/issues/508#issuecomment-884608113

Trying to accomplish more consistency with folder names. Where before
area/infra was being used as some kind of pseudo namespace, move
everything into area/apps/{foo} that fits that pattern.

Things that are cross-cutting concerns or languages are left unnamespaced

Things that map directly to a folder name use that folder name

Set a deleteAfter date of the next wg-k8s-infra meeting

- add area/apps (formerly area/cluster-infra)
- add area/apps/{foo} for each app (formly area/infra/{app} for some)
- add area/bash
- add area/terraform (formerly area/infra/terraform)
- add area/infra
- add area/k8s.gcr.io
- add area/audit
- add area/policy
- rm area/infra/monitoring
- rm area/infra/reliability