### PR TITLE
Enable image preloading in master periodic jobs

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -313,3 +313,5 @@ presets:
 - labels:
     preset-e2e-scalability-periodics-master: "true"
   env:
+  - name: NODE_PRELOAD_IMAGES
+    value: k8s.gcr.io/pause:3.1


### PR DESCRIPTION
The goal is to start prefetching image that is used by pod startup latency measurement so that during the measurement we do not fetch any images and measure time without pulling images, as pod startup latency is defined.

In the next PR I will enable this for other tests (like presubmits), but let's have some soak time first.

/assign @wojtek-t 