### PR TITLE
update kubernetes version to 1.21 for csi-secrets-store windows tests

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -240,7 +240,7 @@ presubmits:
         - --deployment=aksengine
         - --aksengine-admin-username=azureuser
         - --aksengine-creds=$(AZURE_CREDENTIALS)
-        - --aksengine-orchestratorRelease=1.20
+        - --aksengine-orchestratorRelease=1.21
         - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
         - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
         - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/test/bats/tests/azure/job_templates/kubernetes_windows.json


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/691 has been merged to use the `node-driver-registrar:v2.3.0`. There is a livenessProbe check now for the driver registration status. Bumping the Kubernetes version to v1.21 for windows tests to see if the fix helps resolve the failures we were seeing before.

ref https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/639

/assign @tam7t 