### PR TITLE
Fix cluster-api periodic mink8s e2e test

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -33,6 +33,10 @@ periodics:
     repo: cluster-api
     base_ref: master
     path_alias: sigs.k8s.io/cluster-api
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
   spec:
     containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-1.21
@@ -64,6 +68,10 @@ periodics:
     repo: cluster-api
     base_ref: master
     path_alias: sigs.k8s.io/cluster-api
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-1.21


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

As we're now building the kindest/node image we the kubernetes folder.

LInk to failed test: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-e2e-main-mink8s/1427664716779491328

/assign @fabriziopandini 