### PR TITLE
config/jobs: add kubekins-e2e k8s-infra canary image build

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-test-infra.yaml
+++ b/config/jobs/image-pushing/k8s-staging-test-infra.yaml
@@ -26,6 +26,29 @@ postsubmits:
           - --project=k8s-staging-test-infra
           - --env-passthrough=PULL_BASE_REF
           - kettle/
+    - name: post-test-infra-push-kubekins-e2e-canary
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-testing-canaries, wg-k8s-infra-canaries, wg-k8s-infra-gcb
+        testgrid-alert-email: k8s-infra-alerts@kubernetes.io
+        testgrid-num-failures-to-alert: '1'
+        description: builds and pushes the kubekins-e2e image
+      run_if_changed: '^(images/kubekins-e2e|kubetest|boskos)/'
+      decorate: true
+      branches:
+      - ^master$
+      max_concurrency: 1
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+        - image: gcr.io/k8s-testimages/image-builder:v20210622-762366a
+          command:
+          - /run.sh
+          args:
+          - --scratch-bucket=gs://k8s-staging-test-infra-gcb
+          - --project=k8s-staging-test-infra
+          - --build-dir=.
+          - images/kubekins-e2e/
     - name: post-test-infra-push-triage
       cluster: k8s-infra-prow-build-trusted
       run_if_changed: '^triage/'


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1523

Push kubekins-e2e to gcr.io/k8s-staging-test-infra, in addition to the existing job that pushes to k8s-testimages