### PR TITLE
Fix command for controller-tools presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/controller-tools/controller-tools-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/controller-tools/controller-tools-presubmits-master.yaml
@@ -10,7 +10,8 @@ presubmits:
       containers:
       - image: golang:1.16
         command:
-        - make test-all
+        - make
+        - test-all
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
       testgrid-tab-name: controller-tools-master


### PR DESCRIPTION
Right now it uses `make test-all` as the commant to exec:
```
could not start the process: exec: "make test-all": executable file not found in $PATH
```

Ref
https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_controller-tools/603/pull-controller-tools-test-master/1431416733045886976

/assign @vincepri 