### PR TITLE
Fix PJs not being labled with tenantIDs

### DIFF
--- a/prow/pjutil/pjutil.go
+++ b/prow/pjutil/pjutil.go
@@ -176,6 +176,7 @@ func specFromJobBase(jb config.JobBase) prowapi.ProwJobSpec {
 		ReporterConfig:  jb.ReporterConfig,
 		RerunAuthConfig: jb.RerunAuthConfig,
 		Hidden:          jb.Hidden,
+		ProwJobDefault:  jb.ProwJobDefault,
 	}
 }
 

--- a/prow/test/data/kubernetes-defaulted-decoration-prow-job.yaml
+++ b/prow/test/data/kubernetes-defaulted-decoration-prow-job.yaml
@@ -43,6 +43,8 @@ spec:
       image: golang:latest
       name: ""
       resources: {}
+  prowjob_defaults:
+    tenant_id: GlobalDefaultID
   refs:
     base_ref: master
     base_sha: basesha

--- a/prow/test/data/kubernetes-explicit-decoration-prow-job.yaml
+++ b/prow/test/data/kubernetes-explicit-decoration-prow-job.yaml
@@ -43,6 +43,8 @@ spec:
       image: golang:latest
       name: ""
       resources: {}
+  prowjob_defaults:
+    tenant_id: GlobalDefaultID
   refs:
     base_ref: master
     base_sha: basesha

--- a/prow/test/data/kubernetes-no-decoration-prow-job.yaml
+++ b/prow/test/data/kubernetes-no-decoration-prow-job.yaml
@@ -29,6 +29,8 @@ spec:
       image: golang:latest
       name: ""
       resources: {}
+  prowjob_defaults:
+    tenant_id: GlobalDefaultID
   refs:
     base_ref: master
     base_sha: basesha

--- a/prow/test/integration/test/BUILD.bazel
+++ b/prow/test/integration/test/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
     ],
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/phony:go_default_library",

--- a/prow/test/integration/test/horologium_test.go
+++ b/prow/test/integration/test/horologium_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	prowjobv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/kube"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -88,6 +89,12 @@ func TestLaunchProwJob(t *testing.T) {
 
 			t.Logf("Ensure there is at least one run of %q", existJobName)
 			pj := getNextRunOrFail(t, existJobName, nil)
+
+			// TODO(mpherman): Make a better test for this.
+			// Hijacking Horlogium Integration test to make sure PJ is created with a tenantID (specifically the default one)
+			if pj.Spec.ProwJobDefault == nil || pj.Spec.ProwJobDefault.TenantID != config.DefaultTenantID {
+				t.Fatalf("ProwJob Not created with TenantID")
+			}
 
 			// Now examines that 'interval' respects the last run instead of a
 			// fixed schedule. For example, if the previous pj started at 00:00:00,


### PR DESCRIPTION
Added a bit to the horlogium integration test to make sure this change actually worked. I will add more robust integration testing around tenantIDs in a followup PR