### PR TITLE
Fix spyglass hyperlink href path

### DIFF
--- a/prow/cmd/deck/static/spyglass/lens.ts
+++ b/prow/cmd/deck/static/spyglass/lens.ts
@@ -195,7 +195,7 @@ class SpyglassImpl implements Spyglass {
     if (typeof attr !== 'undefined') {
         return match;
     }
-    return `</span><a target="_blank" href="'${match}'">${match}</a><span>`;
+    return `</span><a target="_blank" href="${match}">${match}</a><span>`;
   }
 
   private createHyperlinks(parent: Element): void {
@@ -203,7 +203,7 @@ class SpyglassImpl implements Spyglass {
     const re = /((?:href|src)=")?(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig;
 
     for (const elem of Array.from(parent.querySelectorAll<HTMLAnchorElement>('div.linetext>span'))) {
-      elem.outerHTML = elem.innerText.replace(re, this.setLink);
+      elem.innerHTML = elem.innerText.replace(re, this.setLink);
     }
   }
 


### PR DESCRIPTION
Related to https://github.com/kubernetes/test-infra/issues/23311. Fixes bug introduced on https://github.com/kubernetes/test-infra/pull/23429 .

Need to remove the quotes, otherwise the path tried to be resolved is
relative to the host while we would like the href link to be absolute.

For example, the bug `href="'${match}'"` caused the link
`http://127.0.0.1:2379`
to redirect to
`<host>/spyglass/static/buildlog/'http://127.0.0.1:2379'`

Removing the quotes fix this issue.

Additionally, fixes the replacement code to change the `innerHTML` and not
the `outerHTML`. This way the `outerHTML` element isn't changed.