### PR TITLE
provider-openstack: Fix the branch name

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-openstack/OWNERS
+++ b/config/jobs/kubernetes/cloud-provider-openstack/OWNERS
@@ -8,6 +8,8 @@ reviewers:
 approvers:
 - dims
 - lingxiankong
+- ramineni
+- jichenjc
 labels:
 - sig/cloud-provider
 - area/provider/openstack

--- a/config/jobs/kubernetes/cloud-provider-openstack/release-master-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/release-master-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:
-      - ^main$
+      - ^master$
     run_if_changed: '^(pkg\/openstack\/|cmd\/openstack-cloud-controller-manager\/|tests\/e2e\/cloudprovider\/)'
     optional: false
     decorate: true


### PR DESCRIPTION
cloud-provider-openstack doesn't have `main` branch yet, still using `master`.

Also, adding the project maintainers as approvers.