### PR TITLE
config/jobs: clean up stale kubekins tags

### DIFF
--- a/config/jobs/README.md
+++ b/config/jobs/README.md
@@ -139,7 +139,7 @@ periodics:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-1.15
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - "./scripts/ci-aws-cred-test.sh"
 ```

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -46,7 +46,7 @@ latest_stable_k8s_version="1.21" # TODO: bump to 1.22 after testing a pull job
 hostpath_driver_version="v1.7.2"
 
 # We need this image because it has Docker in Docker and go.
-dind_image="gcr.io/k8s-testimages/kubekins-e2e:v20210825-f1955d1-master"
+dind_image="gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master"
 
 # All kubernetes-csi repos which are part of the hostpath driver example.
 # For these repos we generate the full test matrix. For each entry here

--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -55,9 +55,9 @@ presubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-promoter-test
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210226-c001921-1.17
+      - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
         command:
-        - infra/gcp/backup_tools/backup_test.sh
+        - infra/gcp/bash/backup_tools/backup_test.sh
         env:
         # Even though GOPATH is set to /go in the kubekins-e2e image, we set it
         # here anyway in case the underlying image changes (the backup_test.sh

--- a/config/prow/autobump-config/prow-job-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-job-autobump-config.yaml
@@ -17,6 +17,7 @@ extraFiles:
   - "config/jobs/image-pushing/k8s-staging-sig-storage.sh"
   - "config/jobs/kubernetes/sig-cloud-provider/azure/generate.sh"
   - "config/jobs/kubernetes/kops/build_jobs.py"
+  - "config/jobs/kubernetes-csi/gen-jobs.sh"
   - "config/jobs/kubernetes-sigs/sig-windows/generate-presubmits.sh"
   - "config/jobs/README.md"
   - "releng/generate_tests.py"

--- a/config/prow/autobump-config/prow-job-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-job-autobump-config.yaml
@@ -18,7 +18,9 @@ extraFiles:
   - "config/jobs/kubernetes/sig-cloud-provider/azure/generate.sh"
   - "config/jobs/kubernetes/kops/build_jobs.py"
   - "config/jobs/kubernetes-sigs/sig-windows/generate-presubmits.sh"
+  - "config/jobs/README.md"
   - "releng/generate_tests.py"
+  - "releng/test_config.yaml"
   - "images/kubekins-e2e/Dockerfile"
 targetVersion: "latest"
 prefixes:

--- a/prow/spyglass/lenses/metadata/lens_test.go
+++ b/prow/spyglass/lenses/metadata/lens_test.go
@@ -120,7 +120,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						Containers: []v1.Container{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-master",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
 							},
 						},
 					},
@@ -129,7 +129,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						ContainerStatuses: []v1.ContainerStatus{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-master",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
 								Ready: false,
 								State: v1.ContainerState{
 									Terminated: &v1.ContainerStateTerminated{
@@ -145,7 +145,7 @@ func TestHintFromPodInfo(t *testing.T) {
 		},
 		{
 			name:     "stuck images are reported by name",
-			expected: `The test container could not start because it could not pull "gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-master". Check your images. Full message: "rpc error: code = Unknown desc"`,
+			expected: `The test container could not start because it could not pull "gcr.io/k8s-testimages/kubekins-e2e:latest-master". Check your images. Full message: "rpc error: code = Unknown desc"`,
 			info: k8sreporter.PodReport{
 				Pod: &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -155,7 +155,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						Containers: []v1.Container{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-master",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
 							},
 						},
 					},
@@ -164,7 +164,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						ContainerStatuses: []v1.ContainerStatus{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-master",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
 								Ready: false,
 								State: v1.ContainerState{
 									Waiting: &v1.ContainerStateWaiting{
@@ -180,7 +180,7 @@ func TestHintFromPodInfo(t *testing.T) {
 		},
 		{
 			name:     "stuck images are reported by name - errimagepull",
-			expected: `The test container could not start because it could not pull "gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-master". Check your images. Full message: "rpc error: code = Unknown desc"`,
+			expected: `The test container could not start because it could not pull "gcr.io/k8s-testimages/kubekins-e2e:latest-master". Check your images. Full message: "rpc error: code = Unknown desc"`,
 			info: k8sreporter.PodReport{
 				Pod: &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -190,7 +190,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						Containers: []v1.Container{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-master",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
 							},
 						},
 					},
@@ -199,7 +199,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						ContainerStatuses: []v1.ContainerStatus{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-master",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
 								Ready: false,
 								State: v1.ContainerState{
 									Waiting: &v1.ContainerStateWaiting{
@@ -225,7 +225,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						Containers: []v1.Container{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-master",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
 								VolumeMounts: []v1.VolumeMount{
 									{
 										Name:      "some-volume",
@@ -250,7 +250,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						ContainerStatuses: []v1.ContainerStatus{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-master",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
 								Ready: false,
 								State: v1.ContainerState{
 									Waiting: &v1.ContainerStateWaiting{
@@ -282,7 +282,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						Containers: []v1.Container{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-master",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
 							},
 						},
 					},
@@ -305,7 +305,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						Containers: []v1.Container{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-master",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
 							},
 						},
 					},
@@ -334,7 +334,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						Containers: []v1.Container{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-master",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
 							},
 						},
 					},
@@ -343,7 +343,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						ContainerStatuses: []v1.ContainerStatus{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-master",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
 								Ready: false,
 								State: v1.ContainerState{
 									Waiting: &v1.ContainerStateWaiting{
@@ -374,7 +374,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						Containers: []v1.Container{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-master",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
 							},
 						},
 					},
@@ -395,7 +395,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						ContainerStatuses: []v1.ContainerStatus{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-master",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
 								Ready: false,
 								State: v1.ContainerState{
 									Waiting: &v1.ContainerStateWaiting{
@@ -420,7 +420,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						Containers: []v1.Container{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-master",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
 							},
 						},
 					},
@@ -438,7 +438,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						ContainerStatuses: []v1.ContainerStatus{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-master",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
 								Ready: false,
 								State: v1.ContainerState{
 									Waiting: &v1.ContainerStateWaiting{
@@ -463,7 +463,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						Containers: []v1.Container{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-master",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
 							},
 						},
 					},
@@ -494,7 +494,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						ContainerStatuses: []v1.ContainerStatus{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-master",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
 								Ready: false,
 								State: v1.ContainerState{
 									Waiting: &v1.ContainerStateWaiting{

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -388,23 +388,23 @@ nodeK8sVersions:
   dev:
     args:
     - --repo=k8s.io/kubernetes=master
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-master
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
   beta:
     args:
     - --repo=k8s.io/kubernetes=release-1.22
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.22
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
   stable1:
     args:
     - --repo=k8s.io/kubernetes=release-1.21
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.21
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
   stable2:
     args:
     - --repo=k8s.io/kubernetes=release-1.20
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.20
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
   stable3:
     args:
     - --repo=k8s.io/kubernetes=release-1.19
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20210302-a6bf478-1.19
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
 
 nodeTestSuites:
   default:


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1523#issuecomment-912031929
- Followup to: https://github.com/kubernetes/test-infra/pull/23532

This addresses a number of job definitions, scripts or docs that use stale kubekins tags. Then update the job image autobump config to catch these in the future