### PR TITLE
prep secrets-store-csi-driver jobs for default branch rename

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -7,7 +7,8 @@ presubmits:
     always_run: true
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
-    - master
+    - ^main$
+    - ^master$
     - ^release-*
     labels:
     spec:
@@ -30,7 +31,8 @@ presubmits:
     always_run: true
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
-    - master
+    - ^main$
+    - ^master$
     - ^release-*
     labels:
     spec:
@@ -55,7 +57,8 @@ presubmits:
     always_run: true
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
-    - master
+    - ^main$
+    - ^master$
     - ^release-*
     labels:
     spec:
@@ -81,7 +84,8 @@ presubmits:
     optional: true
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
-    - master
+    - ^main$
+    - ^master$
     - ^release-*
     labels:
       preset-dind-enabled: "true"
@@ -110,7 +114,8 @@ presubmits:
     always_run: true
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
-    - master
+    - ^main$
+    - ^master$
     - ^release-*
     labels:
       # this is required because we want to run kind in docker
@@ -141,7 +146,8 @@ presubmits:
     always_run: true
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
-    - master
+    - ^main$
+    - ^master$
     - ^release-*
     labels:
       # this is required because we want to run kind in docker
@@ -175,7 +181,8 @@ presubmits:
     optional: true
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
-    - master
+    - ^main$
+    - ^master$
     labels:
       # this is required because we want to run kind in docker
       preset-dind-enabled: "true"
@@ -208,7 +215,8 @@ presubmits:
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     optional: false
     branches:
-    - master
+    - ^main$
+    - ^master$
     - ^release-*
     labels:
       preset-azure-cred: "true"
@@ -264,7 +272,8 @@ presubmits:
     always_run: true
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
-    - master
+    - ^main$
+    - ^master$
     - ^release-*
     labels:
       # this is required because we want to run kind in docker
@@ -297,7 +306,8 @@ presubmits:
     optional: true
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
-    - master
+    - ^main$
+    - ^master$
     - ^release-*
     labels:
       # this is required because we want to run kind in docker
@@ -330,7 +340,8 @@ presubmits:
     always_run: true
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
-    - master
+    - ^main$
+    - ^master$
     - ^release-*
     labels:
     spec:
@@ -358,7 +369,8 @@ presubmits:
     run_if_changed: "^charts/.*"
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
-    - master
+    - ^main$
+    - ^master$
     - ^release-*
     labels:
       # this is required because we want to run kind in docker
@@ -393,7 +405,8 @@ presubmits:
     run_if_changed: "^charts/.*"
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
-    - master
+    - ^main$
+    - ^master$
     - ^release-*
     labels:
       # this is required because we want to run kind in docker
@@ -430,7 +443,8 @@ presubmits:
     run_if_changed: "^charts/.*"
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
-    - master
+    - ^main$
+    - ^master$
     - ^release-*
     labels:
       # this is required because we want to run kind in docker
@@ -468,7 +482,8 @@ postsubmits:
     always_run: true
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
-    - master
+    - ^main$
+    - ^master$
     labels:
       # this is required because we want to run kind in docker
       preset-dind-enabled: "true"
@@ -502,7 +517,8 @@ postsubmits:
     always_run: true
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
-    - master
+    - ^main$
+    - ^master$
     labels:
       # this is required because we want to run kind in docker
       preset-dind-enabled: "true"
@@ -538,7 +554,8 @@ postsubmits:
     always_run: true
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
-    - master
+    - ^main$
+    - ^master$
     labels:
       # this is required because we want to run kind in docker
       preset-dind-enabled: "true"
@@ -574,7 +591,8 @@ postsubmits:
     optional: true
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
-    - master
+    - ^main$
+    - ^master$
     labels:
       # this is required because we want to run kind in docker
       preset-dind-enabled: "true"


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

ref https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/617

This is the 1st step in the checklist for `Anytime` changes updating presubmit and post submit triggers.