### PR TITLE
capz: update reviewers to match capz repo

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/OWNERS
@@ -1,6 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+- alexeldeib
 - andyzhangx
 - brendandburns
 - CecileRobertMichon
@@ -11,9 +12,9 @@ approvers:
 - khenidak
 - nader-ziada
 reviewers:
-- alexeldeib
 - cpanato
 - juan-lee
+- mboersma
 - shysank
 
 labels:


### PR DESCRIPTION
Syncs up with recent changes to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/OWNERS_ALIASES

cc: @alexeldeib