### PR TITLE
Don't use deprecated vars of MinIO in starter

### DIFF
--- a/config/prow/cluster/starter-s3.yaml
+++ b/config/prow/cluster/starter-s3.yaml
@@ -1303,11 +1303,11 @@ stringData:
   service-account.json: |
     {
       "region": "minio",
-      "access_key": "<<CHANGE_ME_MINIO_ACCESS_KEY>>",
+      "access_key": "<<CHANGE_ME_MINIO_ROOT_USER>>",
       "endpoint": "minio.prow.svc.cluster.local",
       "insecure": true,
       "s3_force_path_style": true,
-      "secret_key": "<<CHANGE_ME_MINIO_SECRET_KEY>>"
+      "secret_key": "<<CHANGE_ME_MINIO_ROOT_PASSWORD>>"
     }
 ---
 apiVersion: v1
@@ -1319,11 +1319,11 @@ stringData:
   service-account.json: |
     {
       "region": "minio",
-      "access_key": "<<CHANGE_ME_MINIO_ACCESS_KEY>>",
+      "access_key": "<<CHANGE_ME_MINIO_ROOT_USER>>",
       "endpoint": "minio.prow.svc.cluster.local",
       "insecure": true,
       "s3_force_path_style": true,
-      "secret_key": "<<CHANGE_ME_MINIO_SECRET_KEY>>"
+      "secret_key": "<<CHANGE_ME_MINIO_ROOT_PASSWORD>>"
     }
 ---
 apiVersion: apps/v1
@@ -1368,10 +1368,10 @@ spec:
         - server
         - /data
         env:
-        - name: MINIO_ACCESS_KEY
-          value: "<<CHANGE_ME_MINIO_ACCESS_KEY>>"
-        - name: MINIO_SECRET_KEY
-          value: "<<CHANGE_ME_MINIO_SECRET_KEY>>"
+        - name: MINIO_ROOT_USER
+          value: "<<CHANGE_ME_MINIO_ROOT_USER>>"
+        - name: MINIO_ROOT_PASSWORD
+          value: "<<CHANGE_ME_MINIO_ROOT_PASSWORD>>"
         - name: MINIO_REGION_NAME
           value: minio
         ports:


### PR DESCRIPTION
`MINIO_ACCESS_KEY` & `MINIO_SECRET_KEY` vars were deprecated in MinIO and replaced by  `MINIO_ROOT_USER` and  `MINIO_ROOT_PASSWORD` in https://github.com/minio/minio/pull/11185 and this patch is updating starter-s3.yaml respectively.

Example logs of MinIO pod in from starter-s3.yaml deployment

```
WARNING: MINIO_ACCESS_KEY and MINIO_SECRET_KEY are deprecated.
         Please use MINIO_ROOT_USER and MINIO_ROOT_PASSWORD
API: http://10.244.3.5:9000  http://127.0.0.1:9000 
```