### PR TITLE
update secrets-store-csi-driver jobs post default-branch-rename

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -8,7 +8,6 @@ presubmits:
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
     - ^main$
-    - ^master$
     - ^release-*
     labels:
     spec:
@@ -32,7 +31,6 @@ presubmits:
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
     - ^main$
-    - ^master$
     - ^release-*
     labels:
     spec:
@@ -58,7 +56,6 @@ presubmits:
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
     - ^main$
-    - ^master$
     - ^release-*
     labels:
     spec:
@@ -85,7 +82,6 @@ presubmits:
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
     - ^main$
-    - ^master$
     - ^release-*
     labels:
       preset-dind-enabled: "true"
@@ -115,7 +111,6 @@ presubmits:
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
     - ^main$
-    - ^master$
     - ^release-*
     labels:
       # this is required because we want to run kind in docker
@@ -147,7 +142,6 @@ presubmits:
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
     - ^main$
-    - ^master$
     - ^release-*
     labels:
       # this is required because we want to run kind in docker
@@ -182,7 +176,6 @@ presubmits:
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
     - ^main$
-    - ^master$
     labels:
       # this is required because we want to run kind in docker
       preset-dind-enabled: "true"
@@ -210,7 +203,6 @@ presubmits:
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
     - ^main$
-    - ^master$
     labels:
       # this is required because we want to run kind in docker
       preset-dind-enabled: "true"
@@ -244,7 +236,6 @@ presubmits:
     optional: false
     branches:
     - ^main$
-    - ^master$
     - ^release-*
     labels:
       preset-azure-cred: "true"
@@ -301,7 +292,6 @@ presubmits:
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
     - ^main$
-    - ^master$
     - ^release-*
     labels:
       # this is required because we want to run kind in docker
@@ -335,7 +325,6 @@ presubmits:
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
     - ^main$
-    - ^master$
     - ^release-*
     labels:
       # this is required because we want to run kind in docker
@@ -369,7 +358,6 @@ presubmits:
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
     - ^main$
-    - ^master$
     - ^release-*
     labels:
     spec:
@@ -399,7 +387,6 @@ presubmits:
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
     - ^main$
-    - ^master$
     - ^release-*
     labels:
       # this is required because we want to run kind in docker
@@ -438,7 +425,6 @@ presubmits:
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
     - ^main$
-    - ^master$
     - ^release-*
     labels:
       # this is required because we want to run kind in docker
@@ -474,7 +460,6 @@ presubmits:
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
     - ^main$
-    - ^master$
     - ^release-*
     labels:
       # this is required because we want to run kind in docker
@@ -512,7 +497,6 @@ presubmits:
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
     - ^main$
-    - ^master$
     - ^release-*
     labels:
       # this is required because we want to run kind in docker
@@ -551,7 +535,6 @@ postsubmits:
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
     - ^main$
-    - ^master$
     labels:
       # this is required because we want to run kind in docker
       preset-dind-enabled: "true"
@@ -586,7 +569,6 @@ postsubmits:
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
     - ^main$
-    - ^master$
     labels:
       # this is required because we want to run kind in docker
       preset-dind-enabled: "true"
@@ -623,7 +605,6 @@ postsubmits:
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
     - ^main$
-    - ^master$
     labels:
       # this is required because we want to run kind in docker
       preset-dind-enabled: "true"
@@ -660,7 +641,6 @@ postsubmits:
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
     - ^main$
-    - ^master$
     labels:
       # this is required because we want to run kind in docker
       preset-dind-enabled: "true"


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

This is post-rename cleanup for the default branch rename.

ref: https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/617