### PR TITLE
config/jobs: update ci-test-infra-triage-canary

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-test-infra.yaml
@@ -96,7 +96,7 @@ periodics:
       - name: NUM_WORKERS
         value: "13"
       - name: TRIAGE_DATASET_TABLE
-        value: "k8s-gubernator:temp.triage" # TODO: definitely don't have permission to write here, need our own bq dataset
+        value: "kubernetes-public:k8s_triage.temp" # TODO: definitely don't have permission to write here, need our own bq dataset
       - name: TRIAGE_TEMP_GCS_PATH
         value: "gs://k8s-triage/triage_tests"
       - name: TRIAGE_GCS_PATH


### PR DESCRIPTION
Related:
- part of: https://github.com/kubernetes/k8s.io/issues/1305
- depends on: https://github.com/kubernetes/k8s.io/pull/2461

update it to use `kubernetes-public:k8s_triage.temp` instead of `k8s-gubernator:temp.triage`