### PR TITLE
Add GCE Windows containerd jobs for 20H2 & v1.22

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml
@@ -592,6 +592,59 @@ periodics:
       name: ""
       resources: {}
 - annotations:
+    testgrid-dashboards: google-windows, sig-windows-gce, sig-release-job-config-errors, sig-windows-1.22-release
+    testgrid-tab-name: gce-windows-2019-containerd-1.22
+  decorate: true
+  decoration_config:
+    timeout: 3h0m0s
+  extra_refs:
+  - base_ref: master
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/windows-testing
+    repo: windows-testing
+  interval: 4h
+  labels:
+    preset-common-gce-windows: "true"
+    preset-e2e-gce-windows: "true"
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+    preset-windows-private-registry-cred: "true"
+    preset-windows-repo-list-master: "true"
+    preset-e2e-gce-windows-containerd: "true"
+  name: ci-kubernetes-e2e-windows-gce-2019-containerd-1-22
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --cluster=
+      - --extract=ci/latest-1.22
+      - --gcp-zone=us-west1-b
+      - --ginkgo-parallel=8
+      - --provider=gce
+      - --gcp-nodes=2
+      - --test=false
+      - --test-cmd=$GOPATH/src/sigs.k8s.io/windows-testing/gce/run-e2e.sh
+      - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[Feature:Windows\]
+        --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:\s?[^(Windows)]\w+\]|\[Slow\]|(GMSA\ssupport\sworks\send\sto\send)
+        --minStartupPods=8
+      - --test-cmd-args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[Feature:Windows\]
+        --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:\s?[^(Windows)]\w+\]|\[Slow\]|(GMSA\ssupport\sworks\send\sto\send)
+        --minStartupPods=8
+      - --test-cmd-args=--node-os-distro=windows
+      - --test-cmd-args=--docker-config-file=$(DOCKER_CONFIG_FILE)
+      - --timeout=180m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      env:
+      - name: WINDOWS_NODE_OS_DISTRIBUTION
+        value: win2019
+      - name: PREPULL_YAML
+        value: prepull-head.yaml
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
+      name: ""
+      resources: {}
+- annotations:
     testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-master-release,
       sig-release-job-config-errors
     testgrid-tab-name: gce-windows-20h2-1.22
@@ -644,6 +697,60 @@ periodics:
       - name: PREPULL_YAML
         value: prepull-head.yaml
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-1.22
+      name: ""
+      resources: {}
+- annotations:
+    testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-1.22-release,
+      sig-release-job-config-errors
+    testgrid-tab-name: gce-windows-20h2-containerd-1.22
+  decorate: true
+  decoration_config:
+    timeout: 3h0m0s
+  extra_refs:
+  - base_ref: master
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/windows-testing
+    repo: windows-testing
+  interval: 4h
+  labels:
+    preset-common-gce-windows: "true"
+    preset-e2e-gce-windows: "true"
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+    preset-windows-private-registry-cred: "true"
+    preset-windows-repo-list-master: "true"
+    preset-e2e-gce-windows-containerd: "true"
+  name: ci-kubernetes-e2e-windows-gce-20h2-containerd-1-22
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --cluster=
+      - --extract=ci/latest-1.22
+      - --gcp-zone=us-west1-b
+      - --ginkgo-parallel=8
+      - --provider=gce
+      - --gcp-nodes=2
+      - --test=false
+      - --test-cmd=$GOPATH/src/sigs.k8s.io/windows-testing/gce/run-e2e.sh
+      - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[Feature:Windows\]
+        --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:\s?[^(Windows)]\w+\]|\[Slow\]|(GMSA\ssupport\sworks\send\sto\send)
+        --minStartupPods=8
+      - --test-cmd-args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[Feature:Windows\]
+        --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:\s?[^(Windows)]\w+\]|\[Slow\]|(GMSA\ssupport\sworks\send\sto\send)
+        --minStartupPods=8
+      - --test-cmd-args=--node-os-distro=windows
+      - --test-cmd-args=--docker-config-file=$(DOCKER_CONFIG_FILE)
+      - --timeout=180m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      env:
+      - name: WINDOWS_NODE_OS_DISTRIBUTION
+        value: win20h2
+      - name: PREPULL_YAML
+        value: prepull-head.yaml
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.22
       name: ""
       resources: {}
 - annotations:

--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -157,6 +157,57 @@ periodics:
     testgrid-tab-name: gce-windows-20h2-master
     description: Runs tests on a Kubernetes cluster with Windows 20H2 nodes on GCE
 
+- name: ci-kubernetes-e2e-windows-containerd-gce-20h2
+  decorate: true
+  decoration_config:
+    timeout: 3h
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: windows-testing
+    base_ref: master
+    path_alias: sigs.k8s.io/windows-testing
+  interval: 4h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+    preset-common-gce-windows: "true"
+    preset-e2e-gce-windows: "true"
+    preset-windows-repo-list-master: "true"
+    preset-windows-private-registry-cred: "true"
+    preset-e2e-gce-windows-containerd: "true"
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --check-leaked-resources
+      - --cluster=
+      - --extract=ci/latest
+      - --gcp-zone=us-west1-b
+      - --ginkgo-parallel=8
+      - --provider=gce
+      - --gcp-nodes=2
+      - --test=false
+      - --test-cmd=$GOPATH/src/sigs.k8s.io/windows-testing/gce/run-e2e.sh
+      - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[Feature:Windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:\s?[^(Windows)]\w+\]|\[Slow\]|(GMSA\ssupport\sworks\send\sto\send) --minStartupPods=8
+      - --test-cmd-args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[Feature:Windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:\s?[^(Windows)]\w+\]|\[Slow\]|(GMSA\ssupport\sworks\send\sto\send) --minStartupPods=8
+      - --test-cmd-args=--node-os-distro=windows
+      - --test-cmd-args=--docker-config-file=$(DOCKER_CONFIG_FILE)
+      - --timeout=180m
+      env:
+      - name: WINDOWS_NODE_OS_DISTRIBUTION
+        value: "win20h2"
+      - name: PREPULL_YAML
+        value: "prepull-head.yaml"
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-master
+  annotations:
+    fork-per-release: "true"
+    fork-per-release-replacements: "--extract=ci/latest -> --extract=ci/latest-{{.Version}}"
+    testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-master-release
+    testgrid-tab-name: gce-windows-20h2-containerd-master
+    description: Runs tests on a Kubernetes cluster with Windows 20H2 containerd nodes on GCE
+
 - name: ci-kubernetes-e2e-windows-gce-2004
   decorate: true
   decoration_config:
@@ -400,9 +451,58 @@ periodics:
         value: "prepull-head.yaml"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-1.21
   annotations:
-    testgrid-dashboards: google-windows, sig-windows-gce, sig-node-containerd, sig-windows-master-release
+    testgrid-dashboards: google-windows, sig-windows-gce, sig-node-containerd, sig-windows-1.21-release
     testgrid-tab-name: gce-windows-2019-containerd-1.21
     description: Runs tests on a Kubernetes cluster with Windows containerd nodes on GCE using 1.21 branch
+
+- name: ci-kubernetes-e2e-windows-containerd-gce-20h2-1-21
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: windows-testing
+    base_ref: master
+    path_alias: sigs.k8s.io/windows-testing
+  interval: 4h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+    preset-common-gce-windows: "true"
+    preset-e2e-gce-windows: "true"
+    preset-e2e-gce-windows-containerd: "true"
+    preset-windows-repo-list-master: "true"
+    preset-windows-private-registry-cred: "true"
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --check-leaked-resources
+      - --cluster=
+      - --extract=ci/latest-1.21
+      - --gcp-zone=us-west1-b
+      - --ginkgo-parallel=8
+      - --provider=gce
+      - --gcp-nodes=2
+      - --test=false
+      - --test-cmd=$GOPATH/src/sigs.k8s.io/windows-testing/gce/run-e2e.sh
+      - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[Feature:Windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:\s?[^(Windows)]\w+\]|\[Slow\]|device.plugin.for.Windows|(GMSA\ssupport\sworks\send\sto\send) --minStartupPods=8
+      - --test-cmd-args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[Feature:Windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:\s?[^(Windows)]\w+\]|\[Slow\]|device.plugin.for.Windows|(GMSA\ssupport\sworks\send\sto\send) --minStartupPods=8
+      - --test-cmd-args=--node-os-distro=windows
+      - --test-cmd-args=--docker-config-file=$(DOCKER_CONFIG_FILE)
+      - --timeout=230m
+      env:
+      - name: WINDOWS_NODE_OS_DISTRIBUTION
+        value: "win20h2"
+      - name: PREPULL_YAML
+        value: "prepull-head.yaml"
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.21
+  annotations:
+    testgrid-dashboards: google-windows, sig-windows-gce, sig-node-containerd, sig-windows-1.21-release
+    testgrid-tab-name: gce-windows-20h2-containerd-1.21
+    description: Runs tests on a Kubernetes cluster with Windows 20H2 containerd nodes on GCE using 1.21 branch
 
 - name: ci-kubernetes-e2e-windows-node-throughput
   interval: 6h


### PR DESCRIPTION
The change adds jobs for Windows using Containerd for both 20h2 and v1.22.