### PR TITLE
Include the decorated volumes by the user in the config validation

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1732,7 +1732,7 @@ func validateJobBase(v JobBase, jobType prowapi.ProwJobType, podNamespace string
 	if err := validateAgent(v, podNamespace); err != nil {
 		return err
 	}
-	if err := validatePodSpec(jobType, v.Spec, v.DecorationConfig != nil); err != nil {
+	if err := validatePodSpec(jobType, v.Spec, v.DecorationConfig); err != nil {
 		return err
 	}
 	if err := ValidatePipelineRunSpec(jobType, v.ExtraRefs, v.PipelineRunSpec); err != nil {
@@ -2345,7 +2345,7 @@ func ValidatePipelineRunSpec(jobType prowapi.ProwJobType, extraRefs []prowapi.Re
 	return nil
 }
 
-func validatePodSpec(jobType prowapi.ProwJobType, spec *v1.PodSpec, decorationEnabled bool) error {
+func validatePodSpec(jobType prowapi.ProwJobType, spec *v1.PodSpec, decorationConfig *prowapi.DecorationConfig) error {
 	if spec == nil {
 		return nil
 	}
@@ -2361,7 +2361,7 @@ func validatePodSpec(jobType prowapi.ProwJobType, spec *v1.PodSpec, decorationEn
 		return utilerrors.NewAggregate(append(errs, fmt.Errorf("pod spec must specify at least 1 container, found: %d", n)))
 	}
 
-	if n := len(spec.Containers); n > 1 && !decorationEnabled {
+	if n := len(spec.Containers); n > 1 && decorationConfig == nil {
 		return utilerrors.NewAggregate(append(errs, fmt.Errorf("pod utility decoration must be enabled to use multiple containers: %d", n)))
 	}
 
@@ -2401,20 +2401,21 @@ func validatePodSpec(jobType prowapi.ProwJobType, spec *v1.PodSpec, decorationEn
 	}
 
 	volumeNames := sets.String{}
+	decoratedVolumeNames := decorate.VolumeMounts(decorationConfig)
 	for _, volume := range spec.Volumes {
 		if volumeNames.Has(volume.Name) {
 			errs = append(errs, fmt.Errorf("volume named %q is defined more than once", volume.Name))
 		}
 		volumeNames.Insert(volume.Name)
 
-		if decorate.VolumeMounts().Has(volume.Name) {
+		if decoratedVolumeNames.Has(volume.Name) {
 			errs = append(errs, fmt.Errorf("volume %s is a reserved for decoration", volume.Name))
 		}
 	}
 
 	for i := range spec.Containers {
 		for _, mount := range spec.Containers[i].VolumeMounts {
-			if !volumeNames.Has(mount.Name) && !decorate.VolumeMounts().Has(mount.Name) {
+			if !volumeNames.Has(mount.Name) && !decoratedVolumeNames.Has(mount.Name) {
 				errs = append(errs, fmt.Errorf("volumeMount named %q is undefined", mount.Name))
 			}
 			if decorate.VolumeMountsOnTestContainer().Has(mount.Name) {

--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -68,8 +68,19 @@ func Labels() []string {
 }
 
 // VolumeMounts returns a string set with *MountName consts in it.
-func VolumeMounts() sets.String {
-	return sets.NewString(logMountName, codeMountName, toolsMountName, gcsCredentialsMountName, s3CredentialsMountName)
+func VolumeMounts(dc *prowapi.DecorationConfig) sets.String {
+	ret := sets.NewString(logMountName, codeMountName, toolsMountName, gcsCredentialsMountName, s3CredentialsMountName)
+	if dc == nil {
+		return ret
+	}
+
+	if dc.OauthTokenSecret != nil {
+		ret.Insert(dc.OauthTokenSecret.Name)
+	}
+	for _, sshKeySecret := range dc.SSHKeySecrets {
+		ret.Insert(sshKeySecret)
+	}
+	return ret
 }
 
 // VolumeMountsOnTestContainer returns a string set with *MountName consts in it which are applied to the test container.


### PR DESCRIPTION
When a user specifies a `decoration_config.oauth_token_secret` of `decoration_config.ssh_key_secrets`, we eventually create the corresponding volumes plus the volumeMounts in the `clonerefs` container. 

With this change, we allow the user to reuse the volumes specified in the decoration config by mounting them into different containers.

/cc @stevekuznetsov @alvaroaleman 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>