### PR TITLE
enable docker-in-docker for cloud-provider-gcp tasks.

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
@@ -12,6 +12,7 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    preset-dind-enabled: "true"
   extra_refs:
   - org: kubernetes
     repo: cloud-provider-gcp
@@ -27,6 +28,9 @@ periodics:
         requests:
           cpu: 4
           memory: 14Gi
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -51,6 +51,7 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
+      preset-dind-enabled: "true"
     annotations:
       testgrid-dashboards: provider-gcp-presubmits
       description: End to end test of kubernetes/cloud-provider-gcp.
@@ -58,6 +59,9 @@ presubmits:
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-master
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
         command:
         - runner.sh
         args:


### PR DESCRIPTION
`k/cloud-provider-gcp` is switching to docker from Bazel to build container images, as a step of producing the final tarballs.

This PR enables docker-in-docker (`dind` for short) for all tasks that invokes building, so that docker can be used for building container image.

Note: this change will NOT break current configuration.