### PR TITLE
releng(kubekins, krte): Update Golang versions to go1.16.7

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.16.6
+    GO_VERSION: 1.16.7
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
@@ -22,19 +22,19 @@ variants:
     KIND_VERSION: 0.10.0
   master:
     CONFIG: master
-    GO_VERSION: 1.16.6
+    GO_VERSION: 1.16.7
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.22':
     CONFIG: '1.22'
-    GO_VERSION: 1.16.6
+    GO_VERSION: 1.16.7
     K8S_RELEASE: latest-1.22
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.21':
     CONFIG: '1.21'
-    GO_VERSION: 1.16.6
+    GO_VERSION: 1.16.7
     K8S_RELEASE: stable-1.21
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
Part of https://github.com/kubernetes/release/issues/2196
Ready to land, now that the k/k go1.16.7 PR has merged https://github.com/kubernetes/kubernetes/pull/104199.

/assign @justaugustus @puerco @xmudrii @saschagrunert @BenTheElder 
cc: @kubernetes/release-engineering
