### PR TITLE
config/prow: setup milestones for kubernetes-sigs/boskos

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -363,6 +363,8 @@ milestone_applier:
     main: v0.4
     release-0.4: v0.4
     release-0.3: v0.3
+  kubernetes-sigs/boskos:
+    master: v1.23
   kubernetes-sigs/controller-runtime:
     master: v0.10.x
     release-0.9: v0.9.x
@@ -1001,6 +1003,7 @@ plugins:
 
   kubernetes-sigs/boskos:
     plugins:
+    - milestone
     - override
 
   kubernetes-sigs/kind:

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -901,6 +901,7 @@ plugins:
     - label
     - lgtm
     - lifecycle
+    - milestoneapplier
     - owners-label
     - pony
     - retitle


### PR DESCRIPTION
Enable `milestoneapplier` for kubernetes-sigs so that milestones are auto-applied for repos that have it configured

Enable `milestone` for kubernetes-sigs/boskos so contributors can /milestone there

I'm opting not to configure a specific team for `milestone` mainly out of curiosity, I forget if this plugin supports cross-org teams or not, so I'd like to see if it defaults to `@kubernetes/milestone-maintainers`