### PR TITLE
Rename sig-node-cri tab to sig-node-docker

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -220,7 +220,7 @@ periodics:
       - name: GOPATH
         value: /go
   annotations:
-    testgrid-dashboards: sig-node-containerd, sig-node-cri
+    testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-node-conformance
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - name: ci-containerd-node-e2e-1-4
@@ -281,7 +281,7 @@ periodics:
       - name: GOPATH
         value: /go
   annotations:
-    testgrid-dashboards: sig-node-containerd, sig-node-cri
+    testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-node-features
 - name: ci-containerd-node-e2e-features-1-4
   interval: 1h

--- a/config/jobs/kubernetes/sig-node/node-docker.yaml
+++ b/config/jobs/kubernetes/sig-node/node-docker.yaml
@@ -26,7 +26,7 @@ periodics:
         value: /go
 
   annotations:
-    testgrid-dashboards: sig-node-cri
+    testgrid-dashboards: sig-node-docker
     testgrid-tab-name: docker-node-conformance
 - name: ci-docker-node-features
   interval: 4h
@@ -55,7 +55,7 @@ periodics:
         value: /go
 
   annotations:
-    testgrid-dashboards: sig-node-cri
+    testgrid-dashboards: sig-node-docker
     testgrid-tab-name: docker-node-features
 - name: ci-docker-node-legacy
   interval: 2h
@@ -83,5 +83,5 @@ periodics:
       - name: GOPATH
         value: /go
   annotations:
-    testgrid-dashboards: sig-node-cri
+    testgrid-dashboards: sig-node-docker
     testgrid-tab-name: docker-node-legacy

--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -9,7 +9,7 @@ dashboard_groups:
     - sig-node-containerd-io # jobs in containerd/containerd repository
     - sig-node-ppc64le
     - sig-node-cri-o
-    - sig-node-cri
+    - sig-node-docker
     - sig-node-cri-tools
     - sig-node-node-feature-discovery
     - sig-node-node-problem-detector
@@ -70,7 +70,7 @@ dashboards:
         url: https://gcsweb-ci.svc.ci.openshift.org/gcs/<gcs_prefix>
       base_options: width=10
 
-- name: sig-node-cri
+- name: sig-node-docker
 - name: sig-node-cri-tools
 - name: sig-node-node-feature-discovery
 


### PR DESCRIPTION
Most of the containerd jobs are in sig-node-containerd tab, removed containerd jobs from cri tab and renamed it to docker.
https://github.com/kubernetes/test-infra/issues/23231

Signed-off-by: Aditi Sharma <adi.sky17@gmail.com>