### PR TITLE
config/jobs: move secrets-store-csi-driver to main branch

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -255,7 +255,7 @@ presubmits:
     extra_refs:
     - org: kubernetes
       repo: kubernetes
-      base_ref: master
+      base_ref: main
       path_alias: k8s.io/kubernetes
       workdir: true
     spec:
@@ -279,7 +279,7 @@ presubmits:
         - --aksengine-orchestratorRelease=1.21
         - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
         - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
-        - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/test/bats/tests/azure/job_templates/kubernetes_windows.json
+        - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/main/test/bats/tests/azure/job_templates/kubernetes_windows.json
         - --aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz
         # Specific test args
         - --test-secrets-store-csi-driver
@@ -701,7 +701,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: secrets-store-csi-driver
-    base_ref: master
+    base_ref: main
     path_alias: sigs.k8s.io/secrets-store-csi-driver
   spec:
     containers:
@@ -737,7 +737,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: secrets-store-csi-driver
-    base_ref: master
+    base_ref: main
     path_alias: sigs.k8s.io/secrets-store-csi-driver
   spec:
     containers:


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

This is the next step in the branch rename from `master` to `main`. This is a just before rename change and should be done in conjunction with the actual rename.

Ref: https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/617