### PR TITLE
Run e2e tests for Cluster API also with v1.19 management cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -53,6 +53,41 @@ periodics:
     testgrid-tab-name: capi-e2e-main
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
+- name: periodic-cluster-api-e2e-main-mink8s
+  interval: 1h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api
+    base_ref: master
+    path_alias: sigs.k8s.io/cluster-api
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-1.21
+      args:
+      - runner.sh
+      - "./scripts/ci-e2e.sh"
+      env:
+      - name: GINKGO_SKIP
+        value: "\\[Conformance\\] \\[K8s-Upgrade\\]"
+      # This value determines the minimum Kubernetes
+      # supported version for Cluster API management cluster.
+      - name: KUBERNETES_VERSION_MANAGEMENT
+        value: "stable-1.19"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+    testgrid-tab-name: capi-e2e-main-mink8s
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-verify-book-links-main
   interval: 6h
   decorate: true


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

Partially implements https://github.com/kubernetes-sigs/cluster-api/issues/5078

As long as we're already sure about the variable name, this PR can be merged independently of: https://github.com/kubernetes-sigs/cluster-api/pull/5081