### PR TITLE
Enhance Prow integration test script and add a README file

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -120,7 +120,7 @@ presubmits:
         - --config=ci
         env:
         - name: BAZEL_FETCH_PLEASE
-          value: "true" # integration test fetches a very specific set of targets, define themin integration-test.sh instead of here
+          value: "true" # integration test fetches a very specific set of targets, define them in integration-test.sh instead of here
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/prow/test/integration/README.md
+++ b/prow/test/integration/README.md
@@ -1,0 +1,42 @@
+
+# Run Prow integration tests
+
+## Run everything
+
+This script would [setup](#setup) the environment, [run](#run-test) all the available integration tests, and then [cleans up](#cleanup) everything.
+
+```bash
+./prow/test/integration/integration-test.sh
+```
+
+## Setup
+
+* [Setup a local registry](setup-local-registry.sh).
+* Compile prow components, generate images, and push them to the registry.
+* [Create a local cluster](setup-cluster.sh) using [kind](https://kind.sigs.k8s.io/).
+* Wait for prow components to be ready.
+
+```bash
+./prow/test/integration/integration-test.sh setup
+```
+
+## Run test
+
+After prow is installed on top of the local cluster, run the integration tests under [test](test) directory
+
+Optional parameters:
+
+* [--test_filter](https://docs.bazel.build/versions/main/command-line-reference.html#flag--test_filter) - Specifies a filter to forward to the test framework.
+* [--cache_test_results](https://docs.bazel.build/versions/main/command-line-reference.html#flag--cache_test_results) - Whether to cache test results.
+
+```bash
+./prow/test/integration/integration-test.sh run [--test_filter=TestHook] [--cache_test_results=no]
+```
+
+## Cleanup
+
+Delete the local cluster and the local registry.
+
+```bash
+./prow/test/integration/integration-test.sh teardown
+```


### PR DESCRIPTION
Split the prow integration test script file into 3 functions -
`setup`, `run`, `teardown`.
Support running the entire process as well as calling each function.

Support providing the `run` function with a `test_filter` parameter
to filter tests, and a `cache_test_results` parameter
to avoid caching results and being able to run the same tests.

Add a `README` file to explain how to use it.
