### PR TITLE
Ignore folders while loading kuebconfig files

### DIFF
--- a/prow/kube/config.go
+++ b/prow/kube/config.go
@@ -96,6 +96,9 @@ func LoadClusterConfigs(opts *Options) (map[string]rest.Config, error) {
 			return nil, fmt.Errorf("kubecfg dir: %v", err)
 		}
 		for _, file := range files {
+			if file.IsDir() {
+				continue
+			}
 			candidates = append(candidates, filepath.Join(opts.dir, file.Name()))
 		}
 	}


### PR DESCRIPTION
Those `..+` folders are created by k8s if folder is mounted from a secret/configmap.

```
oc exec -n ci deck-7bd8f9f8cf-gtxl8 -- ls -al /etc/build-farm-credentials/
total 0
drwxrwsrwt    3 root     10006600       180 Aug 18 15:21 .
drwxr-xr-x    1 root     root           128 Aug 18 15:21 ..
drwxr-sr-x    2 root     10006600       140 Aug 18 15:21 ..2021_08_18_15_21_01.243299421
lrwxrwxrwx    1 root     10006600        31 Aug 18 15:21 ..data -> ..2021_08_18_15_21_01.243299421
lrwxrwxrwx    1 root     10006600        24 Aug 18 15:21 app.ci.kubeconfig -> ..data/app.ci.kubeconfig
lrwxrwxrwx    1 root     10006600        23 Aug 18 15:21 arm01.kubeconfig -> ..data/arm01.kubeconfig
lrwxrwxrwx    1 root     10006600        25 Aug 18 15:21 build01.kubeconfig -> ..data/build01.kubeconfig
lrwxrwxrwx    1 root     10006600        25 Aug 18 15:21 build02.kubeconfig -> ..data/build02.kubeconfig
lrwxrwxrwx    1 root     10006600        25 Aug 18 15:21 vsphere.kubeconfig -> ..data/vsphere.kubeconfig

```

/cc @stevekuznetsov @alvaroaleman 