### PR TITLE
Kops - reduce the max # of runs in testgrid

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -173,9 +173,9 @@ def build_test(cloud='aws',
         dashboards.extend(extra_dashboards)
 
     days_of_results = 90
-    if runs_per_week * days_of_results > 7500:
+    if runs_per_week * days_of_results > 4000:
         # testgrid has a limit on number of test runs to show for a job
-        days_of_results = math.floor(7500 / runs_per_week)
+        days_of_results = math.floor(4000 / runs_per_week)
     annotations = {
         'testgrid-dashboards': ', '.join(sorted(dashboards)),
         'testgrid-days-of-results': str(days_of_results),

--- a/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
@@ -157,7 +157,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='903794441882/debian-11-amd64-daily-20210806-726' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --create-args="--image='903794441882/debian-11-amd64-daily-20210807-727' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
           --test=kops \

--- a/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
@@ -1,6 +1,6 @@
 periodics:
 # Runs e2e on the cluster built with latest released kops and latest released k/k
-- cron: '3 * * * *'
+- cron: '3 1-23/3 * * *'
   labels:
     preset-k8s-ssh: "true"
   name: e2e-kops-gce-stable
@@ -61,11 +61,11 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-kops-gce, kops-distro-u2004, kops-gce, kops-k8s-latest, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
+    testgrid-days-of-results: '71'
     testgrid-tab-name: kops-gce-stable
 
 # Runs e2e on the cluster built with latest released kops and k/k master branch
-- cron: '48 * * * *'
+- cron: '48 1-23/3 * * *'
   labels:
     preset-k8s-ssh: "true"
   name: e2e-kops-gce-latest
@@ -128,5 +128,5 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
     testgrid-dashboards: google-kops-gce, kops-distro-u2004, kops-gce, kops-k8s-latest, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
+    testgrid-days-of-results: '71'
     testgrid-tab-name: kops-gce-latest

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -200,7 +200,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-ipv6, kops-k8s-ci, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '89'
+    testgrid-days-of-results: '47'
     testgrid-tab-name: kops-grid-scenario-ipv6-calico
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--ipv6 --api-loadbalancer-type=public --api-loadbalancer-class=network --set=cluster.spec.api.loadBalancer.useForInternalApi=true --set=cluster.spec.cloudControllerManager.cloudProvider=aws --set=cluster.spec.cloudControllerManager.image=hakman/cloud-controller-manager:ipv6-1 --set=cluster.spec.nonMasqueradeCIDR=fd00:10:96::/64 --set=cluster.spec.kubeDNS.upstreamNameservers=2620:119:35::35 --set=cluster.spec.kubeDNS.upstreamNameservers=2620:119:53::53", "feature_flags": "AWSIPv6", "k8s_version": "ci", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
@@ -660,7 +660,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
+    testgrid-days-of-results: '71'
     testgrid-tab-name: kops-aws-misc-ha-euwest1
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004arm64", "extra_flags": "--zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large", "k8s_version": "ci", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
@@ -994,7 +994,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '44'
+    testgrid-days-of-results: '23'
     testgrid-tab-name: kops-aws-misc-updown
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004arm64", "extra_flags": "--zones=eu-central-1a --node-size=m6g.large --master-size=m6g.large", "k8s_version": "latest", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}

--- a/config/jobs/kubernetes/kops/kops-periodics-pipeline.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-pipeline.yaml
@@ -65,7 +65,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-latest, kops-kubetest2, kops-latest, kops-versions, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '44'
+    testgrid-days-of-results: '23'
     testgrid-tab-name: kops-pipeline-updown-kopsmaster
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
@@ -131,7 +131,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.21, kops-kubetest2, kops-latest, kops-versions, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '44'
+    testgrid-days-of-results: '23'
     testgrid-tab-name: kops-pipeline-updown-kops121
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
@@ -197,7 +197,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.20, kops-kubetest2, kops-latest, kops-versions, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '44'
+    testgrid-days-of-results: '23'
     testgrid-tab-name: kops-pipeline-updown-kops120
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
@@ -263,5 +263,5 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.19, kops-kubetest2, kops-latest, kops-versions, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '44'
+    testgrid-days-of-results: '23'
     testgrid-tab-name: kops-pipeline-updown-kops119

--- a/config/jobs/kubernetes/kops/kops-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-upgrades.yaml
@@ -63,7 +63,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '89'
+    testgrid-days-of-results: '47'
     testgrid-tab-name: kops-aws-upgrade-k121-ko121-to-klatest-kolatest
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
@@ -127,7 +127,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '89'
+    testgrid-days-of-results: '47'
     testgrid-tab-name: kops-aws-upgrade-k120-ko120-to-k121-ko121
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
@@ -191,7 +191,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '89'
+    testgrid-days-of-results: '47'
     testgrid-tab-name: kops-aws-upgrade-k119-ko119-to-k120-ko120
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
@@ -255,7 +255,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '89'
+    testgrid-days-of-results: '47'
     testgrid-tab-name: kops-aws-upgrade-k120-kolatest-to-k121-kolatest
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
@@ -319,5 +319,5 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '89'
+    testgrid-days-of-results: '47'
     testgrid-tab-name: kops-aws-upgrade-k120-ko120-to-k121-kolatest

--- a/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
@@ -65,7 +65,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-ci, kops-kubetest2, kops-latest, kops-versions, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
+    testgrid-days-of-results: '71'
     testgrid-tab-name: kops-aws-k8s-latest
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
@@ -128,7 +128,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.21, kops-kubetest2, kops-latest, kops-versions, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
+    testgrid-days-of-results: '71'
     testgrid-tab-name: kops-aws-k8s-1-21
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
@@ -191,7 +191,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.20, kops-kubetest2, kops-latest, kops-versions, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
+    testgrid-days-of-results: '71'
     testgrid-tab-name: kops-aws-k8s-1-20
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
@@ -254,7 +254,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.19, kops-kubetest2, kops-latest, kops-versions, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
+    testgrid-days-of-results: '71'
     testgrid-tab-name: kops-aws-k8s-1-19
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
@@ -317,7 +317,7 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.18, kops-kubetest2, kops-latest, kops-versions, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
+    testgrid-days-of-results: '71'
     testgrid-tab-name: kops-aws-k8s-1-18
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
@@ -380,5 +380,5 @@ periodics:
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
     testgrid-dashboards: google-aws, kops-distro-deb9, kops-k8s-1.17, kops-kubetest2, kops-latest, kops-versions, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
+    testgrid-days-of-results: '71'
     testgrid-tab-name: kops-aws-k8s-1-17


### PR DESCRIPTION
We're still experiencing this after numerous attempts to reduce the number of columns in the testgrid tab:

```
Internal Error: Refresh, and file an issue if problem persists. (Your table may be too big; consider lower `days_of_results` or `enable_test_methods = false`).
```

https://testgrid.k8s.io/kops-versions#kops-aws-k8s-latest

Reducing it once more before opening a GH issue.

Note that the GCE jobs were manually edited to match their AWS equivalents, since they arent managed by build_jobs.py yet.

https://testgrid.k8s.io/kops-gce#kops-gce-latest