### PR TITLE
kube.Options: add NoInClusterConfig

### DIFF
--- a/prow/kube/config.go
+++ b/prow/kube/config.go
@@ -134,6 +134,9 @@ func LoadClusterConfigs(opts *Options) (map[string]rest.Config, error) {
 		}
 	}
 
+	if opts.noInClusterConfig {
+		return allKubeCfgs, nil
+	}
 	return mergeConfigs(localCfg, allKubeCfgs, currentContext)
 }
 
@@ -142,6 +145,7 @@ type Options struct {
 	file               string
 	dir                string
 	projectedTokenFile string
+	noInClusterConfig  bool
 }
 
 type ConfigOptions func(*Options)
@@ -164,6 +168,13 @@ func ConfigFile(file string) ConfigOptions {
 func ConfigProjectedTokenFile(projectedTokenFile string) ConfigOptions {
 	return func(kc *Options) {
 		kc.projectedTokenFile = projectedTokenFile
+	}
+}
+
+// noInClusterConfig indicates that there is no InCluster Config to load
+func NoInClusterConfig(noInClusterConfig bool) ConfigOptions {
+	return func(kc *Options) {
+		kc.noInClusterConfig = noInClusterConfig
 	}
 }
 

--- a/prow/kube/config_test.go
+++ b/prow/kube/config_test.go
@@ -120,6 +120,7 @@ func TestLoadClusterConfigs(t *testing.T) {
 		kubeconfig         string
 		kubeconfigDir      string
 		projectedTokenFile string
+		noInClusterConfig  bool
 		expected           map[string]rest.Config
 		expectedErr        bool
 	}{
@@ -219,12 +220,37 @@ func TestLoadClusterConfigs(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:              "no inCluster config",
+			kubeconfig:        filepath.Join(filepath.Join("testdata", "load_from_kubeconfig"), "kubeconfig2"),
+			kubeconfigDir:     filepath.Join("testdata", "no_inCluster_config"),
+			noInClusterConfig: true,
+			expected: map[string]rest.Config{
+				"app.ci": {
+					Host:        "https://api.ci.l2s4.p1.openshiftapps.com:6443",
+					BearerToken: "REDACTED",
+				},
+				"build01": {
+					Host:        "https://api.build01.ci.devcluster.openshift.com:6443",
+					BearerToken: "REDACTED",
+				},
+				"build02": {
+					Host:        "https://api.build02.gcp.ci.openshift.org:6443",
+					BearerToken: "REDACTED",
+				},
+				"hive": {
+					Host:        "https://api.hive.9xw5.p1.openshiftapps.com:6443",
+					BearerToken: "REDACTED",
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			actual, actualErr := LoadClusterConfigs(NewConfig(ConfigFile(tc.kubeconfig),
-				ConfigDir(tc.kubeconfigDir), ConfigProjectedTokenFile(tc.projectedTokenFile)))
+				ConfigDir(tc.kubeconfigDir), ConfigProjectedTokenFile(tc.projectedTokenFile),
+				NoInClusterConfig(tc.noInClusterConfig)))
 			if tc.expectedErr != (actualErr != nil) {
 				t.Errorf("%s: actualErr %v does not match expectedErr %v", tc.name, actualErr, tc.expectedErr)
 				return

--- a/prow/kube/testdata/no_inCluster_config/kubeconfig
+++ b/prow/kube/testdata/no_inCluster_config/kubeconfig
@@ -1,0 +1,29 @@
+apiVersion: v1
+clusters:
+  - cluster:
+      server: https://api.build01.ci.devcluster.openshift.com:6443
+    name: api-build01-ci-devcluster-openshift-com:6443
+  - cluster:
+      server: https://api.hive.9xw5.p1.openshiftapps.com:6443
+    name: api-hive-9xw5-p1-openshiftapps-com:6443
+contexts:
+  - context:
+      cluster: api-build01-ci-devcluster-openshift-com:6443
+      namespace: hongkliu-test
+      user: hongkailiu/api-build01-ci-devcluster-openshift-com:6443
+    name: build01
+  - context:
+      cluster: api-hive-9xw5-p1-openshiftapps-com:6443
+      namespace: hongkliu-test
+      user: hongkliu/api-hive-9xw5-p1-openshiftapps-com:6443
+    name: hive
+current-context: build01
+kind: Config
+preferences: {}
+users:
+  - name: hongkailiu/api-build01-ci-devcluster-openshift-com:6443
+    user:
+      token: REDACTED
+  - name: hongkliu/api-hive-9xw5-p1-openshiftapps-com:6443
+    user:
+      token: REDACTED


### PR DESCRIPTION
Where I plan to use this:

https://github.com/openshift/ci-tools/blob/a155604fa72d4034d15c7ef78ad82dd394cbcbf4/pkg/util/client.go#L52-L69

Then we do not need to copy the same code over there.
I will modify the function's signature, removing the current context. No references of it except a unit test.

/cc @alvaroaleman @stevekuznetsov 