### PR TITLE
 Add cloud-provider-openstack e2e for openstack cinder csi test

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-openstack/release-master-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/release-master-presubmits.yaml
@@ -34,3 +34,37 @@ presubmits:
     annotations:
       testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
       testgrid-tab-name: presubmit-e2e-test
+  - name: openstack-cloud-csi-cinder-e2e-test
+    labels:
+      preset-service-account: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    path_alias: "k8s.io/cloud-provider-openstack"
+    always_run: false
+    branches:
+      - ^master$
+    run_if_changed: '^(pkg\/csi\/cinder\/|cmd\/cinder-csi-plugin\/|tests\/e2e\/csi\/cinder\/)'
+    optional: false
+    decorate: true
+    decoration_config:
+      timeout: 3h
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210825-f1955d1-master
+          env:
+          - name: "BOSKOS_HOST"
+            value: "boskos.test-pods.svc.cluster.local"
+          command:
+          - "runner.sh"
+          - "./tests/ci-csi-cinder-e2e.sh"
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: 1
+    annotations:
+      testgrid-dashboards: provider-openstack-openstack-csi-cinder
+      testgrid-tab-name: presubmit-e2e-test

--- a/config/testgrids/kubernetes/sig-cloud-provider/openstack/config.yaml
+++ b/config/testgrids/kubernetes/sig-cloud-provider/openstack/config.yaml
@@ -3,6 +3,7 @@ dashboard_groups:
   dashboard_names:
     - provider-openstack-cloud-provider-openstack
     - provider-openstack-openstack-cloud-controller-manager
+    - provider-openstack-openstack-csi-cinder
 
 dashboards:
 - name: provider-openstack-cloud-provider-openstack
@@ -38,6 +39,7 @@ dashboards:
       alert_options:
         alert_mail_to_addresses: provider.openstack+testgrid@gmail.com
 - name: provider-openstack-openstack-cloud-controller-manager
+- name: provider-openstack-openstack-csi-cinder
 
 test_groups:
 - name: ci-presubmit-cloud-provider-openstack-acceptance-test-e2e-conformance


### PR DESCRIPTION
follow up of https://github.com/kubernetes/test-infra/pull/23328

this PR is to add a CI job to run functional test for openstack csi cinder 

/cc @jichenjc @ramineni
