### PR TITLE
Tide: Only set own status to success if its not already set

### DIFF
--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -1257,8 +1257,13 @@ func (c *Controller) mergePRs(sp subpool, prs []PullRequest) error {
 	return fmt.Errorf("failed merging %v%s: %v", failed, batch, utilerrors.NewAggregate(errs))
 }
 
-// setTideStatusSuccess calls github api to change tide status context to success
+// setTideStatusSuccess ensures the tide context is set to success
 func setTideStatusSuccess(pr PullRequest, ghc githubClient, cfg *config.Config, log *logrus.Entry) error {
+	// Do not waste api tokens and risk hitting the 2.5k context limit by setting it to success if it is
+	// already set to success.
+	if prHasSuccessfullTideStatusContext(pr) {
+		return nil
+	}
 	return ghc.CreateStatus(
 		string(pr.Repository.Owner.Login),
 		string(pr.Repository.Name),
@@ -1268,6 +1273,21 @@ func setTideStatusSuccess(pr PullRequest, ghc githubClient, cfg *config.Config, 
 			State:     "success",
 			TargetURL: targetURL(cfg, &pr, log),
 		})
+}
+
+func prHasSuccessfullTideStatusContext(pr PullRequest) bool {
+	for _, commit := range pr.Commits.Nodes {
+		if commit.Commit.OID != pr.HeadRefOID {
+			continue
+		}
+		for _, context := range commit.Commit.Status.Contexts {
+			if strings.EqualFold(string(context.Context), statusContext) {
+				return strings.EqualFold(string(context.State), string(githubql.StatusStateSuccess))
+			}
+		}
+	}
+
+	return false
 }
 
 // tryMerge attempts 1 merge and returns a bool indicating if we should try

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -4635,3 +4635,36 @@ func TestTenantIDs(t *testing.T) {
 		})
 	}
 }
+
+func TestSetTideStatusSuccess(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name string
+		pr   PullRequest
+
+		expectApiCall bool
+	}{
+		{
+			name:          "Status is set",
+			expectApiCall: true,
+		},
+		{
+			name: "PR already has tide status set to success, no api call is made",
+			pr:   PullRequest{Commits: struct{ Nodes []struct{ Commit Commit } }{Nodes: []struct{ Commit Commit }{{Commit: Commit{Status: CommitStatus{Contexts: []Context{{Context: "tide", State: githubql.StatusState("success")}}}}}}}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ghc := &fgc{}
+			err := setTideStatusSuccess(tc.pr, ghc, &config.Config{}, logrus.WithField("test", tc.name))
+			if err != nil {
+				t.Fatalf("failed to set status: %v", err)
+			}
+
+			if ghc.setStatus != tc.expectApiCall {
+				t.Errorf("expected CreateStatusApiCall: %t, got CreateStatusApiCall: %t", tc.expectApiCall, ghc.setStatus)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Currently, we set our own status unconditionally to success prior to
merging. This change makes us skip that if it is already set to success,
e.G. because the status controller did that or we did it ourselve in a
prior iteration (and failed to merge).

Fixes https://github.com/kubernetes/test-infra/issues/22143