### PR TITLE
Enable prow transfer-issue plugin for kubernetes org

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -770,6 +770,7 @@ plugins:
     - size
     - skip
     - slackevents
+    - transfer-issue
     - trick-or-treat
     - trigger
     - verify-owners


### PR DESCRIPTION
This PR enables the Prow transfer-issue plugin for the kubernetes org.

Now that https://github.com/kubernetes/test-infra/pull/23153 is merged I'm unsure if there is more to get this enabled than this change.

Do we want to enable for individual repos instead? My use case is to be able to transfer kubectl issues from k/k to the kubectl repo.