### PR TITLE
triage: don't set ACLs when uploading

### DIFF
--- a/triage/update_summaries.sh
+++ b/triage/update_summaries.sh
@@ -97,7 +97,7 @@ mkdir -p slices
   triage_tests/*.json
 
 gsutil_cp() {
-  gsutil -h 'Cache-Control: no-store, must-revalidate' -m cp -Z -a public-read "$@"
+  gsutil -h 'Cache-Control: no-store, must-revalidate' -m cp -Z "$@"
 }
 
 gsutil_cp failure_data.json "${TRIAGE_GCS_PATH}/"


### PR DESCRIPTION
Related:
- part of: https://github.com/kubernetes/k8s.io/issues/1305
- followup to: https://github.com/kubernetes/test-infra/pull/23235

The triage job is currently failing by trying to set ACLs on a bucket that has UBLA set. Stop doing that, and trust that the bucket's IAM settings are correctly configured for public read