### PR TITLE
Add new artifact file format handling to links lens

### DIFF
--- a/prow/spyglass/lenses/links/links.css
+++ b/prow/spyglass/lenses/links/links.css
@@ -1,21 +1,32 @@
 body {
     padding-bottom: 20px;
 }
+
 .name {
     width: 10%;
 }
 
-.link {
-    display: inline-block;
-    margin-left: 10px;
-    font-size: 14px;
-    font-family: monospace;
+.hidden-links {
+    visibility: collapse;
+    display: none;
 }
 
-td {
-    text-align: unset !important;
+.expander {
+    font-weight: bold;
+    font-size: 1.5em;
+}
+
+.expander:last-of-type {
+    text-align: right;
 }
 
 button {
     user-select: none;
+}
+
+td.link {
+    margin-left: 10px;
+    font-size: 14px;
+    font-family: monospace;
+    width: 100%;
 }

--- a/prow/spyglass/lenses/links/links.go
+++ b/prow/spyglass/lenses/links/links.go
@@ -38,7 +38,7 @@ const (
 	title    = "Debugging links"
 	priority = 20
 
-	bytesLimit = 10 * 1024
+	bytesLimit = 20 * 1024
 )
 
 func init() {
@@ -113,9 +113,14 @@ func clickableLink(link string, spyglassConfig config.Spyglass) string {
 }
 
 type link struct {
-	Name string
-	URL  string
-	Link string
+	Name string `json:"name"`
+	URL  string `json:"url"`
+	Link string `json:"-"`
+}
+
+type linkGroup struct {
+	Title string `json:"title"`
+	Links []link `json:"links"`
 }
 
 func toLink(jobPath string, content []byte, spyglassConfig config.Spyglass) link {
@@ -127,24 +132,51 @@ func toLink(jobPath string, content []byte, spyglassConfig config.Spyglass) link
 	}
 }
 
+func parseLinkFile(jobPath string, content []byte, spyglassConfig config.Spyglass) (linkGroup, error) {
+	if extension := filepath.Ext(jobPath); extension == ".json" {
+		group := linkGroup{}
+		if err := json.Unmarshal(content, &group); err != nil {
+			return group, err
+		}
+		for i := range group.Links {
+			group.Links[i].Link = clickableLink(group.Links[i].URL, spyglassConfig)
+		}
+		return group, nil
+	}
+	// Wrap a single link inside a linkGroup.
+	wrappedLink := toLink(jobPath, content, spyglassConfig)
+	return linkGroup{
+		Title: wrappedLink.Name,
+		Links: []link{
+			wrappedLink,
+		},
+	}, nil
+}
+
 // Body renders link to logs.
 func (lens Lens) Body(artifacts []api.Artifact, resourceDir string, data string, config json.RawMessage, spyglassConfig config.Spyglass) string {
-	var links []link
+	var linkGroups []linkGroup
 	for _, artifact := range artifacts {
+		jobPath := artifact.JobPath()
 		content, err := artifact.ReadAtMost(bytesLimit)
 		if err != nil && err != io.EOF {
-			logrus.WithError(err).Warnf("Failed to read artifact file: %q", artifact.JobPath())
+			logrus.WithError(err).Warnf("Failed to read artifact file: %q", jobPath)
 			continue
 		}
-		links = append(links, toLink(artifact.JobPath(), content, spyglassConfig))
+		group, err := parseLinkFile(jobPath, content, spyglassConfig)
+		if err != nil {
+			logrus.WithError(err).Warnf("Failed to parse link file: %q", jobPath)
+			continue
+		}
+		linkGroups = append(linkGroups, group)
 	}
 
-	sort.Slice(links, func(i, j int) bool { return links[i].Name < links[j].Name })
+	sort.Slice(linkGroups, func(i, j int) bool { return linkGroups[i].Title < linkGroups[j].Title })
 
 	params := struct {
-		Links []link
+		LinkGroups []linkGroup
 	}{
-		Links: links,
+		LinkGroups: linkGroups,
 	}
 
 	output, err := renderTemplate(resourceDir, "body", params)

--- a/prow/spyglass/lenses/links/links.ts
+++ b/prow/spyglass/lenses/links/links.ts
@@ -18,8 +18,28 @@ async function handleCopy(this: HTMLButtonElement) {
     copyMessage(this.dataset.link || "");
 }
 
+function addLinksExpanders(): void {
+    const expanders = document.querySelectorAll<HTMLTableRowElement>('tr.links-expander');
+    for (const expander of Array.from(expanders)) {
+        expander.onclick = () => {
+            const tbody = expander.parentElement!.nextElementSibling!;
+            const icon = expander.querySelector('i')!;
+            if (tbody.classList.contains('hidden-links')) {
+                tbody.classList.remove('hidden-links');
+                icon.innerText = 'expand_less';
+            } else {
+                tbody.classList.add('hidden-links');
+                icon.innerText = 'expand_more';
+            }
+            spyglass.contentUpdated();
+        };
+    }
+}
+
 window.addEventListener('load', () => {
     for (const button of Array.from(document.querySelectorAll<HTMLButtonElement>("button.copy"))) {
         button.addEventListener('click', handleCopy);
     }
 });
+
+window.addEventListener('DOMContentLoaded', addLinksExpanders);

--- a/prow/spyglass/lenses/links/template.html
+++ b/prow/spyglass/lenses/links/template.html
@@ -5,22 +5,28 @@
 
 {{define "body"}}
 <table class="mdl-data-table mdl-js-data-table mdl-shadow--2dp">
-    <tbody>
-        {{range $ix, $link := .Links}}
-        <tr>
-            <td class="name">{{$link.Name}}</td>
-            <td>
-                <button class="copy" data-link="{{$link.URL}}">Copy</button>
-                <div class="link">
-                    {{if $link.Link}}
-                        <a href="{{$link.Link}}">{{$link.URL}}</a>
-                    {{else}}
-                        {{$link.URL}}
-                    {{end}}
-                </div>
+  <tbody>
+    {{range $ix, $linkGroup := .LinkGroups}}
+      <tr class="header links-expander">
+        <td class="mdl-data-table__cell--non-numeric expander"><h6>{{$linkGroup.Title}}</h6></td>
+        <td class="mdl-data-table__cell--non-numeric expander"><i class="icon-button material-icons arrow-icon noselect">expand_more</i></td>
+      </tr>
+      <tbody class="hidden-links">
+        {{range $jx, $link := $linkGroup.Links}}
+          <tr>
+            <td class="mdl-data-table__cell--non-numeric">{{$link.Name}}</td>
+            <td class="mdl-data-table__cell--non-numeric link">
+              <button class="copy" data-link="{{$link.URL}}">Copy</button>
+                {{if $link.Link}}
+                  <a href="{{$link.Link}}">{{$link.URL}}</a>
+                {{else}}
+                  {{$link.URL}}
+                {{end}}
             </td>
-        </tr>
+          </tr>
         {{end}}
-    </tbody>
+      </tbody>
+    {{end}}
+  </tbody>
 </table>
 {{end}}


### PR DESCRIPTION
Instead of presenting single links in the `links` lens, allow to group them into logical entities that can be viewed on demand, just like the tests in the `JUnit` lens.

Therefore, instead of providing a simple `.txt` file, lens user can feed it with a `.json` describing the name of the group as well as the names describing particular links.

Additionally, wrap the links from `.txt` files into a group containing just the link contained in the file so the old format is handled properly as well.

/assign @mborsz 