### PR TITLE
Job-history page: log on debug level instead of warning when director…

### DIFF
--- a/prow/cmd/deck/job_history.go
+++ b/prow/cmd/deck/job_history.go
@@ -245,7 +245,7 @@ func (bucket blobStorageBucket) listBuildIDs(ctx context.Context, root string) (
 			if err == nil {
 				ids = append(ids, i)
 			} else {
-				logrus.WithField("gcs-path", dir).Warningf("unrecognized directory name (expected int64): %s", leaf)
+				logrus.WithFields(logrus.Fields{"gcs-path": dir, "dir-name": leaf}).Debug("Unrecognized directory name (expected int64)")
 			}
 		}
 		if listErr != nil {


### PR DESCRIPTION
…y name is not int64

Fixes https://github.com/kubernetes/test-infra/issues/23538

There are three scenarios this might occur:
- occasional accident
- tenant manipulate their owned GCS bucket
- prow somehow messed up build ID

The first two scenarios are not something prow oncall should worry about, the last one should be easily tell from prow UI