### PR TITLE
updating depstat jobs to include all staging modules

### DIFF
--- a/config/jobs/kubernetes/sig-arch/kubernetes-depstat-periodical.yaml
+++ b/config/jobs/kubernetes/sig-arch/kubernetes-depstat-periodical.yaml
@@ -27,7 +27,7 @@ periodics:
           go install github.com/kubernetes-sigs/depstat@latest
           popd
 
-          depstat stats --json | tee "${WORKDIR}/stats-base.json";
+          depstat stats -m "k8s.io/kubernetes$(ls staging/src/k8s.io | awk '{printf ",k8s.io/" $0}')" --json | tee "${WORKDIR}/stats-base.json";
     annotations:
       testgrid-create-test-group: "true"
       testgrid-dashboards: sig-testing-misc

--- a/config/jobs/kubernetes/sig-arch/kubernetes-depstat.yaml
+++ b/config/jobs/kubernetes/sig-arch/kubernetes-depstat.yaml
@@ -26,10 +26,10 @@ presubmits:
           go install github.com/kubernetes-sigs/depstat@latest
           popd
 
-          depstat stats --json > "${WORKDIR}/stats.json"
+          depstat stats -m "k8s.io/kubernetes$(ls staging/src/k8s.io | awk '{printf ",k8s.io/" $0}')" --json > "${WORKDIR}/stats.json"
           git reset --hard HEAD
           git checkout -b base "${PULL_BASE_SHA}"
-          depstat stats --json > "${WORKDIR}/stats-base.json"
+          depstat stats -m "k8s.io/kubernetes$(ls staging/src/k8s.io | awk '{printf ",k8s.io/" $0}')" --json > "${WORKDIR}/stats-base.json"
           diff -s -u --ignore-all-space "${WORKDIR}"/stats-base.json "${WORKDIR}"/stats.json || true
     annotations:
       testgrid-create-test-group: "true"


### PR DESCRIPTION
See https://github.com/kubernetes-sigs/depstat/issues/45 and [this](https://github.com/kubernetes-sigs/depstat/pull/48#issuecomment-891050444) comment. Basically this would allow us to use all staging modules as main modules thus providing more accurate stats for k/k.




Signed-off-by: RinkiyaKeDad <arshsharma461@gmail.com>