### PR TITLE
Promote node e2e serial-containerd to more dashboards

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -241,8 +241,10 @@ periodics:
           cpu: 4
           memory: 6Gi
   annotations:
-    testgrid-dashboards: sig-node-kubelet
+    testgrid-dashboards: sig-release-master-informing, sig-node-kubelet, sig-node-release-blocking
     testgrid-tab-name: node-kubelet-serial-containerd
+    testgrid-alert-email: kubernetes-sig-node+testgrid@googlegroups.com,kubernetes-sig-node-test-failures@googlegroups.com
+    description: "Uses kubetest to run serial node-e2e tests (+Serial, -Flaky|Benchmark|Node*Feature)"
 
 - name: ci-kubernetes-node-kubelet-eviction
   interval: 4h30m


### PR DESCRIPTION
Now that this CI job is green, we should endeavor to keep it green by marking it as release blocker (for more folks to pay attention to it)

/assign @SergeyKanzhelev @ehashman 
/sig node

![image](https://user-images.githubusercontent.com/23304/128618020-2eab3cb1-2910-4166-8d10-0d4afccecb61.png)

Signed-off-by: Davanum Srinivas <davanum@gmail.com>