### PR TITLE
capg: set kubernetes to the 1.20 release branch to build the conformance

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics.yaml
@@ -59,7 +59,7 @@ periodics:
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
   - org: kubernetes
     repo: kubernetes
-    base_ref: release-1.19
+    base_ref: release-1.20
     path_alias: k8s.io/kubernetes
   spec:
     containers:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
@@ -167,7 +167,7 @@ presubmits:
     extra_refs:
     - org: kubernetes
       repo: kubernetes
-      base_ref: release-1.19
+      base_ref: release-1.20
       path_alias: k8s.io/kubernetes
     spec:
       containers:


### PR DESCRIPTION
- remove unsued image-builder repo becasue now we are using a pre-backed image
- set the conformance to use the 1.20 kubernetes release branch to build the conformance tests


related: https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/404

/assign @dims 