### PR TITLE
config/jobs: add metrics-bigquery-canary

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-test-infra.yaml
@@ -1,0 +1,31 @@
+periodics:
+- name: metrics-bigquery-canary
+  interval: 10m # TODO(spiffxp): change to cron when non-canary
+  cluster: k8s-infra-prow-build-trusted
+  decorate: true
+  max_concurrency: 1
+  extra_refs:
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+  annotations:
+    testgrid-dashboards: wg-k8s-infra-canaries, sig-testing-canaries
+    testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: '99' # TODO(spiffxp): back down to 2 when non-canary
+    description: Runs BigQuery queries to generate data for metrics.
+  rerun_auth_config:
+    github_team_slugs:
+    # proxy for wg-k8s-infra-oncall
+    - org: kubernetes
+      slug: wg-k8s-infra-leads
+    # proxy for test-infra-oncall
+    - org: kubernetes
+      slug: test-infra-admins
+  spec:
+    serviceAccountName: k8s-metrics
+    containers:
+    - image: gcr.io/k8s-testimages/bigquery:v20210707-0f9c540
+      args:
+      - ./metrics/bigquery.py
+      - --bucket=gs://k8s-project-metrics
+      - --project=k8s-infra-prow-build-trusted


### PR DESCRIPTION
Related:
- part of: https://github.com/kubernetes/k8s.io/issues/1306
- uses SA and GCS setup in: https://github.com/kubernetes/k8s.io/pull/2442

Verify we can query k8s-gubernator:build and write to gs://k8s-project-metrics from k8s-infra-prow-build-trusted