### PR TITLE
test images: Adds windows-servercore-cache postsubmit job

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-e2e-test-images.sh
+++ b/config/jobs/image-pushing/k8s-staging-e2e-test-images.sh
@@ -51,6 +51,7 @@ readonly IMAGES=(
     volume/rbd
     volume/nfs
     volume/gluster
+    windows-servercore-cache
 )
 
 cat >"${OUTPUT}" <<EOF

--- a/config/jobs/image-pushing/k8s-staging-e2e-test-images.yaml
+++ b/config/jobs/image-pushing/k8s-staging-e2e-test-images.yaml
@@ -1328,6 +1328,45 @@ postsubmits:
               # We override that with the volume/gluster image.
               - name: WHAT
                 value: "volume/gluster"
+    - name: post-kubernetes-push-e2e-windows-servercore-cache-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-testing-images, wg-k8s-infra-gcb
+      decorate: true
+      # we only need to run if the test images have been changed.
+      run_if_changed: '^test\/images\/windows-servercore-cache\/'
+      branches:
+        - ^master$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20210622-762366a
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR
+              # images are pushed to.
+              - --project=k8s-staging-e2e-test-images
+              # This is the same as above, but with -gcb appended.
+              - --scratch-bucket=gs://k8s-staging-e2e-test-images-gcb
+              - --env-passthrough=PULL_BASE_REF,PULL_BASE_SHA,WHAT
+              - --build-dir=.
+              - test/images
+            env:
+              # By default, the E2E test image's WHAT is all-conformance.
+              # We override that with the windows-servercore-cache image.
+              - name: WHAT
+                value: "windows-servercore-cache"
 
 periodics:
   # NOTE(claudiub): The base image for the Windows E2E test images is nanoserver.


### PR DESCRIPTION
The job that's currently building the windows-servercore image is periodic (once per month), but we have recently added support for Windows Server 2022 for it, and we need a way to trigger the job.