### PR TITLE
Images/git: Build for ppc64le

### DIFF
--- a/images/git/Dockerfile
+++ b/images/git/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-prow/alpine:v20210618-2814345
+FROM gcr.io/k8s-prow/alpine:v20210818-e6fa606
 
 ARG IMAGE_ARG
 ENV IMAGE=${IMAGE_ARG}

--- a/images/git/cloudbuild.yaml
+++ b/images/git/cloudbuild.yaml
@@ -4,7 +4,7 @@ steps:
     args:
     - build
     - --tag=gcr.io/$PROJECT_ID/git:$_GIT_TAG
-    - --platform=linux/amd64,linux/arm64/v8
+    - --platform=linux/amd64,linux/arm64/v8,linux/ppc64le
     - --build-arg=IMAGE_ARG=gcr.io/$PROJECT_ID/git:$_GIT_TAG
     - --push
     - .


### PR DESCRIPTION
This commit adds a Google Cloud Build definition for building git
ppc64le images and pushing them as a manifest list together with their
ppc64le counterparts.

Blocked on: #23276

/cc @mkumatag 
/cc @stevekuznetsov

rel: #16588 