### PR TITLE
Sub: log debug instead of error when job is not found

### DIFF
--- a/prow/pubsub/subscriber/subscriber.go
+++ b/prow/pubsub/subscriber/subscriber.go
@@ -275,7 +275,7 @@ func (poh *postsubmitJobHandler) getProwJobSpec(cfg prowCfgClient, pe ProwJobEve
 	if poh.GitClient != nil { // Get from inrepoconfig only when GitClient is provided
 		postsubmitsWithInrepoconfig, err := cfg.GetPostsubmits(poh.GitClient, orgRepo, baseSHAGetter)
 		if err != nil {
-			logrus.WithError(err).Debug("Failed to get postsubmits")
+			logrus.WithError(err).Debug("Failed to get postsubmits from inrepoconfig")
 		} else {
 			postsubmits = postsubmitsWithInrepoconfig
 		}
@@ -363,7 +363,9 @@ func (s *Subscriber) handleProwJob(l *logrus.Entry, jh jobHandler, msg messageIn
 
 	prowJobSpec, labels, err := jh.getProwJobSpec(s.ConfigAgent.Config(), pe)
 	if err != nil {
-		l.WithError(err).Errorf("failed to create job %q", pe.Name)
+		// These are user errors, i.e. missing fields, requested prowjob doesn't exist etc.
+		// These errors are already surfaced to user via pubsub two lines below.
+		l.WithError(err).WithField("name", pe.Name).Debug("Failed getting prowjob spec")
 		prowJob = pjutil.NewProwJob(prowapi.ProwJobSpec{}, nil, pe.Annotations)
 		reportProwJobFailure(&prowJob, err)
 		return err


### PR DESCRIPTION
Prowjobs are retrieved from configmap, there is no network activity, so if a prowjob is not found it's very likely due to user error, this should be logged as debug in prow