### PR TITLE
Fix kettle image canary build

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-test-infra.yaml
+++ b/config/jobs/image-pushing/k8s-staging-test-infra.yaml
@@ -24,7 +24,7 @@ postsubmits:
           args:
           - --scratch-bucket=gs://k8s-staging-test-infra-gcb
           - --project=k8s-staging-test-infra
-          - --env-passthrough=PULL_BASE_REF
+          - --build-dir=.
           - kettle/
     - name: post-test-infra-push-kubekins-e2e-canary
       cluster: k8s-infra-prow-build-trusted


### PR DESCRIPTION
Part of : https://github.com/kubernetes/k8s.io/issues/1523.

Drop unused env variable PULL_BASE_REF
Signed-off-by: Arnaud Meukam <ameukam@gmail.com>