### PR TITLE
GitHub reporter: Respect timeout

### DIFF
--- a/prow/crier/reporters/github/BUILD.bazel
+++ b/prow/crier/reporters/github/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//prow/github/report:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/reconcile:go_default_library",
+        "@org_golang_x_sync//semaphore:go_default_library",
     ],
 )
 
@@ -40,5 +41,6 @@ go_test(
         "//prow/github/fakegithub:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@org_golang_x_sync//semaphore:go_default_library",
     ],
 )

--- a/prow/crier/reporters/github/reporter_test.go
+++ b/prow/crier/reporters/github/reporter_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/semaphore"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
@@ -164,9 +165,9 @@ func TestPresumitReportingLocks(t *testing.T) {
 
 func TestShardedLockCleanup(t *testing.T) {
 	t.Parallel()
-	sl := &shardedLock{mapLock: &sync.Mutex{}, locks: map[simplePull]*sync.Mutex{}}
+	sl := &shardedLock{mapLock: semaphore.NewWeighted(1), locks: map[simplePull]*semaphore.Weighted{}}
 	key := simplePull{"org", "repo", 1}
-	sl.locks[key] = &sync.Mutex{}
+	sl.locks[key] = semaphore.NewWeighted(1)
 	sl.cleanup()
 	if _, exists := sl.locks[key]; exists {
 		t.Error("lock didn't get cleaned up")

--- a/prow/external-plugins/refresh/server.go
+++ b/prow/external-plugins/refresh/server.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -182,7 +183,7 @@ func (s *server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent
 		}
 
 		s.log.WithFields(l.Data).Infof("Refreshing the status of job %q (pj: %s)", pj.Spec.Job, pj.ObjectMeta.Name)
-		if err := report.Report(s.ghc, reportTemplate, pj, reportTypes); err != nil {
+		if err := report.Report(context.Background(), s.ghc, reportTemplate, pj, reportTypes); err != nil {
 			s.log.WithError(err).WithFields(l.Data).Info("Failed report.")
 		}
 	}

--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -142,6 +142,10 @@ func (f *FakeClient) BotUser() (*github.UserData, error) {
 	return &github.UserData{Login: botName}, nil
 }
 
+func (f *FakeClient) BotUserCheckerWithContext(_ context.Context) (func(candidate string) bool, error) {
+	return f.BotUserChecker()
+}
+
 func (f *FakeClient) BotUserChecker() (func(candidate string) bool, error) {
 	return func(candidate string) bool {
 		candidate = strings.TrimSuffix(candidate, "[bot]")
@@ -212,6 +216,10 @@ func (f *FakeClient) ListOpenIssues(org, repo string) ([]github.Issue, error) {
 
 // ListIssueComments returns comments.
 func (f *FakeClient) ListIssueComments(owner, repo string, number int) ([]github.IssueComment, error) {
+	return f.ListIssueCommentsWithContext(context.Background(), owner, repo, number)
+}
+
+func (f *FakeClient) ListIssueCommentsWithContext(ctx context.Context, owner, repo string, number int) ([]github.IssueComment, error) {
 	f.lock.RLock()
 	defer f.lock.RUnlock()
 	return append([]github.IssueComment{}, f.IssueComments[number]...), nil
@@ -240,6 +248,10 @@ func (f *FakeClient) ListIssueEvents(owner, repo string, number int) ([]github.L
 
 // CreateComment adds a comment to a PR
 func (f *FakeClient) CreateComment(owner, repo string, number int, comment string) error {
+	return f.CreateCommentWithContext(context.Background(), owner, repo, number, comment)
+}
+
+func (f *FakeClient) CreateCommentWithContext(_ context.Context, owner, repo string, number int, comment string) error {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 	f.IssueCommentID++
@@ -254,6 +266,10 @@ func (f *FakeClient) CreateComment(owner, repo string, number int, comment strin
 
 // EditComment edits a comment. Its a stub that does nothing.
 func (f *FakeClient) EditComment(org, repo string, ID int, comment string) error {
+	return f.EditCommentWithContext(context.Background(), org, repo, ID, comment)
+}
+
+func (f *FakeClient) EditCommentWithContext(_ context.Context, org, repo string, ID int, comment string) error {
 	return nil
 }
 
@@ -288,6 +304,10 @@ func (f *FakeClient) CreateIssueReaction(org, repo string, ID int, reaction stri
 
 // DeleteComment deletes a comment.
 func (f *FakeClient) DeleteComment(owner, repo string, ID int) error {
+	return f.DeleteCommentWithContext(context.Background(), owner, repo, ID)
+}
+
+func (f *FakeClient) DeleteCommentWithContext(_ context.Context, owner, repo string, ID int) error {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 	f.IssueCommentsDeleted = append(f.IssueCommentsDeleted, fmt.Sprintf("%s/%s#%d", owner, repo, ID))
@@ -431,6 +451,9 @@ func (f *FakeClient) GetSingleCommit(org, repo, SHA string) (github.RepositoryCo
 
 // CreateStatus adds a status context to a commit.
 func (f *FakeClient) CreateStatus(owner, repo, SHA string, s github.Status) error {
+	return f.CreateStatusWithContext(context.Background(), owner, repo, SHA, s)
+}
+func (f *FakeClient) CreateStatusWithContext(_ context.Context, owner, repo, SHA string, s github.Status) error {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 	if f.Error != nil {

--- a/prow/github/report/report_test.go
+++ b/prow/github/report/report_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package report
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -229,7 +230,7 @@ type fakeGhClient struct {
 	status []github.Status
 }
 
-func (gh fakeGhClient) BotUserChecker() (func(string) bool, error) {
+func (gh fakeGhClient) BotUserCheckerWithContext(_ context.Context) (func(string) bool, error) {
 	return func(candidate string) bool {
 		return candidate == "BotName"
 	}, nil
@@ -237,7 +238,7 @@ func (gh fakeGhClient) BotUserChecker() (func(string) bool, error) {
 
 const maxLen = 140
 
-func (gh *fakeGhClient) CreateStatus(org, repo, ref string, s github.Status) error {
+func (gh *fakeGhClient) CreateStatusWithContext(_ context.Context, org, repo, ref string, s github.Status) error {
 	if d := s.Description; len(d) > maxLen {
 		return fmt.Errorf("%s is len %d, more than max of %d chars", d, len(d), maxLen)
 	}
@@ -245,16 +246,16 @@ func (gh *fakeGhClient) CreateStatus(org, repo, ref string, s github.Status) err
 	return nil
 
 }
-func (gh fakeGhClient) ListIssueComments(org, repo string, number int) ([]github.IssueComment, error) {
+func (gh fakeGhClient) ListIssueCommentsWithContext(_ context.Context, org, repo string, number int) ([]github.IssueComment, error) {
 	return nil, nil
 }
-func (gh fakeGhClient) CreateComment(org, repo string, number int, comment string) error {
+func (gh fakeGhClient) CreateCommentWithContext(_ context.Context, org, repo string, number int, comment string) error {
 	return nil
 }
-func (gh fakeGhClient) DeleteComment(org, repo string, ID int) error {
+func (gh fakeGhClient) DeleteCommentWithContext(_ context.Context, org, repo string, ID int) error {
 	return nil
 }
-func (gh fakeGhClient) EditComment(org, repo string, ID int, comment string) error {
+func (gh fakeGhClient) EditCommentWithContext(_ context.Context, org, repo string, ID int, comment string) error {
 	return nil
 }
 
@@ -373,7 +374,7 @@ func TestReportStatus(t *testing.T) {
 				},
 			}
 			// Run
-			if err := reportStatus(ghc, pj); err != nil {
+			if err := reportStatus(context.Background(), ghc, pj); err != nil {
 				t.Error(err)
 			}
 			// Check

--- a/prow/jenkins/controller.go
+++ b/prow/jenkins/controller.go
@@ -51,12 +51,7 @@ type jenkinsClient interface {
 }
 
 type githubClient interface {
-	BotUserChecker() (func(candidate string) bool, error)
-	CreateStatus(org, repo, ref string, s github.Status) error
-	ListIssueComments(org, repo string, number int) ([]github.IssueComment, error)
-	CreateComment(org, repo string, number int, comment string) error
-	DeleteComment(org, repo string, ID int) error
-	EditComment(org, repo string, ID int, comment string) error
+	reportlib.GitHubClient
 	GetPullRequestChanges(org, repo string, number int) ([]github.PullRequestChange, error)
 }
 
@@ -229,7 +224,7 @@ func (c *Controller) Sync() error {
 		jConfig := c.config()
 		for report := range reportCh {
 			reportTemplate := jConfig.ReportTemplateForRepo(report.Spec.Refs)
-			if err := reportlib.Report(c.ghc, reportTemplate, report, reportTypes); err != nil {
+			if err := reportlib.Report(context.Background(), c.ghc, reportTemplate, report, reportTypes); err != nil {
 				reportErrs = append(reportErrs, err)
 				c.log.WithFields(pjutil.ProwJobFields(&report)).WithError(err).Warn("Failed to report ProwJob status")
 			}

--- a/prow/jenkins/controller_test.go
+++ b/prow/jenkins/controller_test.go
@@ -155,32 +155,32 @@ func (f *fghc) GetPullRequestChanges(org, repo string, number int) ([]github.Pul
 	return f.changes, f.err
 }
 
-func (f *fghc) BotUserChecker() (func(string) bool, error) {
+func (f *fghc) BotUserCheckerWithContext(context.Context) (func(string) bool, error) {
 	return func(candidate string) bool {
 		return candidate == "bot"
 	}, nil
 }
-func (f *fghc) CreateStatus(org, repo, ref string, s github.Status) error {
+func (f *fghc) CreateStatusWithContext(_ context.Context, org, repo, ref string, s github.Status) error {
 	f.Lock()
 	defer f.Unlock()
 	return nil
 }
-func (f *fghc) ListIssueComments(org, repo string, number int) ([]github.IssueComment, error) {
+func (f *fghc) ListIssueCommentsWithContext(_ context.Context, org, repo string, number int) ([]github.IssueComment, error) {
 	f.Lock()
 	defer f.Unlock()
 	return nil, nil
 }
-func (f *fghc) CreateComment(org, repo string, number int, comment string) error {
+func (f *fghc) CreateCommentWithContext(_ context.Context, org, repo string, number int, comment string) error {
 	f.Lock()
 	defer f.Unlock()
 	return nil
 }
-func (f *fghc) DeleteComment(org, repo string, ID int) error {
+func (f *fghc) DeleteCommentWithContext(_ context.Context, org, repo string, ID int) error {
 	f.Lock()
 	defer f.Unlock()
 	return nil
 }
-func (f *fghc) EditComment(org, repo string, ID int, comment string) error {
+func (f *fghc) EditCommentWithContext(_ context.Context, org, repo string, ID int, comment string) error {
 	f.Lock()
 	defer f.Unlock()
 	return nil


### PR DESCRIPTION
Currently, the GitHub reporter will never timeout, making it possible
that all Crier workers get stuck. This change fixes that.