### PR TITLE
Add Workload Metric PodMonitors to parallel existing Prometheus ServiceMonitors.

### DIFF
--- a/config/prow/cluster/crier_deployment.yaml
+++ b/config/prow/cluster/crier_deployment.yaml
@@ -49,6 +49,9 @@ spec:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
           value: "/etc/kubeconfig/config"
+        ports:
+        - name: metrics
+          containerPort: 9090
         volumeMounts:
         - mountPath: /etc/kubeconfig
           name: kubeconfig

--- a/config/prow/cluster/deck_deployment.yaml
+++ b/config/prow/cluster/deck_deployment.yaml
@@ -41,8 +41,10 @@ spec:
         image: gcr.io/k8s-prow/deck:v20210818-b81cb0bc7b
         imagePullPolicy: Always
         ports:
-          - name: http
-            containerPort: 8080
+        - name: http
+          containerPort: 8080
+        - name: metrics
+          containerPort: 9090
         args:
         - --tide-url=http://tide/
         - --hook-url=http://hook:8888/plugin-help

--- a/config/prow/cluster/ghproxy.yaml
+++ b/config/prow/cluster/ghproxy.yaml
@@ -60,7 +60,10 @@ spec:
         - --push-gateway=pushgateway
         - --serve-metrics=true
         ports:
-        - containerPort: 8888
+        - name: main
+          containerPort: 8888
+        - name: metrics
+          containerPort: 9090
         volumeMounts:
         - name: cache
           mountPath: /cache

--- a/config/prow/cluster/hook_deployment.yaml
+++ b/config/prow/cluster/hook_deployment.yaml
@@ -53,8 +53,10 @@ spec:
         - name: KUBECONFIG
           value: "/etc/kubeconfig/config"
         ports:
-          - name: http
-            containerPort: 8888
+        - name: http
+          containerPort: 8888
+        - name: metrics
+          containerPort: 9090
         volumeMounts:
         - name: slack
           mountPath: /etc/slack

--- a/config/prow/cluster/horologium_deployment.yaml
+++ b/config/prow/cluster/horologium_deployment.yaml
@@ -40,6 +40,9 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
+        ports:
+        - name: metrics
+          containerPort: 9090
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/config/prow/cluster/monitoring/BUILD.bazel
+++ b/config/prow/cluster/monitoring/BUILD.bazel
@@ -9,6 +9,7 @@ release(
     component("prometheus_operator_rbac", MULTI_KIND),
     component("prometheus_operator", "deployment"),
     component("prow_servicemonitors", MULTI_KIND),
+    component("prow_podmonitors", MULTI_KIND),
     component("prometheus_rbac", MULTI_KIND),
     component("prow", "prometheus"),
     component("prometheus_expose", MULTI_KIND),

--- a/config/prow/cluster/monitoring/prow_podmonitors.yaml
+++ b/config/prow/cluster/monitoring/prow_podmonitors.yaml
@@ -1,0 +1,176 @@
+# PROW_INSTANCE_SPECIFIC
+# Note that these PodMonitors are GKE Workload Metrics PodMonitors, not Prometheus PodMonitors.
+# The apiversion must be specified to properly interact with these resources in clusters that
+# have both CRDs installed.
+---
+apiVersion: monitoring.gke.io/v1alpha1
+kind: PodMonitor
+metadata:
+  labels:
+    app: deck
+  name: deck
+  namespace: prow-monitoring
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+      - default
+  selector:
+    matchLabels:
+      app: deck
+---
+apiVersion: monitoring.gke.io/v1alpha1
+kind: PodMonitor
+metadata:
+  labels:
+    app: ghproxy
+  name: ghproxy
+  namespace: prow-monitoring
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+      - default
+  selector:
+    matchLabels:
+      app: ghproxy
+---
+apiVersion: monitoring.gke.io/v1alpha1
+kind: PodMonitor
+metadata:
+  labels:
+    app: hook
+  name: hook
+  namespace: prow-monitoring
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - default
+  selector:
+    matchLabels:
+      app: hook
+---
+apiVersion: monitoring.gke.io/v1alpha1
+kind: PodMonitor
+metadata:
+  labels:
+    app: plank
+  name: plank
+  namespace: prow-monitoring
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - default
+  selector:
+    matchLabels:
+      app: prow-controller-manager
+---
+apiVersion: monitoring.gke.io/v1alpha1
+kind: PodMonitor
+metadata:
+  labels:
+    app: sinker
+  name: sinker
+  namespace: prow-monitoring
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - default
+  selector:
+    matchLabels:
+      app: sinker
+---
+apiVersion: monitoring.gke.io/v1alpha1
+kind: PodMonitor
+metadata:
+  labels:
+    app: tide
+  name: tide
+  namespace: prow-monitoring
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - default
+  selector:
+    matchLabels:
+      app: tide
+---
+apiVersion: monitoring.gke.io/v1alpha1
+kind: PodMonitor
+metadata:
+  labels:
+    app: horologium
+  name: horologium
+  namespace: prow-monitoring
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - default
+  selector:
+    matchLabels:
+      app: horologium
+---
+apiVersion: monitoring.gke.io/v1alpha1
+kind: PodMonitor
+metadata:
+  labels:
+    app: crier
+  name: crier
+  namespace: prow-monitoring
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - default
+  selector:
+    matchLabels:
+      app: crier
+---
+apiVersion: monitoring.gke.io/v1alpha1
+kind: PodMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: kubernetes-external-secrets
+    app: kubernetes-external-secrets
+  name: kubernetes-external-secrets
+  namespace: prow-monitoring
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    port: prometheus
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - default
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubernetes-external-secrets

--- a/config/prow/cluster/prow_controller_manager_deployment.yaml
+++ b/config/prow/cluster/prow_controller_manager_deployment.yaml
@@ -44,6 +44,9 @@ spec:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
           value: "/etc/kubeconfig/config"
+        ports:
+        - name: metrics
+          containerPort: 9090
         volumeMounts:
         - mountPath: /etc/kubeconfig
           name: kubeconfig

--- a/config/prow/cluster/sinker_deployment.yaml
+++ b/config/prow/cluster/sinker_deployment.yaml
@@ -27,6 +27,9 @@ spec:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
           value: "/etc/kubeconfig/config"
+        ports:
+        - name: metrics
+          containerPort: 9090
         volumeMounts:
         - mountPath: /etc/kubeconfig
           name: kubeconfig

--- a/config/prow/cluster/tide_deployment.yaml
+++ b/config/prow/cluster/tide_deployment.yaml
@@ -47,6 +47,8 @@ spec:
         ports:
         - name: http
           containerPort: 8888
+        - name: metrics
+          containerPort: 9090
         volumeMounts:
         - name: oauth
           mountPath: /etc/github


### PR DESCRIPTION
[Existing Prometheus ServiceMonitors](https://github.com/kubernetes/test-infra/blob/ee7b4691653361c381b0c0616a5a93042a5aaef0/config/prow/cluster/monitoring/prow_servicemonitors.yaml)
Similar to this PR: https://github.com/GoogleCloudPlatform/oss-test-infra/pull/942

Everything else should be in place so I expect metrics to start showing up in the dashboard after this merges.
/assign @chaodaiG 