### PR TITLE
config/jobs: promote metrics-bigquery-canary

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -72,34 +72,6 @@ periodics:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
     description: Runs BigQuery queries, summarizes results into clusters, and uploads to GCS for go.k8s.io/triage
 
-- name: metrics-bigquery
-  interval: 24h
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/bigquery:v20210707-0f9c540
-      args:
-      - --scenario=execute
-      - --
-      - test-infra/metrics/bigquery.py
-      - --
-      - --bucket=gs://k8s-metrics
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
-      volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
-    volumes:
-    - name: service
-      secret:
-        secretName: triage-service-account
-  annotations:
-    testgrid-dashboards: sig-testing-misc
-    testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
-    testgrid-num-failures-to-alert: '2'
-    description: Runs BigQuery queries to generate data for metrics.
-
 - name: metrics-kettle
   interval: 1h
   spec:

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-test-infra.yaml
@@ -1,6 +1,6 @@
 periodics:
-- name: metrics-bigquery-canary
-  interval: 10m # TODO(spiffxp): change to cron when non-canary
+- name: metrics-bigquery
+  cron: "03 0-23/6 * * *"  # like interval: 6h, but explicitly starting at 00:03 UTC
   cluster: k8s-infra-prow-build-trusted
   decorate: true
   max_concurrency: 1
@@ -9,9 +9,9 @@ periodics:
     repo: test-infra
     base_ref: master
   annotations:
-    testgrid-dashboards: wg-k8s-infra-canaries, sig-testing-canaries
+    testgrid-dashboards: sig-testing-misc, wg-k8s-infra-prow
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: '99' # TODO(spiffxp): back down to 2 when non-canary
+    testgrid-num-failures-to-alert: '2'
     description: Runs BigQuery queries to generate data for metrics.
   rerun_auth_config:
     github_team_slugs:
@@ -27,5 +27,5 @@ periodics:
     - image: gcr.io/k8s-testimages/bigquery:v20210707-0f9c540
       args:
       - ./metrics/bigquery.py
-      - --bucket=gs://k8s-project-metrics
+      - --bucket=gs://k8s-metrics
       - --project=k8s-infra-prow-build-trusted


### PR DESCRIPTION
remove the old job which runs on google.com prow and runs using
bootstrap

rename the canary job to become the original job

the new job differs from the old job in that:
- it runs on k8s-infra prow
- it runs every 6h starting at 00:03 UTC instead of 24h interval
- it also shows up on wg-k8s-infra-prow testgrid

/hold
this is dependent on having successfully moved the bucket to the
kubernetes.io GCP org