### PR TITLE
config: add needs-sig to issues in kubernetes/test-infra

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -692,6 +692,18 @@ require_matching_label:
   issues: true
   prs: true
   regexp: ^priority/
+- missing_label: needs-sig
+  org: kubernetes
+  repo: test-infra
+  issues: true
+  regexp: ^(sig|wg|committee)/
+  missing_comment: |
+    There are no sig labels on this issue. Please add an appropriate label by using one of the following commands:
+    - `/sig <group-name>`
+    - `/wg <group-name>`
+    - `/committee <group-name>`
+
+    Please see the [group list](https://git.k8s.io/community/sig-list.md) for a listing of the SIGs, working groups, and committees available.
 
 retitle:
   allow_closed_issues: true
@@ -863,6 +875,7 @@ plugins:
     - milestone
     - override
     - project
+    - require-matching-label
 
   kubernetes/utils:
     plugins:


### PR DESCRIPTION
To better help with triage and distinguish between:
- issues that relate to tooling owned by sig testing
- issues that relate to tooling owned by other sigs
- issues that relate to jobs owned by other sigs