### PR TITLE
Unprotect the gh-pages branch in nfs-ganesha-server-and-external-provisioner for helm chart release action

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -473,6 +473,10 @@ branch-protection:
           required_status_checks:
             contexts:
             - Kubespray CI Pipeline
+        nfs-ganesha-server-and-external-provisioner:
+          branches:
+            gh-pages:
+              protect: false
         nfs-subdir-external-provisioner:
           branches:
             gh-pages:


### PR DESCRIPTION
As previously done in #20453, we are automating the helm chart release in the [nfs-ganesha-server-and-external-provisioner](pull/65) repository: [kubernetes-sigs/nfs-ganesha-server-and-external-provisioner#65](https://github.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner/issues/65)

In order to do that, we need to configure prow to ignore the `gh-pages` branch as it will be used by github action's user which cannot sign CLA.
No PR's will be approved for this branch and the `gh-pages` branch will be used only as helm chart repository.

@wongma7 @kmova

