### PR TITLE
Switch to go1.17 for security-profiles-operator jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/security-profiles-operator/seccomp-operator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/security-profiles-operator/seccomp-operator-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
       testgrid-create-test-group: 'true'
     spec:
       containers:
-      - image: golang:1.16
+      - image: golang:1.17
         command:
         - hack/pull-security-profiles-operator-build
 
@@ -20,7 +20,7 @@ presubmits:
       testgrid-create-test-group: 'true'
     spec:
       containers:
-      - image: golang:1.16
+      - image: golang:1.17
         command:
         - hack/pull-security-profiles-operator-verify
 
@@ -32,7 +32,7 @@ presubmits:
       testgrid-create-test-group: 'true'
     spec:
       containers:
-      - image: golang:1.16
+      - image: golang:1.17
         command:
         - hack/pull-security-profiles-operator-test-unit
 


### PR DESCRIPTION
Using the go 1.17 images for the CI jobs.