### PR TITLE
config/prow: setup autobumping of community-hosted kubekins

### DIFF
--- a/config/prow/autobump-config/prow-job-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-job-autobump-config.yaml
@@ -22,8 +22,13 @@ extraFiles:
   - "images/kubekins-e2e/Dockerfile"
 targetVersion: "latest"
 prefixes:
-  - name: "K8s-Test-Images"
+  - name: "Prowjob Images"
     prefix: "gcr.io/k8s-testimages/"
+    repo: "https://github.com/kubernetes/test-infra"
+    summarise: false
+    consistentImages: false
+  - name: "Kubekins"
+    prefix: "gcr.io/k8s-staging-test-infra/kubekins"
     repo: "https://github.com/kubernetes/test-infra"
     summarise: false
     consistentImages: false

--- a/kubetest/README.md
+++ b/kubetest/README.md
@@ -1,6 +1,7 @@
 # Deprecation Notice
 
-July 14, 2020:  
+**July 14, 2020**
+  
 kubetest is deprecated in favor of [kubetest2](https://github.com/kubernetes-sigs/kubetest2), 
 so kubetest is moving to a maintenance mode only and we are not taking PRs except for urgent bug fixes. 
 


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1523#issuecomment-912031929
- Followup to: https://github.com/kubernetes/test-infra/pull/23465

Calling out community-hosted kubekins to get bumped at the same time as everything in k8s-testimages

Then include a commit that will cause a new version of kubekins to get pushed, which should trigger a new autobump PR to confirm this worked