### PR TITLE
releng(kpromo): Bump images to v0.2.1-2

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -78,7 +78,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v0.2.0-1
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v0.2.1-2
         command:
         - /kpromo
         args:

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -13,7 +13,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-promoter
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v0.2.0-1
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v0.2.1-2
         command:
         - /kpromo
         args:
@@ -65,7 +65,7 @@ periodics:
     #               one's name to 'k8s-infra-artifact-promoter'?
     serviceAccountName: k8s-infra-gcr-promoter
     containers:
-    - image: k8s.gcr.io/artifact-promoter/kpromo:v0.2.0-1
+    - image: k8s.gcr.io/artifact-promoter/kpromo:v0.2.1-2
       command:
       - /kpromo
       args:


### PR DESCRIPTION
Image bump for https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/415.

Needed to fix [CI failures](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-k8sio-file-promo/1435127641098162176) for https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/413, https://github.com/kubernetes/k8s.io/issues/2624.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @justinsb @puerco @saschagrunert @ameukam @cpanato
cc: @kubernetes-sigs/release-engineering
/hold for promotion PR