### PR TITLE
Add summary of guidelines for help-wanted issues to help plugin config

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -102,6 +102,14 @@ approve:
   - kubernetes-sigs/gateway-api
   lgtm_acts_as_approve: false
 
+help:
+  help_guidelines_summary: |
+                        Please ensure that the issue body includes answers to the following questions:
+                        - Why are we solving this issue?
+                        - To address this issue, are there any code changes? If there are code changes, what needs to be done in the code and what places can the assignee treat as reference points?
+                        - Does this issue have zero to low barrier of entry?
+                        - How can the assignee reach out to you for help?
+
 # Lower bounds in number of lines changed; XS is assumed to be zero.
 size:
   s:   10


### PR DESCRIPTION
Add summary of guidelines in `plugins.yaml` as a follow up to https://github.com/kubernetes/test-infra/pull/23140
/sig contributor-experience