### PR TITLE
Use extra refs for pulling in capz scripts for Windows e2e tests

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.22-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.22-windows.yaml
@@ -55,18 +55,19 @@ periodics:
       securityContext:
         privileged: true
 - name: ci-kubernetes-e2e-capz-azure-windows-dockershim-1-22
-  interval: 3h
-  path_alias: "sigs.k8s.io/cluster-api-provider-azure"
-  always_run: false
-  optional: true
+  interval: 12h
   decorate: true
   decoration_config:
     timeout: 4h
-  max_concurrency: 5
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: master
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
   spec:
     containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-1.22

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -236,17 +236,18 @@ periodics:
     description: Staging job for new Windows tests on a Kubernetes cluster provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - name: ci-kubernetes-e2e-capz-staging-dockershim-windows
   interval: 8h
-  path_alias: "sigs.k8s.io/cluster-api-provider-azure"
-  always_run: false
-  optional: true
   decorate: true
   decoration_config:
     timeout: 4h
-  max_concurrency: 5
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: master
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
   spec:
     containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master


### PR DESCRIPTION
The template I used as a reference was for pre-submits, this fixes it so it pulls in the CAPZ components and now uses https://github.com/kubernetes/test-infra/blob/e86fab497e41c78cff5571306b350cadd823d206/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml#L293 as a reference

/sig windows
/assign @marosset 