### PR TITLE
Jira plugin: Do not insert links into literal codeblocks

### DIFF
--- a/prow/plugins/jira/jira.go
+++ b/prow/plugins/jira/jira.go
@@ -186,6 +186,11 @@ func getLines(text string) []line {
 			prefixCount++
 		}
 		l := line{content: rawLine, replacing: true}
+
+		// Literal codeblocks
+		if strings.HasPrefix(rawLine, "    ") {
+			l.replacing = false
+		}
 		if prefixCount%2 == 1 {
 			l.replacing = false
 		}

--- a/prow/plugins/jira/jira_test.go
+++ b/prow/plugins/jira/jira_test.go
@@ -456,6 +456,11 @@ is very important` + "\n```bash\n" +
 				"\n```\n" + `[ABC-123](https://my-jira.com/browse/ABC-123)
 `,
 		},
+		{
+			name:     "Multiline codeblock that is denoted through four leading spaces",
+			body:     "I meant to do this test:\r\n\r\n    operator_test.go:1914: failed to read output from pod unique-id-header-test-1: container \"curl\" in pod \"unique-id-header-ABC-123\" is waiting to start: ContainerCreating\r\n\r\n",
+			expected: "I meant to do this test:\r\n\r\n    operator_test.go:1914: failed to read output from pod unique-id-header-test-1: container \"curl\" in pod \"unique-id-header-ABC-123\" is waiting to start: ContainerCreating\r\n\r\n",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
It already deals with code lines that are denoted through surrounding
triple backticks, but not if they are denoted with four leading spaces.