### PR TITLE
k/website: update config.

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -404,6 +404,8 @@ branch-protection:
               protect: true
             release-1.20:
               protect: true
+            release-1.21:
+              protect: true
     kubernetes-client:
       protect: true
       required_status_checks:

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -371,7 +371,7 @@ milestone_applier:
     release-0.6: v0.6.x
     release-0.5: v0.5.x
   kubernetes/website:
-    dev-1.22: 1.22
+    dev-1.23: 1.23
 
 repo_milestone:
   # Default maintainer


### PR DESCRIPTION
Adds the release-1.21 to the list of protected branches and
also updates the milestone applier for the dev-1.23 branch
to be 1.23.

Signed-off-by: Victor Palade <victor@cloudflavor.io>

/cc @kubernetes/sig-docs-leads