### PR TITLE
Add documentation to silence slack notifications at the ProwJob level

### DIFF
--- a/prow/cmd/crier/README.md
+++ b/prow/cmd/crier/README.md
@@ -171,6 +171,21 @@ postsubmits:
             command:
               - echo
 ```
+To silence notifications at the ProwJob level you can pass an empty slice to `reporter_config.slack.job_states_to_report`:
+postsubmits:
+```yaml
+  some-org/some-repo:
+    - name: example-job
+      decorate: true
+      reporter_config:
+        slack:
+          job_states_to_report: []
+      spec:
+        containers:
+          - image: alpine
+            command:
+              - echo
+```
 
 ## Implementation details
 


### PR DESCRIPTION
Adds documentation to silence slack notifications by setting `reporter_config.slack.job_states_to_report` to `[]` at the ProwJob level.

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>