### PR TITLE
Spyglass example match Gubernator docs

### DIFF
--- a/prow/spyglass/README.md
+++ b/prow/spyglass/README.md
@@ -100,7 +100,7 @@ deck:
     - lens:
         name: junit
       required_files:
-      - ^artifacts/junit.*\.xml$
+      - ^artifacts/junit_[^/]*\.xml$
     - lens:
         name: podinfo
       required_files:


### PR DESCRIPTION
In [Gubernator's docs](https://github.com/kubernetes/test-infra/tree/master/gubernator#job-artifact-gcs-layout) it says:

> Any JUnit XML reports should be named junit_*.xml and placed under ./artifacts as well.

I highly doubt it was intended to read that as a regex and not a
glob (junit_____.xml only is not very useful compared to
junit_words-and-stuff.xml) so I believe the default Spyglass example
should match the rest of the system. Alternatively, I could update
Gubernator's page.

I also believe we endorse `junit_*.xml` being found in any subdirectory,
which neither of the statements support. I could update both to match
this if desired.