### PR TITLE
Throttle sub to only process 10 messages at a time

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1081,6 +1081,10 @@ func (rac RerunAuthConfigs) GetRerunAuthConfig(refs *prowapi.Refs) prowapi.Rerun
 	return rac["*"]
 }
 
+const (
+	defaultMaxOutstandingMessages = 10
+)
+
 // PubsubSubscriptions maps GCP projects to a list of Topics
 type PubsubSubscriptions map[string][]string
 
@@ -1092,6 +1096,8 @@ type PubSubTrigger struct {
 	Project         string   `json:"project"`
 	Topics          []string `json:"topics"`
 	AllowedClusters []string `json:"allowed_clusters"`
+	// MaxOutstandingMessages is the max number of messaged being processed, default is 10
+	MaxOutstandingMessages int `json:"max_outstanding_messages"`
 }
 
 // GitHubOptions allows users to control how prow applications display GitHub website links.
@@ -1387,6 +1393,11 @@ func loadConfig(prowConfig, jobConfig string, additionalProwConfigDirs []string,
 				Topics:          topics,
 				AllowedClusters: []string{"*"},
 			})
+		}
+	}
+	for i, trigger := range nc.PubSubTriggers {
+		if trigger.MaxOutstandingMessages == 0 {
+			nc.PubSubTriggers[i].MaxOutstandingMessages = defaultMaxOutstandingMessages
 		}
 	}
 

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -2450,9 +2450,10 @@ pubsub_subscriptions:
 			verify: func(c *Config) error {
 				if diff := cmp.Diff(c.PubSubTriggers, PubSubTriggers([]PubSubTrigger{
 					{
-						Project:         "projA",
-						Topics:          []string{"topicB", "topicC"},
-						AllowedClusters: []string{"*"},
+						Project:                "projA",
+						Topics:                 []string{"topicB", "topicC"},
+						AllowedClusters:        []string{"*"},
+						MaxOutstandingMessages: 10,
 					},
 				})); diff != "" {
 					return fmt.Errorf("want(-), got(+): \n%s", diff)

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -951,6 +951,7 @@ pubsub_subscriptions:
 pubsub_triggers:
   - allowed_clusters:
       - ""
+    max_outstanding_messages: 0
     project: ' '
     topics:
       - ""

--- a/prow/pubsub/subscriber/subscriber_test.go
+++ b/prow/pubsub/subscriber/subscriber_test.go
@@ -94,7 +94,7 @@ func (c *pubSubTestClient) new(ctx context.Context, project string) (pubsubClien
 	return c, nil
 }
 
-func (c *pubSubTestClient) subscription(id string) subscriptionInterface {
+func (c *pubSubTestClient) subscription(id string, maxOutstandingMessages int) subscriptionInterface {
 	return &fakeSubscription{name: id, messageChan: c.messageChan}
 }
 


### PR DESCRIPTION
Currently the default is 1000 according to https://github.com/googleapis/google-cloud-go/blob/22ffc18e522c0f943db57f8c943e7356067bedfd/pubsub/subscription.go#L536, I had ran an experiment and confirmed that this is the case. Allowing 1000 pubsub messages to be processed at a time could throttle quite a bit, especially in cases of inrepoconfig where there are lots of I/O