### PR TITLE
kubekins/krte: Build go1.17 variants and bump 1.22 version marker

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -29,7 +29,7 @@ variants:
   '1.22':
     CONFIG: '1.22'
     GO_VERSION: 1.16.7
-    K8S_RELEASE: latest-1.22
+    K8S_RELEASE: stable-1.22
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.21':

--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -9,7 +9,7 @@ variants:
     UPGRADE_DOCKER: 'true'
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.17rc2
+    GO_VERSION: 1.17
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
@@ -22,7 +22,7 @@ variants:
     KIND_VERSION: 0.10.0
   master:
     CONFIG: master
-    GO_VERSION: 1.16.7
+    GO_VERSION: 1.17
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
Needed for https://github.com/kubernetes/kubernetes/pull/103692.
go1.17 tracking: https://github.com/kubernetes/release/issues/2169

- Build go1.17 variants
- Bump 1.22 version marker to `stable-1.22`

Signed-off-by: Stephen Augustus <foo@auggie.dev>