### PR TITLE
Filter Tide Pools, History and Queries based on TenantID

### DIFF
--- a/prow/cmd/deck/tide_test.go
+++ b/prow/cmd/deck/tide_test.go
@@ -26,18 +26,84 @@ import (
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/tide"
 	"k8s.io/test-infra/prow/tide/history"
+
+	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 )
 
 func TestFilterHidden(t *testing.T) {
+	exampleConfigNoDefaults := config.Config{
+		ProwConfig: config.ProwConfig{
+			ProwJobDefaultEntries: []*config.ProwJobDefaultEntry{
+				{
+					OrgRepo: "tenanted",
+					Cluster: "*",
+					Config: &prowapi.ProwJobDefault{
+						TenantID: "t",
+					},
+				},
+				{
+					OrgRepo: "tenanted/repo",
+					Cluster: "*",
+					Config: &prowapi.ProwJobDefault{
+						TenantID: "t/r",
+					},
+				},
+				{
+					OrgRepo: "other",
+					Cluster: "*",
+					Config: &prowapi.ProwJobDefault{
+						TenantID: "o",
+					},
+				},
+			},
+		},
+	}
+	exampleConfigWithDefaults := config.Config{
+		ProwConfig: config.ProwConfig{
+			ProwJobDefaultEntries: []*config.ProwJobDefaultEntry{
+				{
+					OrgRepo: "*",
+					Cluster: "*",
+					Config: &prowapi.ProwJobDefault{
+						TenantID: "Default",
+					},
+				},
+				{
+					OrgRepo: "tenanted",
+					Cluster: "*",
+					Config: &prowapi.ProwJobDefault{
+						TenantID: "t",
+					},
+				},
+				{
+					OrgRepo: "tenanted/repo",
+					Cluster: "*",
+					Config: &prowapi.ProwJobDefault{
+						TenantID: "t/r",
+					},
+				},
+				{
+					OrgRepo: "other",
+					Cluster: "*",
+					Config: &prowapi.ProwJobDefault{
+						TenantID: "o",
+					},
+				},
+			},
+		},
+	}
+
 	tests := []struct {
 		name string
 
 		hiddenRepos []string
 		hiddenOnly  bool
 		showHidden  bool
+		tenantIDs   []string
 		queries     []config.TideQuery
 		pools       []tide.Pool
 		hist        map[string][]history.Record
+		cfg         config.Config
 
 		expectedQueries []config.TideQuery
 		expectedPools   []tide.Pool
@@ -206,6 +272,420 @@ func TestFilterHidden(t *testing.T) {
 				"kubernetes/kubernetes:master":         {{Action: "TRIGGER_BATCH"}, {Action: "MERGE_BATCH"}},
 			},
 		},
+		{
+			name: "public frontend. Config has no defaults",
+			cfg:  exampleConfigNoDefaults,
+			hiddenRepos: []string{
+				"kubernetes-security",
+				"kubernetes/website",
+			},
+			hiddenOnly: false,
+			queries: []config.TideQuery{
+				{
+					Repos: []string{"kubernetes/test-infra", "kubernetes/kubernetes"},
+				},
+				{
+					Repos: []string{"kubernetes/website", "kubernetes/docs"},
+				},
+				{
+					Repos: []string{"kubernetes/apiserver", "kubernetes-security/apiserver"},
+				},
+			},
+			pools: []tide.Pool{
+				{Org: "kubernetes", Repo: "test-infra"},
+				{Org: "kubernetes", Repo: "kubernetes"},
+				{Org: "kubernetes", Repo: "website"},
+				{Org: "kubernetes", Repo: "docs"},
+				{Org: "kubernetes", Repo: "apiserver"},
+				{Org: "kubernetes-security", Repo: "apiserver"},
+			},
+			hist: map[string][]history.Record{
+				"kubernetes/test-infra:master":         {{Action: "MERGE"}, {Action: "TRIGGER"}},
+				"kubernetes/website:master":            {{Action: "MERGE_BATCH"}, {Action: "TRIGGER_BATCH"}},
+				"kubernetes-security/apiserver:master": {{Action: "TRIGGER"}, {Action: "MERGE"}},
+				"kubernetes/kubernetes:master":         {{Action: "TRIGGER_BATCH"}, {Action: "MERGE_BATCH"}},
+			},
+
+			expectedQueries: []config.TideQuery{
+				{
+					Repos: []string{"kubernetes/test-infra", "kubernetes/kubernetes"},
+				},
+			},
+			expectedPools: []tide.Pool{
+				{Org: "kubernetes", Repo: "test-infra"},
+				{Org: "kubernetes", Repo: "kubernetes"},
+				{Org: "kubernetes", Repo: "docs"},
+				{Org: "kubernetes", Repo: "apiserver"},
+			},
+			expectedHist: map[string][]history.Record{
+				"kubernetes/test-infra:master": {{Action: "MERGE"}, {Action: "TRIGGER"}},
+				"kubernetes/kubernetes:master": {{Action: "TRIGGER_BATCH"}, {Action: "MERGE_BATCH"}},
+			},
+		},
+		{
+			name: "private frontend config has no defaults",
+			cfg:  exampleConfigNoDefaults,
+			hiddenRepos: []string{
+				"kubernetes-security",
+				"kubernetes/website",
+			},
+			hiddenOnly: true,
+			queries: []config.TideQuery{
+				{
+					Repos: []string{"kubernetes/test-infra", "kubernetes/kubernetes"},
+				},
+				{
+					Repos: []string{"kubernetes/website", "kubernetes/docs"},
+				},
+				{
+					Repos: []string{"kubernetes/apiserver", "kubernetes-security/apiserver"},
+				},
+			},
+			pools: []tide.Pool{
+				{Org: "kubernetes", Repo: "test-infra"},
+				{Org: "kubernetes", Repo: "kubernetes"},
+				{Org: "kubernetes", Repo: "website"},
+				{Org: "kubernetes", Repo: "docs"},
+				{Org: "kubernetes", Repo: "apiserver"},
+				{Org: "kubernetes-security", Repo: "apiserver"},
+			},
+			hist: map[string][]history.Record{
+				"kubernetes/test-infra:master":         {{Action: "MERGE"}, {Action: "TRIGGER"}},
+				"kubernetes/website:master":            {{Action: "MERGE_BATCH"}, {Action: "TRIGGER_BATCH"}},
+				"kubernetes-security/apiserver:master": {{Action: "TRIGGER"}, {Action: "MERGE"}},
+				"kubernetes/kubernetes:master":         {{Action: "TRIGGER_BATCH"}, {Action: "MERGE_BATCH"}},
+			},
+
+			expectedQueries: []config.TideQuery{
+				{
+					Repos: []string{"kubernetes/website", "kubernetes/docs"},
+				},
+				{
+					Repos: []string{"kubernetes/apiserver", "kubernetes-security/apiserver"},
+				},
+			},
+			expectedPools: []tide.Pool{
+				{Org: "kubernetes", Repo: "website"},
+				{Org: "kubernetes-security", Repo: "apiserver"},
+			},
+			expectedHist: map[string][]history.Record{
+				"kubernetes/website:master":            {{Action: "MERGE_BATCH"}, {Action: "TRIGGER_BATCH"}},
+				"kubernetes-security/apiserver:master": {{Action: "TRIGGER"}, {Action: "MERGE"}},
+			},
+		},
+		{
+			name:      "Nothing matches tenantID",
+			tenantIDs: []string{"nothing"},
+			cfg:       exampleConfigWithDefaults,
+			queries: []config.TideQuery{
+				{
+					Repos: []string{"kubernetes/test-infra", "kubernetes/kubernetes"},
+				},
+				{
+					Repos: []string{"kubernetes/website", "kubernetes/docs"},
+				},
+				{
+					Repos: []string{"kubernetes/apiserver", "kubernetes-security/apiserver"},
+				},
+			},
+			pools: []tide.Pool{
+				{Org: "kubernetes", Repo: "test-infra"},
+				{Org: "kubernetes", Repo: "kubernetes"},
+				{Org: "kubernetes", Repo: "website"},
+				{Org: "kubernetes", Repo: "docs"},
+				{Org: "kubernetes", Repo: "apiserver"},
+				{Org: "kubernetes-security", Repo: "apiserver"},
+			},
+			hist: map[string][]history.Record{
+				"kubernetes/test-infra:master":         {{Action: "MERGE"}, {Action: "TRIGGER"}},
+				"kubernetes/website:master":            {{Action: "MERGE_BATCH"}, {Action: "TRIGGER_BATCH"}},
+				"kubernetes-security/apiserver:master": {{Action: "TRIGGER"}, {Action: "MERGE"}},
+				"kubernetes/kubernetes:master":         {{Action: "TRIGGER_BATCH"}, {Action: "MERGE_BATCH"}},
+			},
+
+			expectedQueries: []config.TideQuery{},
+			expectedPools:   []tide.Pool{},
+			expectedHist:    map[string][]history.Record{},
+		},
+		{
+			name:       "frontend for everything no tenantID",
+			cfg:        exampleConfigNoDefaults,
+			showHidden: true,
+			hiddenRepos: []string{
+				"kubernetes-security",
+				"kubernetes/website",
+			},
+
+			pools: []tide.Pool{
+				{Org: "kubernetes", Repo: "test-infra"},
+				{Org: "kubernetes", Repo: "kubernetes"},
+				{Org: "kubernetes", Repo: "website"},
+				{Org: "kubernetes", Repo: "docs"},
+				{Org: "kubernetes", Repo: "apiserver"},
+				{Org: "kubernetes-security", Repo: "apiserver"},
+			},
+			expectedPools: []tide.Pool{
+				{Org: "kubernetes", Repo: "test-infra"},
+				{Org: "kubernetes", Repo: "kubernetes"},
+				{Org: "kubernetes", Repo: "website"},
+				{Org: "kubernetes", Repo: "docs"},
+				{Org: "kubernetes", Repo: "apiserver"},
+				{Org: "kubernetes-security", Repo: "apiserver"},
+			},
+
+			queries: []config.TideQuery{
+				{
+					Repos: []string{"kubernetes/test-infra", "kubernetes/kubernetes"},
+				},
+				{
+					Repos: []string{"kubernetes/website", "kubernetes/docs"},
+				},
+				{
+					Repos: []string{"kubernetes/apiserver", "kubernetes-security/apiserver"},
+				},
+			},
+			expectedQueries: []config.TideQuery{
+				{
+					Repos: []string{"kubernetes/test-infra", "kubernetes/kubernetes"},
+				},
+				{
+					Repos: []string{"kubernetes/website", "kubernetes/docs"},
+				},
+				{
+					Repos: []string{"kubernetes/apiserver", "kubernetes-security/apiserver"},
+				},
+			},
+			hist: map[string][]history.Record{
+				"kubernetes/test-infra:master":         {{Action: "MERGE"}, {Action: "TRIGGER"}},
+				"kubernetes/website:master":            {{Action: "MERGE_BATCH"}, {Action: "TRIGGER_BATCH"}},
+				"kubernetes-security/apiserver:master": {{Action: "TRIGGER"}, {Action: "MERGE"}},
+				"kubernetes/kubernetes:master":         {{Action: "TRIGGER_BATCH"}, {Action: "MERGE_BATCH"}},
+			},
+			expectedHist: map[string][]history.Record{
+				"kubernetes/test-infra:master":         {{Action: "MERGE"}, {Action: "TRIGGER"}},
+				"kubernetes/website:master":            {{Action: "MERGE_BATCH"}, {Action: "TRIGGER_BATCH"}},
+				"kubernetes-security/apiserver:master": {{Action: "TRIGGER"}, {Action: "MERGE"}},
+				"kubernetes/kubernetes:master":         {{Action: "TRIGGER_BATCH"}, {Action: "MERGE_BATCH"}},
+			},
+		},
+		{
+			name:      "Tenated front end",
+			cfg:       exampleConfigNoDefaults,
+			tenantIDs: []string{"t"},
+			queries: []config.TideQuery{
+				{
+					Repos: []string{"kubernetes/test-infra", "kubernetes/kubernetes"},
+				},
+				{
+					Repos: []string{"kubernetes/website", "kubernetes/docs"},
+				},
+				{
+					Repos: []string{"kubernetes/apiserver", "kubernetes-security/apiserver"},
+				},
+				{
+					Repos: []string{"tenanted/test"},
+				},
+			},
+			pools: []tide.Pool{
+				{Org: "kubernetes", Repo: "test-infra"},
+				{Org: "kubernetes", Repo: "kubernetes"},
+				{Org: "kubernetes", Repo: "website"},
+				{Org: "kubernetes", Repo: "docs"},
+				{Org: "kubernetes", Repo: "apiserver"},
+				{Org: "kubernetes-security", Repo: "apiserver"},
+				{Org: "tenanted", Repo: "test"},
+				{Org: "clustered-tenant", Repo: "test", TenantIDs: []string{"t"}},
+			},
+			hist: map[string][]history.Record{
+				"kubernetes/test-infra:master":         {{Action: "MERGE"}, {Action: "TRIGGER"}},
+				"kubernetes/website:master":            {{Action: "MERGE_BATCH"}, {Action: "TRIGGER_BATCH"}},
+				"kubernetes-security/apiserver:master": {{Action: "TRIGGER"}, {Action: "MERGE"}},
+				"kubernetes/kubernetes:master":         {{Action: "TRIGGER_BATCH"}, {Action: "MERGE_BATCH"}},
+				"tenanted/test:master":                 {{Action: "TRIGGER_BATCH"}, {Action: "MERGE_BATCH"}},
+				"clustered-tenant/test:master":         {{Action: "TRIGGER_BATCH", TenantIDs: []string{"t"}}, {Action: "MERGE_BATCH"}},
+			},
+
+			expectedQueries: []config.TideQuery{
+				{
+					Repos: []string{"tenanted/test"},
+				},
+			},
+			expectedPools: []tide.Pool{
+				{Org: "tenanted", Repo: "test"},
+				{Org: "clustered-tenant", Repo: "test", TenantIDs: []string{"t"}},
+			},
+			expectedHist: map[string][]history.Record{
+				"tenanted/test:master":         {{Action: "TRIGGER_BATCH"}, {Action: "MERGE_BATCH"}},
+				"clustered-tenant/test:master": {{Action: "TRIGGER_BATCH", TenantIDs: []string{"t"}}, {Action: "MERGE_BATCH"}},
+			},
+		},
+		{
+			name: "tenantID on Deck ignores hidden repos",
+			cfg:  exampleConfigNoDefaults,
+			hiddenRepos: []string{
+				"tenanted",
+			},
+			tenantIDs: []string{"t"},
+			queries: []config.TideQuery{
+				{
+					Repos: []string{"kubernetes/test-infra", "kubernetes/kubernetes"},
+				},
+				{
+					Repos: []string{"kubernetes/website", "kubernetes/docs"},
+				},
+				{
+					Repos: []string{"kubernetes/apiserver", "kubernetes-security/apiserver"},
+				},
+				{
+					Repos: []string{"tenanted/test"},
+				},
+			},
+			pools: []tide.Pool{
+				{Org: "kubernetes", Repo: "test-infra"},
+				{Org: "kubernetes", Repo: "kubernetes"},
+				{Org: "kubernetes", Repo: "website"},
+				{Org: "kubernetes", Repo: "docs"},
+				{Org: "kubernetes", Repo: "apiserver"},
+				{Org: "kubernetes-security", Repo: "apiserver"},
+				{Org: "tenanted", Repo: "test"},
+				{Org: "clustered-tenant", Repo: "test", TenantIDs: []string{"t"}},
+			},
+			hist: map[string][]history.Record{
+				"kubernetes/test-infra:master":         {{Action: "MERGE"}, {Action: "TRIGGER"}},
+				"kubernetes/website:master":            {{Action: "MERGE_BATCH"}, {Action: "TRIGGER_BATCH"}},
+				"kubernetes-security/apiserver:master": {{Action: "TRIGGER"}, {Action: "MERGE"}},
+				"kubernetes/kubernetes:master":         {{Action: "TRIGGER_BATCH"}, {Action: "MERGE_BATCH"}},
+				"tenanted/test:master":                 {{Action: "TRIGGER_BATCH"}, {Action: "MERGE_BATCH"}},
+				"clustered-tenant/test:master":         {{Action: "TRIGGER_BATCH", TenantIDs: []string{"t"}}, {Action: "MERGE_BATCH"}},
+			},
+
+			expectedQueries: []config.TideQuery{
+				{
+					Repos: []string{"tenanted/test"},
+				},
+			},
+			expectedPools: []tide.Pool{
+				{Org: "tenanted", Repo: "test"},
+				{Org: "clustered-tenant", Repo: "test", TenantIDs: []string{"t"}},
+			},
+			expectedHist: map[string][]history.Record{
+				"tenanted/test:master":         {{Action: "TRIGGER_BATCH"}, {Action: "MERGE_BATCH"}},
+				"clustered-tenant/test:master": {{Action: "TRIGGER_BATCH", TenantIDs: []string{"t"}}, {Action: "MERGE_BATCH"}},
+			},
+		},
+		{
+			name: "hidden repos ignores tenanted",
+			cfg:  exampleConfigNoDefaults,
+			hiddenRepos: []string{
+				"kubernetes-security",
+				"kubernetes/website",
+				"tenanted",
+			},
+			hiddenOnly: true,
+			queries: []config.TideQuery{
+				{
+					Repos: []string{"kubernetes/test-infra", "kubernetes/kubernetes"},
+				},
+				{
+					Repos: []string{"kubernetes/website", "kubernetes/docs"},
+				},
+				{
+					Repos: []string{"kubernetes/apiserver", "kubernetes-security/apiserver"},
+				},
+				{
+					Repos: []string{"tenanted/test"},
+				},
+			},
+			pools: []tide.Pool{
+				{Org: "kubernetes", Repo: "test-infra"},
+				{Org: "kubernetes", Repo: "kubernetes"},
+				{Org: "kubernetes", Repo: "website"},
+				{Org: "kubernetes", Repo: "docs"},
+				{Org: "kubernetes", Repo: "apiserver"},
+				{Org: "kubernetes-security", Repo: "apiserver"},
+				{Org: "tenanted", Repo: "test"},
+				{Org: "clustered-tenant", Repo: "test", TenantIDs: []string{"t"}},
+			},
+			hist: map[string][]history.Record{
+				"kubernetes/test-infra:master":         {{Action: "MERGE", TenantIDs: []string{config.DefaultTenantID}}, {Action: "TRIGGER"}},
+				"kubernetes/website:master":            {{Action: "MERGE_BATCH"}, {Action: "TRIGGER_BATCH"}},
+				"kubernetes-security/apiserver:master": {{Action: "TRIGGER"}, {Action: "MERGE"}},
+				"kubernetes/kubernetes:master":         {{Action: "TRIGGER_BATCH"}, {Action: "MERGE_BATCH"}},
+				"tenanted/test:master":                 {{Action: "TRIGGER_BATCH"}, {Action: "MERGE_BATCH"}},
+			},
+
+			expectedQueries: []config.TideQuery{
+				{
+					Repos: []string{"kubernetes/website", "kubernetes/docs"},
+				},
+				{
+					Repos: []string{"kubernetes/apiserver", "kubernetes-security/apiserver"},
+				},
+				{
+					Repos: []string{"tenanted/test"},
+				},
+			},
+			expectedPools: []tide.Pool{
+				{Org: "kubernetes", Repo: "website"},
+				{Org: "kubernetes-security", Repo: "apiserver"},
+				{Org: "tenanted", Repo: "test"},
+			},
+			expectedHist: map[string][]history.Record{
+				"kubernetes/website:master":            {{Action: "MERGE_BATCH"}, {Action: "TRIGGER_BATCH"}},
+				"kubernetes-security/apiserver:master": {{Action: "TRIGGER"}, {Action: "MERGE"}},
+				"tenanted/test:master":                 {{Action: "TRIGGER_BATCH"}, {Action: "MERGE_BATCH"}},
+			},
+		},
+		{
+			name: "public frontend with default tenantIDs assigned still respects hidden repos",
+
+			hiddenRepos: []string{
+				"kubernetes-security",
+				"kubernetes/website",
+			},
+			hiddenOnly: false,
+			queries: []config.TideQuery{
+				{
+					Repos: []string{"kubernetes/test-infra", "kubernetes/kubernetes"},
+				},
+				{
+					Repos: []string{"kubernetes/website", "kubernetes/docs"},
+				},
+				{
+					Repos: []string{"kubernetes/apiserver", "kubernetes-security/apiserver"},
+				},
+			},
+			pools: []tide.Pool{
+				{Org: "kubernetes", Repo: "test-infra", TenantIDs: []string{config.DefaultTenantID}},
+				{Org: "kubernetes", Repo: "kubernetes", TenantIDs: []string{config.DefaultTenantID}},
+				{Org: "kubernetes", Repo: "website", TenantIDs: []string{config.DefaultTenantID}},
+				{Org: "kubernetes", Repo: "docs", TenantIDs: []string{config.DefaultTenantID}},
+				{Org: "kubernetes", Repo: "apiserver", TenantIDs: []string{config.DefaultTenantID}},
+				{Org: "kubernetes-security", Repo: "apiserver", TenantIDs: []string{config.DefaultTenantID}},
+			},
+			hist: map[string][]history.Record{
+				"kubernetes/test-infra:master":         {{Action: "MERGE", TenantIDs: []string{config.DefaultTenantID}}, {Action: "TRIGGER"}},
+				"kubernetes/website:master":            {{Action: "MERGE_BATCH", TenantIDs: []string{config.DefaultTenantID}}, {Action: "TRIGGER_BATCH"}},
+				"kubernetes-security/apiserver:master": {{Action: "TRIGGER", TenantIDs: []string{config.DefaultTenantID}}, {Action: "MERGE"}},
+				"kubernetes/kubernetes:master":         {{Action: "TRIGGER_BATCH", TenantIDs: []string{config.DefaultTenantID}}, {Action: "MERGE_BATCH"}},
+			},
+
+			expectedQueries: []config.TideQuery{
+				{
+					Repos: []string{"kubernetes/test-infra", "kubernetes/kubernetes"},
+				},
+			},
+			expectedPools: []tide.Pool{
+				{Org: "kubernetes", Repo: "test-infra", TenantIDs: []string{config.DefaultTenantID}},
+				{Org: "kubernetes", Repo: "kubernetes", TenantIDs: []string{config.DefaultTenantID}},
+				{Org: "kubernetes", Repo: "docs", TenantIDs: []string{config.DefaultTenantID}},
+				{Org: "kubernetes", Repo: "apiserver", TenantIDs: []string{config.DefaultTenantID}},
+			},
+			expectedHist: map[string][]history.Record{
+				"kubernetes/test-infra:master": {{Action: "MERGE", TenantIDs: []string{config.DefaultTenantID}}, {Action: "TRIGGER"}},
+				"kubernetes/kubernetes:master": {{Action: "TRIGGER_BATCH", TenantIDs: []string{config.DefaultTenantID}}, {Action: "MERGE_BATCH"}},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -218,6 +698,8 @@ func TestFilterHidden(t *testing.T) {
 			hiddenOnly: test.hiddenOnly,
 			showHidden: test.showHidden,
 			log:        logrus.WithField("agent", "tide"),
+			tenantIDs:  test.tenantIDs,
+			cfg:        test.cfg,
 		}
 
 		gotQueries := ta.filterHiddenQueries(test.queries)

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -647,6 +647,12 @@ func (p *Plank) mergeDefaultDecorationConfig(repo, cluster string, jobDC *prowap
 	return merged
 }
 
+// GetProwJobDefault finds the resolved prowJobDefault config for a given repo and
+// cluster
+func (c *Config) GetProwJobDefault(repo, cluster string) *prowapi.ProwJobDefault {
+	return c.mergeProwJobDefault(repo, cluster, nil)
+}
+
 // GuessDefaultDecorationConfig attempts to find the resolved default decoration
 // config for a given repo and cluster. It is primarily used for best effort
 // guesses about GCS configuration for undecorated jobs.

--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -291,6 +291,17 @@ type TideQuery struct {
 	ExcludedRepos []string `json:"excludedRepos,omitempty"`
 }
 
+func (q TideQuery) TenantIDs(cfg Config) []string {
+	res := sets.String{}
+	for _, org := range q.Orgs {
+		res.Insert(cfg.GetProwJobDefault(org, "*").TenantID)
+	}
+	for _, repo := range q.Repos {
+		res.Insert(cfg.GetProwJobDefault(repo, "*").TenantID)
+	}
+	return res.List()
+}
+
 // tideQueryConfig contains the subset of attributes by which we de-duplicate
 // tide queries. Together with tideQueryTarget it must contain the full set
 // of all TideQuery properties.


### PR DESCRIPTION
Sorry for the long PR, most of the changes are unit tests.
Continuing work for Private repo multi-tenancy
/assign @chaodaiG @cjwagner 
/hold