### PR TITLE
releng: `kpromo` config cleanups

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -71,8 +71,6 @@ presubmits:
       testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
       testgrid-num-failures-to-alert: '10'
     decorate: true
-    # TODO(releng): Remove once testing is complete
-    optional: true
     skip_report: false
     run_if_changed: '^artifacts\/(filestores|manifests)\/.*\/*.yaml'
     max_concurrency: 10
@@ -80,15 +78,14 @@ presubmits:
     - ^main$
     spec:
       containers:
-      # TODO(releng): Use a promoted image here once testing is complete
-      - image: gcr.io/k8s-staging-releng-test/kpromo-amd64:v0.2.0-1
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v0.2.0-1
         command:
         - /kpromo
         args:
         - run
         - files
         - --manifests=/home/prow/go/src/github.com/kubernetes/k8s.io/artifacts/
-        # TODO(releng): Use '--dry-run=false' (or '--confirm') once testing is complete
+        - --use-service-account
         - --dry-run=true
   kubernetes-sigs/k8s-container-image-promoter:
   # Run promoter e2e tests.

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -1,5 +1,31 @@
 postsubmits:
   kubernetes/k8s.io:
+  - name: post-k8sio-file-promo
+    cluster: k8s-infra-prow-build-trusted
+    decorate: true
+    run_if_changed: '^artifacts\/(filestores|manifests)\/.*\/*.yaml'
+    # Never run more than 1 job at a time. This is because we don't want to run
+    # into a case where an older manifest PR merge gets run last (after a newer
+    # one).
+    max_concurrency: 1
+    branches:
+    - ^main$
+    spec:
+      serviceAccountName: k8s-infra-gcr-promoter
+      containers:
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v0.2.0-1
+        command:
+        - /kpromo
+        args:
+        - run
+        - files
+        - --manifests=/home/prow/go/src/github.com/kubernetes/k8s.io/artifacts/
+        - --use-service-account
+        - --dry-run=false
+    annotations:
+      testgrid-dashboards: sig-release-releng-blocking, wg-k8s-infra-k8sio
+      testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
   - name: post-k8sio-image-promo
     cluster: k8s-infra-prow-build-trusted
     decorate: true
@@ -40,23 +66,19 @@ periodics:
     #               one's name to 'k8s-infra-artifact-promoter'?
     serviceAccountName: k8s-infra-gcr-promoter
     containers:
-    # TODO(releng): Use a promoted image here once testing is complete
-    - image: gcr.io/k8s-staging-releng-test/kpromo-amd64:v0.2.0-1
-      # TODO(releng): Remove once a promoted image is in use
-      imagePullPolicy: Always
+    - image: k8s.gcr.io/artifact-promoter/kpromo:v0.2.0-1
       command:
       - /kpromo
       args:
       - run
       - files
       - --manifests=/home/prow/go/src/github.com/kubernetes/k8s.io/artifacts/
-      # TODO(releng): Use '--dry-run=false' (or '--confirm') once testing is complete
-      - --dry-run=true
+      - --use-service-account
+      - --dry-run=false
   annotations:
     testgrid-dashboards: sig-release-releng-blocking, wg-k8s-infra-k8sio
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
-    # TODO(releng): Lower the alert threshold to '1' once testing is complete
-    testgrid-num-failures-to-alert: '10'
+    testgrid-num-failures-to-alert: '1'
   rerun_auth_config:
     github_team_slugs:
       - org: kubernetes


### PR DESCRIPTION
Part of https://github.com/kubernetes/k8s.io/issues/2624.

- use k8s.gcr.io/artifact-promoter/kpromo:v0.2.0-1 (ref: https://github.com/kubernetes/k8s.io/pull/2664)
- use service account for promotion
- make presubmit blocking for file promotion PRs (presubmit has been running successfully against https://github.com/kubernetes/k8s.io/pull/2663)
- flip periodic job to `--dry-run=false`
- add postsubmit

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @ameukam @puerco @saschagrunert @cpanato
cc: @kubernetes/release-engineering