### PR TITLE
Update Golang canary jobs for kubernetes/kubernetes

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.21.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.21.yaml
@@ -1482,38 +1482,6 @@ presubmits:
     - release-1.21
     cluster: k8s-infra-prow-build
     decorate: true
-    labels:
-      preset-dind-enabled: "true"
-      preset-service-account: "true"
-    name: pull-kubernetes-dependencies-go-canary
-    path_alias: k8s.io/kubernetes
-    skip_report: true
-    spec:
-      containers:
-      - args:
-        - make
-        - verify
-        command:
-        - runner.sh
-        env:
-        - name: WHAT
-          value: external-dependencies-version vendor vendor-licenses
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-go-canary
-        name: main
-        resources:
-          limits:
-            cpu: "2"
-            memory: 1288490188800m
-          requests:
-            cpu: "2"
-            memory: 1288490188800m
-        securityContext:
-          privileged: true
-  - always_run: false
-    branches:
-    - release-1.21
-    cluster: k8s-infra-prow-build
-    decorate: true
     name: pull-kubernetes-files-remake
     path_alias: k8s.io/kubernetes
     run_if_changed: Makefile.generated_files|make-rules
@@ -1552,34 +1520,6 @@ presubmits:
         command:
         - runner.sh
         image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-1.21
-        name: ""
-        resources:
-          limits:
-            cpu: "6"
-            memory: 15Gi
-          requests:
-            cpu: "6"
-            memory: 15Gi
-        securityContext:
-          privileged: true
-  - always_run: false
-    branches:
-    - release-1.21
-    cluster: k8s-infra-prow-build
-    decorate: true
-    labels:
-      preset-dind-enabled: "true"
-      preset-service-account: "true"
-    name: pull-kubernetes-integration-go-canary
-    path_alias: k8s.io/kubernetes
-    skip_report: true
-    spec:
-      containers:
-      - args:
-        - ./hack/jenkins/test-dockerized.sh
-        command:
-        - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-go-canary
         name: ""
         resources:
           limits:
@@ -1682,46 +1622,6 @@ presubmits:
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
         image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-1.21
-        imagePullPolicy: Always
-        name: ""
-        resources:
-          limits:
-            cpu: "7"
-            memory: 12Gi
-          requests:
-            cpu: "7"
-            memory: 12Gi
-        securityContext:
-          privileged: true
-  - always_run: false
-    branches:
-    - release-1.21
-    cluster: k8s-infra-prow-build
-    decorate: true
-    labels:
-      preset-dind-enabled: "true"
-      preset-service-account: "true"
-    name: pull-kubernetes-verify-go-canary
-    path_alias: k8s.io/kubernetes
-    skip_report: true
-    spec:
-      containers:
-      - args:
-        - ./hack/jenkins/verify-dockerized.sh
-        command:
-        - runner.sh
-        env:
-        - name: EXCLUDE_TYPECHECK
-          value: "y"
-        - name: EXCLUDE_FILES_REMAKE
-          value: "y"
-        - name: EXCLUDE_GODEP
-          value: "y"
-        - name: KUBE_VERIFY_GIT_BRANCH
-          value: release-1.21
-        - name: REPO_DIR
-          value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-go-canary
         imagePullPolicy: Always
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml
@@ -1606,39 +1606,6 @@ presubmits:
     branches:
     - release-1.22
     cluster: k8s-infra-prow-build
-    context: pull-kubernetes-dependencies-go-canary
-    decorate: true
-    labels:
-      preset-dind-enabled: "true"
-      preset-service-account: "true"
-    name: pull-kubernetes-dependencies-go-canary
-    path_alias: k8s.io/kubernetes
-    skip_report: true
-    spec:
-      containers:
-      - args:
-        - make
-        - verify
-        command:
-        - runner.sh
-        env:
-        - name: WHAT
-          value: external-dependencies-version vendor vendor-licenses
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-go-canary
-        name: main
-        resources:
-          limits:
-            cpu: "2"
-            memory: 1288490188800m
-          requests:
-            cpu: "2"
-            memory: 1288490188800m
-        securityContext:
-          privileged: true
-  - always_run: false
-    branches:
-    - release-1.22
-    cluster: k8s-infra-prow-build
     context: pull-kubernetes-files-remake
     decorate: true
     name: pull-kubernetes-files-remake
@@ -1680,35 +1647,6 @@ presubmits:
         command:
         - runner.sh
         image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-1.22
-        name: ""
-        resources:
-          limits:
-            cpu: "6"
-            memory: 15Gi
-          requests:
-            cpu: "6"
-            memory: 15Gi
-        securityContext:
-          privileged: true
-  - always_run: false
-    branches:
-    - release-1.22
-    cluster: k8s-infra-prow-build
-    context: pull-kubernetes-integration-go-canary
-    decorate: true
-    labels:
-      preset-dind-enabled: "true"
-      preset-service-account: "true"
-    name: pull-kubernetes-integration-go-canary
-    path_alias: k8s.io/kubernetes
-    skip_report: true
-    spec:
-      containers:
-      - args:
-        - ./hack/jenkins/test-dockerized.sh
-        command:
-        - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-go-canary
         name: ""
         resources:
           limits:
@@ -1922,47 +1860,6 @@ presubmits:
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
         image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-1.22
-        imagePullPolicy: Always
-        name: ""
-        resources:
-          limits:
-            cpu: "7"
-            memory: 12Gi
-          requests:
-            cpu: "7"
-            memory: 12Gi
-        securityContext:
-          privileged: true
-  - always_run: false
-    branches:
-    - release-1.22
-    cluster: k8s-infra-prow-build
-    context: pull-kubernetes-verify-go-canary
-    decorate: true
-    labels:
-      preset-dind-enabled: "true"
-      preset-service-account: "true"
-    name: pull-kubernetes-verify-go-canary
-    path_alias: k8s.io/kubernetes
-    skip_report: true
-    spec:
-      containers:
-      - args:
-        - ./hack/jenkins/verify-dockerized.sh
-        command:
-        - runner.sh
-        env:
-        - name: EXCLUDE_TYPECHECK
-          value: "y"
-        - name: EXCLUDE_FILES_REMAKE
-          value: "y"
-        - name: EXCLUDE_GODEP
-          value: "y"
-        - name: KUBE_VERIFY_GIT_BRANCH
-          value: release-1.22
-        - name: REPO_DIR
-          value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-go-canary
         imagePullPolicy: Always
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-testing/dependencies.yaml
+++ b/config/jobs/kubernetes/sig-testing/dependencies.yaml
@@ -52,7 +52,7 @@ presubmits:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: sig-release-releng-informing, sig-testing-canaries
     always_run: false
-    skip_report: true
+    skip_report: false
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes/sig-testing/dependencies.yaml
+++ b/config/jobs/kubernetes/sig-testing/dependencies.yaml
@@ -46,7 +46,6 @@ presubmits:
     skip_branches:
     - release-\d+.\d+ # per-release job
     annotations:
-      fork-per-release: "true"
       testgrid-num-failures-to-alert: '10'
       testgrid-alert-stale-results-hours: '24'
       testgrid-create-test-group: 'true'

--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -41,7 +41,6 @@ presubmits:
     skip_branches:
     - release-\d+.\d+ # per-release job
     annotations:
-      fork-per-release: "true"
       testgrid-num-failures-to-alert: '10'
       testgrid-alert-stale-results-hours: '24'
       testgrid-create-test-group: 'true'

--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -36,7 +36,7 @@ presubmits:
   - name: pull-kubernetes-integration-go-canary
     cluster: k8s-infra-prow-build
     always_run: false
-    skip_report: true
+    skip_report: false
     decorate: true
     skip_branches:
     - release-\d+.\d+ # per-release job

--- a/config/jobs/kubernetes/sig-testing/make-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/make-test.yaml
@@ -71,6 +71,39 @@ presubmits:
             requests:
               cpu: 4
               memory: "36Gi"
+  - name: pull-kubernetes-unit-go-canary
+    annotations:
+      testgrid-num-failures-to-alert: '10'
+      testgrid-alert-stale-results-hours: '24'
+      testgrid-create-test-group: 'true'
+      testgrid-dashboards: sig-release-releng-informing, sig-testing-canaries
+    decorate: true
+    cluster: k8s-infra-prow-build
+    skip_branches:
+    - release-\d+.\d+ # per-release job
+    labels:
+      preset-service-account: "true"
+    always_run: false
+    skip_report: false
+    path_alias: k8s.io/kubernetes
+    spec:
+      # unit tests have no business requiring root or doing privileged operations
+      securityContext:
+        runAsUser: 2000
+        allowPrivilegeEscalation: false
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-go-canary
+          command:
+            - make
+            - test
+          # TODO: direct copy from pull-kubernetes-bazel-test, tune these
+          resources:
+            limits:
+              cpu: 4
+              memory: "36Gi"
+            requests:
+              cpu: 4
+              memory: "36Gi"
 periodics:
   - interval: 1h
     name: ci-kubernetes-unit

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -55,7 +55,6 @@ presubmits:
     skip_branches:
     - release-\d+.\d+ # per-release job
     annotations:
-      fork-per-release: "true"
       testgrid-num-failures-to-alert: '10'
       testgrid-alert-stale-results-hours: '24'
       testgrid-create-test-group: 'true'

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -50,7 +50,7 @@ presubmits:
   - name: pull-kubernetes-verify-go-canary
     cluster: k8s-infra-prow-build
     always_run: false
-    skip_report: true
+    skip_report: false
     decorate: true
     skip_branches:
     - release-\d+.\d+ # per-release job


### PR DESCRIPTION
- Enable GH report for kubernetes/kubernetes presubmits
- Remove release-branch presubmits
- Add pull-kubernetes-unit-go-canary

From @liggitt in https://github.com/kubernetes/kubernetes/pull/103692#issuecomment-898442646:

> do we have canary versions of pull-kubernetes-dependencies / pull-kubernetes-verify / pull-kubernetes-integration / pull-kubernetes-unit running with go1.17rc2 so we can have confidence all CI is actually green on go1.17 prior to merge?

Part of go1.17 pre-release bump: https://github.com/kubernetes/release/issues/2169, https://github.com/kubernetes/kubernetes/pull/103692

Background on go canaries: https://github.com/kubernetes/test-infra/pull/21107, https://github.com/kubernetes/test-infra/pull/21110, https://github.com/kubernetes/kubernetes/pull/98572

/assign @spiffxp @dims @BenTheElder 
cc: @kubernetes/release-engineering 