### PR TITLE
[go1.17] Update kubernetes/kubernetes jobs to Golang 1.17

### DIFF
--- a/config/jobs/kubernetes/sig-instrumentation/verify-govet-levee.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/verify-govet-levee.yaml
@@ -17,7 +17,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         imagePullPolicy: IfNotPresent
         command:
         - make

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -56,7 +56,7 @@ presubmits:
         - --test_args=--ginkgo.focus=\[Feature:Ingress\]|\[Feature:NEG\]|Loadbalancing|LoadBalancers --ginkgo.skip=\[Feature:kubemci\]|\[Disruptive\]|\[Feature:IngressScale\]
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gci-gce-ingress
         - --timeout=320m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         resources:
           requests:
             memory: "6Gi"
@@ -124,7 +124,7 @@ presubmits:
         - --test_args=--ginkgo.focus=\[sig-network\]|\[Conformance\]|\[Feature:NetworkPolicy\]|\[Feature:NetworkPolicyEndPort\] --ginkgo.skip=\[Feature:(Networking-IPv6|Example|Federation|PerformanceDNS|KubeProxyDaemonSetMigration|SCTP)\]|DualStack|GCE|Disruptive|Serial|SNAT|LoadBalancer|ESIPP
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-ubuntu-gce-network-policies
         - --timeout=150m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         resources:
           requests:
             memory: "6Gi"
@@ -172,7 +172,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gci-gce-ipvs
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         resources:
           requests:
             memory: "6Gi"
@@ -224,7 +224,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GCEAlphaFeature\] --minStartupPods=8
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
   annotations:
     testgrid-dashboards: google-gce, sig-network-gce
     testgrid-tab-name: gce-alpha-api
@@ -252,7 +252,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:PerformanceDNS\]
       - --timeout=60m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
   annotations:
     testgrid-dashboards: sig-network-gce
     testgrid-tab-name: gce-coredns-performance
@@ -279,7 +279,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:PerformanceDNS\]
       - --timeout=60m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
   annotations:
     testgrid-dashboards: sig-network-gce
     testgrid-tab-name: gce-kubedns-performance
@@ -304,7 +304,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
 
 - interval: 6h
   name: ci-kubernetes-e2e-gce-coredns-performance-nodecache
@@ -330,7 +330,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:PerformanceDNS\]
       - --timeout=60m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
   annotations:
     testgrid-dashboards: sig-network-gce
     testgrid-tab-name: gce-coredns-performance-nodecache
@@ -358,7 +358,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:PerformanceDNS\]
       - --timeout=60m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
   annotations:
     testgrid-dashboards: sig-network-gce
     testgrid-tab-name: gce-kubedns-performance-nodecache
@@ -384,7 +384,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
 
 - interval: 6h
   name: ci-kubernetes-e2e-gci-gce-ingress
@@ -409,7 +409,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Ingress\]|\[Feature:NEG\]
       - --timeout=320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       resources:
         limits:
           cpu: 1
@@ -446,7 +446,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Ingress\]|\[Feature:NEG\]
       - --timeout=320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       resources:
         limits:
           cpu: 1
@@ -480,7 +480,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
   annotations:
     testgrid-dashboards: sig-network-gce
     testgrid-tab-name: gci-gce-ingress-manual-network
@@ -510,7 +510,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
   annotations:
     testgrid-dashboards: google-gce, google-gci
     testgrid-tab-name: ip-alias
@@ -537,7 +537,7 @@ periodics:
       # skip ESIPP should work from pods #97081
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|ESIPP.*should.work.from.pods --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
   annotations:
     testgrid-num-failures-to-alert: '6'
     testgrid-alert-stale-results-hours: '24'
@@ -562,7 +562,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
 
 - interval: 6h
   name: ci-kubernetes-e2e-gci-gce-kube-dns-nodecache
@@ -586,7 +586,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
 
 - interval: 6h
   name: ci-kubernetes-e2e-gci-gce-serial-kube-dns
@@ -610,7 +610,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
 
 - interval: 6h
   name: ci-kubernetes-e2e-gci-gce-serial-kube-dns-nodecache
@@ -635,7 +635,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
 
 - interval: 6h
   name: ci-kubernetes-e2e-ubuntu-gce-network-policies
@@ -676,7 +676,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[sig-network\]|\[Conformance\]|\[Feature:NetworkPolicy\]|\[Feature:NetworkPolicyEndPort\] --ginkgo.skip=\[Feature:(Networking-IPv6|Example|Federation|PerformanceDNS|KubeProxyDaemonSetMigration|SCTP)\]|DualStack|GCE|Disruptive|Serial|SNAT|LoadBalancer|ESIPP
       - --extract=ci/latest
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       resources:
         requests:
           memory: "6Gi"

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -66,7 +66,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
@@ -122,7 +122,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-containerd-gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
         - --timeout=80m     # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         resources:
           requests:
             memory: "6Gi"
@@ -145,7 +145,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         args:
         - --root=/go/src
         - --job=$(JOB_NAME)
@@ -184,7 +184,7 @@ presubmits:
       testgrid-create-test-group: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         args:
         - --root=/go/src
         - --repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)
@@ -223,7 +223,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -262,7 +262,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         args:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - --timeout=260
@@ -305,7 +305,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - --timeout=260
@@ -346,7 +346,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         args:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - --timeout=440
@@ -380,7 +380,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
           args:
             - --repo=k8s.io/kubernetes=$(PULL_REFS)
             - --repo=k8s.io/release
@@ -414,7 +414,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
           args:
             - --repo=k8s.io/kubernetes=$(PULL_REFS)
             - --repo=k8s.io/release
@@ -448,7 +448,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
           args:
             - --repo=k8s.io/kubernetes=$(PULL_REFS)
             - --repo=k8s.io/release
@@ -484,7 +484,7 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -522,7 +522,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -560,7 +560,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -600,7 +600,7 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -639,7 +639,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
           args:
             - --repo=k8s.io/kubernetes=$(PULL_REFS)
             - --repo=k8s.io/release
@@ -676,7 +676,7 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -713,7 +713,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
           args:
             - --root=/go/src
             - "--job=$(JOB_NAME)"
@@ -756,7 +756,7 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"

--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -43,7 +43,7 @@ presubmits:
         - --timeout=80m
         securityContext:
           privileged: true
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         resources:
           requests:
             memory: "6Gi"
@@ -91,7 +91,7 @@ presubmits:
         - --timeout=120m
         securityContext:
           privileged: true
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         resources:
           requests:
             memory: "6Gi"
@@ -137,7 +137,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-csi-serial
         - --test_args=--ginkgo.focus=CSI.*(\[Serial\]|\[Disruptive\]) --ginkgo.skip=\[Flaky\]|\[Feature:.+\]|\[Slow\] --minStartupPods=8
         - --timeout=150m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         resources:
           requests:
             memory: "6Gi"
@@ -180,7 +180,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-iscsi
         - --test_args=--ginkgo.focus=\[Driver:.iscsi\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
         - --timeout=120m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         resources:
           requests:
             memory: "6Gi"
@@ -222,7 +222,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-iscsi-serial
         - --test_args=--ginkgo.focus=\[Driver:.iscsi\].*(\[Serial\]|\[Disruptive\]) --ginkgo.skip=\[Flaky\] --minStartupPods=8
         - --timeout=120m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         resources:
           requests:
             memory: "6Gi"
@@ -260,7 +260,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-storage-disruptive
         - --test_args=--ginkgo.focus=\[sig-storage\].*\[Disruptive\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
         - --timeout=240m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         resources:
           requests:
             memory: "6Gi"
@@ -292,7 +292,7 @@ periodics:
       - --ginkgo-parallel=30
       - --test_args=--ginkgo.focus=\[Driver:.iscsi\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
   annotations:
     testgrid-num-columns-recent: '20'
 - interval: 24h
@@ -317,7 +317,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Driver:.iscsi\].*(\[Serial\]|\[Disruptive\]) --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
   annotations:
     testgrid-num-columns-recent: '20'
 - interval: 24h
@@ -339,7 +339,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:VolumeSnapshotDataSource\] --ginkgo.skip=\[Disruptive\]|\[Flaky\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
   annotations:
     testgrid-num-columns-recent: '20'
     testgrid-num-failures-to-alert: '6'

--- a/config/jobs/kubernetes/sig-testing/dependencies.yaml
+++ b/config/jobs/kubernetes/sig-testing/dependencies.yaml
@@ -21,7 +21,7 @@ presubmits:
       - name: main
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         args:
         - make
         - verify

--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -18,7 +18,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         command:
         - runner.sh
         args:
@@ -88,7 +88,7 @@ periodics:
     description: "Ends up running: make test-cmd test-integration"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
     path_alias: k8s.io/kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/krte:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-testimages/krte:v20210824-2dc36d0-master
         command:
         - wrapper.sh
         - bash
@@ -110,7 +110,7 @@ presubmits:
     path_alias: k8s.io/kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/krte:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-testimages/krte:v20210824-2dc36d0-master
         command:
         - wrapper.sh
         - bash
@@ -213,7 +213,7 @@ presubmits:
     path_alias: k8s.io/kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/krte:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-testimages/krte:v20210824-2dc36d0-master
         command:
         - wrapper.sh
         - bash
@@ -252,7 +252,7 @@ presubmits:
     path_alias: k8s.io/kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/krte:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-testimages/krte:v20210824-2dc36d0-master
         command:
         - wrapper.sh
         - bash

--- a/config/jobs/kubernetes/sig-testing/make-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/make-test.yaml
@@ -19,7 +19,7 @@ presubmits:
         runAsUser: 2000
         allowPrivilegeEscalation: false
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
           command:
             - make
             - test
@@ -128,7 +128,7 @@ periodics:
         runAsUser: 2000
         allowPrivilegeEscalation: false
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
           command:
             - make
             - test
@@ -158,7 +158,7 @@ periodics:
         runAsUser: 2000
         allowPrivilegeEscalation: false
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
           command:
             - runner.sh
             - bash
@@ -188,7 +188,7 @@ periodics:
         runAsUser: 2000
         allowPrivilegeEscalation: false
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
           command:
             - runner.sh
             - bash
@@ -219,7 +219,7 @@ periodics:
         runAsUser: 2000
         allowPrivilegeEscalation: false
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
           command:
             - runner.sh
             - bash

--- a/config/jobs/kubernetes/sig-testing/typecheck.yaml
+++ b/config/jobs/kubernetes/sig-testing/typecheck.yaml
@@ -19,7 +19,7 @@ presubmits:
       - name: main
         command:
         - make
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         resources:
           limits:
             cpu: 5

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -17,7 +17,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -117,7 +117,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       imagePullPolicy: Always
       command:
       - runner.sh


### PR DESCRIPTION
To merge https://github.com/kubernetes/kubernetes/pull/103692, we need to cut kubernetes/kubernetes over to using Golang 1.17.

This PR only touches presubmits/periodics targeting kubernetes/kubernetes; there are lots of jobs outside of that repo that use kubekins-e2e/krte, so we're carefully trying to not cause churn on other repos.

Continuation of https://github.com/kubernetes/test-infra/pull/23354.
go1.17 tracking: https://github.com/kubernetes/release/issues/2169

- [go1.17] Use go1.17 for kubernetes/kubernetes kind presubmits
  Image ref: gcr.io/k8s-testimages/krte:v20210824-2dc36d0-master
- [go1.17] Use go1.17 for kubernetes/kubernetes kubekins-e2e jobs
  Image ref: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master

Signed-off-by: Stephen Augustus <foo@auggie.dev>

~/hold for comms to k-dev~ https://groups.google.com/g/kubernetes-dev/c/5kiB72M8518
/priority critical-urgent
/assign @liggitt @saschagrunert @puerco @cpanato @jeremyrickard 
cc: @kubernetes/sig-release @kubernetes/sig-instrumentation-approvers @kubernetes/sig-network-pr-reviews @kubernetes/sig-node-pr-reviews @kubernetes/sig-scalability @kubernetes/sig-testing