### PR TITLE
Add a default tenantID when none is provided

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -70,6 +70,8 @@ const (
 	// it up if present. This allows components to include the config version
 	// in their logs, which can be useful for debugging.
 	ConfigVersionFileName = "VERSION"
+
+	DefaultTenantID = "GlobalDefaultID"
 )
 
 // Config is a read-only snapshot of the config.
@@ -621,6 +623,9 @@ func (pc *ProwConfig) mergeProwJobDefault(repo, cluster string, jobDefault *prow
 	merged = jobDefault.ApplyDefault(merged)
 	if merged == nil {
 		merged = &prowapi.ProwJobDefault{}
+	}
+	if merged.TenantID == "" {
+		merged.TenantID = DefaultTenantID
 	}
 	return merged
 }

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -4063,9 +4063,9 @@ func TestSetPeriodicProwJobDefaults(t *testing.T) {
 		expected      *prowapi.ProwJobDefault
 	}{
 		{
-			id:       "No ProwJobDefault in job or in config, expect no changes",
+			id:       "No ProwJobDefault in job or in config, expect DefaultTenantID",
 			config:   &Config{ProwConfig: ProwConfig{}},
-			expected: &prowapi.ProwJobDefault{},
+			expected: &prowapi.ProwJobDefault{TenantID: DefaultTenantID},
 		},
 		{
 			id: "no default in job or in config's by repo config, expect default entry",
@@ -4455,9 +4455,9 @@ func TestSetProwJobDefaults(t *testing.T) {
 		expected     *prowapi.ProwJobDefault
 	}{
 		{
-			id:       "No ProwJobDefault in job or in config, expect no changes",
+			id:       "No ProwJobDefault in job or in config, expect DefaultTenantID",
 			config:   &Config{ProwConfig: ProwConfig{}},
-			expected: &prowapi.ProwJobDefault{},
+			expected: &prowapi.ProwJobDefault{TenantID: DefaultTenantID},
 		},
 		{
 			id: "no default in job or in config's by repo config, expect default entry",

--- a/prow/deck/jobs/jobs.go
+++ b/prow/deck/jobs/jobs.go
@@ -125,6 +125,10 @@ func (c *filteringProwJobLister) TenantIDMatch(pj prowapi.ProwJob) bool {
 	return false
 }
 
+func tenantIDMissingOrDefault(pj prowapi.ProwJob) bool {
+	return pj.Spec.ProwJobDefault == nil || pj.Spec.ProwJobDefault.TenantID == "" || pj.Spec.ProwJobDefault.TenantID == config.DefaultTenantID
+}
+
 func (c *filteringProwJobLister) ListProwJobs(selector string) ([]prowapi.ProwJob, error) {
 	prowJobList := &prowapi.ProwJobList{}
 	parsedSelector, err := labels.Parse(selector)
@@ -149,7 +153,7 @@ func (c *filteringProwJobLister) ListProwJobs(selector string) ([]prowapi.ProwJo
 			if shouldHide && (c.showHidden || c.hiddenOnly) {
 				// If Hidden and we are showing Hidden we add it
 				filtered = append(filtered, item)
-			} else if !shouldHide && !c.hiddenOnly && (item.Spec.ProwJobDefault == nil || item.Spec.ProwJobDefault.TenantID == "") {
+			} else if !shouldHide && !c.hiddenOnly && tenantIDMissingOrDefault(item) {
 				// If not Hidden then show if not hiddenOnly AND if no tenantID
 				filtered = append(filtered, item)
 			}

--- a/prow/deck/jobs/jobs_test.go
+++ b/prow/deck/jobs/jobs_test.go
@@ -664,6 +664,53 @@ func TestListProwJobs(t *testing.T) {
 			expected:   sets.NewString("Hidden ID"),
 			hiddenOnly: true,
 		},
+		{
+			name: "pjs with tenantIDs will not show up on Deck with no tenantID",
+			prowJobs: []func(*prowapi.ProwJob) runtime.Object{
+				func(in *prowapi.ProwJob) runtime.Object {
+					in.Name = "tenantedID"
+					in.Spec.ProwJobDefault = &prowapi.ProwJobDefault{TenantID: "ID"}
+					return in
+				},
+				func(in *prowapi.ProwJob) runtime.Object {
+					in.Name = "Other ID"
+					in.Spec.ProwJobDefault = &prowapi.ProwJobDefault{TenantID: "Other ID"}
+					return in
+				},
+			},
+			expected: sets.NewString(),
+		},
+		{
+			name: "pjs with Default ID will  show up on Deck with no tenantID",
+			prowJobs: []func(*prowapi.ProwJob) runtime.Object{
+				func(in *prowapi.ProwJob) runtime.Object {
+					in.Name = "tenantedID"
+					in.Spec.ProwJobDefault = &prowapi.ProwJobDefault{TenantID: config.DefaultTenantID}
+					return in
+				},
+				func(in *prowapi.ProwJob) runtime.Object {
+					in.Name = "Other ID"
+					in.Spec.ProwJobDefault = &prowapi.ProwJobDefault{TenantID: "Other ID"}
+					return in
+				},
+			},
+			expected: sets.NewString("tenantedID"),
+		},
+		{
+			name: "empty tenantID counts as no tenantID",
+			prowJobs: []func(*prowapi.ProwJob) runtime.Object{
+				func(in *prowapi.ProwJob) runtime.Object {
+					in.Name = "empty tenant id"
+					in.Spec.ProwJobDefault = &prowapi.ProwJobDefault{TenantID: ""}
+					return in
+				},
+				func(in *prowapi.ProwJob) runtime.Object {
+					in.Name = "No ProwJobDefault"
+					return in
+				},
+			},
+			expected: sets.NewString("empty tenant id", "No ProwJobDefault"),
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
Change config for ProwJobDefaults so if no TenantID is set, it is replaced with a global default.
Change Deck to look for this global default tenantID it no tenantID is set for Deck, so public instance of Deck will not need any changes. 

/assign @chaodaiG @cjwagner 
/hold