### PR TITLE
prow sub shutdown returns nil instead of error

### DIFF
--- a/prow/pubsub/subscriber/server.go
+++ b/prow/pubsub/subscriber/server.go
@@ -227,7 +227,7 @@ func (s *PullServer) Run(ctx context.Context) error {
 		select {
 		// Parent context. Shutdown
 		case <-ctx.Done():
-			return ctx.Err()
+			return nil
 		// Current thread context, it may be failing already
 		case <-derivedCtx.Done():
 			err = errGroup.Wait()


### PR DESCRIPTION
ctx.Done() is invoked on pod shutdown, which happens when prow upgrades, and every time sub spits out errors saying context cancelled and failed to run pull server. ctx.Done() shouldn't be invoked by any error conditions, so should be safe to return nil here