### PR TITLE
Add Deck filtering for Prowjobs based on tenantID

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -47,6 +47,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/pjutil/pprof"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -102,17 +103,6 @@ const (
 	PodSpec string = "pod_spec"
 )
 
-type tenantIDs []string
-
-func (ids *tenantIDs) Set(value string) error {
-	*ids = append(*ids, value)
-	return nil
-}
-
-func (ids *tenantIDs) String() string {
-	return strings.Join(*ids, ",")
-}
-
 type options struct {
 	config                configflagutil.ConfigOptions
 	pluginsConfig         pluginsflagutil.PluginOptions
@@ -137,7 +127,7 @@ type options struct {
 	rerunCreatesJob       bool
 	allowInsecure         bool
 	dryRun                bool
-	tenantIDs             tenantIDs
+	tenantIDs             flagutil.Strings
 }
 
 func (o *options) Validate() error {
@@ -165,8 +155,8 @@ func (o *options) Validate() error {
 		}
 	}
 
-	if o.hiddenOnly && o.showHidden || o.tenantIDs != nil && (o.hiddenOnly && o.showHidden) {
-		return errors.New("'--hidden-only', 'tenantID', and '--show-hidden' are mutually exclusive, 'hidden-only' shows only hidden job, 'tenantID' shows all jobs with matching ID and 'show-hidden' shows both hidden and non-hidden jobs")
+	if (o.hiddenOnly && o.showHidden) || (o.tenantIDs.Strings() != nil && (o.hiddenOnly || o.showHidden)) {
+		return errors.New("'--hidden-only', '--tenant-id', and '--show-hidden' are mutually exclusive, 'hidden-only' shows only hidden job, '--tenant-id' shows all jobs with matching ID and 'show-hidden' shows both hidden and non-hidden jobs")
 	}
 	return nil
 }
@@ -192,7 +182,7 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	fs.BoolVar(&o.rerunCreatesJob, "rerun-creates-job", false, "Change the re-run option in Deck to actually create the job. **WARNING:** Only use this with non-public deck instances, otherwise strangers can DOS your Prow instance")
 	fs.BoolVar(&o.allowInsecure, "allow-insecure", false, "Allows insecure requests for CSRF and GitHub oauth.")
 	fs.BoolVar(&o.dryRun, "dry-run", false, "Whether or not to make mutating API calls to GitHub.")
-	fs.Var(&o.tenantIDs, "tenant-id", "The tenantID used by the ProwJobs that should be displayed by this instance of Deck")
+	fs.Var(&o.tenantIDs, "tenant-id", "The tenantID(s) used by the ProwJobs that should be displayed by this instance of Deck. This flag can be repeated.")
 	o.config.AddFlags(fs)
 	o.instrumentation.AddFlags(fs)
 	o.kubernetes.AddFlags(fs)
@@ -435,7 +425,7 @@ func main() {
 		indexHandler(w, r)
 	})
 
-	ja := jobs.NewJobAgent(context.Background(), pjListingClient, o.hiddenOnly, o.showHidden, o.tenantIDs, podLogClients, cfg)
+	ja := jobs.NewJobAgent(context.Background(), pjListingClient, o.hiddenOnly, o.showHidden, o.tenantIDs.Strings(), podLogClients, cfg)
 	ja.Start()
 
 	// setup prod only handlers. These handlers can work with runlocal as long

--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -277,7 +277,8 @@ func TestHandleProwJobs(t *testing.T) {
 			},
 		},
 	}
-	fakeJa := jobs.NewJobAgent(context.Background(), kc, false, true, map[string]jobs.PodLogClient{}, fca{}.Config)
+
+	fakeJa := jobs.NewJobAgent(context.Background(), kc, false, true, []string{}, map[string]jobs.PodLogClient{}, fca{}.Config)
 	fakeJa.Start()
 
 	handler := handleProwJobs(fakeJa, logrus.WithField("handler", "/prowjobs.js"))

--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -81,6 +81,8 @@ func (ca fca) Config() *config.Config {
 }
 
 func TestOptions_Validate(t *testing.T) {
+	setTenantIDs := flagutil.Strings{}
+	setTenantIDs.Set("Test")
 	var testCases = []struct {
 		name        string
 		input       options
@@ -123,6 +125,35 @@ func TestOptions_Validate(t *testing.T) {
 				config:                configflagutil.ConfigOptions{ConfigPath: "test"},
 				oauthURL:              "website",
 				githubOAuthConfigFile: "something",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "hidden only and show hidden are mutually exclusive",
+			input: options{
+				config:     configflagutil.ConfigOptions{ConfigPath: "test"},
+				hiddenOnly: true,
+				showHidden: true,
+			},
+			expectedErr: true,
+		},
+		{
+			name: "show hidden and tenantIds are mutually exclusive",
+			input: options{
+				config:     configflagutil.ConfigOptions{ConfigPath: "test"},
+				hiddenOnly: false,
+				showHidden: true,
+				tenantIDs:  setTenantIDs,
+			},
+			expectedErr: true,
+		},
+		{
+			name: "hiddenOnly and tenantIds are mutually exclusive",
+			input: options{
+				config:     configflagutil.ConfigOptions{ConfigPath: "test"},
+				hiddenOnly: true,
+				showHidden: false,
+				tenantIDs:  setTenantIDs,
 			},
 			expectedErr: true,
 		},

--- a/prow/cmd/deck/tide.go
+++ b/prow/cmd/deck/tide.go
@@ -52,8 +52,6 @@ type tideAgent struct {
 	hiddenOnly  bool
 	showHidden  bool
 
-	tenentIDs []string
-
 	sync.Mutex
 	pools   []tide.Pool
 	history map[string][]history.Record

--- a/prow/cmd/deck/tide.go
+++ b/prow/cmd/deck/tide.go
@@ -52,6 +52,8 @@ type tideAgent struct {
 	hiddenOnly  bool
 	showHidden  bool
 
+	tenentIDs []string
+
 	sync.Mutex
 	pools   []tide.Pool
 	history map[string][]history.Record

--- a/prow/deck/jobs/jobs.go
+++ b/prow/deck/jobs/jobs.go
@@ -138,9 +138,11 @@ func (c *filteringProwJobLister) ListProwJobs(selector string) ([]prowapi.ProwJo
 
 	var filtered []prowapi.ProwJob
 	for _, item := range prowJobList.Items {
-		if len(c.tenantIDs) != 0 && c.TenantIDMatch(item) {
-			// Deck has tenantID and it matches Prowjob
-			filtered = append(filtered, item)
+		if len(c.tenantIDs) != 0 {
+			if c.TenantIDMatch(item) {
+				// Deck has tenantID and it matches Prowjob
+				filtered = append(filtered, item)
+			}
 		} else if len(c.tenantIDs) == 0 {
 			// Deck has no tenantID
 			shouldHide := item.Spec.Hidden || c.pjHasHiddenRefs(item)
@@ -148,7 +150,7 @@ func (c *filteringProwJobLister) ListProwJobs(selector string) ([]prowapi.ProwJo
 				// If Hidden and we are showing Hidden we add it
 				filtered = append(filtered, item)
 			} else if !shouldHide && !c.hiddenOnly && (item.Spec.ProwJobDefault == nil || item.Spec.ProwJobDefault.TenantID == "") {
-				// If not Hidden then show if not hiddenOnly OR if no tenantID
+				// If not Hidden then show if not hiddenOnly AND if no tenantID
 				filtered = append(filtered, item)
 			}
 		}

--- a/prow/deck/jobs/jobs_test.go
+++ b/prow/deck/jobs/jobs_test.go
@@ -271,6 +271,7 @@ func TestListProwJobs(t *testing.T) {
 		showHidden  bool
 		expected    sets.String
 		expectedErr bool
+		tenantIDs   []string
 	}{
 		{
 			name:        "list error results in filter error",
@@ -471,6 +472,198 @@ func TestListProwJobs(t *testing.T) {
 			},
 			hiddenRepos: sets.NewString("hide/me", "hidden-org"),
 		},
+		{
+			name: "tenantID on lister will not show jobs without id",
+			prowJobs: []func(*prowapi.ProwJob) runtime.Object{
+				func(in *prowapi.ProwJob) runtime.Object {
+					in.Name = "no ID"
+					return in
+				},
+				func(in *prowapi.ProwJob) runtime.Object {
+					in.Name = "no ID hidden"
+					in.Spec.Hidden = true
+					return in
+				},
+			},
+			expected:  sets.NewString(),
+			tenantIDs: []string{"ID"},
+		},
+		{
+			name: "tenantID ID on lister will show jobs with id",
+			prowJobs: []func(*prowapi.ProwJob) runtime.Object{
+				func(in *prowapi.ProwJob) runtime.Object {
+					in.Name = "no ID"
+					return in
+				},
+				func(in *prowapi.ProwJob) runtime.Object {
+					in.Name = "ID"
+					in.Spec.ProwJobDefault = &prowapi.ProwJobDefault{TenantID: "ID"}
+					return in
+				},
+			},
+			expected:  sets.NewString("ID"),
+			tenantIDs: []string{"ID"},
+		},
+		{
+			name: "tenantID on lister will not show jobs with different id",
+			prowJobs: []func(*prowapi.ProwJob) runtime.Object{
+				func(in *prowapi.ProwJob) runtime.Object {
+					in.Name = "Wrong ID"
+					in.Spec.ProwJobDefault = &prowapi.ProwJobDefault{TenantID: "Wrong ID"}
+					return in
+				},
+				func(in *prowapi.ProwJob) runtime.Object {
+					in.Name = "ID"
+					in.Spec.ProwJobDefault = &prowapi.ProwJobDefault{TenantID: "ID"}
+					return in
+				},
+			},
+			expected:  sets.NewString("ID"),
+			tenantIDs: []string{"ID"},
+		},
+		{
+			name: "tenantIDs on lister will show all matching jobs",
+			prowJobs: []func(*prowapi.ProwJob) runtime.Object{
+				func(in *prowapi.ProwJob) runtime.Object {
+					in.Name = "Wrong ID"
+					in.Spec.ProwJobDefault = &prowapi.ProwJobDefault{TenantID: "Wrong ID"}
+					return in
+				},
+				func(in *prowapi.ProwJob) runtime.Object {
+					in.Name = "ID"
+					in.Spec.ProwJobDefault = &prowapi.ProwJobDefault{TenantID: "ID"}
+					return in
+				},
+				func(in *prowapi.ProwJob) runtime.Object {
+					in.Name = "Other ID"
+					in.Spec.ProwJobDefault = &prowapi.ProwJobDefault{TenantID: "Other ID"}
+					return in
+				},
+			},
+			expected:  sets.NewString("ID", "Other ID"),
+			tenantIDs: []string{"ID", "Other ID"},
+		},
+		{
+			name: "tenantIDs on lister will show hidden jobs with correct ID",
+			prowJobs: []func(*prowapi.ProwJob) runtime.Object{
+				func(in *prowapi.ProwJob) runtime.Object {
+					in.Name = "Wrong ID"
+					in.Spec.Hidden = true
+					in.Spec.ProwJobDefault = &prowapi.ProwJobDefault{TenantID: "Wrong ID"}
+					return in
+				},
+				func(in *prowapi.ProwJob) runtime.Object {
+					in.Name = "ID"
+					in.Spec.ProwJobDefault = &prowapi.ProwJobDefault{TenantID: "ID"}
+					in.Spec.Hidden = true
+					return in
+				},
+				func(in *prowapi.ProwJob) runtime.Object {
+					in.Name = "Other ID"
+					in.Spec.Hidden = true
+					in.Spec.ProwJobDefault = &prowapi.ProwJobDefault{TenantID: "Other ID"}
+					return in
+				},
+			},
+			expected:  sets.NewString("ID", "Other ID"),
+			tenantIDs: []string{"ID", "Other ID"},
+		},
+		{
+			name: "hidden repo with correct ID still shows if matching tenantIDs",
+			prowJobs: []func(*prowapi.ProwJob) runtime.Object{
+				func(in *prowapi.ProwJob) runtime.Object {
+					in.Name = "hidden-repo"
+					in.Spec.ExtraRefs = []prowapi.Refs{{Org: "hide", Repo: "me"}}
+					in.Spec.ProwJobDefault = &prowapi.ProwJobDefault{TenantID: "ID"}
+					return in
+				},
+				func(in *prowapi.ProwJob) runtime.Object {
+					in.Name = "hidden-org"
+					in.Spec.ExtraRefs = []prowapi.Refs{{Org: "hidden-org"}}
+					in.Spec.ProwJobDefault = &prowapi.ProwJobDefault{TenantID: "ID"}
+					return in
+				},
+			},
+			expected:    sets.NewString("hidden-repo", "hidden-org"),
+			hiddenRepos: sets.NewString("hide/me", "hidden-org"),
+			tenantIDs:   []string{"ID"},
+		},
+		{
+			name: "hidden repo with tenantIDs will still show if show hidden",
+			prowJobs: []func(*prowapi.ProwJob) runtime.Object{
+				func(in *prowapi.ProwJob) runtime.Object {
+					in.Name = "hidden-repo"
+					in.Spec.ExtraRefs = []prowapi.Refs{{Org: "hide", Repo: "me"}}
+					in.Spec.ProwJobDefault = &prowapi.ProwJobDefault{TenantID: "ID"}
+					return in
+				},
+				func(in *prowapi.ProwJob) runtime.Object {
+					in.Name = "hidden-org"
+					in.Spec.ExtraRefs = []prowapi.Refs{{Org: "hidden-org"}}
+					in.Spec.ProwJobDefault = &prowapi.ProwJobDefault{TenantID: "ID"}
+					return in
+				},
+			},
+			expected:    sets.NewString("hidden-repo", "hidden-org"),
+			hiddenRepos: sets.NewString("hide/me", "hidden-org"),
+			showHidden:  true,
+		},
+		{
+			name: "hidden repo with tenantIDs will still show if hidden only",
+			prowJobs: []func(*prowapi.ProwJob) runtime.Object{
+				func(in *prowapi.ProwJob) runtime.Object {
+					in.Name = "hidden-repo"
+					in.Spec.ExtraRefs = []prowapi.Refs{{Org: "hide", Repo: "me"}}
+					in.Spec.ProwJobDefault = &prowapi.ProwJobDefault{TenantID: "ID"}
+					return in
+				},
+				func(in *prowapi.ProwJob) runtime.Object {
+					in.Name = "hidden-org"
+					in.Spec.ExtraRefs = []prowapi.Refs{{Org: "hidden-org"}}
+					in.Spec.ProwJobDefault = &prowapi.ProwJobDefault{TenantID: "ID"}
+					return in
+				},
+			},
+			expected:    sets.NewString("hidden-repo", "hidden-org"),
+			hiddenRepos: sets.NewString("hide/me", "hidden-org"),
+			hiddenOnly:  true,
+		},
+		{
+			name: "pjs with tenantIDs marked hidden will still show up if showHidden is true",
+			prowJobs: []func(*prowapi.ProwJob) runtime.Object{
+				func(in *prowapi.ProwJob) runtime.Object {
+					in.Name = "ID"
+					in.Spec.Hidden = true
+					in.Spec.ProwJobDefault = &prowapi.ProwJobDefault{TenantID: "ID"}
+					return in
+				},
+				func(in *prowapi.ProwJob) runtime.Object {
+					in.Name = "Other ID"
+					in.Spec.ProwJobDefault = &prowapi.ProwJobDefault{TenantID: "Other ID"}
+					return in
+				},
+			},
+			expected:   sets.NewString("ID"),
+			showHidden: true,
+		},
+		{
+			name: "pjs with tenantIDs will show up on Deck with hiddenOnly",
+			prowJobs: []func(*prowapi.ProwJob) runtime.Object{
+				func(in *prowapi.ProwJob) runtime.Object {
+					in.Name = "Hidden ID"
+					in.Spec.Hidden = true
+					in.Spec.ProwJobDefault = &prowapi.ProwJobDefault{TenantID: "ID"}
+					return in
+				},
+				func(in *prowapi.ProwJob) runtime.Object {
+					in.Name = "Other ID"
+					in.Spec.ProwJobDefault = &prowapi.ProwJobDefault{TenantID: "Other ID"}
+					return in
+				},
+			},
+			expected:   sets.NewString("Hidden ID"),
+			hiddenOnly: true,
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -489,6 +682,7 @@ func TestListProwJobs(t *testing.T) {
 			},
 			hiddenOnly: testCase.hiddenOnly,
 			showHidden: testCase.showHidden,
+			tenantIDs:  testCase.tenantIDs,
 			cfg:        func() *config.Config { return &config.Config{} },
 		}
 

--- a/prow/spyglass/spyglass_test.go
+++ b/prow/spyglass/spyglass_test.go
@@ -215,7 +215,7 @@ test/e2e/e2e.go:137 BeforeSuite on Node 1 failed test/e2e/e2e.go:137
 			},
 		},
 	}
-	fakeJa = jobs.NewJobAgent(context.Background(), kc, false, true, map[string]jobs.PodLogClient{kube.DefaultClusterAlias: fpkc("clusterA"), "trusted": fpkc("clusterB")}, fca{}.Config)
+	fakeJa = jobs.NewJobAgent(context.Background(), kc, false, true, []string{}, map[string]jobs.PodLogClient{kube.DefaultClusterAlias: fpkc("clusterA"), "trusted": fpkc("clusterB")}, fca{}.Config)
 	fakeJa.Start()
 	os.Exit(m.Run())
 }
@@ -416,7 +416,7 @@ func TestJobPath(t *testing.T) {
 			},
 		},
 	}
-	fakeJa = jobs.NewJobAgent(context.Background(), kc, false, true, map[string]jobs.PodLogClient{kube.DefaultClusterAlias: fpkc("clusterA"), "trusted": fpkc("clusterB")}, fca{}.Config)
+	fakeJa = jobs.NewJobAgent(context.Background(), kc, false, true, []string{}, map[string]jobs.PodLogClient{kube.DefaultClusterAlias: fpkc("clusterA"), "trusted": fpkc("clusterB")}, fca{}.Config)
 	fakeJa.Start()
 	testCases := []struct {
 		name       string
@@ -557,7 +557,7 @@ func TestProwJobName(t *testing.T) {
 			},
 		},
 	}
-	fakeJa = jobs.NewJobAgent(context.Background(), kc, false, true, map[string]jobs.PodLogClient{kube.DefaultClusterAlias: fpkc("clusterA"), "trusted": fpkc("clusterB")}, fca{}.Config)
+	fakeJa = jobs.NewJobAgent(context.Background(), kc, false, true, []string{}, map[string]jobs.PodLogClient{kube.DefaultClusterAlias: fpkc("clusterA"), "trusted": fpkc("clusterB")}, fca{}.Config)
 	fakeJa.Start()
 	testCases := []struct {
 		name       string
@@ -670,7 +670,7 @@ func TestRunPath(t *testing.T) {
 			},
 		},
 	}
-	fakeJa = jobs.NewJobAgent(context.Background(), kc, false, true, map[string]jobs.PodLogClient{kube.DefaultClusterAlias: fpkc("clusterA"), "trusted": fpkc("clusterB")}, fca{}.Config)
+	fakeJa = jobs.NewJobAgent(context.Background(), kc, false, true, []string{}, map[string]jobs.PodLogClient{kube.DefaultClusterAlias: fpkc("clusterA"), "trusted": fpkc("clusterB")}, fca{}.Config)
 	fakeJa.Start()
 	testCases := []struct {
 		name       string
@@ -794,7 +794,7 @@ func TestRunToPR(t *testing.T) {
 			},
 		},
 	}
-	fakeJa = jobs.NewJobAgent(context.Background(), kc, false, true, map[string]jobs.PodLogClient{kube.DefaultClusterAlias: fpkc("clusterA"), "trusted": fpkc("clusterB")}, fca{}.Config)
+	fakeJa = jobs.NewJobAgent(context.Background(), kc, false, true, []string{}, map[string]jobs.PodLogClient{kube.DefaultClusterAlias: fpkc("clusterA"), "trusted": fpkc("clusterB")}, fca{}.Config)
 	fakeJa.Start()
 	testCases := []struct {
 		name      string
@@ -980,7 +980,7 @@ func TestProwToGCS(t *testing.T) {
 				},
 			},
 		}
-		fakeJa = jobs.NewJobAgent(context.Background(), kc, false, true, map[string]jobs.PodLogClient{kube.DefaultClusterAlias: fpkc("clusterA"), "trusted": fpkc("clusterB")}, fakeConfigAgent.Config)
+		fakeJa = jobs.NewJobAgent(context.Background(), kc, false, true, []string{}, map[string]jobs.PodLogClient{kube.DefaultClusterAlias: fpkc("clusterA"), "trusted": fpkc("clusterB")}, fakeConfigAgent.Config)
 		fakeJa.Start()
 		sg := New(context.Background(), fakeJa, fakeConfigAgent.Config, io.NewGCSOpener(fakeGCSClient), false)
 
@@ -1113,7 +1113,7 @@ func TestGCSPathRoundTrip(t *testing.T) {
 				},
 			},
 		}
-		fakeJa = jobs.NewJobAgent(context.Background(), kc, false, true, map[string]jobs.PodLogClient{kube.DefaultClusterAlias: fpkc("clusterA"), "trusted": fpkc("clusterB")}, fakeConfigAgent.Config)
+		fakeJa = jobs.NewJobAgent(context.Background(), kc, false, true, []string{}, map[string]jobs.PodLogClient{kube.DefaultClusterAlias: fpkc("clusterA"), "trusted": fpkc("clusterB")}, fakeConfigAgent.Config)
 		fakeJa.Start()
 
 		fakeGCSClient := fakeGCSServer.Client()
@@ -1192,7 +1192,7 @@ func TestTestGridLink(t *testing.T) {
 	}
 
 	kc := fkc{}
-	fakeJa = jobs.NewJobAgent(context.Background(), kc, false, true, map[string]jobs.PodLogClient{kube.DefaultClusterAlias: fpkc("clusterA"), "trusted": fpkc("clusterB")}, fca{}.Config)
+	fakeJa = jobs.NewJobAgent(context.Background(), kc, false, true, []string{}, map[string]jobs.PodLogClient{kube.DefaultClusterAlias: fpkc("clusterA"), "trusted": fpkc("clusterB")}, fca{}.Config)
 	fakeJa.Start()
 
 	tg := TestGrid{c: &tgconf.Configuration{
@@ -1285,7 +1285,7 @@ func TestFetchArtifactsPodLog(t *testing.T) {
 			},
 		},
 	}
-	fakeJa = jobs.NewJobAgent(context.Background(), kc, false, true, map[string]jobs.PodLogClient{kube.DefaultClusterAlias: fpkc("clusterA"), "trusted": fpkc("clusterB")}, fakeConfigAgent.Config)
+	fakeJa = jobs.NewJobAgent(context.Background(), kc, false, true, []string{}, map[string]jobs.PodLogClient{kube.DefaultClusterAlias: fpkc("clusterA"), "trusted": fpkc("clusterB")}, fakeConfigAgent.Config)
 	fakeJa.Start()
 
 	fakeGCSClient := fakeGCSServer.Client()
@@ -1469,7 +1469,7 @@ func TestResolveSymlink(t *testing.T) {
 
 	for _, tc := range testCases {
 		fakeConfigAgent := fca{}
-		fakeJa = jobs.NewJobAgent(context.Background(), fkc{}, false, true, map[string]jobs.PodLogClient{kube.DefaultClusterAlias: fpkc("clusterA"), "trusted": fpkc("clusterB")}, fakeConfigAgent.Config)
+		fakeJa = jobs.NewJobAgent(context.Background(), fkc{}, false, true, []string{}, map[string]jobs.PodLogClient{kube.DefaultClusterAlias: fpkc("clusterA"), "trusted": fpkc("clusterB")}, fakeConfigAgent.Config)
 		fakeJa.Start()
 
 		fakeGCSClient := fakeGCSServer.Client()
@@ -1571,7 +1571,7 @@ func TestExtraLinks(t *testing.T) {
 					},
 				},
 			}
-			fakeJa = jobs.NewJobAgent(context.Background(), fkc{}, false, true, map[string]jobs.PodLogClient{kube.DefaultClusterAlias: fpkc("clusterA"), "trusted": fpkc("clusterB")}, fakeConfigAgent.Config)
+			fakeJa = jobs.NewJobAgent(context.Background(), fkc{}, false, true, []string{}, map[string]jobs.PodLogClient{kube.DefaultClusterAlias: fpkc("clusterA"), "trusted": fpkc("clusterB")}, fakeConfigAgent.Config)
 			fakeJa.Start()
 			sg := New(context.Background(), fakeJa, fakeConfigAgent.Config, io.NewGCSOpener(gcsClient), false)
 


### PR DESCRIPTION
This is a continuation of the multi-tenancy work. Split the Unit tests into another commit to make it easier to review.  
/assign @chaodaiG @cjwagner 
/hold