### PR TITLE
config/jobs: use k8s-infra hosted kubekins-e2e in canary jobs

### DIFF
--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -51,7 +51,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210825-f1955d1-go-canary
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8e9c-go-canary
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -105,7 +105,7 @@ periodics:
   decorate: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -146,7 +146,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Variable.Expansion --ginkgo.skip=\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=40m
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: sig-testing-canaries

--- a/config/jobs/kubernetes/sig-testing/make-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/make-test.yaml
@@ -92,7 +92,7 @@ presubmits:
         runAsUser: 2000
         allowPrivilegeEscalation: false
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210825-f1955d1-go-canary
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8e9c-go-canary
           command:
             - make
             - test
@@ -188,7 +188,7 @@ periodics:
         runAsUser: 2000
         allowPrivilegeEscalation: false
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210825-f1955d1-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8e9c-master
           command:
             - runner.sh
             - bash


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1523#issuecomment-912031929
- Followup to: https://github.com/kubernetes/test-infra/pull/23458

Choosing frequent canary jobs that are passing
- ci-kubernetes-cached-make-test
- ci-kubernetes-e2e-gce-canary
- ci-kubernetes-e2e-prow-canary
- pull-kubernetes-unit-go-canary
- pull-kubernetes-integration-go-canary