### PR TITLE
Add custom-error-pages to ingress-nginx postsubmits

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-ingress-nginx.yaml
+++ b/config/jobs/image-pushing/k8s-staging-ingress-nginx.yaml
@@ -224,3 +224,23 @@ postsubmits:
               - --scratch-bucket=gs://k8s-staging-ingress-nginx-gcb
               - --env-passthrough=PULL_BASE_REF,PULL_BASE_SHA
               - images/kube-webhook-certgen
+
+    - name: post-ingress-nginx-build-custom-error-pages-image
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-network-ingress-nginx, wg-k8s-infra-gcb
+      decorate: true
+      run_if_changed: 'images/custom-error-pages/.*'
+      branches:
+        - ^main$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20210622-762366a
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-ingress-nginx
+              - --scratch-bucket=gs://k8s-staging-ingress-nginx-gcb
+              - --env-passthrough=PULL_BASE_REF,PULL_BASE_SHA
+              - images/custom-error-pages


### PR DESCRIPTION
After adding a cloudbuild config in https://github.com/kubernetes/ingress-nginx/pull/7460 the image still had to be added to the test infrastructure.

I followed the instructions left by @rikatz in a comment on that PR and I hope I did everything right :)  
If I didn't I'll be happy to update theis PR.