### PR TITLE
mv from k/k test/e2e_node/jenkins/ to test-infra jobs/e2e_node/

### DIFF
--- a/jobs/e2e_node/cos-init-live-restore.yaml
+++ b/jobs/e2e_node/cos-init-live-restore.yaml
@@ -1,0 +1,22 @@
+#cloud-config
+
+runcmd:
+  - cp /usr/lib/systemd/system/docker.service /etc/systemd/system/
+  - sed -i -e 's/-s overlay/-s overlay2/g' /etc/systemd/system/docker.service
+  - systemctl daemon-reload
+  - echo '{"live-restore":true}' > /etc/docker/daemon.json
+  - systemctl restart docker
+  - mount /tmp /tmp -o remount,exec,suid
+  - usermod -a -G docker jenkins
+  - mkdir -p /var/lib/kubelet
+  - mkdir -p /home/kubernetes/containerized_mounter/rootfs
+  - mount --bind /home/kubernetes/containerized_mounter/ /home/kubernetes/containerized_mounter/
+  - mount -o remount, exec /home/kubernetes/containerized_mounter/
+  - wget https://dl.k8s.io/gci-mounter/mounter.tar -O /tmp/mounter.tar
+  - tar xvf /tmp/mounter.tar -C /home/kubernetes/containerized_mounter/rootfs
+  - mkdir -p /home/kubernetes/containerized_mounter/rootfs/var/lib/kubelet
+  - mount --rbind /var/lib/kubelet /home/kubernetes/containerized_mounter/rootfs/var/lib/kubelet
+  - mount --make-rshared /home/kubernetes/containerized_mounter/rootfs/var/lib/kubelet
+  - mount --bind /proc /home/kubernetes/containerized_mounter/rootfs/proc
+  - mount --bind /dev /home/kubernetes/containerized_mounter/rootfs/dev
+  - rm /tmp/mounter.tar

--- a/jobs/e2e_node/gci-init-gpu.yaml
+++ b/jobs/e2e_node/gci-init-gpu.yaml
@@ -1,0 +1,19 @@
+#cloud-config
+
+runcmd:
+  - modprobe configs
+  - docker run -v /dev:/dev -v /home/kubernetes/bin/nvidia:/rootfs/nvidia -v /etc/os-release:/rootfs/etc/os-release -v /proc/sysrq-trigger:/sysrq -e BASE_DIR=/rootfs/nvidia --privileged k8s.gcr.io/cos-nvidia-driver-install@sha256:cb55c7971c337fece62f2bfe858662522a01e43ac9984a2dd1dd5c71487d225c
+  - mount /tmp /tmp -o remount,exec,suid
+  - usermod -a -G docker jenkins
+  - mkdir -p /var/lib/kubelet
+  - mkdir -p /home/kubernetes/containerized_mounter/rootfs
+  - mount --bind /home/kubernetes/containerized_mounter/ /home/kubernetes/containerized_mounter/
+  - mount -o remount, exec /home/kubernetes/containerized_mounter/
+  - wget https://dl.k8s.io/gci-mounter/mounter.tar -O /tmp/mounter.tar
+  - tar xvf /tmp/mounter.tar -C /home/kubernetes/containerized_mounter/rootfs
+  - mkdir -p /home/kubernetes/containerized_mounter/rootfs/var/lib/kubelet
+  - mount --rbind /var/lib/kubelet /home/kubernetes/containerized_mounter/rootfs/var/lib/kubelet
+  - mount --make-rshared /home/kubernetes/containerized_mounter/rootfs/var/lib/kubelet
+  - mount --bind /proc /home/kubernetes/containerized_mounter/rootfs/proc
+  - mount --bind /dev /home/kubernetes/containerized_mounter/rootfs/dev
+  - rm /tmp/mounter.tar

--- a/jobs/e2e_node/gci-init.yaml
+++ b/jobs/e2e_node/gci-init.yaml
@@ -1,0 +1,17 @@
+#cloud-config
+
+runcmd:
+  - mount /tmp /tmp -o remount,exec,suid
+  - usermod -a -G docker jenkins
+  - mkdir -p /var/lib/kubelet
+  - mkdir -p /home/kubernetes/containerized_mounter/rootfs
+  - mount --bind /home/kubernetes/containerized_mounter/ /home/kubernetes/containerized_mounter/
+  - mount -o remount, exec /home/kubernetes/containerized_mounter/
+  - wget https://dl.k8s.io/gci-mounter/mounter.tar -O /tmp/mounter.tar
+  - tar xvf /tmp/mounter.tar -C /home/kubernetes/containerized_mounter/rootfs
+  - mkdir -p /home/kubernetes/containerized_mounter/rootfs/var/lib/kubelet
+  - mount --rbind /var/lib/kubelet /home/kubernetes/containerized_mounter/rootfs/var/lib/kubelet
+  - mount --make-rshared /home/kubernetes/containerized_mounter/rootfs/var/lib/kubelet
+  - mount --bind /proc /home/kubernetes/containerized_mounter/rootfs/proc
+  - mount --bind /dev /home/kubernetes/containerized_mounter/rootfs/dev
+  - rm /tmp/mounter.tar

--- a/jobs/e2e_node/image-config-serial-cpu-manager.yaml
+++ b/jobs/e2e_node/image-config-serial-cpu-manager.yaml
@@ -10,6 +10,6 @@ images:
   cos-stable1:
     image_family: cos-81-lts # docker v19.03.6, deprecated after 2021-06-24
     project: cos-cloud
-    metadata: "user-data<test/e2e_node/jenkins/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"
+    metadata: "user-data</workspace/test-infra/jobs/e2e_node/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"
     # Using `n1-standard-4` to enable CPU manager node e2e tests.
     machine: n1-standard-4

--- a/jobs/e2e_node/image-config-serial.yaml
+++ b/jobs/e2e_node/image-config-serial.yaml
@@ -10,7 +10,7 @@ images:
     image_family: cos-81-lts # deprecated after 2021-06-24
     project: cos-cloud
     machine: n1-standard-2 # These tests need a lot of memory
-    metadata: "user-data<test/e2e_node/jenkins/gci-init-gpu.yaml,gci-update-strategy=update_disabled"
+    metadata: "user-data</workspace/test-infra/jobs/e2e_node/gci-init-gpu.yaml,gci-update-strategy=update_disabled"
     resources:
       accelerators:
         - type: nvidia-tesla-k80
@@ -19,4 +19,4 @@ images:
     image_family: cos-89-lts # deprecated after 2021-12-17
     project: cos-cloud
     machine: n1-standard-2 # These tests need a lot of memory
-    metadata: "user-data<test/e2e_node/jenkins/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"
+    metadata: "user-data</workspace/test-infra/jobs/e2e_node/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/image-config.yaml
+++ b/jobs/e2e_node/image-config.yaml
@@ -8,8 +8,8 @@ images:
   cos-stable1:
     image_family: cos-89-lts
     project: cos-cloud
-    metadata: "user-data<test/e2e_node/jenkins/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"
+    metadata: "user-data</workspace/test-infra/jobs/e2e_node/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"
   cos-stable2:
     image_family: cos-81-lts
     project: cos-cloud
-    metadata: "user-data<test/e2e_node/jenkins/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"
+    metadata: "user-data</workspace/test-infra/jobs/e2e_node/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/perf-image-config.yaml
+++ b/jobs/e2e_node/perf-image-config.yaml
@@ -4,7 +4,7 @@ images:
     image_family: cos-89-lts
     project: cos-cloud
     machine: n1-standard-16
-    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
+    metadata: "user-data</workspace/test-infra/jobs/e2e_node/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'Node Performance Testing'
   ubuntu:


### PR DESCRIPTION
 /cc @cynepco3hahue
Follow up of https://github.com/kubernetes/kubernetes/pull/99606

> You can check all yaml in use here - https://github.com/kubernetes/test-infra/tree/master/jobs/e2e_node
> for example https://github.com/kubernetes/test-infra/blob/c3498c0da35fccae2d803a6aa356a638dcb0d6a4/jobs/e2e_node/image-config-serial-cpu-manager.yaml#L13
> In general it can be nice to create a PR for the test infra to move all relevant yamls under it, similar to - https://github.com/kubernetes/test-infra/blob/c3498c0da35fccae2d803a6aa356a638dcb0d6a4/jobs/e2e_node/image-config-serial-hugepages.yaml#L8