### PR TITLE
commenter: seed pseudorandom generator and use `rand.Shuffle`

### DIFF
--- a/robots/commenter/main.go
+++ b/robots/commenter/main.go
@@ -229,12 +229,11 @@ func run(c client, query, sort string, asc, random bool, commenter func(meta) (s
 	problems := []string{}
 	log.Printf("Found %d matches", len(issues))
 	if random {
-		dest := make([]github.Issue, len(issues))
-		perm := rand.Perm(len(issues))
-		for i, v := range perm {
-			dest[v] = issues[i]
-		}
-		issues = dest
+		rand.Seed(time.Now().UnixNano())
+		rand.Shuffle(len(issues), func(i, j int) {
+			issues[i], issues[j] = issues[j], issues[i]
+		})
+
 	}
 	for n, i := range issues {
 		if ceiling > 0 && n == ceiling {


### PR DESCRIPTION
https://pkg.go.dev/math/rand says:
> Use the Seed function to initialize the default Source if different
> behavior is required for each run

Without the seed, we did not actually get the desired behavior where
issues were randomly shuffled in each run.

Also, use `rand.Shuffle` instead of reimplementing it.
