### PR TITLE
Add EKS Anywhere to list of projects using Prow

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -105,7 +105,7 @@ Prow is used by the following organizations and projects:
 - [Feast](https://github.com/gojek/feast)
 - [Falco](http://prow.falco.org)
 - [TiDB](https://prow.tidb.io)
-- [Amazon EKS Distro](https://prow.eks.amazonaws.com/)
+- [Amazon EKS Distro and Amazon EKS Anywhere](https://prow.eks.amazonaws.com/)
 - [KubeSphere](https://prow.kubesphere.io)
 - [OpenYurt](https://github.com/openyurtio/openyurt)
 


### PR DESCRIPTION
The [EKS Anywhere](https://github.com/aws/eks-anywhere) Open source project is now live and we use Prow to test and manage our CI/CD for both EKS Distro and, now EKS Anywhere (it's so beautiful 🥺). Thank you for helping out with doubts and clarifications in the Prow Kubernetes slack channel! 🥂 