### PR TITLE
Extend the help plugin to include summary of issue guidelines

### DIFF
--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -96,6 +96,13 @@ type Help struct {
 	// HelpGuidelinesURL is the URL of the help page, which provides guidance on how and when to use the help wanted and good first issue labels.
 	// The default value is "https://git.k8s.io/community/contributors/guide/help-wanted.md".
 	HelpGuidelinesURL string `json:"help_guidelines_url,omitempty"`
+	// Guidelines summary is the message displayed when an issue is labeled with help-wanted and/or good-first-issue reflecting
+	// a summary of the guidelines that an issue should follow to qualify as help-wanted or good-first-issue. The main purpose
+	// of a summary is to try and increase visibility of these guidelines to the author of the issue alongisde providing the
+	// HelpGuidelinesURL which will provide a more detailed version of the guidelines.
+	//
+	// HelpGuidelinesSummary is the summary of the guide lines for a help-wanted issue.
+	HelpGuidelinesSummary string `json:"help_guidelines_summary,omitempty"`
 }
 
 func (h *Help) setDefaults() {

--- a/prow/plugins/plugin-config-documented.yaml
+++ b/prow/plugins/plugin-config-documented.yaml
@@ -390,6 +390,14 @@ heart:
     # Compiles into CommentRe during config load.
     commentregexp: ' '
 help:
+    # Guidelines summary is the message displayed when an issue is labeled with help-wanted and/or good-first-issue reflecting
+    # a summary of the guidelines that an issue should follow to qualify as help-wanted or good-first-issue. The main purpose
+    # of a summary is to try and increase visibility of these guidelines to the author of the issue alongisde providing the
+    # HelpGuidelinesURL which will provide a more detailed version of the guidelines.
+
+    # HelpGuidelinesSummary is the summary of the guide lines for a help-wanted issue.
+    help_guidelines_summary: ' '
+
     # HelpGuidelinesURL is the URL of the help page, which provides guidance on how and when to use the help wanted and good first issue labels.
     # The default value is "https://git.k8s.io/community/contributors/guide/help-wanted.md".
     help_guidelines_url: ' '


### PR DESCRIPTION
- Add a new field to the help plugin config to accept user-defined summary of guidelines for help-wanted/good-first-issue issues.
- If field not specified then, default to only linking help guideline url (existing behaviour)
- Add tests for the extension


Fixes #23129