### PR TITLE
Force cgroup v1 and trim the ignition for crio swap job

### DIFF
--- a/jobs/e2e_node/swap/crio_swap1g.ign
+++ b/jobs/e2e_node/swap/crio_swap1g.ign
@@ -5,6 +5,11 @@
   "systemd": {
     "units": [
       {
+        "contents": "[Unit]\nDescription=Enable cgroup v1\nBefore=network-online.target\nConditionFirstBoot=yes\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/rpm-ostree kargs --append systemd.unified_cgroup_hierarchy=0 --reboot\n[Install]\n\nWantedBy=multi-user.target\n",
+        "enabled": true,
+        "name": "cgroupv1.service"
+      },
+      {
         "contents": "[Unit]\nDescription=Enable swap on CoreOS\nBefore=swap-enable.service\nConditionFirstBoot=yes\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c \"sudo rpm-ostree install dbus-tools && sudo systemctl reboot\"\n[Install]\n\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "dbus-send-install.service"
@@ -15,7 +20,7 @@
         "name": "swap-enable.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/sbin/setenforce 1\nExecStartPre=/usr/bin/bash -c '/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /tmp/kubelet-e2e.pp https://storage.googleapis.com/cri-o/selinux/kubelet-e2e.pp'\nExecStartPre=/usr/sbin/semodule -i /tmp/kubelet-e2e.pp\nExecStartPre=/usr/bin/bash -c '/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /usr/local/crio-install.sh  https://raw.githubusercontent.com/cri-o/cri-o/master/scripts/get -t 4d14fd61d2d533a0bb81557b54d3505be830efa7'\nExecStartPre=/usr/bin/bash /usr/local/crio-install.sh\nExecStartPre=/usr/bin/mkdir -p /var/lib/kubelet\nExecStartPre=/usr/bin/chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet\nExecStartPre=/usr/bin/mount /tmp /tmp -o remount,exec,suid\nExecStartPre=/usr/bin/chcon -u system_u -r object_r -t container_runtime_exec_t /usr/local/bin/crio /usr/local/bin/crio-status /usr/local/bin/runc /usr/local/bin/crun\nExecStartPre=/usr/bin/chcon -u system_u -r object_r -t bin_t /usr/local/bin/conmon /usr/local/bin/crictl /usr/local/bin/pinns\nExecStartPre=/usr/bin/chcon -R -u system_u -r object_r -t bin_t /opt/cni/bin/\nExecStartPre=/usr/bin/rm -f  /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=/usr/bin/bash -c 'echo -e \"[crio.runtime]\\n  default_runtime = \\\\\\\"runc\\\\\\\"\\n[crio.runtime.runtimes]\\n  [crio.runtime.runtimes.runc]\\n    runtime_path=\\\\\\\"/usr/local/bin/runc\\\\\\\"\" \u003e /etc/crio/crio.conf.d/20-runc.conf'\nExecStartPre=/usr/bin/bash -c 'echo -e \"[crio.runtime]\\n  [crio.runtime.runtimes]\\n  [crio.runtime.runtimes.test-handler]\\n    runtime_path=\\\\\\\"/usr/local/bin/crun\\\\\\\"\" \u003e /etc/crio/crio.conf.d/10-crun.conf'\nExecStartPre=/usr/bin/chcon -R -u system_u -r object_r -t container_config_t /etc/crio /etc/crio/crio.conf /usr/local/share/oci-umount/oci-umount.d/crio-umount.conf\nExecStartPre=/usr/bin/systemctl enable crio.service\nExecStartPre=/usr/bin/chcon -R -u system_u -r object_r -t systemd_unit_file_t /usr/local/lib/systemd/system/crio.service\nExecStart=/usr/bin/systemctl start crio.service\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /usr/local/crio-nodee2e-installer.sh  https://raw.githubusercontent.com/cri-o/cri-o/779df9510cf8d5d71ef51ebd3f80859a0282b40b/scripts/node_e2e_installer'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }


### PR DESCRIPTION
Trims the ignition file by using node e2e specific installer for crio and forces the system to boot in cgroup v1.

Signed-off-by: Harshal Patil <harpatil@redhat.com>