### PR TITLE
Revert "bump promoter jobs"

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -13,7 +13,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v20210805-v1.337.0-136-g8f6bfde
+      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v2.4.1
         command:
         - cip
         args:
@@ -36,7 +36,7 @@ presubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-vuln-scanning
       containers:
-      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v20210805-v1.337.0-136-g8f6bfde
+      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v2.4.1
         command:
         - cip
         args:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -659,7 +659,7 @@ postsubmits:
     spec:
       serviceAccountName: pusher
       containers:
-      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v20210805-v1.337.0-136-g8f6bfde
+      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v2.4.1
         command:
         - cip
         args:

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -13,7 +13,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-promoter
       containers:
-      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v20210805-v1.337.0-136-g8f6bfde
+      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v2.4.1
         command:
         - cip
         args:
@@ -46,7 +46,7 @@ periodics:
     # https://github.com/kubernetes/k8s.io/pull/695.
     serviceAccountName: k8s-infra-gcr-promoter
     containers:
-    - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v20210805-v1.337.0-136-g8f6bfde
+    - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v2.4.1
       command:
       - cip
       args:


### PR DESCRIPTION
This reverts commit 61a7566a0899fa0e46a098ede5ec22471c7d8a9b.

Unfortunately I forgot to change the calling conventions because in the
meantime since the last update, (vs version `v2.4.1`), the promoter uses
slightly different flags.

See https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/k8s.io/2476/pull-k8sio-cip/1423412661231554560 for a log (reproduced below):

```
Error: unknown shorthand flag: 't' in -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
Usage:
  cip [command]

Available Commands:
  audit       Run the image auditor
  completion  generate the autocompletion script for the specified shell
  help        Help about any command
  run         Promote images from a staging registry to production
  version     output version information

Flags:
      --dry-run            test run promotion without modifying any registry
  -h, --help               help for cip
      --log-level string   the logging verbosity, either 'panic', 'fatal', 'error', 'warning', 'info', 'debug', 'trace' (default "info")

Use "cip [command] --help" for more information about a command.

time="2021-08-05T22:38:03Z" level=fatal msg="unknown shorthand flag: 't' in -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io"
```