### PR TITLE
Revert "Switch from Service Account to Workload Identity"

### DIFF
--- a/config/jobs/bazelbuild/rules_k8s/rules_k8s_config.yaml
+++ b/config/jobs/bazelbuild/rules_k8s/rules_k8s_config.yaml
@@ -11,11 +11,19 @@ presubmits:
         - bash
         - -c
         - |
-          gcloud container clusters get-credentials testing --zone=us-central1-f --project=rules-k8s \
+          gcloud auth activate-service-account --key-file=/etc/gcp/service-account.json \
+          && gcloud container clusters get-credentials testing --zone=us-central1-f --project=rules-k8s \
           && echo "startup --host_jvm_args=-Duser.name=prow" > /root/.bazelrc \
           && ./test-e2e.sh
         env:
         - name: USER
           value: prow
+        volumeMounts:
+        - name: service-account
+          mountPath: /etc/gcp
+      volumes:
+      - name: service-account
+        secret:
+          secretName: service-account
     annotations:
       testgrid-dashboards: google-rules_k8s


### PR DESCRIPTION
This reverts commit 5a9114f46bcc2131f698860171ab8088f325f398. (and PR #23444)

The test isn't working due to a permission issue: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/bazelbuild_rules_k8s/665/pull-rules-k8s-e2e/1433501744628764672