### PR TITLE
Protect kubernetes/enhancements

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -246,6 +246,10 @@ branch-protection:
             - continuous-integration/travis-ci
           required_pull_request_reviews:
             required_approving_review_count: 1
+        enhancements:
+          restrictions: # only allow admins
+            users: []
+            teams: []
         git-sync:
           enforce_admins: true
           restrictions: # only allow admins


### PR DESCRIPTION
This should be sufficient to disallow manual merges of unapproved PRs in k/enhancments repo.

@cblecker @spiffxp I think this is what was suggested in our slack convo?

LMK if I need to do anything else?