### PR TITLE
KubernetesOptions: use $KUBECONFIG only if it is not empty

### DIFF
--- a/prow/flagutil/kubernetes_cluster_clients.go
+++ b/prow/flagutil/kubernetes_cluster_clients.go
@@ -151,11 +151,12 @@ func (o *KubernetesOptions) LoadClusterConfigs(callBacks ...func()) (map[string]
 	}
 
 	if o.kubeconfig == "" && o.kubeconfigDir == "" {
-		value := os.Getenv(clientcmd.RecommendedConfigPathEnvVar)
-		if kubeconfigsFromEnv := strings.Split(value, ":"); len(kubeconfigsFromEnv) > 0 &&
-			len(kubeconfigsFromEnv) > len(o.clusterConfigs) {
-			errs = append(errs, fmt.Errorf("%s env var with value %s had %d elements but only got %d kubeconfigs",
-				clientcmd.RecommendedConfigPathEnvVar, value, len(kubeconfigsFromEnv), len(o.clusterConfigs)))
+		if envVal := os.Getenv(clientcmd.RecommendedConfigPathEnvVar); envVal != "" {
+			if kubeconfigsFromEnv := strings.Split(envVal, ":"); len(kubeconfigsFromEnv) > 0 &&
+				len(kubeconfigsFromEnv) > len(o.clusterConfigs) {
+				errs = append(errs, fmt.Errorf("%s env var with value %s had %d elements but only got %d kubeconfigs",
+					clientcmd.RecommendedConfigPathEnvVar, envVal, len(kubeconfigsFromEnv), len(o.clusterConfigs)))
+			}
 		}
 	}
 


### PR DESCRIPTION
Compare it with 

https://github.com/kubernetes/test-infra/blob/2b1a79430de5f3a62481d1b743312e1a0742ca00/prow/flagutil/kubernetes_cluster_clients.go#L102-L104

The non-empty gate is missing.

/cc @alvaroaleman @stevekuznetsov 