### PR TITLE
update kubernetes version to 1.22 for azure IPv6 job

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -956,7 +956,7 @@ periodics:
       - --aksengine-agentpoolcount=2
       - --aksengine-admin-username=azureuser
       - --aksengine-creds=$(AZURE_CREDENTIALS)
-      - --aksengine-orchestratorRelease=1.21
+      - --aksengine-orchestratorRelease=1.22
       - --aksengine-mastervmsize=Standard_DS2_v2
       - --aksengine-agentvmsize=Standard_D4s_v3
       - --aksengine-deploy-custom-k8s
@@ -965,7 +965,8 @@ periodics:
       - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/nightly/aks-engine-nightly-linux-amd64.tar.gz
       # Specific test args
       - --ginkgo-parallel=30
-      - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\]
+      # TODO (aramase) remove oidc issuer test from skip after changes in aks-engine/switch to capz for IPv6 jobs
+      - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\]|ServiceAccountIssuerDiscovery.should.support.OIDC.discovery.of.service.account.issuer
       securityContext:
         privileged: true
   annotations:


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

This should fix cluster creation failure for azure IPv6 jobs. I was able to repro this with `v1.21`. No issues with `v1.22`.

```bash
azureuser@k8s-master-20844957-0:~$ kubectl get nodes -o wide
NAME                        STATUS   ROLES    AGE     VERSION                             INTERNAL-IP              EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
k8s-agentpool1-20844957-0   Ready    agent    8m3s    v1.23.0-alpha.0.55+5be21c50c269fc   2001:1234:5678:9abc::5   <none>        Ubuntu 16.04.7 LTS   4.15.0-1113-azure   docker://20.10.7+azure
k8s-agentpool1-20844957-1   Ready    agent    7m42s   v1.23.0-alpha.0.55+5be21c50c269fc   2001:1234:5678:9abc::4   <none>        Ubuntu 16.04.7 LTS   4.15.0-1113-azure   docker://20.10.7+azure
k8s-master-20844957-0       Ready    master   10m     v1.23.0-alpha.0.55+5be21c50c269fc   2001:1234:5678:9abc::6   <none>        Ubuntu 16.04.7 LTS   4.15.0-1113-azure   docker://20.10.7+azure
k8s-master-20844957-1       Ready    master   10m     v1.23.0-alpha.0.55+5be21c50c269fc   2001:1234:5678:9abc::8   <none>        Ubuntu 16.04.7 LTS   4.15.0-1113-azure   docker://20.10.7+azure
k8s-master-20844957-2       Ready    master   10m     v1.23.0-alpha.0.55+5be21c50c269fc   2001:1234:5678:9abc::7   <none>        Ubuntu 16.04.7 LTS   4.15.0-1113-azure   docker://20.10.7+azure
```

/assign @feiskyer
