### PR TITLE
config/jobs: remove refs to old Azure provider branch

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
@@ -57,7 +57,6 @@ postsubmits:
       decorate: true
       branches:
         - ^main$
-        - ^master$
         - ^release-0.3$
         - ^release-0.4$
         # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string

--- a/config/jobs/image-pushing/k8s-staging-provider-azure.yaml
+++ b/config/jobs/image-pushing/k8s-staging-provider-azure.yaml
@@ -16,7 +16,6 @@ postsubmits:
       # probably does).
       branches:
         - ^main$
-        - ^master$
         # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
         - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       spec:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-postsubmits.yaml
@@ -11,7 +11,6 @@ postsubmits:
       preset-azure-anonymous-pull: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     branches:
-      - ^master$
       - ^main$
     spec:
       containers:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -7,7 +7,6 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     branches:
     # The script this job runs is not in all branches.
-    - ^master$
     - ^main$
     spec:
       containers:
@@ -25,7 +24,6 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     branches:
     # The script this job runs is not in all branches.
-    - ^master$
     - ^main$
     spec:
       containers:
@@ -50,7 +48,6 @@ presubmits:
       preset-azure-anonymous-pull: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^master$
     - ^main$
     spec:
       containers:
@@ -83,7 +80,6 @@ presubmits:
       preset-azure-anonymous-pull: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^master$
     - ^main$
     spec:
       containers:
@@ -117,7 +113,6 @@ presubmits:
       preset-azure-anonymous-pull: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^master$
     - ^main$
     spec:
       containers:
@@ -151,7 +146,6 @@ presubmits:
       preset-azure-anonymous-pull: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^master$
     - ^main$
     spec:
       containers:
@@ -186,7 +180,6 @@ presubmits:
       preset-azure-anonymous-pull: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^master$
     - ^main$
     spec:
       containers:
@@ -214,7 +207,6 @@ presubmits:
       preset-dind-enabled: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^master$
     - ^main$
     spec:
       containers:
@@ -243,7 +235,6 @@ presubmits:
       preset-azure-cred-only: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^master$
     - ^main$
     spec:
       containers:
@@ -276,7 +267,6 @@ presubmits:
       preset-azure-cred-only: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^master$
     - ^main$
     spec:
       containers:
@@ -315,7 +305,6 @@ presubmits:
       preset-azure-cred-only: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^master$
     - ^main$
     spec:
       containers:
@@ -349,7 +338,6 @@ presubmits:
       preset-azure-cred-only: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^master$
     - ^main$
     spec:
       containers:
@@ -383,7 +371,6 @@ presubmits:
       preset-service-account: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^master$
     - ^main$
     spec:
       containers:
@@ -406,7 +393,6 @@ presubmits:
       path_alias: k8s.io/test-infra
     branches:
     # The script this job runs is not in all branches.
-    - ^master$
     - ^main$
     spec:
       containers:


### PR DESCRIPTION
Now that cluster-api-provider-azure has renamed to use the `main` branch, we can clean up dangling references to the previous name.

cc: @CecileRobertMichon