### PR TITLE
Add a presubmit for kubernetes-sigs/controller-tools

### DIFF
--- a/config/jobs/kubernetes-sigs/controller-tools/OWNERS
+++ b/config/jobs/kubernetes-sigs/controller-tools/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/devel/owners.md
+approvers:
+  - alvaroaleman
+  - mengqiy
+  - pwittrock
+  - vincepri

--- a/config/jobs/kubernetes-sigs/controller-tools/controller-tools-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/controller-tools/controller-tools-presubmits-master.yaml
@@ -1,0 +1,16 @@
+presubmits:
+  kubernetes-sigs/controller-tools:
+  - name: pull-controller-tools-test-master
+    decorate: true
+    always_run: true
+    path_alias: sigs.k8s.io/controller-tools
+    branches:
+    - ^master$
+    spec:
+      containers:
+      - image: golang:1.16
+        command:
+        - make test-all
+    annotations:
+      testgrid-dashboards: sig-api-machinery-kubebuilder
+      testgrid-tab-name: controller-tools-master


### PR DESCRIPTION
This adds a basic presubmit for controller-tools which today doesn't have any presubmit testing of the code.

Requires https://github.com/kubernetes-sigs/controller-tools/pull/602
/hold
/assign @vincepri 