### PR TITLE
Allow /approve to be misspelled as /approved

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -3,6 +3,7 @@
 ## New features
 
 New features added to each component:
+  - *August 27th, 2021* The prow `approve` plugin now accepts `/approved` as a synonym for `/approve`.
   - *August 24, 2021* Postsubmit Prow jobs now support the `always_run` field.
     This field interacts with the `run_if_changed` and `skip_if_only_changed`
     fields as follows:

--- a/prow/plugins/approve/approve.go
+++ b/prow/plugins/approve/approve.go
@@ -40,11 +40,12 @@ const (
 	// PluginName defines this plugin's registered name.
 	PluginName = "approve"
 
-	approveCommand       = "APPROVE"
-	cancelArgument       = "cancel"
-	lgtmCommand          = "LGTM"
-	noIssueArgument      = "no-issue"
-	removeApproveCommand = "REMOVE-APPROVE"
+	approveCommand          = "APPROVE"
+	alternateApproveCommand = "APPROVED"
+	cancelArgument          = "cancel"
+	lgtmCommand             = "LGTM"
+	noIssueArgument         = "no-issue"
+	removeApproveCommand    = "REMOVE-APPROVE"
 )
 
 var (
@@ -530,7 +531,7 @@ func isApprovalCommand(isBot func(string) bool, lgtmActsAsApprove bool, c *comme
 
 	for _, match := range commandRegex.FindAllStringSubmatch(c.Body, -1) {
 		cmd := strings.ToUpper(match[1])
-		if (cmd == lgtmCommand && lgtmActsAsApprove) || cmd == approveCommand || cmd == removeApproveCommand {
+		if (cmd == lgtmCommand && lgtmActsAsApprove) || cmd == approveCommand || cmd == alternateApproveCommand || cmd == removeApproveCommand {
 			return true
 		}
 	}
@@ -606,7 +607,7 @@ func addApprovers(approversHandler *approvers.Approvers, approveComments []*comm
 				approversHandler.RemoveApprover(c.Author)
 				continue
 			}
-			if name != approveCommand && name != lgtmCommand {
+			if name != approveCommand && name != alternateApproveCommand && name != lgtmCommand {
 				continue
 			}
 			args := strings.ToLower(strings.TrimSpace(match[2]))
@@ -623,7 +624,7 @@ func addApprovers(approversHandler *approvers.Approvers, approveComments []*comm
 				)
 			}
 
-			if name == approveCommand {
+			if name == approveCommand || name == alternateApproveCommand {
 				approversHandler.AddApprover(
 					c.Author,
 					c.HTMLURL,

--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -1520,6 +1520,19 @@ func TestHandleGenericComment(t *testing.T) {
 			lgtmActsAsApprove: true,
 			expectHandle:      true,
 		},
+		{
+			name: "misspelled /approve as /approved, but whatever",
+			commentEvent: github.GenericCommentEvent{
+				Action: github.GenericCommentActionCreated,
+				IsPR:   true,
+				Body:   "/approved",
+				Number: 1,
+				User: github.User{
+					Login: "author",
+				},
+			},
+			expectHandle: true,
+		},
 	}
 
 	var handled bool


### PR DESCRIPTION
Tim did this [here](https://github.com/kubernetes/kubernetes/pull/95768#pullrequestreview-638066179) a while back and then Clayton just did it twice [here](https://github.com/openshift/origin/pull/26369#issuecomment-899554796) and [here](https://github.com/openshift/origin/pull/26351#issuecomment-899554605), and those are just ones I know about... (It doesn't seem to be possible to search PRs for the string "`/approved`"; github just ignores the slash.)

Anyway, a modest proposal.
(This intentionally does not change any of the documentation, though maybe it ought to be mentioned *somewhere*?)