### PR TITLE
images/alpine: Build for s390x

### DIFF
--- a/images/alpine/cloudbuild.yaml
+++ b/images/alpine/cloudbuild.yaml
@@ -4,7 +4,7 @@ steps:
     args:
     - build
     - --tag=gcr.io/$PROJECT_ID/alpine:$_GIT_TAG
-    - --platform=linux/amd64,linux/arm64/v8,linux/ppc64le
+    - --platform=linux/amd64,linux/arm64/v8,linux/ppc64le,linux/s390x
     - --build-arg=IMAGE_ARG=gcr.io/$PROJECT_ID/alpine:$_GIT_TAG
     - --push
     - .


### PR DESCRIPTION
This commit adds a Google Cloud Build definition for building alpine
s390x images and pushing them as a manifest list together with their
s390x counterparts.

/cc @stevekuznetsov

rel: #16588