### PR TITLE
Make Sub cache git clients used for inrepo config.

### DIFF
--- a/prow/cmd/sub/BUILD.bazel
+++ b/prow/cmd/sub/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/client/clientset/versioned/typed/prowjobs/v1:go_default_library",
+        "//prow/config:go_default_library",
         "//prow/config/secret:go_default_library",
         "//prow/crier/reporters/pubsub:go_default_library",
         "//prow/flagutil:go_default_library",

--- a/prow/cmd/sub/main.go
+++ b/prow/cmd/sub/main.go
@@ -29,6 +29,7 @@ import (
 
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	prowv1 "k8s.io/test-infra/prow/client/clientset/versioned/typed/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/config/secret"
 	"k8s.io/test-infra/prow/crier/reporters/pubsub"
 	"k8s.io/test-infra/prow/flagutil"
@@ -137,7 +138,7 @@ func main() {
 		ConfigAgent:   configAgent,
 		Metrics:       promMetrics,
 		ProwJobClient: kubeClient,
-		GitClient:     gitClientFactory,
+		GitClient:     config.NewInRepoConfigGitCache(gitClientFactory),
 		Reporter:      pubsub.NewReporter(configAgent.Config), // reuse crier reporter
 	}
 

--- a/prow/config/inrepoconfig.go
+++ b/prow/config/inrepoconfig.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sync"
 
 	"github.com/sirupsen/logrus"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -186,4 +187,72 @@ func DefaultAndValidateProwYAML(c *Config, p *ProwYAML, identifier string) error
 	}
 
 	return utilerrors.NewAggregate(errs)
+}
+
+// InRepoConfigGitCache is a wrapper around a git.ClientFactory that allows for
+// threadsafe reuse of git.RepoClients when one already exists for the specified repo.
+type InRepoConfigGitCache struct {
+	git.ClientFactory
+	cache map[string]*skipCleanRepoClient
+	sync.RWMutex
+}
+
+func NewInRepoConfigGitCache(factory git.ClientFactory) git.ClientFactory {
+	if factory == nil {
+		// Don't wrap a nil git factory, keep it nil so that errors are handled properly.
+		return nil
+	}
+	return &InRepoConfigGitCache{
+		ClientFactory: factory,
+		cache:         map[string]*skipCleanRepoClient{},
+	}
+}
+
+func (c *InRepoConfigGitCache) ClientFor(org, repo string) (git.RepoClient, error) {
+	key := fmt.Sprintf("%s/%s", org, repo)
+	c.RLock()
+	cached, err := func() (git.RepoClient, error) {
+		defer c.RUnlock()
+
+		if client, ok := c.cache[key]; ok {
+			client.Lock()
+			// Don't unlock the client unless we get an error or the consumer indicates they are done by Clean()ing.
+			if err := client.Fetch(); err != nil {
+				client.Unlock()
+				return nil, err
+			}
+			return client, nil
+		}
+		return nil, nil
+	}()
+	if cached != nil || err != nil {
+		return cached, err
+	}
+
+	// The repo client was not cached, create a new one.
+	c.Lock()
+	defer c.Unlock()
+	coreClient, err := c.ClientFactory.ClientFor(org, repo)
+	if err != nil {
+		return nil, err
+	}
+	client := &skipCleanRepoClient{
+		RepoClient: coreClient,
+	}
+	client.Lock()
+	c.cache[key] = client
+	return client, nil
+}
+
+var _ git.RepoClient = &skipCleanRepoClient{}
+
+type skipCleanRepoClient struct {
+	git.RepoClient
+	sync.Mutex
+}
+
+func (rc *skipCleanRepoClient) Clean() error {
+	// Skip cleaning and unlock to allow reuse as a cached entry.
+	rc.Unlock()
+	return nil
 }


### PR DESCRIPTION
This `InRepoConfigGitCache` will reuse `GitRepo` clients in order to avoid a local clone every time an inrepo config lookup is needed. Now the local clone is skipped and we can simply fetch and reuse the repo instead. The cache has no pruning or garbage collection at this time, but I don't think the `localgit` client does either so we shouldn't ever use more than twice the amount of disk space we used before and we may use less disk in high concurrency cases. This should also allow us to reduce the number of deployment replicas so even if each pod uses more disk we'll still likely use less over all.
We are just trying this out on Sub to start with.

/assign @chaodaiG 
/cc @listx @alvaroaleman 