### PR TITLE
Workaround for Bugzilla REST issue.

### DIFF
--- a/prow/bugzilla/client.go
+++ b/prow/bugzilla/client.go
@@ -407,7 +407,7 @@ func traverseDown(c Client, bug *Bug, bugCache *bugDetailsCache, errGroup *errgr
 // SubComponents are a Red Hat bugzilla specific extra field.
 func (c *client) GetSubComponentsOnBug(id int) (map[string][]string, error) {
 	logger := c.logger.WithFields(logrus.Fields{methodField: "GetSubComponentsOnBug", "id": id})
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/rest/bug/%d", c.endpoint, id), nil)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/rest/bug?id=%d", c.endpoint, id), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -442,7 +442,7 @@ func (c *client) GetSubComponentsOnBug(id int) (map[string][]string, error) {
 // https://bugzilla.readthedocs.io/en/latest/api/core/v1/bug.html#get-bug
 func (c *client) GetExternalBugPRsOnBug(id int) ([]ExternalBug, error) {
 	logger := c.logger.WithFields(logrus.Fields{methodField: "GetExternalBugPRsOnBug", "id": id})
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/rest/bug/%d", c.endpoint, id), nil)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/rest/bug?id=%d", c.endpoint, id), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/prow/bugzilla/client_test.go
+++ b/prow/bugzilla/client_test.go
@@ -1021,12 +1021,12 @@ func TestGetExternalBugPRsOnBug(t *testing.T) {
 			http.Error(w, "400 Bad Request", http.StatusBadRequest)
 			return
 		}
-		if !strings.HasPrefix(r.URL.Path, "/rest/bug/") {
+		if !strings.HasPrefix(r.URL.Path, "/rest/bug") {
 			t.Errorf("incorrect path to get a bug: %s", r.URL.Path)
 			http.Error(w, "400 Bad Request", http.StatusBadRequest)
 			return
 		}
-		id, err := strconv.Atoi(strings.TrimPrefix(r.URL.Path, "/rest/bug/"))
+		id, err := strconv.Atoi(r.URL.Query().Get("id"))
 		if err != nil {
 			t.Errorf("malformed bug id: %s", r.URL.Path)
 			http.Error(w, "400 Bad Request", http.StatusBadRequest)


### PR DESCRIPTION
Another couple places that are using the currently broken `/rest/bugs/{id}` endpoint.