### PR TITLE
releng: Update repo presubmits to use Golang 1.17

### DIFF
--- a/config/jobs/kubernetes-sigs/downloadkubernetes/downloadkubernetes-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/downloadkubernetes/downloadkubernetes-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: "sigs.k8s.io/downloadkubernetes"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
         imagePullPolicy: Always
         command:
         - make
@@ -22,7 +22,7 @@ presubmits:
     path_alias: "sigs.k8s.io/downloadkubernetes"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
         imagePullPolicy: Always
         command:
         - make

--- a/config/jobs/kubernetes-sigs/mdtoc/mdtoc-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/mdtoc/mdtoc-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     path_alias: sigs.k8s.io/mdtoc
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
         imagePullPolicy: Always
         command:
         - make
@@ -22,7 +22,7 @@ presubmits:
     path_alias: sigs.k8s.io/mdtoc
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
         imagePullPolicy: Always
         command:
         - make

--- a/config/jobs/kubernetes-sigs/release-utils/release-utils-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/release-utils/release-utils-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     path_alias: "sigs.k8s.io/release-utils"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
         imagePullPolicy: Always
         command:
         - go
@@ -25,7 +25,7 @@ presubmits:
     path_alias: "sigs.k8s.io/release-utils"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
         imagePullPolicy: Always
         command:
         - go

--- a/config/jobs/kubernetes-sigs/zeitgeist/zeitgeist-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/zeitgeist/zeitgeist-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     path_alias: "sigs.k8s.io/zeitgeist"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
         imagePullPolicy: Always
         command:
         - make
@@ -22,7 +22,7 @@ presubmits:
     path_alias: "sigs.k8s.io/zeitgeist"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
         imagePullPolicy: Always
         command:
         - make
@@ -38,7 +38,7 @@ presubmits:
     path_alias: "sigs.k8s.io/zeitgeist"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
         imagePullPolicy: Always
         command:
         - make

--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -46,7 +46,7 @@ presubmits:
     path_alias: k8s.io/release
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
         imagePullPolicy: Always
         command:
         - make
@@ -63,7 +63,7 @@ presubmits:
     path_alias: k8s.io/release
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
         imagePullPolicy: Always
         command:
         - make
@@ -80,7 +80,7 @@ presubmits:
     path_alias: k8s.io/release
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
         imagePullPolicy: Always
         command:
         - make

--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -204,7 +204,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
         imagePullPolicy: Always
         command:
         - make


### PR DESCRIPTION
Now that [kubernetes/kubernetes uses Golang 1.17](https://github.com/kubernetes/release/issues/2169), we default to the new major version for @kubernetes/release-engineering presubmits.

Image ref: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17

Needed for https://github.com/kubernetes/release/pull/2223.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @saschagrunert @cpanato @puerco @jeremyrickard 