### PR TITLE
Labels: Allow to set up restricted labels not everyone can set

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -201,6 +201,7 @@ type TeamClient interface {
 	RemoveTeamRepo(id int, org, repo string) error
 	ListTeamInvitations(org string, id int) ([]OrgInvitation, error)
 	TeamHasMember(org string, teamID int, memberLogin string) (bool, error)
+	TeamBySlugHasMember(org string, teamSlug string, memberLogin string) (bool, error)
 	GetTeamBySlug(slug string, org string) (*Team, error)
 }
 
@@ -4487,6 +4488,22 @@ func (c *client) TeamHasMember(org string, teamID int, memberLogin string) (bool
 		}
 	}
 	return false, nil
+}
+
+func (c *client) TeamBySlugHasMember(org string, teamSlug string, memberLogin string) (bool, error) {
+	durationLogger := c.log("TeamBySlugHasMember", teamSlug, org)
+	defer durationLogger()
+
+	if c.fake {
+		return false, nil
+	}
+	exitCode, err := c.request(&request{
+		method:    http.MethodGet,
+		path:      fmt.Sprintf("/orgs/%s/teams/%s/memberships/%s", org, teamSlug, memberLogin),
+		org:       org,
+		exitCodes: []int{200, 404},
+	}, nil)
+	return exitCode == 200, err
 }
 
 // GetTeamBySlug returns information about that team

--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -141,6 +141,14 @@ type FakeClient struct {
 
 	// lock to be thread safe
 	lock sync.RWMutex
+
+	// Team is a map org->teamSlug->TeamWithMembers
+	Teams map[string]map[string]TeamWithMembers
+}
+
+type TeamWithMembers struct {
+	Team    github.Team
+	Members sets.String
 }
 
 func (f *FakeClient) BotUser() (*github.UserData, error) {
@@ -674,6 +682,15 @@ func (f *FakeClient) ListTeamMembers(org string, teamID int, role string) ([]git
 		return []github.TeamMember{}, nil
 	}
 	return members, nil
+}
+
+func (f *FakeClient) TeamBySlugHasMember(org string, teamSlug string, memberLogin string) (bool, error) {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+	if f.Teams[org] != nil {
+		return f.Teams[org][teamSlug].Members.Has(memberLogin), nil
+	}
+	return false, nil
 }
 
 // IsCollaborator returns true if the user is a collaborator of the repo.

--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -374,6 +374,29 @@ type Label struct {
 	// AdditionalLabels is a set of additional labels enabled for use
 	// on top of the existing "kind/*", "priority/*", and "area/*" labels.
 	AdditionalLabels []string `json:"additional_labels"`
+
+	// RestrictedLabels allows to configure labels that can only be modified
+	// by users that belong to at least one of the configured teams. The key
+	// defines to which repos this applies and can be `*` for global, an org
+	// or a repo in org/repo notation.
+	RestrictedLabels map[string][]RestrictedLabel `json:"restricted_labels,omitempty"`
+}
+
+func (l Label) RestrictedLabelsFor(org, repo string) map[string]RestrictedLabel {
+	result := map[string]RestrictedLabel{}
+	for _, orgRepoKey := range []string{"*", org, org + "/" + repo} {
+		for _, restrictedLabel := range l.RestrictedLabels[orgRepoKey] {
+			result[strings.ToLower(restrictedLabel.Label)] = restrictedLabel
+		}
+	}
+
+	return result
+}
+
+type RestrictedLabel struct {
+	Label        string   `json:"label"`
+	AllowedTeams []string `json:"allowed_teams"`
+	AllowedUsers []string `json:"allowed_users"`
 }
 
 // Trigger specifies a configuration for a single trigger.

--- a/prow/plugins/label/BUILD.bazel
+++ b/prow/plugins/label/BUILD.bazel
@@ -16,7 +16,10 @@ go_test(
         "//prow/github/fakegithub:go_default_library",
         "//prow/labels:go_default_library",
         "//prow/plugins:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
+        "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
     ],
 )
 

--- a/prow/plugins/plugin-config-documented.yaml
+++ b/prow/plugins/plugin-config-documented.yaml
@@ -404,6 +404,13 @@ label:
     # on top of the existing "kind/*", "priority/*", and "area/*" labels.
     additional_labels:
       - ""
+
+    # RestrictedLabels allows to configure labels that can only be modified
+    # by users that belong to at least one of the configured teams. The key
+    # defines to which repos this applies and can be `*` for global, an org
+    # or a repo in org/repo notation.
+    restricted_labels:
+        "": null
 lgtm:
   - # Repos is either of the form org/repos or just org.
     repos:


### PR DESCRIPTION
Currently, everyone who is trusted can add/remove labels through the
labels plugin. Sometimes only a restricted set of ppl should be able to
do that. This change extend the labels plugin to allow setting up
`restricted_labels` for this purpose.

/assign @stevekuznetsov 