### PR TITLE
Add versions 4.7 and 4.9 to OpenShift Virtualization on TestGrid

### DIFF
--- a/config/testgrids/openshift/openshift-virtualization.yaml
+++ b/config/testgrids/openshift/openshift-virtualization.yaml
@@ -1,39 +1,65 @@
 dashboards:
 - name: redhat-openshift-virtualization
   dashboard_tab:
-  # 4.8
-  - name: e2e-deploy-4.8
-    test_group_name: branch-ci-openshift-cnv-cnv-ci-release-4.8-e2e-deploy
-    base_options: width=14
-    open_test_template:
-      url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
-    file_bug_template:
-      options:
-      - key: classification
-        value: Red Hat
-      - key: product
-        value: OpenShift Virtualization
-      - key: short_desc
-        value: 'test: <test-name>'
-      - key: cf_environment
-        value: 'test: <test-name>'
-      - key: comment
-        value: 'test: <test-name> failed, see job: <test-url>'
-      url: https://bugzilla.redhat.com/enter_bug.cgi
-    open_bug_template:
-      url: https://github.com/openshift-cnv/cnv-ci/issues/
-    results_url_template:
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: https://github.com/kubevirt/kubevirt/search
-    code_search_url_template:
-      url: https://github.com/kubevirt/kubevirt/compare/<start-custom-0>...<end-custom-0>
-  - name: e2e-upgrade-4.8
-    test_group_name: branch-ci-openshift-cnv-cnv-ci-release-4.8-e2e-upgrade
-    base_options: width=14
-    open_test_template:
-      url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
-    file_bug_template:
-      options:
+    # 4.7
+    - name: e2e-deploy-4.7
+      test_group_name: branch-ci-openshift-cnv-cnv-ci-release-4.7-e2e-deploy
+      base_options: width=14
+      open_test_template:
+        url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+      file_bug_template:
+        options:
+          - key: classification
+            value: Red Hat
+          - key: product
+            value: OpenShift Virtualization
+          - key: short_desc
+            value: 'test: <test-name>'
+          - key: cf_environment
+            value: 'test: <test-name>'
+          - key: comment
+            value: 'test: <test-name> failed, see job: <test-url>'
+        url: https://bugzilla.redhat.com/enter_bug.cgi
+      open_bug_template:
+        url: https://github.com/openshift-cnv/cnv-ci/issues/
+      results_url_template:
+        url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+      code_search_path: https://github.com/kubevirt/kubevirt/search
+      code_search_url_template:
+        url: https://github.com/kubevirt/kubevirt/compare/<start-custom-0>...<end-custom-0>
+    - name: e2e-upgrade-4.7
+      test_group_name: branch-ci-openshift-cnv-cnv-ci-release-4.7-e2e-upgrade
+      base_options: width=14
+      open_test_template:
+        url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+      file_bug_template:
+        options:
+          - key: classification
+            value: Red Hat
+          - key: product
+            value: OpenShift Virtualization
+          - key: short_desc
+            value: 'test: <test-name>'
+          - key: cf_environment
+            value: 'test: <test-name>'
+          - key: comment
+            value: 'test: <test-name> failed, see job: <test-url>'
+        url: https://bugzilla.redhat.com/enter_bug.cgi
+      open_bug_template:
+        url: https://github.com/openshift-cnv/cnv-ci/issues/
+      results_url_template:
+        url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+      code_search_path: https://github.com/kubevirt/kubevirt/search
+      code_search_url_template:
+        url: https://github.com/kubevirt/kubevirt/compare/<start-custom-0>...<end-custom-0>
+    # 4.8
+    - name: e2e-deploy-4.8
+      test_group_name: branch-ci-openshift-cnv-cnv-ci-release-4.8-e2e-deploy
+      base_options: width=14
+      open_test_template:
+        url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+      file_bug_template:
+        options:
         - key: classification
           value: Red Hat
         - key: product
@@ -44,19 +70,107 @@ dashboards:
           value: 'test: <test-name>'
         - key: comment
           value: 'test: <test-name> failed, see job: <test-url>'
-      url: https://bugzilla.redhat.com/enter_bug.cgi
-    open_bug_template:
-      url: https://github.com/openshift-cnv/cnv-ci/issues/
-    results_url_template:
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: https://github.com/kubevirt/kubevirt/search
-    code_search_url_template:
-      url: https://github.com/kubevirt/kubevirt/compare/<start-custom-0>...<end-custom-0>
+        url: https://bugzilla.redhat.com/enter_bug.cgi
+      open_bug_template:
+        url: https://github.com/openshift-cnv/cnv-ci/issues/
+      results_url_template:
+        url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+      code_search_path: https://github.com/kubevirt/kubevirt/search
+      code_search_url_template:
+        url: https://github.com/kubevirt/kubevirt/compare/<start-custom-0>...<end-custom-0>
+    - name: e2e-upgrade-4.8
+      test_group_name: branch-ci-openshift-cnv-cnv-ci-release-4.8-e2e-upgrade
+      base_options: width=14
+      open_test_template:
+        url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+      file_bug_template:
+        options:
+          - key: classification
+            value: Red Hat
+          - key: product
+            value: OpenShift Virtualization
+          - key: short_desc
+            value: 'test: <test-name>'
+          - key: cf_environment
+            value: 'test: <test-name>'
+          - key: comment
+            value: 'test: <test-name> failed, see job: <test-url>'
+        url: https://bugzilla.redhat.com/enter_bug.cgi
+      open_bug_template:
+        url: https://github.com/openshift-cnv/cnv-ci/issues/
+      results_url_template:
+        url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+      code_search_path: https://github.com/kubevirt/kubevirt/search
+      code_search_url_template:
+        url: https://github.com/kubevirt/kubevirt/compare/<start-custom-0>...<end-custom-0>
+    # 4.9
+    - name: e2e-deploy-4.9
+      test_group_name: branch-ci-openshift-cnv-cnv-ci-release-4.9-e2e-deploy
+      base_options: width=14
+      open_test_template:
+        url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+      file_bug_template:
+        options:
+          - key: classification
+            value: Red Hat
+          - key: product
+            value: OpenShift Virtualization
+          - key: short_desc
+            value: 'test: <test-name>'
+          - key: cf_environment
+            value: 'test: <test-name>'
+          - key: comment
+            value: 'test: <test-name> failed, see job: <test-url>'
+        url: https://bugzilla.redhat.com/enter_bug.cgi
+      open_bug_template:
+        url: https://github.com/openshift-cnv/cnv-ci/issues/
+      results_url_template:
+        url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+      code_search_path: https://github.com/kubevirt/kubevirt/search
+      code_search_url_template:
+        url: https://github.com/kubevirt/kubevirt/compare/<start-custom-0>...<end-custom-0>
+    - name: e2e-upgrade-4.9
+      test_group_name: branch-ci-openshift-cnv-cnv-ci-release-4.9-e2e-upgrade
+      base_options: width=14
+      open_test_template:
+        url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+      file_bug_template:
+        options:
+          - key: classification
+            value: Red Hat
+          - key: product
+            value: OpenShift Virtualization
+          - key: short_desc
+            value: 'test: <test-name>'
+          - key: cf_environment
+            value: 'test: <test-name>'
+          - key: comment
+            value: 'test: <test-name> failed, see job: <test-url>'
+        url: https://bugzilla.redhat.com/enter_bug.cgi
+      open_bug_template:
+        url: https://github.com/openshift-cnv/cnv-ci/issues/
+      results_url_template:
+        url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+      code_search_path: https://github.com/kubevirt/kubevirt/search
+      code_search_url_template:
+        url: https://github.com/kubevirt/kubevirt/compare/<start-custom-0>...<end-custom-0>
 
 test_groups:
-  - days_of_results: 14
+  - days_of_results: 21
+    gcs_prefix: origin-ci-test/logs/branch-ci-openshift-cnv-cnv-ci-release-4.7-e2e-deploy
+    name: branch-ci-openshift-cnv-cnv-ci-release-4.7-e2e-deploy
+  - days_of_results: 21
+    gcs_prefix: origin-ci-test/logs/branch-ci-openshift-cnv-cnv-ci-release-4.7-e2e-upgrade
+    name: branch-ci-openshift-cnv-cnv-ci-release-4.7-e2e-upgrade
+  - days_of_results: 21
     gcs_prefix: origin-ci-test/logs/branch-ci-openshift-cnv-cnv-ci-release-4.8-e2e-deploy
     name: branch-ci-openshift-cnv-cnv-ci-release-4.8-e2e-deploy
-  - days_of_results: 14
+  - days_of_results: 21
     gcs_prefix: origin-ci-test/logs/branch-ci-openshift-cnv-cnv-ci-release-4.8-e2e-upgrade
     name: branch-ci-openshift-cnv-cnv-ci-release-4.8-e2e-upgrade
+  - days_of_results: 21
+    gcs_prefix: origin-ci-test/logs/branch-ci-openshift-cnv-cnv-ci-release-4.9-e2e-deploy
+    name: branch-ci-openshift-cnv-cnv-ci-release-4.9-e2e-deploy
+  - days_of_results: 21
+    gcs_prefix: origin-ci-test/logs/branch-ci-openshift-cnv-cnv-ci-release-4.9-e2e-upgrade
+    name: branch-ci-openshift-cnv-cnv-ci-release-4.9-e2e-upgrade


### PR DESCRIPTION
We confirmed tests results of v4.8 are displayed in TestGrid correctly, now we're adding the rest of the versions - 4.7 and 4.9.
Also, increasing the number of days to store the results, from 14 to 21.

Signed-off-by: orenc1 <ocohen@redhat.com>