### PR TITLE
Add node e2e CI Job with systemd cgroup driver

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -875,3 +875,34 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: cos-cgroupv2-containerd-node-e2e
+- name: ci-cgroup-systemd-containerd-node-e2e
+  interval: 1h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      args:
+      - --root=/go/src
+      - --repo=k8s.io/kubernetes
+      - --repo=github.com/containerd/containerd=main
+      - --timeout=90
+      - --scenario=kubernetes_e2e
+      - --
+      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/containerd-master/systemd/image-config.yaml
+      - --deployment=node
+      - --gcp-project-type=node-e2e-project
+      - --gcp-zone=us-west1-b
+      - '--node-test-args=--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
+      - --node-tests=true
+      - --provider=gce
+      - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Serial\]"
+      - --timeout=65m
+      env:
+      - name: GOPATH
+        value: /go
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    testgrid-tab-name: cgroup-systemd-containerd-node-e2e
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com

--- a/jobs/e2e_node/containerd/containerd-master/systemd/env
+++ b/jobs/e2e_node/containerd/containerd-master/systemd/env
@@ -6,6 +6,4 @@ CONTAINERD_PKG_PREFIX: 'containerd-cni'
 CONTAINERD_EXTRA_RUNTIME_HANDLER: 'test-handler'
 CONTAINERD_EXTRA_RUNTIME_OPTIONS: |
   BinaryName = "/home/containerd/usr/local/sbin/runc"
-CONTAINERD_CGROUPV2: 'true'
 CONTAINERD_SYSTEMD_CGROUP: 'true'
-

--- a/jobs/e2e_node/containerd/containerd-master/systemd/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-master/systemd/image-config.yaml
@@ -1,0 +1,5 @@
+images:
+  cos-stable:
+    image_family: cos-89-lts
+    project: cos-cloud
+    metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-master/systemd/env,gci-update-strategy=update_disabled"


### PR DESCRIPTION
Add node e2e CI job with containerd as runtime and systemd as cgroup driver

As per the discussions here https://kubernetes.slack.com/archives/C0BP8PW9G/p1628652651139000
and as we are seeing lots of issues with systemd cgroup driver, adding a periodic job with systemd cgroup driver.

Signed-off-by: Aditi Sharma <adi.sky17@gmail.com>