### PR TITLE
Add E2E test for lock contention flags

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -1274,3 +1274,32 @@ periodics:
     testgrid-tab-name: node-kubelet-containerd-performance-test
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "Executes performance e2e tests"
+- name: ci-kubernetes-node-kubelet-lock-contention
+  interval: 4h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220211-6df2c53026-master
+        args:
+          - --repo=k8s.io/kubernetes=master
+          - --timeout=240
+          - --root=/go/src
+          - --scenario=kubernetes_e2e
+          - --
+          - --deployment=node
+          - --gcp-project-type=node-e2e-project
+          - --gcp-zone=us-west1-b
+          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
+          - --node-test-args=--kubelet-flags="--exit-on-lock-contention --lock-file=/var/run/kubelet.lock"
+          - --node-tests=true
+          - --provider=gce
+          - --test_args=--nodes=1 --focus="\[NodeSpecialFeature:LockContention\]" --skip="\[Flaky\]|\[Serial\]"
+        env:
+          - name: GOPATH
+            value: /go
+  annotations:
+    testgrid-dashboards: sig-node-kubelet
+    testgrid-tab-name: kubelet-gce-e2e-lock-contention
+    description: "Contains disruptive tests for the Lock Contention feature."


### PR DESCRIPTION
Adds a new job ci-kubernetes-node-kubelet-lock-contention to the test suite.

This test is created due to the need of `--lock-file` and `--exit-on-lock-contention` 
be moved as flags and into the Kubelet configuration file rather than be dropped.

Adds a new tab in TestGrid named `kubelet-gce-e2e-lock-contention`
running tests focused on `NodeSpecialFeature:LockContention`.

This test was earlier added in the PR: https://github.com/kubernetes/test-infra/pull/22758

However it was later removed in this [commit](https://github.com/kubernetes/test-infra/commit/1b54c26a6ec7e483dcc4c07e81ae96c71a08b269#diff-14f46258d64962b171c1662b99c4e01ea48674ca3ef00b1d9dec13acf2ad91f9)

Corresponding e2e test is at https://github.com/kubernetes/kubernetes/pull/104334

Signed-off-by: Imran Pochi <imran@kinvolk.io>