### PR TITLE
Revert BZ REST issue workaround

### DIFF
--- a/prow/bugzilla/client.go
+++ b/prow/bugzilla/client.go
@@ -407,7 +407,7 @@ func traverseDown(c Client, bug *Bug, bugCache *bugDetailsCache, errGroup *errgr
 // SubComponents are a Red Hat bugzilla specific extra field.
 func (c *client) GetSubComponentsOnBug(id int) (map[string][]string, error) {
 	logger := c.logger.WithFields(logrus.Fields{methodField: "GetSubComponentsOnBug", "id": id})
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/rest/bug?id=%d", c.endpoint, id), nil)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/rest/bug/%d", c.endpoint, id), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -442,7 +442,7 @@ func (c *client) GetSubComponentsOnBug(id int) (map[string][]string, error) {
 // https://bugzilla.readthedocs.io/en/latest/api/core/v1/bug.html#get-bug
 func (c *client) GetExternalBugPRsOnBug(id int) ([]ExternalBug, error) {
 	logger := c.logger.WithFields(logrus.Fields{methodField: "GetExternalBugPRsOnBug", "id": id})
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/rest/bug?id=%d", c.endpoint, id), nil)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/rest/bug/%d", c.endpoint, id), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/prow/bugzilla/client.go
+++ b/prow/bugzilla/client.go
@@ -215,7 +215,7 @@ func (c *client) Endpoint() string {
 // https://bugzilla.readthedocs.io/en/latest/api/core/v1/bug.html#get-bug
 func (c *client) GetBug(id int) (*Bug, error) {
 	logger := c.logger.WithFields(logrus.Fields{methodField: "GetBug", "id": id})
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/rest/bug?id=%d", c.endpoint, id), nil)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/rest/bug/%d", c.endpoint, id), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/prow/bugzilla/client_test.go
+++ b/prow/bugzilla/client_test.go
@@ -76,12 +76,12 @@ func TestGetBug(t *testing.T) {
 			http.Error(w, "400 Bad Request", http.StatusBadRequest)
 			return
 		}
-		if !strings.HasPrefix(r.URL.Path, "/rest/bug") {
+		if !strings.HasPrefix(r.URL.Path, "/rest/bug/") {
 			t.Errorf("incorrect path to get a bug: %s", r.URL.Path)
 			http.Error(w, "400 Bad Request", http.StatusBadRequest)
 			return
 		}
-		if id, err := strconv.Atoi(r.URL.Query().Get("id")); err != nil {
+		if id, err := strconv.Atoi(strings.TrimPrefix(r.URL.Path, "/rest/bug/")); err != nil {
 			t.Errorf("malformed bug id: %s", r.URL.Path)
 			http.Error(w, "400 Bad Request", http.StatusBadRequest)
 			return

--- a/prow/bugzilla/client_test.go
+++ b/prow/bugzilla/client_test.go
@@ -1021,12 +1021,12 @@ func TestGetExternalBugPRsOnBug(t *testing.T) {
 			http.Error(w, "400 Bad Request", http.StatusBadRequest)
 			return
 		}
-		if !strings.HasPrefix(r.URL.Path, "/rest/bug") {
+		if !strings.HasPrefix(r.URL.Path, "/rest/bug/") {
 			t.Errorf("incorrect path to get a bug: %s", r.URL.Path)
 			http.Error(w, "400 Bad Request", http.StatusBadRequest)
 			return
 		}
-		id, err := strconv.Atoi(r.URL.Query().Get("id"))
+		id, err := strconv.Atoi(strings.TrimPrefix(r.URL.Path, "/rest/bug/"))
 		if err != nil {
 			t.Errorf("malformed bug id: %s", r.URL.Path)
 			http.Error(w, "400 Bad Request", http.StatusBadRequest)


### PR DESCRIPTION
No need to carry this anymore, RH BZ should now work again:

```console
$ curl https://bugzilla.redhat.com/rest/bug/1991507
{"bugs":[{"cc_detail":...
```

/cc @emilvberglind @stevekuznetsov 