### PR TITLE
kubetest: run post-test-cmd under the same conditions as pre-test-cmd

### DIFF
--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -319,7 +319,7 @@ func run(deploy deployer, o options) error {
 		}))
 	}
 
-	if o.postTestCmd != "" {
+	if o.postTestCmd != "" && (o.test || (kubemarkUpErr == nil && o.testCmd != "")) {
 		errs = util.AppendError(errs, control.XMLWrap(&suite, "post-test command", func() error {
 			cmdLineTokenized := strings.Fields(os.ExpandEnv(o.postTestCmd))
 			return control.FinishRunning(exec.Command(cmdLineTokenized[0], cmdLineTokenized[1:]...))


### PR DESCRIPTION
`post-test-cmd` runs despite `pre-test-cmd` being skipped when the test does not have the `test` or `test-cmd` set. We believe it'd be better if `post-test-cmd` ran in the same conditions as `pre-test-cmd` for the sake of consistency.

/assign @tosi3k