### PR TITLE
Update image-builder azure-sig presubmit triggers

### DIFF
--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
@@ -25,7 +25,7 @@ presubmits:
     labels:
       preset-azure-cred: "true"
     decorate: true
-    always_run: false
+    run_if_changed: 'images/capi/Makefile|images/capi/scripts/ci-azure-e2e\.sh|images/capi/packer/azure/.*'
     optional: true
     decoration_config:
       timeout: 1h


### PR DESCRIPTION
As discovered in https://github.com/kubernetes-sigs/image-builder/pull/686, the image builder azure-sig presubmit was broken because two PRs that both broke it hadn't run the test. Changing the run_if_changed settings to always trigger the test when something changed that could potentially break azure-sig without breaking azure-vhd: Makefile, azure/* and ci-azure-e2e.sh.

/assign @jsturtevant @codenrhoden @whites11