### PR TITLE
wg-k8s-infra: Add canary jobs for kops-periodics-pipeline* jobs

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/canaries/kops-periodics-pipeline-canary.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/canaries/kops-periodics-pipeline-canary.yaml
@@ -1,0 +1,274 @@
+# 4 jobs, total of 672 runs per week
+periodics:
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "latest", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-pipeline-updown-kopsmaster-canary
+  cluster: k8s-infra-prow-build
+  cron: '54 0-23/1 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210825' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci.txt \
+          --publish-version-marker=gs://k8s-infra-kops-ci-results/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/latest.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=latest.txt \
+          --focus-regex="\[k8s.io\]\sNetworking.*\[Conformance\]" \
+          --skip-regex="\[Slow\]|\[Serial\]" \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "2"
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: latest
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: wg-k8s-infra-canaries
+    testgrid-days-of-results: '11'
+    testgrid-tab-name: kops-pipeline-updown-kopsmaster-canary
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-pipeline-updown-kops122-canary
+  cluster: k8s-infra-prow-build
+  cron: '19 0-23/1 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210825' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.22/latest-ci.txt \
+          --publish-version-marker=gs://k8s-infra-kops-ci-results/markers/release-1.22/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.22.txt \
+          --focus-regex="\[k8s.io\]\sNetworking.*\[Conformance\]" \
+          --skip-regex="\[Slow\]|\[Serial\]" \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "2"
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.22'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: wg-k8s-infra-canaries
+    testgrid-days-of-results: '11'
+    testgrid-tab-name: kops-pipeline-updown-kops122-canary
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.21", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-pipeline-updown-kops121-canary
+  cluster: k8s-infra-prow-build
+  cron: '57 0-23/1 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210825' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.21/latest-ci.txt \
+          --publish-version-marker=gs://k8s-infra-kops-ci-results/markers/release-1.21/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.21.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.21.txt \
+          --focus-regex="\[k8s.io\]\sNetworking.*\[Conformance\]" \
+          --skip-regex="\[Slow\]|\[Serial\]" \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "2"
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.21'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: wg-k8s-infra-canaries
+    testgrid-days-of-results: '11'
+    testgrid-tab-name: kops-pipeline-updown-kops121-canary
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.20", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-pipeline-updown-kops120-canary
+  cluster: k8s-infra-prow-build
+  cron: '23 0-23/1 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210825' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.20/latest-ci.txt \
+          --publish-version-marker=gs://k8s-infra-kops-ci-results/markers/release-1.20/latest-ci-updown-green.txt \
+          --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
+          --test=kops \
+          -- \
+          --ginkgo-args="--debug" \
+          --test-args="-test.timeout=60m -num-nodes=0" \
+          --test-package-marker=stable-1.20.txt \
+          --focus-regex="\[k8s.io\]\sNetworking.*\[Conformance\]" \
+          --skip-regex="\[Slow\]|\[Serial\]" \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "2"
+          memory: 3Gi
+        requests:
+          cpu: "2"
+          memory: 3Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.20'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: wg-k8s-infra-canaries
+    testgrid-days-of-results: '11'
+    testgrid-tab-name: kops-pipeline-updown-kops120-canary


### PR DESCRIPTION
Ref: https://github.com/kubernetes/k8s.io/issues/2625
Followup of : https://github.com/kubernetes/k8s.io/pull/2678

Add canary jobs that publish kops version markers to
gs://k8s-infra-kops-ci-results.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>