### PR TITLE
releng(kpromo): Periodic interval to 1h / add non-blocking presubmit

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -64,6 +64,32 @@ presubmits:
         # script needs it to be defined).
         - name: GOPATH
           value: /go
+  - name: pull-k8sio-file-promo
+    annotations:
+      testgrid-create-test-group: 'true'
+      testgrid-dashboards: sig-release-releng-blocking, wg-k8s-infra-k8sio
+      testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '10'
+    decorate: true
+    # TODO(releng): Remove once testing is complete
+    optional: true
+    skip_report: false
+    run_if_changed: '^artifacts\/(filestores|manifests)\/.*\/*.yaml'
+    max_concurrency: 10
+    branches:
+    - ^main$
+    spec:
+      containers:
+      # TODO(releng): Use a promoted image here once testing is complete
+      - image: gcr.io/k8s-staging-releng-test/kpromo-amd64:v0.2.0-1
+        command:
+        - /kpromo
+        args:
+        - run
+        - files
+        - --manifests=/home/prow/go/src/github.com/kubernetes/k8s.io/artifacts/
+        # TODO(releng): Use '--dry-run=false' (or '--confirm') once testing is complete
+        - --dry-run=true
   kubernetes-sigs/k8s-container-image-promoter:
   # Run promoter e2e tests.
   - name: pull-cip-e2e

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -25,7 +25,8 @@ postsubmits:
       testgrid-num-failures-to-alert: '1'
 
 periodics:
-- interval: 4h
+# TODO(releng): Set this to '4h' once testing is complete
+- interval: 1h
   cluster: k8s-infra-prow-build-trusted
   max_concurrency: 1
   name: ci-k8sio-file-promo


### PR DESCRIPTION
Part of automating file promotion: https://github.com/kubernetes/k8s.io/issues/2624

ref: https://github.com/kubernetes/test-infra/pull/23489, https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/409

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @ameukam @puerco @saschagrunert @cpanato
cc: @kubernetes/release-engineering