### PR TITLE
Fix plugins.label config sharding

### DIFF
--- a/prow/cmd/checkconfig/main_test.go
+++ b/prow/cmd/checkconfig/main_test.go
@@ -1797,6 +1797,12 @@ blunderbuss:
   request_count: 2
   use_status_availability: true`
 	const validOrgPluginsConfig = `
+label:
+  restricted_labels:
+    my-org:
+    - label: cherry-pick-approved
+      allowed_teams:
+      - patch-managers
 plugins:
   my-org:
     plugins:

--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -1794,7 +1794,7 @@ type Override struct {
 
 func (c *Configuration) mergeFrom(other *Configuration) error {
 	var errs []error
-	if diff := cmp.Diff(other, &Configuration{Approve: other.Approve, Bugzilla: other.Bugzilla, ExternalPlugins: other.ExternalPlugins, Lgtm: other.Lgtm, Plugins: other.Plugins}); diff != "" {
+	if diff := cmp.Diff(other, &Configuration{Approve: other.Approve, Bugzilla: other.Bugzilla, ExternalPlugins: other.ExternalPlugins, Label: Label{RestrictedLabels: other.Label.RestrictedLabels}, Lgtm: other.Lgtm, Plugins: other.Plugins}); diff != "" {
 		errs = append(errs, fmt.Errorf("supplemental plugin configuration has config that doesn't support merging: %s", diff))
 	}
 
@@ -1939,7 +1939,7 @@ func getLabelConfigFromRestrictedLabelsSlice(s []RestrictedLabel, label string) 
 }
 
 func (c *Configuration) HasConfigFor() (global bool, orgs sets.String, repos sets.String) {
-	if !reflect.DeepEqual(c, &Configuration{Approve: c.Approve, Bugzilla: c.Bugzilla, ExternalPlugins: c.ExternalPlugins, Label: c.Label, Lgtm: c.Lgtm, Plugins: c.Plugins}) || c.Bugzilla.Default != nil {
+	if !reflect.DeepEqual(c, &Configuration{Approve: c.Approve, Bugzilla: c.Bugzilla, ExternalPlugins: c.ExternalPlugins, Label: Label{RestrictedLabels: c.Label.RestrictedLabels}, Lgtm: c.Lgtm, Plugins: c.Plugins}) || c.Bugzilla.Default != nil {
 		global = true
 	}
 	orgs = sets.String{}

--- a/prow/plugins/config_test.go
+++ b/prow/plugins/config_test.go
@@ -2186,6 +2186,17 @@ func TestMergeFrom(t *testing.T) {
 			},
 		},
 		{
+			name:                "Labels.restricted_config gets merged",
+			in:                  Configuration{Label: Label{AdditionalLabels: []string{"foo"}}},
+			supplementalConfigs: []Configuration{{Label: Label{RestrictedLabels: map[string][]RestrictedLabel{"org": {{Label: "cherry-pick-approved", AllowedTeams: []string{"patch-managers"}}}}}}},
+			expected: Configuration{
+				Label: Label{
+					AdditionalLabels: []string{"foo"},
+					RestrictedLabels: map[string][]RestrictedLabel{"org": {{Label: "cherry-pick-approved", AllowedTeams: []string{"patch-managers"}}}},
+				},
+			},
+		},
+		{
 			name:                "main config has no ExternalPlugins config, supplemental config has, it gets merged",
 			supplementalConfigs: []Configuration{{ExternalPlugins: map[string][]ExternalPlugin{"foo/bar": {{Name: "refresh", Endpoint: "http://refresh", Events: []string{"issue_comment"}}}}}},
 			expected: Configuration{


### PR DESCRIPTION
The check in the merge logic wasn't extended to allow that so it would
bail out.