### PR TITLE
Add cloud-provider-openstack e2e for openstack-cloud-controller-manager

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-openstack/OWNERS
+++ b/config/jobs/kubernetes/cloud-provider-openstack/OWNERS
@@ -2,8 +2,12 @@
 
 reviewers:
 - dims
+- lingxiankong
+- ramineni
+- jichenjc
 approvers:
 - dims
+- lingxiankong
 labels:
 - sig/cloud-provider
 - area/provider/openstack

--- a/config/jobs/kubernetes/cloud-provider-openstack/release-master-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/release-master-presubmits.yaml
@@ -1,0 +1,36 @@
+presubmits:
+  kubernetes/cloud-provider-openstack:
+  - name: openstack-cloud-controller-manager-e2e-test
+    labels:
+      preset-service-account: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    path_alias: "k8s.io/cloud-provider-openstack"
+    always_run: false
+    branches:
+      - ^main$
+    run_if_changed: '^(pkg\/openstack\/|cmd\/openstack-cloud-controller-manager\/|tests\/e2e\/cloudprovider\/)'
+    optional: false
+    decorate: true
+    decoration_config:
+      timeout: 3h
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+          env:
+          - name: "BOSKOS_HOST"
+            value: "boskos.test-pods.svc.cluster.local"
+          command:
+          - "runner.sh"
+          - "./tests/ci-occm-e2e.sh"
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: 1
+    annotations:
+      testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
+      testgrid-tab-name: presubmit-e2e-test

--- a/config/testgrids/conformance/conformance-all.yaml
+++ b/config/testgrids/conformance/conformance-all.yaml
@@ -102,9 +102,6 @@ dashboards:
     - name: periodic-master
       description: Runs conformance tests using kubetest against latest kubernetes master with cloud-provider-openstack
       test_group_name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance
-    - name: periodic-v1.18
-      description: Runs conformance tests using kubetest against kubernetes v1.18 with cloud-provider-openstack
-      test_group_name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.18
     - name: periodic-v1.19
       description: Runs conformance tests using kubetest against kubernetes v1.19 with cloud-provider-openstack
       test_group_name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.19

--- a/config/testgrids/kubernetes/sig-cloud-provider/openstack/config.yaml
+++ b/config/testgrids/kubernetes/sig-cloud-provider/openstack/config.yaml
@@ -2,6 +2,7 @@ dashboard_groups:
 - name: provider-openstack
   dashboard_names:
     - provider-openstack-cloud-provider-openstack
+    - provider-openstack-openstack-cloud-controller-manager
 
 dashboards:
 - name: provider-openstack-cloud-provider-openstack
@@ -9,11 +10,6 @@ dashboards:
     - name: presubmit-master
       description: Runs conformance tests using kubetest against latest kubernetes master with cloud-provider-openstack
       test_group_name: ci-presubmit-cloud-provider-openstack-acceptance-test-e2e-conformance
-      alert_options:
-        alert_mail_to_addresses: provider.openstack+testgrid@gmail.com
-    - name: presubmit-v1.18
-      description: Runs conformance tests using kubetest against kubernetes v1.18 with cloud-provider-openstack
-      test_group_name: ci-presubmit-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.18
       alert_options:
         alert_mail_to_addresses: provider.openstack+testgrid@gmail.com
     - name: presubmit-v1.19
@@ -31,11 +27,6 @@ dashboards:
       test_group_name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance
       alert_options:
         alert_mail_to_addresses: provider.openstack+testgrid@gmail.com
-    - name: periodic-v1.18
-      description: Runs conformance tests using kubetest against kubernetes v1.18 with cloud-provider-openstack
-      test_group_name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.18
-      alert_options:
-        alert_mail_to_addresses: provider.openstack+testgrid@gmail.com
     - name: periodic-v1.19
       description: Runs conformance tests using kubetest against kubernetes v1.19 with cloud-provider-openstack
       test_group_name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.19
@@ -46,15 +37,11 @@ dashboards:
       test_group_name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.20
       alert_options:
         alert_mail_to_addresses: provider.openstack+testgrid@gmail.com
+- name: provider-openstack-openstack-cloud-controller-manager
 
 test_groups:
 - name: ci-presubmit-cloud-provider-openstack-acceptance-test-e2e-conformance
   gcs_prefix: k8s-conform-provider-openstack/pr-logs/ci-cloud-provider-openstack-acceptance-test-e2e-conformance
-  alert_stale_results_hours: 24
-  num_failures_to_alert: 1
-  disable_prowjob_analysis: true
-- name: ci-presubmit-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.18
-  gcs_prefix: k8s-conform-provider-openstack/pr-logs/ci-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.18
   alert_stale_results_hours: 24
   num_failures_to_alert: 1
   disable_prowjob_analysis: true
@@ -70,11 +57,6 @@ test_groups:
   disable_prowjob_analysis: true
 - name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance
   gcs_prefix: k8s-conform-provider-openstack/periodic-logs/ci-cloud-provider-openstack-acceptance-test-e2e-conformance
-  alert_stale_results_hours: 24
-  num_failures_to_alert: 1
-  disable_prowjob_analysis: true
-- name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.18
-  gcs_prefix: k8s-conform-provider-openstack/periodic-logs/ci-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.18
   alert_stale_results_hours: 24
   num_failures_to_alert: 1
   disable_prowjob_analysis: true


### PR DESCRIPTION
This is the first commit for migrating the CI tests from OpenLab to Kubernetes Prow for cloud-provider-openstack.

There are a couple of binaries in cloud-provider-openstack. Specifically, this PR is to add a CI job to run functional test for openstack-cloud-controller-manager.

/cc @jichenjc @ramineni