### PR TITLE
Remove double listed release-blocking jobs.

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -5,7 +5,7 @@ periodics:
   annotations:
     fork-per-release: "true"
     fork-per-release-periodic-interval: 1h 2h 6h 24h
-    testgrid-dashboards: sig-release-master-blocking, sig-node-kubelet, sig-node-release-blocking
+    testgrid-dashboards: sig-release-master-blocking, sig-node-release-blocking
     testgrid-tab-name: node-kubelet-master
     testgrid-alert-email: kubernetes-sig-node+testgrid@googlegroups.com,kubernetes-sig-node-test-failures@googlegroups.com
     description: "Uses kubetest to run a subset of node-e2e tests (+NodeConformance, -Flaky|Serial)"
@@ -242,7 +242,7 @@ periodics:
           cpu: 4
           memory: 6Gi
   annotations:
-    testgrid-dashboards: sig-release-master-informing, sig-node-kubelet, sig-node-release-blocking
+    testgrid-dashboards: sig-release-master-informing, sig-node-release-blocking
     testgrid-tab-name: node-kubelet-serial-containerd
     testgrid-alert-email: kubernetes-sig-node+testgrid@googlegroups.com,kubernetes-sig-node-test-failures@googlegroups.com
     description: "Uses kubetest to run serial node-e2e tests (+Serial, -Flaky|Benchmark|Node*Feature)"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -80,7 +80,7 @@ periodics:
 - annotations:
     fork-per-release-periodic-interval: ""
     testgrid-alert-email: kubernetes-sig-node+testgrid@googlegroups.com,kubernetes-sig-node-test-failures@googlegroups.com
-    testgrid-dashboards: sig-release-1.19-blocking, sig-node-kubelet, sig-node-release-blocking
+    testgrid-dashboards: sig-release-1.19-blocking, sig-node-release-blocking
     testgrid-tab-name: node-kubelet-1.19
   cluster: k8s-infra-prow-build
   interval: 24h

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
@@ -79,7 +79,7 @@ periodics:
 - annotations:
     fork-per-release-periodic-interval: 24h
     testgrid-alert-email: kubernetes-sig-node+testgrid@googlegroups.com,kubernetes-sig-node-test-failures@googlegroups.com
-    testgrid-dashboards: sig-release-1.20-blocking, sig-node-kubelet, sig-node-release-blocking
+    testgrid-dashboards: sig-release-1.20-blocking, sig-node-release-blocking
     testgrid-tab-name: node-kubelet-1.20
   cluster: k8s-infra-prow-build
   interval: 6h

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.21.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.21.yaml
@@ -123,7 +123,7 @@ periodics:
 - annotations:
     fork-per-release-periodic-interval: 6h 24h
     testgrid-alert-email: kubernetes-sig-node+testgrid@googlegroups.com,kubernetes-sig-node-test-failures@googlegroups.com
-    testgrid-dashboards: sig-release-1.21-blocking, sig-node-kubelet, sig-node-release-blocking
+    testgrid-dashboards: sig-release-1.21-blocking, sig-node-release-blocking
     testgrid-tab-name: node-kubelet-1.21
   cluster: k8s-infra-prow-build
   interval: 2h

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml
@@ -123,7 +123,7 @@ periodics:
 - annotations:
     fork-per-release-periodic-interval: 2h 6h 24h
     testgrid-alert-email: kubernetes-sig-node+testgrid@googlegroups.com,kubernetes-sig-node-test-failures@googlegroups.com
-    testgrid-dashboards: sig-release-1.22-blocking, sig-node-kubelet, sig-node-release-blocking
+    testgrid-dashboards: sig-release-1.22-blocking, sig-node-release-blocking
     testgrid-tab-name: node-kubelet-1.22
   cluster: k8s-infra-prow-build
   interval: 1h


### PR DESCRIPTION
This PR removes double listed jobs (from sig-node-kubelet) which were present in both `sig-node-release-blocking` and `sig-node-kubelet` dashboards.
#23231 

Signed-off-by: Rayan Das <rayandas91@gmail.com>