### PR TITLE
prow: expose retest status in metrics

### DIFF
--- a/prow/kube/BUILD.bazel
+++ b/prow/kube/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
         "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
         "@io_k8s_apimachinery//pkg/api/equality:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/util/diff:go_default_library",
         "@io_k8s_client_go//rest:go_default_library",
     ],

--- a/prow/kube/metrics.go
+++ b/prow/kube/metrics.go
@@ -41,6 +41,8 @@ var (
 		"base_ref",
 		// the cluster the job runs on
 		"cluster",
+		// whether or not the job was a retest
+		"retest",
 	}
 	prowJobs = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "prowjobs",
@@ -61,10 +63,11 @@ type jobLabel struct {
 	repo         string
 	baseRef      string
 	cluster      string
+	retest       string
 }
 
 func (jl *jobLabel) values() []string {
-	return []string{jl.jobNamespace, jl.jobName, jl.jobType, jl.state, jl.org, jl.repo, jl.baseRef, jl.cluster}
+	return []string{jl.jobNamespace, jl.jobName, jl.jobType, jl.state, jl.org, jl.repo, jl.baseRef, jl.cluster, jl.retest}
 }
 
 func init() {
@@ -92,6 +95,12 @@ func getJobLabel(pj prowapi.ProwJob) jobLabel {
 		jl.org = pj.Spec.ExtraRefs[0].Org
 		jl.repo = pj.Spec.ExtraRefs[0].Repo
 		jl.baseRef = pj.Spec.ExtraRefs[0].BaseRef
+	}
+
+	if retest, exists := pj.ObjectMeta.Labels[RetestLabel]; exists && retest == "true" {
+		jl.retest = "true"
+	} else {
+		jl.retest = "false"
 	}
 
 	return jl

--- a/prow/kube/prowjob.go
+++ b/prow/kube/prowjob.go
@@ -61,4 +61,6 @@ const (
 	// PullLabel is added in resources created by prow and
 	// carries the PR number associated with the job, eg 321.
 	PullLabel = "prow.k8s.io/refs.pull"
+	// RetestLabel exposes if the job was created by a re-test request.
+	RetestLabel = "prow.k8s.io/retest"
 )

--- a/prow/pjutil/pjutil.go
+++ b/prow/pjutil/pjutil.go
@@ -87,17 +87,20 @@ func createRefs(pr github.PullRequest, baseSHA string) prowapi.Refs {
 // NewPresubmit converts a config.Presubmit into a prowapi.ProwJob.
 // The prowapi.Refs are configured correctly per the pr, baseSHA.
 // The eventGUID becomes a github.EventGUID label.
-func NewPresubmit(pr github.PullRequest, baseSHA string, job config.Presubmit, eventGUID string) prowapi.ProwJob {
+func NewPresubmit(pr github.PullRequest, baseSHA string, job config.Presubmit, eventGUID string, additionalLabels map[string]string) prowapi.ProwJob {
 	refs := createRefs(pr, baseSHA)
 	labels := make(map[string]string)
 	for k, v := range job.Labels {
 		labels[k] = v
 	}
+	for k, v := range additionalLabels {
+		labels[k] = v
+	}
+	labels[github.EventGUID] = eventGUID
 	annotations := make(map[string]string)
 	for k, v := range job.Annotations {
 		annotations[k] = v
 	}
-	labels[github.EventGUID] = eventGUID
 	return NewProwJob(PresubmitSpec(job, refs), labels, annotations)
 }
 

--- a/prow/plugins/override/override.go
+++ b/prow/plugins/override/override.go
@@ -398,7 +398,7 @@ Only the following contexts were expected:
 				return oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, resp))
 			}
 
-			pj := pjutil.NewPresubmit(*pr, baseSHA, *pre, e.GUID)
+			pj := pjutil.NewPresubmit(*pr, baseSHA, *pre, e.GUID, nil)
 			now := metav1.Now()
 			pj.Status = prowapi.ProwJobStatus{
 				StartTime:      now,

--- a/prow/plugins/trigger/generic-comment.go
+++ b/prow/plugins/trigger/generic-comment.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/kube"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/config"
@@ -132,7 +133,12 @@ func handleGenericComment(c Client, trigger plugins.Trigger, gc github.GenericCo
 	if needsHelp, note := pjutil.ShouldRespondWithHelp(gc.Body, len(toTest)); needsHelp {
 		return addHelpComment(c.GitHubClient, gc.Body, org, repo, pr.Base.Ref, pr.Number, presubmits, gc.HTMLURL, commentAuthor, note, c.Logger)
 	}
-	return RunRequested(c, pr, baseSHA, toTest, gc.GUID)
+	// we want to be able to track re-tests separately from the general body of tests
+	additionalLabels := map[string]string{}
+	if pjutil.RetestRe.MatchString(gc.Body) || pjutil.RetestRequiredRe.MatchString(gc.Body) {
+		additionalLabels[kube.RetestLabel] = "true"
+	}
+	return RunRequestedWithLabels(c, pr, baseSHA, toTest, gc.GUID, additionalLabels)
 }
 
 func HonorOkToTest(trigger plugins.Trigger) bool {

--- a/prow/plugins/trigger/trigger_test.go
+++ b/prow/plugins/trigger/trigger_test.go
@@ -181,7 +181,7 @@ func TestRunRequested(t *testing.T) {
 				Logger:        logrus.WithField("testcase", testCase.name),
 			}
 
-			err := runRequested(client, pr, fakegithub.TestRef, testCase.requestedJobs, "event-guid", time.Nanosecond)
+			err := runRequested(client, pr, fakegithub.TestRef, testCase.requestedJobs, "event-guid", nil, time.Nanosecond)
 			if err == nil && testCase.expectedErr {
 				t.Error("failed to receive an error")
 			}


### PR DESCRIPTION
It is very useful to be able to measure the volume and frequency of
re-tests independently from the volume of total jobs. Adding a label
at ProwJob creation time makes this simple.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @alvaroaleman 
/cc @deads2k 