### PR TITLE
Kubetest - add option for providing pre- and post-test commands

### DIFF
--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -164,6 +164,12 @@ func run(deploy deployer, o options) error {
 	if dumpPreTestLogs != "" {
 		errs = append(errs, dumpRemoteLogs(deploy, o, dumpPreTestLogs, "pre-test")...)
 	}
+	if o.preTestCmd != "" {
+		errs = util.AppendError(errs, control.XMLWrap(&suite, "pre-test command", func() error {
+			cmdLineTokenized := strings.Fields(os.ExpandEnv(o.preTestCmd))
+			return control.FinishRunning(exec.Command(cmdLineTokenized[0], cmdLineTokenized[1:]...))
+		}))
+	}
 
 	testArgs := argFields(o.testArgs, dump, o.clusterIPRange)
 	if o.test {
@@ -302,6 +308,13 @@ func run(deploy deployer, o options) error {
 			}
 			log.Printf("Set %s version to %s", o.publish, string(v))
 			return gcsWrite(o.publish, v)
+		}))
+	}
+
+	if o.postTestCmd != "" {
+		errs = util.AppendError(errs, control.XMLWrap(&suite, "post-test command", func() error {
+			cmdLineTokenized := strings.Fields(os.ExpandEnv(o.postTestCmd))
+			return control.FinishRunning(exec.Command(cmdLineTokenized[0], cmdLineTokenized[1:]...))
 		}))
 	}
 

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -106,6 +106,8 @@ type options struct {
 	nodeTestArgs            string
 	nodeTests               bool
 	outputDir               string
+	preTestCmd              string
+	postTestCmd             string
 	provider                string
 	publish                 string
 	runtimeConfig           string
@@ -173,6 +175,8 @@ func defineFlags() *options {
 	flag.StringVar(&o.nodeTestArgs, "node-test-args", "", "Test args specifically for node e2e tests.")
 	flag.BoolVar(&o.noAllowDup, "no-allow-dup", false, "if set --allow-dup will not be passed to push-build and --stage will error if the build already exists on the gcs path")
 	flag.BoolVar(&o.nodeTests, "node-tests", false, "If true, run node-e2e tests.")
+	flag.StringVar(&o.preTestCmd, "pre-test-cmd", "", "If set, run the provided command before running any tests.")
+	flag.StringVar(&o.postTestCmd, "post-test-cmd", "", "If set, run the provided command after running all the tests.")
 	flag.StringVar(&o.provider, "provider", "", "Kubernetes provider such as gce, gke, aws, etc")
 	flag.StringVar(&o.publish, "publish", "", "Publish version to the specified gs:// path on success")
 	flag.StringVar(&o.runtimeConfig, "runtime-config", "", "If set, API versions can be turned on or off while bringing up the API server.")


### PR DESCRIPTION
Add a way of executing optional pre- and post-test commands. These might be useful when one wants to inject some logic around the test that is independent of the test itself.

/assign @jkaniuk