### PR TITLE
Update testgrid for Kubernetes 1.22

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
@@ -132,7 +132,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 
-- name: periodic-cluster-api-e2e-workload-upgrade-1-21-latest-main
+- name: periodic-cluster-api-e2e-workload-upgrade-1-21-1-22-main
   interval: 24h
   decorate: true
   labels:
@@ -157,9 +157,9 @@ periodics:
         - name: KUBERNETES_VERSION_UPGRADE_FROM
           value: "stable-1.21"
         - name: KUBERNETES_VERSION_UPGRADE_TO
-          value: "ci/latest-1.22"
+          value: "stable-1.22"
         - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.4.13-0"
+          value: "3.5.0-0"
         - name: COREDNS_VERSION_UPGRADE_TO
           value: "v1.8.4"
         - name: GINKGO_FOCUS
@@ -172,6 +172,50 @@ periodics:
           cpu: 7300m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-    testgrid-tab-name: capi-e2e-main-1-21-latest
+    testgrid-tab-name: capi-e2e-main-1-21-1-22
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "2"
+
+- name: periodic-cluster-api-e2e-workload-upgrade-1-22-latest-main
+  interval: 24h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api
+    base_ref: master
+    path_alias: sigs.k8s.io/cluster-api
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210721-2b77449-1.21
+      args:
+        - runner.sh
+        - "./scripts/ci-e2e.sh"
+      env:
+        - name: KUBERNETES_VERSION_UPGRADE_FROM
+          value: "stable-1.22"
+        - name: KUBERNETES_VERSION_UPGRADE_TO
+          value: "ci/latest-1.23"
+        - name: ETCD_VERSION_UPGRADE_TO
+          value: "3.5.0-0"
+        - name: COREDNS_VERSION_UPGRADE_TO
+          value: "v1.8.4"
+        - name: GINKGO_FOCUS
+          value: "\\[K8s-Upgrade\\]"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+    testgrid-tab-name: capi-e2e-main-1-22-latest
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -205,7 +205,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-e2e-full-main
-  - name: pull-cluster-api-e2e-workload-upgrade-1-21-latest-main
+  - name: pull-cluster-api-e2e-workload-upgrade-1-22-latest-main
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -229,11 +229,11 @@ presubmits:
           - "./scripts/ci-e2e.sh"
         env:
           - name: KUBERNETES_VERSION_UPGRADE_FROM
-            value: "stable-1.21"
+            value: "stable-1.22"
           - name: KUBERNETES_VERSION_UPGRADE_TO
-            value: "ci/latest-1.22"
+            value: "ci/latest-1.23"
           - name: ETCD_VERSION_UPGRADE_TO
-            value: "3.4.13-0"
+            value: "3.5.0-0"
           - name: COREDNS_VERSION_UPGRADE_TO
             value: "v1.8.4"
           - name: GINKGO_FOCUS
@@ -246,4 +246,4 @@ presubmits:
             cpu: 7300m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-      testgrid-tab-name: capi-pr-e2e-main-1-21-latest
+      testgrid-tab-name: capi-pr-e2e-main-1-22-latest


### PR DESCRIPTION
Since Kubernetes 1.22 has been released, this PR aims to update jobs accordingly.

Fixes: https://github.com/kubernetes-sigs/cluster-api/issues/5060