### PR TITLE
releng: Tidy `kpromo` job configs

### DIFF
--- a/config/jobs/image-pushing/releng/k8s-staging-artifact-promoter.yaml
+++ b/config/jobs/image-pushing/releng/k8s-staging-artifact-promoter.yaml
@@ -1,35 +1,5 @@
 postsubmits:
   kubernetes/release:
-    - name: post-release-push-image-kpromo
-      cluster: k8s-infra-prow-build-trusted
-      annotations:
-        testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes, wg-k8s-infra-gcb
-        testgrid-alert-email: release-managers+alerts@kubernetes.io
-        testgrid-num-failures-to-alert: '1'
-      decorate: true
-      run_if_changed: '^(cmd\/kpromo\/|pkg\/(api|filepromoter|promobot)\/)'
-      branches:
-        - ^main$
-        # TODO(releng): Remove once repo default branch has been renamed
-        - ^master$
-      spec:
-        serviceAccountName: gcb-builder
-        containers:
-          - image: gcr.io/k8s-testimages/image-builder:v20210622-762366a
-            command:
-              - /run.sh
-            args:
-              - --project=k8s-staging-artifact-promoter
-              - --scratch-bucket=gs://k8s-staging-artifact-promoter-gcb
-              - --build-dir=.
-              - cmd/kpromo
-            env:
-              - name: LOG_TO_STDOUT
-                value: "y"
-      rerun_auth_config:
-        github_team_slugs:
-          - org: kubernetes
-            slug: release-managers
     - name: post-release-push-image-vulndash
       cluster: k8s-infra-prow-build-trusted
       annotations:
@@ -61,6 +31,7 @@ postsubmits:
           - org: kubernetes
             slug: release-managers
   kubernetes-sigs/k8s-container-image-promoter:
+    # TODO(releng): Rename to 'kpromo' once tools are merged
     - name: post-cip-push-image-cip
       cluster: k8s-infra-prow-build-trusted
       annotations:

--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -370,41 +370,6 @@ presubmits:
       testgrid-num-failures-to-alert: '10'
       testgrid-alert-email: release-managers+alerts@kubernetes.io
       testgrid-num-columns-recent: '30'
-  - name: pull-release-image-kpromo
-    cluster: k8s-infra-prow-build
-    decorate: true
-    run_if_changed: '^(cmd\/kpromo\/|pkg\/(api|filepromoter|promobot)\/)'
-    path_alias: k8s.io/release
-    spec:
-      serviceAccountName: gcb-builder-releng-test
-      containers:
-        - image: gcr.io/k8s-testimages/image-builder:v20210622-762366a
-          command:
-            - /run.sh
-          args:
-            - --project=k8s-staging-releng-test
-            - --scratch-bucket=gs://k8s-staging-releng-test
-            - --env-passthrough=PULL_BASE_REF,REGISTRY
-            - --build-dir=.
-            - cmd/kpromo
-          env:
-            - name: LOG_TO_STDOUT
-              value: "y"
-            - name: REGISTRY
-              value: "gcr.io/k8s-staging-releng-test"
-          resources:
-            requests:
-              cpu: 1000m
-              memory: 1Gi
-            limits:
-              cpu: 1000m
-              memory: 1Gi
-    annotations:
-      testgrid-dashboards: sig-release-releng-presubmits
-      testgrid-tab-name: release-image-kpromo
-      testgrid-num-failures-to-alert: '10'
-      testgrid-alert-email: release-managers+alerts@kubernetes.io
-      testgrid-num-columns-recent: '30'
   - name: pull-release-image-kubepkg
     cluster: k8s-infra-prow-build
     decorate: true

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -47,6 +47,7 @@ periodics:
       - /kpromo
       args:
       - run
+      - files
       - --filestores=/home/prow/go/src/github.com/kubernetes/k8s.io/artifacts/filestores/
       - --files=/home/prow/go/src/github.com/kubernetes/k8s.io/artifacts/manifests/
       # TODO(releng): Use '--dry-run=false' (or '--confirm') once testing is complete


### PR DESCRIPTION
- the remaining promotion tools, including `kpromo`, have been moved
  back into the CIP repo
- their GCB config has been merged with the existing CIP
  cloudbuild.yaml, so the individual jobs targeting k/release are no
  longer required
- command invocation for periodic job is fixed to include the
  subcommand (`kpromo run files ...`)

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @ameukam @puerco @saschagrunert @cpanato
cc: @kubernetes/release-engineering
ref: https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/408, https://github.com/kubernetes/k8s.io/issues/2624