### PR TITLE
bump promoter jobs

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -13,7 +13,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v2.4.1
+      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v20210805-v1.337.0-136-g8f6bfde
         command:
         - cip
         args:
@@ -36,7 +36,7 @@ presubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-vuln-scanning
       containers:
-      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v2.4.1
+      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v20210805-v1.337.0-136-g8f6bfde
         command:
         - cip
         args:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -659,7 +659,7 @@ postsubmits:
     spec:
       serviceAccountName: pusher
       containers:
-      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v2.4.1
+      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v20210805-v1.337.0-136-g8f6bfde
         command:
         - cip
         args:

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -13,7 +13,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-promoter
       containers:
-      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v2.4.1
+      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v20210805-v1.337.0-136-g8f6bfde
         command:
         - cip
         args:
@@ -46,7 +46,7 @@ periodics:
     # https://github.com/kubernetes/k8s.io/pull/695.
     serviceAccountName: k8s-infra-gcr-promoter
     containers:
-    - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v2.4.1
+    - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v20210805-v1.337.0-136-g8f6bfde
       command:
       - cip
       args:


### PR DESCRIPTION
This version includes
https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/385,
which has a fix for detecting tag moves (and exiting if an error if such
a "promotion" is attempted).

/cc @tylerferrara @spiffxp @dims