### PR TITLE
[Go 1.17] Bump Kubekins for SIG Node Periodics 

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -46,7 +46,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       args:
       - --repo=github.com/containerd/containerd=main
       - --root=/go/src
@@ -68,7 +68,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         args:
           - --repo=github.com/containerd/containerd=release/1.4
           - --repo=github.com/containerd/cri=release/1.4
@@ -90,7 +90,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         args:
           - --repo=github.com/containerd/containerd=main
           - --root=/go/src
@@ -129,7 +129,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
   annotations:
     testgrid-dashboards: sig-node-containerd, sig-node-cos
     testgrid-tab-name: containerd-e2e-cos
@@ -159,7 +159,7 @@ periodics:
           - --provider=gce
           - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
           - --timeout=50m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
   annotations:
     testgrid-dashboards: sig-node-containerd, sig-node-cos
     testgrid-tab-name: containerd-e2e-cos-1.4
@@ -188,7 +188,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-e2e-ubuntu
@@ -199,7 +199,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -230,7 +230,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes=release-1.21
@@ -260,7 +260,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -290,7 +290,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes=release-1.21
@@ -339,7 +339,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1200m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
   annotations:
     testgrid-dashboards: sig-node-containerd, sig-node-cos
     testgrid-tab-name: soak-cos-gce
@@ -366,7 +366,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-cos-device-plugin-gpu
@@ -395,7 +395,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
   annotations:
     testgrid-dashboards: sig-node-containerd, sig-node-cos
     testgrid-tab-name: e2e-cos
@@ -424,7 +424,7 @@ periodics:
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandPersistentVolumes|VolumeSubpathEnvExpansion|RunAsGroup|NodeLease)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes|Feature:SCTPConnectivity --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
   annotations:
     testgrid-dashboards: sig-node-containerd, sig-node-cos
     testgrid-tab-name: e2e-cos-alpha-features
@@ -449,7 +449,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
   annotations:
     testgrid-dashboards: sig-node-containerd, sig-node-cos
     testgrid-tab-name: e2e-cos-flaky
@@ -477,7 +477,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Ingress\]|\[Feature:NEG\]
       - --timeout=320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
   annotations:
     testgrid-dashboards: sig-network-gce, sig-node-containerd, sig-node-cos
     testgrid-tab-name: e2e-cos-ingress
@@ -507,7 +507,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
   annotations:
     testgrid-dashboards: sig-node-containerd, sig-node-cos
     testgrid-tab-name: e2e-cos-ip-alias
@@ -534,7 +534,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
   annotations:
     testgrid-dashboards: sig-node-containerd, sig-node-cos
     testgrid-tab-name: e2e-cos-proto
@@ -559,7 +559,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
   annotations:
     testgrid-dashboards: sig-node-containerd, sig-node-cos
     testgrid-tab-name: e2e-cos-reboot
@@ -584,7 +584,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
   annotations:
     testgrid-dashboards: sig-node-containerd, sig-node-cos
     testgrid-tab-name: e2e-cos-serial
@@ -610,7 +610,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
   annotations:
     testgrid-dashboards: sig-node-containerd, sig-node-cos
     testgrid-tab-name: e2e-cos-slow
@@ -638,7 +638,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-ubuntu
@@ -649,7 +649,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -679,7 +679,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -709,7 +709,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -756,7 +756,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: image-validation-cos-e2e
@@ -783,7 +783,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: image-validation-ubuntu-e2e
@@ -794,7 +794,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -823,7 +823,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -852,7 +852,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes

--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -6,7 +6,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -38,7 +38,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -70,7 +70,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes

--- a/config/jobs/kubernetes/sig-node/node-docker.yaml
+++ b/config/jobs/kubernetes/sig-node/node-docker.yaml
@@ -6,7 +6,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -35,7 +35,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=200
@@ -64,7 +64,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=200

--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -14,7 +14,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -47,7 +47,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -84,7 +84,7 @@ periodics:
     testgrid-alert-email: kubernetes-sig-node+testgrid@googlegroups.com,kubernetes-sig-node-test-failures@googlegroups.com
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -117,7 +117,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -147,7 +147,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=400
@@ -178,7 +178,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=260
@@ -215,7 +215,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=260
@@ -254,7 +254,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=320
@@ -284,7 +284,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=240
@@ -315,7 +315,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         args:
           - --repo=k8s.io/kubernetes=master
           - --timeout=240
@@ -346,7 +346,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         args:
           - --repo=k8s.io/kubernetes=master
           - --timeout=240
@@ -377,7 +377,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         args:
           - --repo=k8s.io/kubernetes=master
           - --timeout=240
@@ -409,7 +409,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         args:
           - --repo=k8s.io/kubernetes=master
           - --timeout=240
@@ -441,7 +441,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         args:
           - --repo=k8s.io/kubernetes=master
           - --timeout=240
@@ -471,7 +471,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         args:
           - --repo=k8s.io/kubernetes=master
           - --timeout=240
@@ -506,7 +506,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         args:
           - --repo=k8s.io/kubernetes=master
           - --timeout=240
@@ -542,7 +542,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
         args:
           - --repo=k8s.io/kubernetes=master
           - --timeout=90

--- a/config/jobs/kubernetes/sig-node/sig-node-config.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-config.yaml
@@ -23,7 +23,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210808-1eaeec7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210824-2dc36d0-master
   annotations:
     testgrid-dashboards: google-gce, sig-storage-kubernetes
     testgrid-tab-name: gce-containerd


### PR DESCRIPTION
Updated Kubekins image(Go1.17) for node periodics
https://groups.google.com/g/kubernetes-dev/c/5kiB72M8518

Signed-off-by: Aditi Sharma <adi.sky17@gmail.com>