### PR TITLE
Ignore file start with double dots while loading kuebconfig files

### DIFF
--- a/prow/kube/config.go
+++ b/prow/kube/config.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
@@ -96,10 +97,16 @@ func LoadClusterConfigs(opts *Options) (map[string]rest.Config, error) {
 			return nil, fmt.Errorf("kubecfg dir: %v", err)
 		}
 		for _, file := range files {
+			filename := file.Name()
 			if file.IsDir() {
+				logrus.WithField("dir", filename).Info("Ignored directory")
 				continue
 			}
-			candidates = append(candidates, filepath.Join(opts.dir, file.Name()))
+			if strings.HasPrefix(filename, "..") {
+				logrus.WithField("filename", filename).Info("Ignored file starting with double dots")
+				continue
+			}
+			candidates = append(candidates, filepath.Join(opts.dir, filename))
 		}
 	}
 


### PR DESCRIPTION
```
lrwxrwxrwx    1 root     10006600        31 Aug 18 15:21 ..data -> ..2021_08_18_15_21_01.243299421
```

My mistake, fell into another one.
The symlink is not recognized as a directory.

Instead of resolving the link and then checking if it is a folder, we simply ignore all files with dotdot as prefix of the name.

/cc @alvaroaleman 