### PR TITLE
Fix ci-build-and-push-k8s-at-golang-tip-canary job

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/canaries/sig-scalability.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/canaries/sig-scalability.yaml
@@ -405,7 +405,7 @@ periodics:
     testgrid-tab-name: build-and-push-k8s-at-golang-tip-canary
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+    - image: gcr.io/k8s-testimages/bootstrap:v20210709-5168b64
       command:
       - runner.sh
       - bash


### PR DESCRIPTION
The reason for consistent failures of the canary job was that it leveraged `kubekins-e2e` image in the config instead of `bootstrap`. `kubekins-e2e` has Go installation that conflicts with the [scripts](https://github.com/kubernetes/perf-tests/tree/master/golang) used in the job that install a custom Go version instead. This is why `bootstrap` was picked as the job's container image in the first place as it doesn't install Go at all.

I tested this change on my local Prow instance and it works correctly.

Fixes https://github.com/kubernetes/perf-tests/issues/1861.

/cc @ameukam 
/assign @spiffxp 