### PR TITLE
Revert "prow/config.yaml: set merge_method for kubebuilder repos"

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -598,11 +598,8 @@ tide:
     kubernetes-client/gen: squash
     kubernetes-sigs/cluster-api-provider-digitalocean: squash
     kubernetes-sigs/cluster-api-provider-ibmcloud: squash
-    kubernetes-sigs/controller-runtime: squash
-    kubernetes-sigs/controller-tools: squash
     kubernetes-sigs/krew-index: squash
     kubernetes-sigs/krew: squash
-    kubernetes-sigs/kubebuilder: squash
     kubernetes-sigs/kubespray: squash
     kubernetes-sigs/kui: rebase
     kubernetes-sigs/security-profiles-operator: rebase


### PR DESCRIPTION
This reverts commit 77fe92ab57689ef1b9fe2fc83d37404a9a2fad30.

Original PR was #22949