### PR TITLE
releng(kpromo): Drop `--use-service-account` flag

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -85,7 +85,6 @@ presubmits:
         - run
         - files
         - --manifests=/home/prow/go/src/github.com/kubernetes/k8s.io/artifacts/
-        - --use-service-account
         - --dry-run=true
   kubernetes-sigs/k8s-container-image-promoter:
   # Run promoter e2e tests.

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -20,7 +20,6 @@ postsubmits:
         - run
         - files
         - --manifests=/home/prow/go/src/github.com/kubernetes/k8s.io/artifacts/
-        - --use-service-account
         - --dry-run=false
     annotations:
       testgrid-dashboards: sig-release-releng-blocking, wg-k8s-infra-k8sio
@@ -73,7 +72,6 @@ periodics:
       - run
       - files
       - --manifests=/home/prow/go/src/github.com/kubernetes/k8s.io/artifacts/
-      - --use-service-account
       - --dry-run=false
   annotations:
     testgrid-dashboards: sig-release-releng-blocking, wg-k8s-infra-k8sio


### PR DESCRIPTION
In a previous commit (from #23493), the `--use-service-account`
flag was added for `kpromo` jobs, but it might not actually be
necessary (as we're already running in containers with access to
service accounts).

Let's validate this before touching the legacy code paths in CIP
(which handle auth via service account) or building/promoting a
new image containing `gcloud` SDK binaries.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @ameukam @puerco @saschagrunert @cpanato
cc: @kubernetes/release-engineering

---

Example failures:

From https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-k8sio-file-promo/1435127641098162176:

```console
********** START **********
level=info msg="processing destination \"gs://k8s-artifacts-prod/binaries/kops/\""
level=info msg="listing files in bucket k8s-staging-kops with prefix \"kops/releases/\""
level=info msg="listing files in bucket k8s-artifacts-prod with prefix \"binaries/kops/\""
level=info msg="getting service-account-token for \"k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com\""
level=error msg="could not execute cmd gcloud auth --account=k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com print-access-token"
level=warning msg="failed to get service-account-token for \"k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com\": exec: \"gcloud\": executable file not found in $PATH"
level=fatal msg="run `kpromo run files`: error building operations: error building promotion operations for \"gs://k8s-artifacts-prod/binaries/kops/\": error listing objects in \"gs://k8s-artifacts-prod/binaries/kops/\": Get \"https://storage.googleapis.com/storage/v1/b/k8s-artifacts-prod/o?alt=json&delimiter=&endOffset=&pageToken=&prefix=binaries%2Fkops%2F&prettyPrint=false&projection=full&startOffset=&versions=false\": exec: \"gcloud\": executable file not found in $PATH"
```

From https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/k8s.io/2663/pull-k8sio-file-promo/1435121919522246656:

```console
********** START (DRY RUN) **********
level=info msg="processing destination \"gs://k8s-staging-cri-tools/releases/\""
level=info msg="listing files in bucket k8s-artifacts-cri-tools with prefix \"release/\""
level=info msg="listing files in bucket k8s-staging-cri-tools with prefix \"releases/\""
level=info msg="getting service-account-token for \"k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com\""
level=error msg="could not execute cmd gcloud auth --account=k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com print-access-token"
level=warning msg="failed to get service-account-token for \"k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com\": exec: \"gcloud\": executable file not found in $PATH"
level=fatal msg="run `kpromo run files`: error building operations: error building promotion operations for \"gs://k8s-staging-cri-tools/releases/\": error listing objects in \"gs://k8s-staging-cri-tools/releases/\": Get \"https://storage.googleapis.com/storage/v1/b/k8s-staging-cri-tools/o?alt=json&delimiter=&endOffset=&pageToken=&prefix=releases%2F&prettyPrint=false&projection=full&startOffset=&versions=false\": exec: \"gcloud\": executable file not found in $PATH"
```