### PR TITLE
images/alpine: Build for ppc64le

### DIFF
--- a/images/alpine/cloudbuild.yaml
+++ b/images/alpine/cloudbuild.yaml
@@ -4,7 +4,7 @@ steps:
     args:
     - build
     - --tag=gcr.io/$PROJECT_ID/alpine:$_GIT_TAG
-    - --platform=linux/amd64,linux/arm64/v8
+    - --platform=linux/amd64,linux/arm64/v8,linux/ppc64le
     - --build-arg=IMAGE_ARG=gcr.io/$PROJECT_ID/alpine:$_GIT_TAG
     - --push
     - .


### PR DESCRIPTION
This commit adds a Google Cloud Build definition for building alpine
ppc64le images and pushing them as a manifest list together with their
ppc64le counterparts.

/cc @mkumatag 
/cc @stevekuznetsov

rel: #16588 