### PR TITLE
remove failing job ci-ingress-gce-e2e-release-1-6

### DIFF
--- a/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
@@ -202,34 +202,7 @@ periodics:
     testgrid-dashboards: sig-testing-canaries
     testgrid-tab-name: ingress-gce-e2e-canary
     description: Duplicate of ci-ingress-gce-e2e pinned to a k8s-infra community-owned project
-- name: ci-ingress-gce-e2e-release-1-6
-  interval: 6h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-    preset-ingress-master-yaml: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-master
-      args:
-      - --timeout=340
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --cluster=
-      - --env=GCE_GLBC_IMAGE=gcr.io/k8s-ingress-image-push/ingress-gce-glbc-amd64:release-1.6
-      - --extract=ci/latest
-      - --gcp-project-type=ingress-project
-      - --ginkgo-parallel=1
-      - --provider=gce
-      - --test_args=--ginkgo.focus=\[Feature:Ingress\]
-      - --timeout=320m
 
-  annotations:
-    testgrid-dashboards: sig-network-ingress-gce-e2e
-    testgrid-tab-name: ingress-gce-e2e-release-1.6
-    testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com
 - name: ci-ingress-gce-e2e-scale
   interval: 6h
   labels:


### PR DESCRIPTION
discussed in slack 2 weeks ago
https://kubernetes.slack.com/archives/C09QYUH5W/p1626974494064700?thread_ts=1626958633.059800&cid=C09QYUH5W

the job seems to be running an old image and is permanently failing
https://testgrid.k8s.io/sig-network-ingress-gce-e2e#ingress-gce-e2e-release-1.6&width=5

I propose to remove it if is no longer necessary