### PR TITLE
Remove branch protection for gh-pages in secrets-store-csi-driver

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -485,6 +485,10 @@ branch-protection:
           branches:
             gh-pages:
               protect: false
+        secrets-store-csi-driver:
+          branches:
+            gh-pages:
+              protect: false
 
 tide:
   sync_period: 2m


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

The `gh-pages` branch is used for hosting helm charts: https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/693. The github action's user can't sign CLA. So removing the branch protection for that branch.

The `gh-pages` branch will only be used for hosting helm charts.

/cc @tam7t 