### PR TITLE
Remove non-existent and unnecessary cherrypicker service account.

### DIFF
--- a/config/prow/cluster/cherrypicker_deployment.yaml
+++ b/config/prow/cluster/cherrypicker_deployment.yaml
@@ -34,7 +34,6 @@ spec:
       labels:
         app: cherrypicker
     spec:
-      serviceAccountName: cherrypicker
       terminationGracePeriodSeconds: 180
       containers:
       - name: cherrypicker


### PR DESCRIPTION
This was preventing the deployment from creating pods. I don't think the service account is needed.
ref: https://github.com/kubernetes/test-infra/issues/23469
/assign @alvaroaleman 
