### PR TITLE
Fix wrong symlinks of utility images for multiarch

### DIFF
--- a/prow/cmd/clonerefs/BUILD.bazel
+++ b/prow/cmd/clonerefs/BUILD.bazel
@@ -35,8 +35,16 @@ prow_image(
         "github_known_hosts",
         "ssh_config",
     ],
-    symlinks = {
+    symlinks_arm64 = {
+        "/clonerefs": "/app/prow/cmd/clonerefs/app-arm64.binary",
+        "/etc/ssh/ssh_config": "/ssh_config",
+    },
+    symlinks_default = {
         "/clonerefs": "/app/prow/cmd/clonerefs/app.binary",
+        "/etc/ssh/ssh_config": "/ssh_config",
+    },
+    symlinks_ppc64le = {
+        "/clonerefs": "/app/prow/cmd/clonerefs/app-ppc64le.binary",
         "/etc/ssh/ssh_config": "/ssh_config",
     },
     visibility = ["//visibility:public"],

--- a/prow/cmd/entrypoint/BUILD.bazel
+++ b/prow/cmd/entrypoint/BUILD.bazel
@@ -31,7 +31,9 @@ prow_image(
     build_arm64 = True,
     build_ppc64le = True,
     component = NAME,
-    symlinks = {"/entrypoint": "/app/prow/cmd/entrypoint/app.binary"},
+    symlinks_arm64 = {"/entrypoint": "/app/prow/cmd/entrypoint/app-arm64.binary"},
+    symlinks_default = {"/entrypoint": "/app/prow/cmd/entrypoint/app.binary"},
+    symlinks_ppc64le = {"/entrypoint": "/app/prow/cmd/entrypoint/app-ppc64le.binary"},
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/initupload/BUILD.bazel
+++ b/prow/cmd/initupload/BUILD.bazel
@@ -31,7 +31,9 @@ prow_image(
     build_arm64 = True,
     build_ppc64le = True,
     component = NAME,
-    symlinks = {"/initupload": "/app/prow/cmd/initupload/app.binary"},
+    symlinks_arm64 = {"/initupload": "/app/prow/cmd/initupload/app-arm64.binary"},
+    symlinks_default = {"/initupload": "/app/prow/cmd/initupload/app.binary"},
+    symlinks_ppc64le = {"/initupload": "/app/prow/cmd/initupload/app-ppc64le.binary"},
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/sidecar/BUILD.bazel
+++ b/prow/cmd/sidecar/BUILD.bazel
@@ -31,7 +31,9 @@ prow_image(
     build_arm64 = True,
     build_ppc64le = True,
     component = NAME,
-    symlinks = {"/sidecar": "/app/prow/cmd/sidecar/app.binary"},
+    symlinks_arm64 = {"/sidecar": "/app/prow/cmd/sidecar/app-arm64.binary"},
+    symlinks_default = {"/sidecar": "/app/prow/cmd/sidecar/app.binary"},
+    symlinks_ppc64le = {"/sidecar": "/app/prow/cmd/sidecar/app-ppc64le.binary"},
     visibility = ["//visibility:public"],
 )
 

--- a/prow/def.bzl
+++ b/prow/def.bzl
@@ -36,6 +36,9 @@ def prow_image(
         app_name = "app",
         build_arm64 = False,
         build_ppc64le = False,
+        symlinks_default = None,
+        symlinks_arm64 = None,
+        symlinks_ppc64le = None,
         **kwargs):
     go_image(
         name = app_name,
@@ -51,6 +54,7 @@ def prow_image(
         name = name,
         base = ":" + app_name,
         stamp = stamp,
+        symlinks = symlinks_default,
         **kwargs
     )
 
@@ -70,6 +74,7 @@ def prow_image(
             base = ":%s-arm64" % app_name,
             architecture = "arm64",
             stamp = stamp,
+            symlinks = symlinks_arm64,
             **kwargs
         )
 
@@ -89,6 +94,7 @@ def prow_image(
             base = ":%s-ppc64le" % app_name,
             architecture = "ppc64le",
             stamp = stamp,
+            symlinks = symlinks_ppc64le,
             **kwargs
         )
 


### PR DESCRIPTION
Fix wrong symlinks of utility images for multiarch.
I built the Prow utility image for arm64, but it doesn't work, due to the wrong symlinks in root directory.

Signed-off-by: Ruquan Zhao ruquan.zhao@arm.com