### PR TITLE
Tide: Set PRs that have a fulfilled query but are not in pool to sucess

### DIFF
--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -283,11 +283,21 @@ func (sc *statusController) expectedStatus(log *logrus.Entry, queryMap *config.Q
 			}
 			return github.StatusError, fmt.Sprintf(statusNotInPool, fmt.Sprintf(" Merging is blocked by issue%s %s.", s, strings.Join(numbers, ", "))), nil
 		}
+
+		// hasFullfilledQuery is a weird state, it means that the PR is not in the pool but should be. It happens when all requirements were fulfilled
+		// at the time the status controller queried GitHub but not at the time the sync controller queried GitHub.
+		// We just fall through to check if there are missing jobs to avoid wasting api tokens by sending it to pending and then to success in the next
+		// sync or status controller iteration.
+		var hasFullfilledQuery bool
+
 		minDiffCount := -1
 		var minDiff string
 		for _, q := range queryMap.ForRepo(repo) {
 			diff, diffCount := requirementDiff(pr, &q, cc)
-			if sc.config().Tide.DisplayAllQueriesInStatus {
+			if diffCount == 0 {
+				hasFullfilledQuery = true
+				break
+			} else if sc.config().Tide.DisplayAllQueriesInStatus {
 				if diffCount >= 2000 {
 					// Query is for wrong branch
 					continue
@@ -304,7 +314,10 @@ func (sc *statusController) expectedStatus(log *logrus.Entry, queryMap *config.Q
 		if sc.config().Tide.DisplayAllQueriesInStatus && minDiff == "" {
 			minDiff = " No Tide query for branch " + string(pr.BaseRef.Name) + " found."
 		}
-		return github.StatusPending, fmt.Sprintf(statusNotInPool, minDiff), nil
+
+		if !hasFullfilledQuery {
+			return github.StatusPending, fmt.Sprintf(statusNotInPool, minDiff), nil
+		}
 	}
 
 	indexKey := indexKeyPassingJobs(repo, baseSHA, string(pr.HeadRefOID))

--- a/prow/tide/status_test.go
+++ b/prow/tide/status_test.go
@@ -235,7 +235,7 @@ func TestExpectedStatus(t *testing.T) {
 			desc:  fmt.Sprintf(statusNotInPool, " Needs 1, 2, 3, 4, 5, 6, 7 labels."),
 		},
 		{
-			name:              "only failed tide context",
+			name:              "tides own context failed but is ignored",
 			labels:            neededLabels,
 			author:            "batman",
 			firstQueryAuthor:  "batman",
@@ -244,8 +244,8 @@ func TestExpectedStatus(t *testing.T) {
 			contexts:          []Context{{Context: githubql.String(statusContext), State: githubql.StatusStateError}},
 			inPool:            false,
 
-			state: github.StatusPending,
-			desc:  fmt.Sprintf(statusNotInPool, ""),
+			state: github.StatusSuccess,
+			desc:  statusInPool,
 		},
 		{
 			name:              "single bad context",
@@ -462,7 +462,19 @@ func TestExpectedStatus(t *testing.T) {
 			desc:  fmt.Sprintf(statusNotInPool, " Must be in milestone v1.0."),
 		},
 		{
-			name:              "unknown requirement",
+			name:              "not in pool, but all requirements are met",
+			labels:            neededLabels,
+			author:            "batman",
+			firstQueryAuthor:  "batman",
+			secondQueryAuthor: "batman",
+			milestone:         "v1.0",
+			inPool:            false,
+
+			state: github.StatusSuccess,
+			desc:  statusInPool,
+		},
+		{
+			name:              "not in pool, but all requirements are met, including a successful third-party context",
 			labels:            neededLabels,
 			author:            "batman",
 			firstQueryAuthor:  "batman",
@@ -471,8 +483,8 @@ func TestExpectedStatus(t *testing.T) {
 			contexts:          []Context{{Context: githubql.String("job-name"), State: githubql.StatusStateSuccess}},
 			inPool:            false,
 
-			state: github.StatusPending,
-			desc:  fmt.Sprintf(statusNotInPool, ""),
+			state: github.StatusSuccess,
+			desc:  statusInPool,
 		},
 		{
 			name:              "check that min diff query is used",


### PR DESCRIPTION
The tide sync and status controller query independently, which means
they might see different results for a given PR. This currently results
in the status controller sending it to "Pending" with a description of
"Not mergeable.". This status will always be overwritten in the next
iteration by either the sync controller when it merges or the status
controller, because it runs after the sync controller which will then
have noticed the change.

This change makes us detect that and not report the "Not mergeable" but
instead continue to the check if all ProwJobs are current and
potentially setting the PR to success.

We noticed this in conjunction with the `DisplayAllQueriesInStatus`
feature, which uses an emptyness check on the description to see if
there is a query which in the above situation resulted in it reporting
that there is no query.

/assign @cjwagner 
to sanitycheck the reasoning