### PR TITLE
Consolidate containerd testgrid tabs

### DIFF
--- a/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
@@ -7,7 +7,7 @@ presubmits:
     - release/1.5
     decorate: true
     annotations:
-      testgrid-dashboards: sig-node-containerd-io
+      testgrid-dashboards: sig-node-containerd
       testgrid-tab-name: pull-containerd-build
       description: build artifacts
     labels:
@@ -43,7 +43,7 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/test-infra
     annotations:
-      testgrid-dashboards: sig-node-containerd-io
+      testgrid-dashboards: sig-node-containerd
       testgrid-tab-name: pull-containerd-node-e2e
       description: run node e2e tests
     labels:

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -107,33 +107,6 @@ periodics:
     testgrid-tab-name: containerd-build-test-images
     description: "builds test images for development in progress branch of upstream containerd"
 - interval: 1h
-  name: ci-containerd-e2e-cos-gce
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-    preset-e2e-containerd: "true"
-    preset-e2e-containerd-image-load: "true"
-  spec:
-    containers:
-    - args:
-      - --repo=github.com/containerd/containerd=main
-      - --timeout=70
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --extract=ci/latest
-      - --gcp-node-image=gci
-      - --gcp-nodes=4
-      - --gcp-zone=us-west1-b
-      - --ginkgo-parallel=30
-      - --provider=gce
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
-      - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210825-f1955d1-master
-  annotations:
-    testgrid-dashboards: sig-node-containerd, sig-node-cos
-    testgrid-tab-name: containerd-e2e-cos
-- interval: 1h
   name: ci-containerd-e2e-cos-gce-1-4
   labels:
     preset-service-account: "true"
@@ -161,7 +134,7 @@ periodics:
           - --timeout=50m
         image: gcr.io/k8s-testimages/kubekins-e2e:v20210825-f1955d1-master
   annotations:
-    testgrid-dashboards: sig-node-containerd, sig-node-cos
+    testgrid-dashboards: sig-node-cos
     testgrid-tab-name: containerd-e2e-cos-1.4
 
 - interval: 1h
@@ -341,7 +314,7 @@ periodics:
       - --up=false
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210825-f1955d1-master
   annotations:
-    testgrid-dashboards: sig-node-containerd, sig-node-cos
+    testgrid-dashboards: sig-node-cos
     testgrid-tab-name: soak-cos-gce
 - name: ci-cri-containerd-e2e-gce-device-plugin-gpu
   cron: "30 1-23/3 * * *"
@@ -397,7 +370,7 @@ periodics:
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210825-f1955d1-master
   annotations:
-    testgrid-dashboards: sig-node-containerd, sig-node-cos
+    testgrid-dashboards: sig-node-cos
     testgrid-tab-name: e2e-cos
 - interval: 2h
   name: ci-cri-containerd-e2e-cos-gce-alpha-features
@@ -426,7 +399,7 @@ periodics:
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210825-f1955d1-master
   annotations:
-    testgrid-dashboards: sig-node-containerd, sig-node-cos
+    testgrid-dashboards: sig-node-cos
     testgrid-tab-name: e2e-cos-alpha-features
 - interval: 2h
   name: ci-cri-containerd-e2e-cos-gce-flaky
@@ -451,7 +424,7 @@ periodics:
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210825-f1955d1-master
   annotations:
-    testgrid-dashboards: sig-node-containerd, sig-node-cos
+    testgrid-dashboards: sig-node-cos
     testgrid-tab-name: e2e-cos-flaky
 - interval: 2h
   name: ci-cri-containerd-e2e-cos-gce-ingress
@@ -479,7 +452,7 @@ periodics:
       - --timeout=320m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210825-f1955d1-master
   annotations:
-    testgrid-dashboards: sig-network-gce, sig-node-containerd, sig-node-cos
+    testgrid-dashboards: sig-network-gce, sig-node-cos
     testgrid-tab-name: e2e-cos-ingress
     testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com
 - interval: 2h
@@ -509,7 +482,7 @@ periodics:
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210825-f1955d1-master
   annotations:
-    testgrid-dashboards: sig-node-containerd, sig-node-cos
+    testgrid-dashboards: sig-node-cos
     testgrid-tab-name: e2e-cos-ip-alias
 - interval: 2h
   name: ci-cri-containerd-e2e-cos-gce-proto
@@ -536,7 +509,7 @@ periodics:
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210825-f1955d1-master
   annotations:
-    testgrid-dashboards: sig-node-containerd, sig-node-cos
+    testgrid-dashboards: sig-node-cos
     testgrid-tab-name: e2e-cos-proto
 - interval: 1h
   name: ci-cri-containerd-e2e-cos-gce-reboot
@@ -561,7 +534,7 @@ periodics:
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210825-f1955d1-master
   annotations:
-    testgrid-dashboards: sig-node-containerd, sig-node-cos
+    testgrid-dashboards: sig-node-cos
     testgrid-tab-name: e2e-cos-reboot
 - interval: 1h
   name: ci-cri-containerd-e2e-cos-gce-serial
@@ -586,7 +559,7 @@ periodics:
       - --timeout=500m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210825-f1955d1-master
   annotations:
-    testgrid-dashboards: sig-node-containerd, sig-node-cos
+    testgrid-dashboards: sig-node-cos
     testgrid-tab-name: e2e-cos-serial
 - interval: 1h
   name: ci-cri-containerd-e2e-cos-gce-slow
@@ -612,7 +585,7 @@ periodics:
       - --timeout=150m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20210825-f1955d1-master
   annotations:
-    testgrid-dashboards: sig-node-containerd, sig-node-cos
+    testgrid-dashboards: sig-node-cos
     testgrid-tab-name: e2e-cos-slow
 - interval: 1h
   name: ci-cri-containerd-e2e-ubuntu-gce

--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -6,7 +6,6 @@ dashboard_groups:
     - sig-node-cadvisor
     - sig-node-kubelet
     - sig-node-containerd
-    - sig-node-containerd-io # jobs in containerd/containerd repository
     - sig-node-ppc64le
     - sig-node-cri-o
     - sig-node-docker
@@ -18,7 +17,6 @@ dashboard_groups:
     - sig-node-presubmits
 
 dashboards:
-- name: sig-node-containerd-io
 - name: sig-node-release-blocking # Tabs included in this group are defined in the jobs that are included.
 - name: sig-node-critical
   dashboard_tab:


### PR DESCRIPTION
remove tab sig-node-containerd-io
remove cos jobs from containerd tab
remove a redundant job ci-containerd-e2e-cos-gce

Related to https://github.com/kubernetes/test-infra/issues/23231
Signed-off-by: Aditi Sharma <adi.sky17@gmail.com>

/sig node