### PR TITLE
Switch bazelbuild/rules-k8s from Service Account to Workload Identity

### DIFF
--- a/config/jobs/bazelbuild/rules_k8s/rules_k8s_config.yaml
+++ b/config/jobs/bazelbuild/rules_k8s/rules_k8s_config.yaml
@@ -11,19 +11,11 @@ presubmits:
         - bash
         - -c
         - |
-          gcloud auth activate-service-account --key-file=/etc/gcp/service-account.json \
-          && gcloud container clusters get-credentials testing --zone=us-central1-f --project=rules-k8s \
+          gcloud container clusters get-credentials testing --zone=us-central1-f --project=rules-k8s \
           && echo "startup --host_jvm_args=-Duser.name=prow" > /root/.bazelrc \
           && ./test-e2e.sh
         env:
         - name: USER
           value: prow
-        volumeMounts:
-        - name: service-account
-          mountPath: /etc/gcp
-      volumes:
-      - name: service-account
-        secret:
-          secretName: service-account
     annotations:
       testgrid-dashboards: google-rules_k8s


### PR DESCRIPTION
Workload identity has been enabled and associated with this service account, so we should no longer need to explicitly set them.

/assign @cjwagner @fejta 