### PR TITLE
re-enable all node flaky test, move node performance test to new job

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -126,7 +126,7 @@ periodics:
       - --deployment=node
       - --gcp-project-type=node-e2e-project
       - --gcp-zone=us-west1-b
-      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/perf-image-config.yaml
+      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
       - --node-test-args= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/" --server-start-timeout=420s
       - --node-tests=true
       - --provider=gce
@@ -531,3 +531,33 @@ periodics:
     testgrid-tab-name: kubelet-gce-e2e-swap-fedora
     testgrid-alert-email: ehashman@redhat.com, ikema@google.com
     description: Executes E2E suite with swap enabled on Fedora
+
+- name: ci-kubernetes-node-kubelet-performance-test
+  interval: 12h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-master
+        args:
+          - --repo=k8s.io/kubernetes=master
+          - --timeout=90
+          - --root=/go/src
+          - --scenario=kubernetes_e2e
+          - --
+          - --deployment=node
+          - --gcp-project-type=node-e2e-project
+          - --gcp-zone=us-west1-b
+          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/perf-image-config.yaml
+          - --node-test-args= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/" --server-start-timeout=420s
+          - --node-tests=true
+          - --provider=gce
+          - --test_args=--nodes=1
+          - --timeout=60m
+        env:
+          - name: GOPATH
+            value: /go
+  annotations:
+    testgrid-dashboards: sig-node-kubelet
+    testgrid-tab-name: node-performance-test


### PR DESCRIPTION
From: https://github.com/kubernetes/test-infra/pull/19352

Filtering of test runs in perf-image-config.yaml means only specific
tests matching "Node Performance Testing" run in flaky job.

Move flaky test job back to general image-config.yaml.
Create new job config specific to "Node Performance Testing".
Decrease ci interval of new "Node Performance Testing" job to 12h
instead of 2h.

Note: I was not able to check if the dashboard was created or not.
