### PR TITLE
Enable prow transfer-issue plugin for kubernetes-sigs org

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -980,6 +980,7 @@ plugins:
     - shrug
     - size
     - skip
+    - transfer-issue
     - trick-or-treat
     - trigger
     - verify-owners


### PR DESCRIPTION
Followup to https://github.com/kubernetes/test-infra/pull/23456.

This was requested by folks in cluster lifecycle.

/cc @vincepri 
/assign @spiffxp 