### PR TITLE
config/jobs: use community-owned infra for triage

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -27,51 +27,6 @@ periodics:
     testgrid-tab-name: ci-bazel
     description: Runs bazel test //... on the test-infra repo every hour
 
-- name: ci-test-infra-triage
-  decorate: true
-  decoration_config:
-    timeout: 3h
-  interval: 30m
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/triage:latest
-      imagePullPolicy: Always
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
-      # Go incorrectly determines the number of CPUs in a pod, set manually to (2*CPUs-1)
-      # TODO: determine the optimal number of workers, 2*CPU-1 is an assumption
-      - name: NUM_WORKERS
-        value: "13"
-      command:
-      - "timeout"
-      args:
-      - "10800"
-      - "/update_summaries.sh"
-      volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
-      # When changing CPUs, also change NUM_WORKERS above
-      resources:
-        requests:
-          cpu: 7
-          memory: 40Gi
-        limits:
-          cpu: 7
-          memory: 40Gi
-    volumes:
-    - name: service
-      secret:
-        secretName: triage-service-account
-  annotations:
-    testgrid-num-failures-to-alert: '18'
-    testgrid-alert-stale-results-hours: '12'
-    testgrid-dashboards: sig-testing-misc
-    testgrid-tab-name: triage
-    testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
-    description: Runs BigQuery queries, summarizes results into clusters, and uploads to GCS for go.k8s.io/triage
-
 - name: metrics-kettle
   interval: 1h
   spec:

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-test-infra.yaml
@@ -63,7 +63,7 @@ periodics:
       - --bucket=gs://k8s-metrics
       - --project=k8s-infra-prow-build-trusted
 
-- name: ci-test-infra-triage-canary
+- name: ci-test-infra-triage
   interval: 30m
   cluster: k8s-infra-prow-build-trusted
   decorate: true
@@ -73,7 +73,7 @@ periodics:
   annotations:
     testgrid-num-failures-to-alert: '18'
     testgrid-alert-stale-results-hours: '12'
-    testgrid-dashboards: wg-k8s-infra-canaries, sig-testing-canaries
+    testgrid-dashboards: sig-testing-misc, wg-k8s-infra-prow
     testgrid-tab-name: triage
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-alerts@kubernetes.io
     description: Runs BigQuery queries, summarizes results into clusters, and uploads to GCS for go.k8s.io/triage

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-test-infra.yaml
@@ -10,17 +10,14 @@ postsubmits:
     spec:
       serviceAccountName: k8s-triage
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
         command:
         - make
         args:
         - -C
         - ./triage/
         - push-static
-        - push-staging
-        # TODO(spiffxp): when ready to switch
-        # - redirect-static
-        # - redirect-staging
+        - redirect-static
         resources:
           requests:
             memory: "1Gi"
@@ -96,7 +93,7 @@ periodics:
       - name: NUM_WORKERS
         value: "13"
       - name: TRIAGE_DATASET_TABLE
-        value: "kubernetes-public:k8s_triage.temp" # TODO: definitely don't have permission to write here, need our own bq dataset
+        value: "kubernetes-public:k8s_triage.temp"
       - name: TRIAGE_TEMP_GCS_PATH
         value: "gs://k8s-triage/triage_tests"
       - name: TRIAGE_GCS_PATH


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1305
- Followup to: https://github.com/kubernetes/k8s.io/pull/2544

This does the following:
- drop the old ci-test-infra-triage job that used google.com infrastructure
- rename the ci-tewt-infra-triage-canary job using kubernetes.io infrastructure to become the new ci-test-infra-triage job
- push a redirect so URI's referencing gs://k8s-gubernator/triage/index.html will redirect to gs://k8s-triage/index.html
- use a community-owned image to run the triage static files upload job
- drop errant TODO that was addressed in https://github.com/kubernetes/test-infra/pull/23235