### PR TITLE
Add Tenant IDs to TidePools and Tide History Records

### DIFF
--- a/prow/tide/history/history.go
+++ b/prow/tide/history/history.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/apimachinery/pkg/util/sets"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/io"
 )
@@ -120,7 +119,7 @@ type Record struct {
 	BaseSHA   string         `json:"baseSHA,omitempty"`
 	Target    []prowapi.Pull `json:"target,omitempty"`
 	Err       string         `json:"err,omitempty"`
-	TenentIDs sets.String    `json:"tenentids"`
+	TenantIDs []string       `json:"tenantids"`
 }
 
 // New creates a new History struct with the specificed recordLog size limit.
@@ -150,7 +149,7 @@ func New(maxRecordsPerKey int, opener io.Opener, path string) (*History, error) 
 }
 
 // Record appends an entry to the recordlog specified by the poolKey.
-func (h *History) Record(poolKey, action, baseSHA, err string, targets []prowapi.Pull, tenentIDs sets.String) {
+func (h *History) Record(poolKey, action, baseSHA, err string, targets []prowapi.Pull, tenantIDs []string) {
 	t := now()
 	sort.Sort(ByNum(targets))
 	h.addRecord(
@@ -161,7 +160,7 @@ func (h *History) Record(poolKey, action, baseSHA, err string, targets []prowapi
 			BaseSHA:   baseSHA,
 			Target:    targets,
 			Err:       err,
-			TenentIDs: tenentIDs,
+			TenantIDs: tenantIDs,
 		},
 	)
 }

--- a/prow/tide/history/history.go
+++ b/prow/tide/history/history.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/io"
 )
@@ -114,11 +115,12 @@ func writeHistory(opener opener, path string, hist map[string][]*Record) error {
 
 // Record is an entry describing one action that Tide has taken (e.g. TRIGGER or MERGE).
 type Record struct {
-	Time    time.Time      `json:"time"`
-	Action  string         `json:"action"`
-	BaseSHA string         `json:"baseSHA,omitempty"`
-	Target  []prowapi.Pull `json:"target,omitempty"`
-	Err     string         `json:"err,omitempty"`
+	Time      time.Time      `json:"time"`
+	Action    string         `json:"action"`
+	BaseSHA   string         `json:"baseSHA,omitempty"`
+	Target    []prowapi.Pull `json:"target,omitempty"`
+	Err       string         `json:"err,omitempty"`
+	TenentIDs sets.String    `json:"tenentids"`
 }
 
 // New creates a new History struct with the specificed recordLog size limit.
@@ -148,17 +150,18 @@ func New(maxRecordsPerKey int, opener io.Opener, path string) (*History, error) 
 }
 
 // Record appends an entry to the recordlog specified by the poolKey.
-func (h *History) Record(poolKey, action, baseSHA, err string, targets []prowapi.Pull) {
+func (h *History) Record(poolKey, action, baseSHA, err string, targets []prowapi.Pull, tenentIDs sets.String) {
 	t := now()
 	sort.Sort(ByNum(targets))
 	h.addRecord(
 		poolKey,
 		&Record{
-			Time:    t,
-			Action:  action,
-			BaseSHA: baseSHA,
-			Target:  targets,
-			Err:     err,
+			Time:      t,
+			Action:    action,
+			BaseSHA:   baseSHA,
+			Target:    targets,
+			Err:       err,
+			TenentIDs: tenentIDs,
 		},
 	)
 }

--- a/prow/tide/history/history_test.go
+++ b/prow/tide/history/history_test.go
@@ -28,7 +28,6 @@ import (
 
 	"cloud.google.com/go/storage"
 	"k8s.io/apimachinery/pkg/util/diff"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	pkgio "k8s.io/test-infra/prow/io"
@@ -70,9 +69,9 @@ func TestHistory(t *testing.T) {
 	time5 := nextTime()
 	hist.Record("pool C", "TRIGGER_BATCH", "sha C1", "", []prowapi.Pull{testMeta(6, "joe"), testMeta(8, "me")}, nil)
 	time6 := nextTime()
-	hist.Record("pool B", "TRIGGER", "sha B4", "", []prowapi.Pull{testMeta(7, "abe")}, sets.String{})
+	hist.Record("pool B", "TRIGGER", "sha B4", "", []prowapi.Pull{testMeta(7, "abe")}, []string{})
 	time7 := nextTime()
-	hist.Record("pool D", "TRIGGER", "sha D1", "", []prowapi.Pull{testMeta(8, "joe")}, sets.String{}.Insert("testID"))
+	hist.Record("pool D", "TRIGGER", "sha D1", "", []prowapi.Pull{testMeta(8, "joe")}, []string{"testID"})
 
 	expected := map[string][]*Record{
 		"pool A": {
@@ -93,7 +92,7 @@ func TestHistory(t *testing.T) {
 				Target: []prowapi.Pull{
 					testMeta(7, "abe"),
 				},
-				TenentIDs: sets.String{},
+				TenantIDs: []string{},
 			},
 			&Record{
 				Time:    time4,
@@ -132,7 +131,7 @@ func TestHistory(t *testing.T) {
 				Target: []prowapi.Pull{
 					testMeta(8, "joe"),
 				},
-				TenentIDs: sets.String{}.Insert("testID"),
+				TenantIDs: []string{"testID"},
 			},
 		},
 	}

--- a/prow/tide/history/history_test.go
+++ b/prow/tide/history/history_test.go
@@ -292,14 +292,14 @@ func TestWriteHistory(t *testing.T) {
 			recMap: map[string][]*Record{
 				"o/r:b": {{Action: "MERGE"}},
 			},
-			expectedWritten: `{"o/r:b":[{"time":"0001-01-01T00:00:00Z","action":"MERGE"}]}`,
+			expectedWritten: `{"o/r:b":[{"time":"0001-01-01T00:00:00Z","action":"MERGE","tenantids":null}]}`,
 		},
 		{
 			name: "write history with multiple records",
 			recMap: map[string][]*Record{
 				"o/r:b": {{Action: "MERGE3"}, {Action: "MERGE2"}, {Action: "MERGE1"}},
 			},
-			expectedWritten: `{"o/r:b":[{"time":"0001-01-01T00:00:00Z","action":"MERGE3"},{"time":"0001-01-01T00:00:00Z","action":"MERGE2"},{"time":"0001-01-01T00:00:00Z","action":"MERGE1"}]}`,
+			expectedWritten: `{"o/r:b":[{"time":"0001-01-01T00:00:00Z","action":"MERGE3","tenantids":null},{"time":"0001-01-01T00:00:00Z","action":"MERGE2","tenantids":null},{"time":"0001-01-01T00:00:00Z","action":"MERGE1","tenantids":null}]}`,
 		},
 		{
 			name: "write history, with multiple pools",
@@ -307,7 +307,7 @@ func TestWriteHistory(t *testing.T) {
 				"o/r:b":  {{Action: "MERGE"}},
 				"o/r:b2": {{Action: "MERGE2"}, {Action: "MERGE1"}},
 			},
-			expectedWritten: `{"o/r:b":[{"time":"0001-01-01T00:00:00Z","action":"MERGE"}],"o/r:b2":[{"time":"0001-01-01T00:00:00Z","action":"MERGE2"},{"time":"0001-01-01T00:00:00Z","action":"MERGE1"}]}`,
+			expectedWritten: `{"o/r:b":[{"time":"0001-01-01T00:00:00Z","action":"MERGE","tenantids":null}],"o/r:b2":[{"time":"0001-01-01T00:00:00Z","action":"MERGE2","tenantids":null},{"time":"0001-01-01T00:00:00Z","action":"MERGE1","tenantids":null}]}`,
 		},
 	}
 

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -141,7 +141,7 @@ type Pool struct {
 	Error    string
 
 	// All of the TenantIDs associated with PRs in the pool.
-	TenantIDs sets.String
+	TenantIDs []string
 }
 
 // Prometheus Metrics
@@ -1618,7 +1618,7 @@ func (c *Controller) syncSubpool(sp subpool, blocks []blockers.Blocker) (Pool, e
 		"batch-pending": prNumbers(batchPending),
 	}).Info("Subpool accumulated.")
 
-	tenentIDs := sp.TenantIDs()
+	tenantIDs := sp.TenantIDs()
 	var act Action
 	var targets []PullRequest
 	var err error
@@ -1637,7 +1637,7 @@ func (c *Controller) syncSubpool(sp subpool, blocks []blockers.Blocker) (Pool, e
 				sp.sha,
 				errorString,
 				prMeta(targets...),
-				tenentIDs,
+				tenantIDs,
 			)
 		}
 	}
@@ -1664,7 +1664,7 @@ func (c *Controller) syncSubpool(sp subpool, blocks []blockers.Blocker) (Pool, e
 			Blockers: blocks,
 			Error:    errorString,
 
-			TenantIDs: tenentIDs,
+			TenantIDs: tenantIDs,
 		},
 		err
 }
@@ -1723,7 +1723,7 @@ type subpool struct {
 	presubmits map[int][]config.Presubmit
 }
 
-func (sp subpool) TenantIDs() sets.String {
+func (sp subpool) TenantIDs() []string {
 	ids := sets.String{}
 	for _, pj := range sp.pjs {
 		if pj.Spec.ProwJobDefault == nil || pj.Spec.ProwJobDefault.TenantID == "" {
@@ -1732,7 +1732,7 @@ func (sp subpool) TenantIDs() sets.String {
 			ids.Insert(pj.Spec.ProwJobDefault.TenantID)
 		}
 	}
-	return ids
+	return ids.List()
 }
 
 func poolKey(org, repo, branch string) string {

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -1618,6 +1618,7 @@ func (c *Controller) syncSubpool(sp subpool, blocks []blockers.Blocker) (Pool, e
 		"batch-pending": prNumbers(batchPending),
 	}).Info("Subpool accumulated.")
 
+	tenentIDs := sp.TenantIDs()
 	var act Action
 	var targets []PullRequest
 	var err error
@@ -1636,6 +1637,7 @@ func (c *Controller) syncSubpool(sp subpool, blocks []blockers.Blocker) (Pool, e
 				sp.sha,
 				errorString,
 				prMeta(targets...),
+				tenentIDs,
 			)
 		}
 	}
@@ -1662,7 +1664,7 @@ func (c *Controller) syncSubpool(sp subpool, blocks []blockers.Blocker) (Pool, e
 			Blockers: blocks,
 			Error:    errorString,
 
-			TenantIDs: sp.TenantIDs(),
+			TenantIDs: tenentIDs,
 		},
 		err
 }

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -4525,7 +4525,7 @@ func TestTenantIDs(t *testing.T) {
 		{
 			name: "one PJ",
 			pjs: []prowapi.ProwJob{
-				prowapi.ProwJob{
+				{
 					Spec: prowapi.ProwJobSpec{
 						ProwJobDefault: &prowapi.ProwJobDefault{
 							TenantID: "test",
@@ -4538,14 +4538,14 @@ func TestTenantIDs(t *testing.T) {
 		{
 			name: "multiple PJs with same ID",
 			pjs: []prowapi.ProwJob{
-				prowapi.ProwJob{
+				{
 					Spec: prowapi.ProwJobSpec{
 						ProwJobDefault: &prowapi.ProwJobDefault{
 							TenantID: "test",
 						},
 					},
 				},
-				prowapi.ProwJob{
+				{
 					Spec: prowapi.ProwJobSpec{
 						ProwJobDefault: &prowapi.ProwJobDefault{
 							TenantID: "test",
@@ -4558,14 +4558,14 @@ func TestTenantIDs(t *testing.T) {
 		{
 			name: "multiple PJs with different ID",
 			pjs: []prowapi.ProwJob{
-				prowapi.ProwJob{
+				{
 					Spec: prowapi.ProwJobSpec{
 						ProwJobDefault: &prowapi.ProwJobDefault{
 							TenantID: "test",
 						},
 					},
 				},
-				prowapi.ProwJob{
+				{
 					Spec: prowapi.ProwJobSpec{
 						ProwJobDefault: &prowapi.ProwJobDefault{
 							TenantID: "other",
@@ -4578,14 +4578,14 @@ func TestTenantIDs(t *testing.T) {
 		{
 			name: "no tenantID in prowJob",
 			pjs: []prowapi.ProwJob{
-				prowapi.ProwJob{
+				{
 					Spec: prowapi.ProwJobSpec{
 						ProwJobDefault: &prowapi.ProwJobDefault{
 							TenantID: "test",
 						},
 					},
 				},
-				prowapi.ProwJob{
+				{
 					Spec: prowapi.ProwJobSpec{
 						ProwJobDefault: &prowapi.ProwJobDefault{},
 					},
@@ -4596,14 +4596,14 @@ func TestTenantIDs(t *testing.T) {
 		{
 			name: "no pjDefault in prowJob",
 			pjs: []prowapi.ProwJob{
-				prowapi.ProwJob{
+				{
 					Spec: prowapi.ProwJobSpec{
 						ProwJobDefault: &prowapi.ProwJobDefault{
 							TenantID: "test",
 						},
 					},
 				},
-				prowapi.ProwJob{
+				{
 					Spec: prowapi.ProwJobSpec{},
 				},
 			},
@@ -4612,14 +4612,14 @@ func TestTenantIDs(t *testing.T) {
 		{
 			name: "multiple no tenant PJs",
 			pjs: []prowapi.ProwJob{
-				prowapi.ProwJob{
+				{
 					Spec: prowapi.ProwJobSpec{
 						ProwJobDefault: &prowapi.ProwJobDefault{
 							TenantID: "",
 						},
 					},
 				},
-				prowapi.ProwJob{
+				{
 					Spec: prowapi.ProwJobSpec{},
 				},
 			},

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/go-test/deep"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	fuzz "github.com/google/gofuzz"
 	githubql "github.com/shurcooL/githubv4"
 	"github.com/sirupsen/logrus"
@@ -2111,6 +2112,7 @@ func TestSync(t *testing.T) {
 				SuccessPRs: []PullRequest{mergeableA},
 				Action:     Merge,
 				Target:     []PullRequest{mergeableA},
+				TenantIDs:  []string{},
 			}},
 		},
 		{
@@ -2128,6 +2130,7 @@ func TestSync(t *testing.T) {
 				SuccessPRs: []PullRequest{unknownA},
 				Action:     Merge,
 				Target:     []PullRequest{unknownA},
+				TenantIDs:  []string{},
 			}},
 		},
 		{
@@ -2140,6 +2143,7 @@ func TestSync(t *testing.T) {
 				SuccessPRs: []PullRequest{mergeableA},
 				Action:     Merge,
 				Target:     []PullRequest{mergeableA},
+				TenantIDs:  []string{},
 			}},
 		},
 		{
@@ -2152,6 +2156,7 @@ func TestSync(t *testing.T) {
 				SuccessPRs: []PullRequest{mergeableA},
 				Action:     Merge,
 				Target:     []PullRequest{mergeableA},
+				TenantIDs:  []string{},
 			}},
 		},
 		{
@@ -2164,6 +2169,7 @@ func TestSync(t *testing.T) {
 				SuccessPRs: []PullRequest{mergeableA},
 				Action:     Merge,
 				Target:     []PullRequest{mergeableA},
+				TenantIDs:  []string{},
 			}},
 		},
 	}
@@ -4509,12 +4515,12 @@ func TestTenantIDs(t *testing.T) {
 	tests := []struct {
 		name     string
 		pjs      []prowapi.ProwJob
-		expected sets.String
+		expected []string
 	}{
 		{
 			name:     "no PJs",
 			pjs:      []prowapi.ProwJob{},
-			expected: sets.String{},
+			expected: []string{},
 		},
 		{
 			name: "one PJ",
@@ -4527,7 +4533,7 @@ func TestTenantIDs(t *testing.T) {
 					},
 				},
 			},
-			expected: sets.String{}.Insert("test"),
+			expected: []string{"test"},
 		},
 		{
 			name: "multiple PJs with same ID",
@@ -4547,7 +4553,7 @@ func TestTenantIDs(t *testing.T) {
 					},
 				},
 			},
-			expected: sets.String{}.Insert("test"),
+			expected: []string{"test"},
 		},
 		{
 			name: "multiple PJs with different ID",
@@ -4567,7 +4573,7 @@ func TestTenantIDs(t *testing.T) {
 					},
 				},
 			},
-			expected: sets.String{}.Insert("test", "other"),
+			expected: []string{"test", "other"},
 		},
 		{
 			name: "no tenantID in prowJob",
@@ -4585,7 +4591,7 @@ func TestTenantIDs(t *testing.T) {
 					},
 				},
 			},
-			expected: sets.String{}.Insert("test", ""),
+			expected: []string{"test", ""},
 		},
 		{
 			name: "no pjDefault in prowJob",
@@ -4601,7 +4607,7 @@ func TestTenantIDs(t *testing.T) {
 					Spec: prowapi.ProwJobSpec{},
 				},
 			},
-			expected: sets.String{}.Insert("test", ""),
+			expected: []string{"test", ""},
 		},
 		{
 			name: "multiple no tenant PJs",
@@ -4617,13 +4623,13 @@ func TestTenantIDs(t *testing.T) {
 					Spec: prowapi.ProwJobSpec{},
 				},
 			},
-			expected: sets.String{}.Insert(""),
+			expected: []string{""},
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			sp := subpool{pjs: tc.pjs}
-			if diff := cmp.Diff(tc.expected, sp.TenantIDs()); diff != "" {
+			if diff := cmp.Diff(tc.expected, sp.TenantIDs(), cmpopts.SortSlices(func(x, y string) bool { return strings.Compare(x, y) > 0 })); diff != "" {
 				t.Errorf("expected tenantIDs differ from actual: %s", diff)
 			}
 		})


### PR DESCRIPTION
Continuing work on private repo multi-tenancy. Adds TenantID to Tide Pools and Tide History records in order to filter based on ID on Deck