### PR TITLE
Fix cherrypicker deployment

### DIFF
--- a/config/prow/cluster/cherrypicker_deployment.yaml
+++ b/config/prow/cluster/cherrypicker_deployment.yaml
@@ -42,6 +42,9 @@ spec:
         image: gcr.io/k8s-prow/cherrypicker:v20210908-7cf307fffc
         imagePullPolicy: Always
         args:
+        - --github-token-path=/etc/github/oauth
+        - --github-endpoint=http://ghproxy
+        - --github-endpoint=https://api.github.com
         - --dry-run=false
         ports:
           - name: http


### PR DESCRIPTION
The GitHub token path does not get defaulted, so we need to set it.
Also, use ghproxy

/assign @chaodaiG 