### PR TITLE
wg-k8s-infra: fix typos for canary sig-scalability jobs

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/canaries/sig-scalability.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/canaries/sig-scalability.yaml
@@ -172,7 +172,7 @@ periodics:
       args:
       - --cluster=kubemark-500
       - --extract=ci/latest
-      - --gcp-master-size=n1-standard-4
+      - --gcp-master-size=e2-standard-4
       - --gcp-node-image=gci
       - --gcp-node-size=e2-standard-8
       - --gcp-nodes=8
@@ -464,7 +464,7 @@ periodics:
       - --env=CL2_LOAD_TEST_THROUGHPUT=50
       - --env=KUBEMARK_CONTROLLER_MANAGER_TEST_ARGS=--profiling --kube-api-qps=200 --kube-api-burst=200
       - --env=KUBEMARK_SCHEDULER_TEST_ARGS=--profiling --kube-api-qps=200 --kube-api-burst=200
-      - --extract=gs://k8ss-infra-scale-golang-builds/ci/latest-1.18.txt
+      - --extract=gs://k8s-infra-scale-golang-builds/ci/latest-1.18.txt
       - --gcp-node-size=e2-standard-8
       - --gcp-nodes=50
       - --gcp-project=k8s-infra-e2e-scale-5k-project
@@ -564,7 +564,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=540m
         - --use-logexporter
-        - --logexporter-gcs-path=gs://sig-scalability-logs/$(JOB_NAME)/$(BUILD_ID)
+        - --logexporter-gcs-path=gs://k8s-infra-scalability-tests-logs/$(JOB_NAME)/$(BUILD_ID)
         resources:
           limits:
             # Using 6 CPU to speed up bazel build phase (4 is enough for the test itself)


### PR DESCRIPTION
- fix typo in the name of a GCS bucket
- change instance type for master instance
- use community-owned bucket for logs destination

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>