### PR TITLE
config/jobs: use community-owned kubekins

### DIFF
--- a/config/jobs/GoogleCloudPlatform/k8s-multicluster-ingress/k8s-multicluster-ingress-config.yaml
+++ b/config/jobs/GoogleCloudPlatform/k8s-multicluster-ingress/k8s-multicluster-ingress-config.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - "--repo=github.com/GoogleCloudPlatform/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -43,7 +43,7 @@ postsubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - "--repo=k8s.io/test-infra=master"
         - "--root=/go/src/"
@@ -69,7 +69,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --repo=github.com/GoogleCloudPlatform/k8s-multicluster-ingress=master
       - --root=/go/src

--- a/config/jobs/cadvisor/cadvisor.yaml
+++ b/config/jobs/cadvisor/cadvisor.yaml
@@ -25,7 +25,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/kubernetes"
@@ -81,7 +81,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --job=$(JOB_NAME)
       - --root=/go/src

--- a/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
@@ -15,7 +15,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -52,7 +52,7 @@ presubmits:
     spec:
       containers:
       - name: pull-containerd-node-e2e
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         env:
         - name: USE_TEST_INFRA_LOG_DUMPING
           value: "true"

--- a/config/jobs/containerd/cri/containerd-cri-presubmit-jobs.yaml
+++ b/config/jobs/containerd/cri/containerd-cri-presubmit-jobs.yaml
@@ -9,7 +9,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         env:
         - name: GO111MODULE
           value: "off"
@@ -44,7 +44,7 @@ presubmits:
     spec:
       containers:
       - name: pull-cri-containerd-node-e2e
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - sh
         - -c
@@ -74,7 +74,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - "--repo=github.com/containerd/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -102,7 +102,7 @@ presubmits:
     spec:
       containers:
       - name: pull-cri-containerd-windows-cri
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:

--- a/config/jobs/image-pushing/k8s-staging-test-infra.yaml
+++ b/config/jobs/image-pushing/k8s-staging-test-infra.yaml
@@ -26,11 +26,11 @@ postsubmits:
           - --project=k8s-staging-test-infra
           - --build-dir=.
           - kettle/
-    - name: post-test-infra-push-kubekins-e2e-canary
+    - name: post-test-infra-push-kubekins-e2e
       cluster: k8s-infra-prow-build-trusted
       annotations:
-        testgrid-dashboards: sig-testing-canaries, wg-k8s-infra-canaries, wg-k8s-infra-gcb
-        testgrid-alert-email: k8s-infra-alerts@kubernetes.io
+        testgrid-dashboards: sig-testing-images, wg-k8s-infra-gcb
+        testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com, k8s-infra-alerts@kubernetes.io
         testgrid-num-failures-to-alert: '1'
         description: builds and pushes the kubekins-e2e image
       run_if_changed: '^(images/kubekins-e2e|kubetest|boskos)/'

--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
@@ -19,7 +19,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -70,7 +70,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -115,7 +115,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -166,7 +166,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -211,7 +211,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -266,7 +266,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -311,7 +311,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -359,7 +359,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -410,7 +410,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -455,7 +455,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -506,7 +506,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -551,7 +551,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -606,7 +606,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -651,7 +651,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -699,7 +699,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -739,7 +739,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -789,7 +789,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -839,7 +839,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -889,7 +889,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -935,7 +935,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -985,7 +985,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -1035,7 +1035,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -1081,7 +1081,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -1131,7 +1131,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -1177,7 +1177,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -1227,7 +1227,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -1277,7 +1277,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -1327,7 +1327,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -1373,7 +1373,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -1423,7 +1423,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -1473,7 +1473,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -1519,7 +1519,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -1569,7 +1569,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -1615,7 +1615,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -1667,7 +1667,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -1719,7 +1719,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -1771,7 +1771,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -1823,7 +1823,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -1875,7 +1875,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -1927,7 +1927,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -1979,7 +1979,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -2031,7 +2031,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -2083,7 +2083,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-manual-job-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-manual-job-config.yaml
@@ -22,7 +22,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -82,7 +82,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes-csi/csi-driver-iscsi/csi-driver-iscsi-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-iscsi/csi-driver-iscsi-config.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/csi-driver-nfs/csi-driver-nfs-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-nfs/csi-driver-nfs-config.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/csi-driver-nfs/csi-driver-nfs-unmanaged.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-nfs/csi-driver-nfs-unmanaged.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -37,7 +37,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -61,7 +61,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -92,7 +92,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -139,7 +139,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest

--- a/config/jobs/kubernetes-csi/csi-driver-smb/csi-driver-smb-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-smb/csi-driver-smb-config.yaml
@@ -10,7 +10,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -33,7 +33,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -58,7 +58,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -83,7 +83,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -106,7 +106,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -135,7 +135,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -181,7 +181,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -229,7 +229,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -282,7 +282,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -333,7 +333,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -408,7 +408,7 @@ presubmits:
           value: "prepull-head.yaml"
         - name: REGISTRY
           value: "gcr.io/kubernetes-e2e-test-images"
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         securityContext:
             privileged: true
     annotations:

--- a/config/jobs/kubernetes-csi/csi-driver-windows-poc/csi-driver-windows-poc-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-windows-poc/csi-driver-windows-poc-config.yaml
@@ -17,7 +17,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py

--- a/config/jobs/kubernetes-csi/csi-lib-utils/csi-lib-utils-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-lib-utils/csi-lib-utils-config.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/csi-proxy/csi-proxy-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-proxy/csi-proxy-config.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -54,7 +54,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -102,7 +102,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -150,7 +150,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -198,7 +198,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/csi-test/csi-test-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-test/csi-test-config.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
+++ b/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
@@ -19,7 +19,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -70,7 +70,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -115,7 +115,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -166,7 +166,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -211,7 +211,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -266,7 +266,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -311,7 +311,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -359,7 +359,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/external-health-monitor/external-health-monitor-config.yaml
+++ b/config/jobs/kubernetes-csi/external-health-monitor/external-health-monitor-config.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
@@ -19,7 +19,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -70,7 +70,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -115,7 +115,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -166,7 +166,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -211,7 +211,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -266,7 +266,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -311,7 +311,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -359,7 +359,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-manual-job-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-manual-job-config.yaml
@@ -19,7 +19,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
+++ b/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
@@ -19,7 +19,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -70,7 +70,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -115,7 +115,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -166,7 +166,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -211,7 +211,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -266,7 +266,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -311,7 +311,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -359,7 +359,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
+++ b/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
@@ -19,7 +19,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -70,7 +70,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -115,7 +115,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -166,7 +166,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -211,7 +211,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -266,7 +266,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -311,7 +311,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -359,7 +359,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -46,7 +46,7 @@ latest_stable_k8s_version="1.21" # TODO: bump to 1.22 after testing a pull job
 hostpath_driver_version="v1.7.2"
 
 # We need this image because it has Docker in Docker and go.
-dind_image="gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master"
+dind_image="gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master"
 
 # All kubernetes-csi repos which are part of the hostpath driver example.
 # For these repos we generate the full test matrix. For each entry here

--- a/config/jobs/kubernetes-csi/lib-volume-populator/lib-volume-populator-config.yaml
+++ b/config/jobs/kubernetes-csi/lib-volume-populator/lib-volume-populator-config.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
+++ b/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
@@ -19,7 +19,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -70,7 +70,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -115,7 +115,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -166,7 +166,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -211,7 +211,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -266,7 +266,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -311,7 +311,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -359,7 +359,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
+++ b/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
@@ -19,7 +19,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -70,7 +70,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -115,7 +115,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -166,7 +166,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -211,7 +211,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -266,7 +266,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -311,7 +311,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -359,7 +359,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/volume-data-source-validator/volume-data-source-validator-config.yaml
+++ b/config/jobs/kubernetes-csi/volume-data-source-validator/volume-data-source-validator-config.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/alibaba-cloud-csi-driver/alibaba-cloud-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/alibaba-cloud-csi-driver/alibaba-cloud-csi-driver.yaml
@@ -6,7 +6,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - make
         args:
@@ -21,7 +21,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - make
         args:
@@ -36,7 +36,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - make
         args:
@@ -51,7 +51,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits.yaml
@@ -25,7 +25,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "runner.sh"
         args:
@@ -47,7 +47,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "runner.sh"
         args:

--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-periodics.yaml
@@ -14,7 +14,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -42,7 +42,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -70,7 +70,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -98,7 +98,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -126,7 +126,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -29,7 +29,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -51,7 +51,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -75,7 +75,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -99,7 +99,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             - runner.sh
           args:
@@ -123,7 +123,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             - runner.sh
           args:
@@ -147,7 +147,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             - runner.sh
           args:

--- a/config/jobs/kubernetes-sigs/aws-efs-csi-driver/aws-efs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-efs-csi-driver/aws-efs-csi-driver-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -29,7 +29,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -51,7 +51,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/aws-fsx-csi-driver/aws-fsx-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-fsx-csi-driver/aws-fsx-csi-driver-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -29,7 +29,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -51,7 +51,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/aws-load-balancer-controller/aws-alb-ingress-controller-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-load-balancer-controller/aws-alb-ingress-controller-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -25,7 +25,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -54,7 +54,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -10,7 +10,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -33,7 +33,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -57,7 +57,7 @@ presubmits:
       preset-azure-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -81,7 +81,7 @@ presubmits:
       preset-azure-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -112,7 +112,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -161,7 +161,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -211,7 +211,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -264,7 +264,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -319,7 +319,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -371,7 +371,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -423,7 +423,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -468,7 +468,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -498,7 +498,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -551,7 +551,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -605,7 +605,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest

--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-periodics-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-periodics-config.yaml
@@ -17,7 +17,7 @@ periodics:
     workdir: true
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - kubetest

--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-v2-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-v2-config.yaml
@@ -10,7 +10,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -36,7 +36,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -61,7 +61,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -89,7 +89,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -125,7 +125,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -179,7 +179,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -234,7 +234,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -292,7 +292,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -352,7 +352,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -398,7 +398,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
@@ -10,7 +10,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -33,7 +33,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -57,7 +57,7 @@ presubmits:
       preset-azure-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -81,7 +81,7 @@ presubmits:
       preset-azure-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -112,7 +112,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -158,7 +158,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -206,7 +206,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -257,7 +257,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -300,7 +300,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -331,7 +331,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -383,7 +383,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -436,7 +436,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -485,7 +485,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest

--- a/config/jobs/kubernetes-sigs/blob-csi-driver/blob-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/blob-csi-driver/blob-csi-driver-config.yaml
@@ -10,7 +10,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -33,7 +33,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -58,7 +58,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -83,7 +83,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -114,7 +114,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -162,7 +162,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -208,7 +208,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -259,7 +259,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -310,7 +310,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest

--- a/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
+++ b/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
@@ -31,7 +31,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - make

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -10,7 +10,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -42,7 +42,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         command:
         - runner.sh
         - kubetest
@@ -99,7 +99,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         command:
         - runner.sh
         - kubetest
@@ -159,7 +159,7 @@ presubmits:
         workdir: true
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
           command:
             - runner.sh
             - kubetest
@@ -219,7 +219,7 @@ presubmits:
         workdir: true
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
           command:
             - runner.sh
             - kubetest
@@ -279,7 +279,7 @@ presubmits:
         workdir: true
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
           command:
           - runner.sh
           - ./scripts/ci-entrypoint.sh
@@ -311,7 +311,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -344,7 +344,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
       - runner.sh
       - kubetest
@@ -404,7 +404,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
       - runner.sh
       - kubetest
@@ -466,7 +466,7 @@ periodics:
       path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
       - runner.sh
       - kubetest
@@ -528,7 +528,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
       - runner.sh
       - kubetest
@@ -585,7 +585,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
       - runner.sh
       - kubetest
@@ -643,7 +643,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
       - runner.sh
       - kubetest
@@ -710,7 +710,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
       - runner.sh
       - kubetest
@@ -770,7 +770,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
       - runner.sh
       - kubetest
@@ -827,7 +827,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
       - runner.sh
       - kubetest
@@ -884,7 +884,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
       - runner.sh
       - kubetest
@@ -939,7 +939,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - kubetest
@@ -1002,7 +1002,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - kubetest

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-0.7.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-0.7.yaml
@@ -10,7 +10,7 @@ presubmits:
         preset-service-account: "true"
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
             command:
               - runner.sh
             args:
@@ -42,7 +42,7 @@ presubmits:
           workdir: true
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
             command:
               - runner.sh
               - kubetest
@@ -99,7 +99,7 @@ presubmits:
           workdir: true
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
             command:
               - runner.sh
               - kubetest
@@ -159,7 +159,7 @@ presubmits:
           workdir: true
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
             command:
               - runner.sh
               - kubetest
@@ -219,7 +219,7 @@ presubmits:
           workdir: true
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
             command:
               - runner.sh
               - kubetest
@@ -268,7 +268,7 @@ presubmits:
         preset-service-account: "true"
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
             command:
               - runner.sh
             args:

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.0.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.0.yaml
@@ -10,7 +10,7 @@ presubmits:
         preset-service-account: "true"
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
             command:
               - runner.sh
             args:
@@ -42,7 +42,7 @@ presubmits:
           workdir: true
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
             command:
               - runner.sh
               - kubetest
@@ -99,7 +99,7 @@ presubmits:
           workdir: true
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
             command:
               - runner.sh
               - kubetest
@@ -159,7 +159,7 @@ presubmits:
           workdir: true
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
             command:
               - runner.sh
               - kubetest
@@ -219,7 +219,7 @@ presubmits:
           workdir: true
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
             command:
               - runner.sh
               - kubetest
@@ -268,7 +268,7 @@ presubmits:
         preset-service-account: "true"
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
             command:
               - runner.sh
             args:

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.1.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.1.yaml
@@ -10,7 +10,7 @@ presubmits:
         preset-service-account: "true"
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
             command:
               - runner.sh
             args:
@@ -42,7 +42,7 @@ presubmits:
           workdir: true
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
             command:
               - runner.sh
               - kubetest
@@ -99,7 +99,7 @@ presubmits:
           workdir: true
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
             command:
               - runner.sh
               - kubetest
@@ -159,7 +159,7 @@ presubmits:
           workdir: true
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
             command:
               - runner.sh
               - kubetest
@@ -219,7 +219,7 @@ presubmits:
           workdir: true
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
             command:
               - runner.sh
               - kubetest
@@ -268,7 +268,7 @@ presubmits:
         preset-service-account: "true"
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
             command:
               - runner.sh
             args:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-0-6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-0-6.yaml
@@ -17,7 +17,7 @@ periodics:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
       command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -55,7 +55,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
         command:
           - "runner.sh"
           - "./scripts/ci-e2e.sh"
@@ -95,7 +95,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
         command:
           - "runner.sh"
           - "./scripts/ci-conformance.sh"
@@ -144,7 +144,7 @@ periodics:
       path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
         env:
           - name: BOSKOS_HOST
             value: "boskos.test-pods.svc.cluster.local"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
@@ -17,7 +17,7 @@ periodics:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -58,7 +58,7 @@ periodics:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
         - "runner.sh"
         - "./scripts/ci-e2e-eks.sh"
@@ -96,7 +96,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         command:
           - "runner.sh"
           - "./scripts/ci-conformance.sh"
@@ -148,7 +148,7 @@ periodics:
       path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         env:
           - name: BOSKOS_HOST
             value: "boskos.test-pods.svc.cluster.local"
@@ -191,7 +191,7 @@ periodics:
       path_alias: k8s.io/test-infra
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         command:
           - runner.sh
           - bash

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
@@ -17,7 +17,7 @@ postsubmits:
         preset-aws-credential: "true"
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
             command:
               - "runner.sh"
               - "./scripts/ci-e2e.sh"
@@ -57,7 +57,7 @@ postsubmits:
         preset-aws-credential: "true"
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
             command:
               - "runner.sh"
               - "./scripts/ci-e2e-eks.sh"
@@ -97,7 +97,7 @@ postsubmits:
         preset-aws-credential: "true"
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
             command:
               - "runner.sh"
               - "./scripts/ci-conformance.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-0.6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-0.6.yaml
@@ -10,7 +10,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -26,7 +26,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -42,7 +42,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
         command:
         - "make"
         - "verify"
@@ -80,7 +80,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
           command:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"
@@ -123,7 +123,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
           command:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"
@@ -163,7 +163,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
           command:
             - "runner.sh"
             - "./scripts/ci-e2e.sh"
@@ -201,7 +201,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
           command:
             - "runner.sh"
             - "./scripts/ci-e2e-eks.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -24,7 +24,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -41,7 +41,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         command:
         - "make"
         - "verify"
@@ -80,7 +80,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
           command:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"
@@ -123,7 +123,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
           command:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"
@@ -164,7 +164,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
           command:
             - "runner.sh"
             - "./scripts/ci-e2e.sh"
@@ -208,7 +208,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
           command:
             - "runner.sh"
             - "./scripts/ci-e2e.sh"
@@ -247,7 +247,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
           command:
             - "runner.sh"
             - "./scripts/ci-e2e-eks.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-release-0-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-release-0-4.yaml
@@ -15,7 +15,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
         command:
         - "runner.sh"
         - "./scripts/ci-conformance.sh"
@@ -47,7 +47,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
         command:
         - "runner.sh"
         - "./scripts/ci-conformance.sh"
@@ -83,7 +83,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
       command:
       - "runner.sh"
       - "./scripts/ci-e2e.sh"
@@ -114,7 +114,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
       command:
       - "runner.sh"
       - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
@@ -15,7 +15,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         command:
         - "runner.sh"
         - "./scripts/ci-conformance.sh"
@@ -47,7 +47,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         command:
         - "runner.sh"
         - "./scripts/ci-conformance.sh"
@@ -83,7 +83,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
       - "runner.sh"
       - "./scripts/ci-e2e.sh"
@@ -112,7 +112,7 @@ periodics:
       path_alias: k8s.io/test-infra
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
       - runner.sh
       - bash
@@ -149,7 +149,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
       - "runner.sh"
       - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-postsubmits-release-0-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-postsubmits-release-0-4.yaml
@@ -14,7 +14,7 @@ postsubmits:
     - release-0.4
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-postsubmits.yaml
@@ -14,7 +14,7 @@ postsubmits:
       - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-0-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-0-4.yaml
@@ -10,7 +10,7 @@ presubmits:
       - ^release-0.4$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -27,7 +27,7 @@ presubmits:
       - ^release-0.4$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -51,7 +51,7 @@ presubmits:
       - ^release-0.4$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -83,7 +83,7 @@ presubmits:
       - ^release-0.4$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -116,7 +116,7 @@ presubmits:
       - ^release-0.4$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -150,7 +150,7 @@ presubmits:
       - ^release-0.4$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -174,7 +174,7 @@ presubmits:
       - ^release-0.4$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
         command:
         - "runner.sh"
         - "make"
@@ -200,7 +200,7 @@ presubmits:
       - ^release-0.4$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
         command:
         - "runner.sh"
         - "./scripts/ci-conformance.sh"
@@ -232,7 +232,7 @@ presubmits:
       - ^release-0.4$
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
           command:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"
@@ -263,7 +263,7 @@ presubmits:
       - command:
         - runner.sh
         - ./scripts/ci-apidiff.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-apidiff-release-0-4

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -27,7 +27,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -51,7 +51,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -83,7 +83,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -116,7 +116,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -149,7 +149,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -183,7 +183,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -210,7 +210,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         command:
         - "runner.sh"
         - "make"
@@ -238,7 +238,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         command:
         - "runner.sh"
         - "./scripts/ci-conformance.sh"
@@ -270,7 +270,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         command:
         - "runner.sh"
         - "./scripts/ci-conformance.sh"
@@ -308,7 +308,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
           command:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"
@@ -341,7 +341,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
           command:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"
@@ -377,7 +377,7 @@ presubmits:
       - command:
         - runner.sh
         - ./scripts/ci-apidiff.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-apidiff-main
@@ -396,7 +396,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         command:
         - runner.sh
         - bash

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics-release-0-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics-release-0-4.yaml
@@ -15,7 +15,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
       command:
         - "runner.sh"
         - "./scripts/ci-conformance.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics.yaml
@@ -15,7 +15,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
         - "runner.sh"
         - "./scripts/ci-conformance.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits-release-0-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits-release-0-4.yaml
@@ -9,7 +9,7 @@ presubmits:
     - ^release-0.4$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -24,7 +24,7 @@ presubmits:
     - ^release-0.4$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -39,7 +39,7 @@ presubmits:
     - ^release-0.4$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
         command:
         - make
         args:
@@ -80,7 +80,7 @@ presubmits:
     - ^release-0.4$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
         command:
           - "runner.sh"
           - "./scripts/ci-e2e.sh"
@@ -109,7 +109,7 @@ presubmits:
     - ^release-0.4$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
         command:
           - "runner.sh"
           - "./scripts/ci-e2e.sh"
@@ -141,7 +141,7 @@ presubmits:
     - ^release-0.4$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
         command:
           - "runner.sh"
           - "./scripts/ci-conformance.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -24,7 +24,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -39,7 +39,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - make
         args:
@@ -80,7 +80,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
           - "runner.sh"
           - "./scripts/ci-e2e.sh"
@@ -109,7 +109,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
           - "runner.sh"
           - "./scripts/ci-e2e.sh"
@@ -141,7 +141,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
           - "runner.sh"
           - "./scripts/ci-conformance.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-release-0-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-release-0-3.yaml
@@ -25,7 +25,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         env:
           - name: "BOSKOS_HOST"
             value: "boskos.test-pods.svc.cluster.local"
@@ -73,7 +73,7 @@ periodics:
       path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         env:
           - name: "BOSKOS_HOST"
             value: "boskos.test-pods.svc.cluster.local"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics.yaml
@@ -13,7 +13,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - "runner.sh"
       - "./scripts/ci-build.sh"
@@ -34,7 +34,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - "runner.sh"
       - "./scripts/ci-test.sh"
@@ -63,7 +63,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         env:
           - name: "BOSKOS_HOST"
             value: "boskos.test-pods.svc.cluster.local"
@@ -111,7 +111,7 @@ periodics:
       path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         env:
           - name: "BOSKOS_HOST"
             value: "boskos.test-pods.svc.cluster.local"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-0-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-0-3.yaml
@@ -9,7 +9,7 @@ presubmits:
       - ^release-0.3$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "./scripts/ci-test.sh"
         resources:
@@ -28,7 +28,7 @@ presubmits:
       - ^release-0.3$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "./scripts/ci-build.sh"
         resources:
@@ -50,7 +50,7 @@ presubmits:
       - ^release-0.3$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -86,7 +86,7 @@ presubmits:
       path_alias: "sigs.k8s.io/image-builder"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           env:
             - name: "BOSKOS_HOST"
               value: "boskos.test-pods.svc.cluster.local"
@@ -133,7 +133,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           env:
             - name: "BOSKOS_HOST"
               value: "boskos.test-pods.svc.cluster.local"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "./scripts/ci-test.sh"
         resources:
@@ -28,7 +28,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "./scripts/ci-build.sh"
         resources:
@@ -50,7 +50,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -81,7 +81,7 @@ presubmits:
       timeout: 3h
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           env:
             - name: "BOSKOS_HOST"
               value: "boskos.test-pods.svc.cluster.local"
@@ -128,7 +128,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           env:
             - name: "BOSKOS_HOST"
               value: "boskos.test-pods.svc.cluster.local"
@@ -171,7 +171,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           env:
             - name: "BOSKOS_HOST"
               value: "boskos.test-pods.svc.cluster.local"
@@ -208,7 +208,7 @@ presubmits:
       timeout: 3h
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           env:
             - name: "BOSKOS_HOST"
               value: "boskos.test-pods.svc.cluster.local"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits.yaml
@@ -15,7 +15,7 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         resources:
           requests:
@@ -31,7 +31,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - "./scripts/ci-test.sh"
@@ -45,7 +45,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "./scripts/ci-build.sh"
         resources:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-nested/cluster-api-provider-nested-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-nested/cluster-api-provider-nested-periodics.yaml
@@ -13,7 +13,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - "runner.sh"
       - "./scripts/ci-build.sh"
@@ -38,7 +38,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - "runner.sh"
       - "./scripts/ci-test.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-nested/cluster-api-provider-nested-presubmits-release-0-1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-nested/cluster-api-provider-nested-presubmits-release-0-1.yaml
@@ -10,7 +10,7 @@ presubmits:
     - ^release-0.1
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "runner.sh"
         - "./scripts/ci-test.sh"
@@ -31,7 +31,7 @@ presubmits:
     - ^release-0.1
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "runner.sh"
         - "./scripts/ci-build.sh"
@@ -55,7 +55,7 @@ presubmits:
     - ^release-0.1
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-nested/cluster-api-provider-nested-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-nested/cluster-api-provider-nested-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "runner.sh"
         - "./scripts/ci-test.sh"
@@ -31,7 +31,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "runner.sh"
         - "./scripts/ci-build.sh"
@@ -55,7 +55,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics.yaml
@@ -22,7 +22,7 @@ periodics:
   max_concurrency: 1
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       env:
       - name: "BOSKOS_HOST"
         value: "boskos.test-pods.svc.cluster.local"
@@ -72,7 +72,7 @@ periodics:
   max_concurrency: 1
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       env:
       - name: "BOSKOS_HOST"
         value: "boskos.test-pods.svc.cluster.local"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-postsubmits.yaml
@@ -19,7 +19,7 @@ postsubmits:
     max_concurrency: 1
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         env:
         - name: "BOSKOS_HOST"
           value: "boskos.test-pods.svc.cluster.local"
@@ -62,7 +62,7 @@ postsubmits:
     max_concurrency: 1
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         env:
         - name: "BOSKOS_HOST"
           value: "boskos.test-pods.svc.cluster.local"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "./scripts/ci-build.sh"
         # docker-in-docker needs privileged mode
@@ -29,7 +29,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "./scripts/ci-test.sh"
         resources:
@@ -59,7 +59,7 @@ presubmits:
       path_alias: "sigs.k8s.io/image-builder"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           env:
           - name: "BOSKOS_HOST"
             value: "boskos.test-pods.svc.cluster.local"
@@ -103,7 +103,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           env:
           - name: "BOSKOS_HOST"
             value: "boskos.test-pods.svc.cluster.local"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-ci.yaml
@@ -13,7 +13,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
       - runner.sh
       args:
@@ -51,7 +51,7 @@ postsubmits:
     max_concurrency: 1
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         resources:
           requests:
             cpu: "1000m"
@@ -82,7 +82,7 @@ postsubmits:
     max_concurrency: 1
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         resources:
           requests:
             cpu: "1000m"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -86,7 +86,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         command:
         - hack/check-lint.sh
     annotations:
@@ -141,7 +141,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         command:
         - hack/verify-crds.sh
     annotations:
@@ -157,7 +157,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         resources:
           requests:
             cpu: "500m"
@@ -185,7 +185,7 @@ presubmits:
     max_concurrency: 3
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
@@ -17,7 +17,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       args:
         - runner.sh
         - "./scripts/ci-e2e.sh"
@@ -61,7 +61,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       args:
         - runner.sh
         - "./scripts/ci-e2e.sh"
@@ -105,7 +105,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       args:
         - runner.sh
         - "./scripts/ci-e2e.sh"
@@ -149,7 +149,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       args:
         - runner.sh
         - "./scripts/ci-e2e.sh"
@@ -193,7 +193,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       args:
         - runner.sh
         - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -11,7 +11,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
       - "./scripts/ci-test.sh"
       resources:
@@ -39,7 +39,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -74,7 +74,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"
@@ -106,7 +106,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
       - "runner.sh"
       - "make"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-3.yaml
@@ -11,7 +11,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
       command:
       - "./scripts/ci-test.sh"
       resources:
@@ -35,7 +35,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -60,7 +60,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
       command:
       - "runner.sh"
       - "make"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -12,7 +12,7 @@ presubmits:
     - ^operator-0.4$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         command:
         - runner.sh
         - ./scripts/ci-build.sh
@@ -39,7 +39,7 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         resources:
           requests:
             cpu: 7300m
@@ -62,7 +62,7 @@ presubmits:
       - command:
         - runner.sh
         - ./scripts/ci-apidiff.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-apidiff-main
@@ -78,7 +78,7 @@ presubmits:
     - ^operator-0.4$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         command:
         - "runner.sh"
         - ./scripts/ci-verify.sh
@@ -100,7 +100,7 @@ presubmits:
     - ^operator-0.4$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         args:
         - runner.sh
         - ./scripts/ci-test.sh
@@ -122,7 +122,7 @@ presubmits:
     - ^operator-0.4$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         args:
         - runner.sh
         - ./scripts/ci-test.sh
@@ -152,7 +152,7 @@ presubmits:
     run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|errors|exp|feature|hack|scripts|test|third_party|util)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -181,7 +181,7 @@ presubmits:
     run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|errors|exp|feature|hack|scripts|test|third_party|util)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -216,7 +216,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -253,7 +253,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-0-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-0-3.yaml
@@ -11,7 +11,7 @@ presubmits:
     - ^release-0.3$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
         command:
         - runner.sh
         - ./scripts/ci-build.sh
@@ -36,7 +36,7 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
         resources:
           requests:
             cpu: 7300m
@@ -58,7 +58,7 @@ presubmits:
       - command:
         - runner.sh
         - ./scripts/ci-apidiff.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.3
       testgrid-tab-name: capi-pr-apidiff-release-0-3
@@ -73,7 +73,7 @@ presubmits:
     - ^release-0.3$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
         command:
         - "runner.sh"
         - "make"
@@ -95,7 +95,7 @@ presubmits:
     - ^release-0.3$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
         args:
         - runner.sh
         - ./scripts/ci-test.sh
@@ -117,7 +117,7 @@ presubmits:
     run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|errors|exp|feature|hack|scripts|test|third_party|util)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -146,7 +146,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.18
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.18
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits.yaml
@@ -50,7 +50,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -81,7 +81,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -112,7 +112,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
@@ -67,7 +67,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -97,7 +97,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -127,7 +127,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -157,7 +157,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.17.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.17.yaml
@@ -67,7 +67,7 @@ presubmits:
     - ^release-1.17$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -97,7 +97,7 @@ presubmits:
     - ^release-1.17$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -127,7 +127,7 @@ presubmits:
     - ^release-1.17$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.18.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.18.yaml
@@ -67,7 +67,7 @@ presubmits:
     - ^release-1.18$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -97,7 +97,7 @@ presubmits:
     - ^release-1.18$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -127,7 +127,7 @@ presubmits:
     - ^release-1.18$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.19.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.19.yaml
@@ -67,7 +67,7 @@ presubmits:
     - ^release-1.19$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -97,7 +97,7 @@ presubmits:
     - ^release-1.19$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -127,7 +127,7 @@ presubmits:
     - ^release-1.19$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.20.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.20.yaml
@@ -67,7 +67,7 @@ presubmits:
     - ^release-1.20$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -97,7 +97,7 @@ presubmits:
     - ^release-1.20$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -127,7 +127,7 @@ presubmits:
     - ^release-1.20$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.21.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.21.yaml
@@ -67,7 +67,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -97,7 +97,7 @@ presubmits:
     - ^release-1.21$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -127,7 +127,7 @@ presubmits:
     - ^release-1.21$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.22.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.22.yaml
@@ -67,7 +67,7 @@ presubmits:
     - release-1.22
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -97,7 +97,7 @@ presubmits:
     - release-1.22
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -127,7 +127,7 @@ presubmits:
     - release-1.22
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh

--- a/config/jobs/kubernetes-sigs/e2e-framework/e2e-framework-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/e2e-framework/e2e-framework-presubmits.yaml
@@ -26,7 +26,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh

--- a/config/jobs/kubernetes-sigs/etcdadm/etcdadm-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/etcdadm/etcdadm-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "./hack/verify-all.sh"
     annotations:
@@ -21,7 +21,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/gateway-api/gateway-api-config.yaml
+++ b/config/jobs/kubernetes-sigs/gateway-api/gateway-api-config.yaml
@@ -13,7 +13,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
           # generic runner script, handles DIND, bazelrc for caching, etc.
           - runner.sh
@@ -36,7 +36,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh

--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -30,7 +30,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -50,7 +50,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -70,7 +70,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -91,7 +91,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"

--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml
@@ -6,7 +6,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver=release-0.7"
       - "--root=/go/src"
@@ -42,7 +42,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver"
       - "--root=/go/src"
@@ -78,7 +78,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver"
       - "--root=/go/src"
@@ -115,7 +115,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver"
       - "--root=/go/src"

--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-windows.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-windows.yaml
@@ -36,7 +36,7 @@ periodics:
         value: "win2004"
       - name: PREPULL_YAML
         value: "prepull-head.yaml"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       securityContext:
           privileged: true
   annotations:
@@ -80,7 +80,7 @@ periodics:
         value: "win20h2"
       - name: PREPULL_YAML
         value: "prepull-head.yaml"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       securityContext:
           privileged: true
   annotations:
@@ -124,7 +124,7 @@ periodics:
         value: "win2019"
       - name: PREPULL_YAML
         value: "prepull-head.yaml"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       securityContext:
           privileged: true
   annotations:
@@ -170,7 +170,7 @@ periodics:
         value: "prepull-head.yaml"
       - name: KUBE_FEATURE_GATES
         value: "CSIMigrationGCE=true"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       securityContext:
           privileged: true
   annotations:
@@ -216,7 +216,7 @@ periodics:
         value: "prepull-head.yaml"
       - name: KUBE_FEATURE_GATES
         value: "CSIMigrationGCE=true"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       securityContext:
           privileged: true
   annotations:
@@ -262,7 +262,7 @@ periodics:
         value: "prepull-head.yaml"
       - name: KUBE_FEATURE_GATES
         value: "CSIMigrationGCE=true"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       securityContext:
           privileged: true
   annotations:
@@ -309,7 +309,7 @@ presubmits:
           value: "win2019"
         - name: PREPULL_YAML
           value: "prepull-head.yaml"
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         securityContext:
           privileged: true
     annotations:
@@ -356,7 +356,7 @@ presubmits:
           value: "win20h2"
         - name: PREPULL_YAML
           value: "prepull-head.yaml"
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         securityContext:
           privileged: true
     annotations:

--- a/config/jobs/kubernetes-sigs/gcp-filestore-csi-driver/gcp-filestore-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-filestore-csi-driver/gcp-filestore-csi-driver-config.yaml
@@ -76,7 +76,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"

--- a/config/jobs/kubernetes-sigs/ibm-vpc-block-csi-driver/ibm-vpc-block-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/ibm-vpc-block-csi-driver/ibm-vpc-block-csi-driver.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Build test in ibm-vpc-block-csi-driver repo.
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-ova-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-ova-presubmits.yaml
@@ -15,7 +15,7 @@ presubmits:
       max_concurrency: 3
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
             args:
               - runner.sh
               - "./images/capi/scripts/ci-ova.sh"

--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
     path_alias: sigs.k8s.io/image-builder
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
           - runner.sh
           - "./images/capi/scripts/ci-azure-e2e.sh"
@@ -33,7 +33,7 @@ presubmits:
     path_alias: sigs.k8s.io/image-builder
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
           - runner.sh
           - "./images/capi/scripts/ci-azure-e2e.sh"
@@ -55,7 +55,7 @@ presubmits:
     path_alias: sigs.k8s.io/image-builder
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           args:
             - runner.sh
             - "./images/capi/scripts/ci-json-sort.sh"
@@ -74,7 +74,7 @@ presubmits:
     path_alias: sigs.k8s.io/image-builder
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           args:
           - runner.sh
           - "./images/capi/scripts/ci-packer-validate.sh"
@@ -93,7 +93,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           args:
             - runner.sh
             - "./images/capi/scripts/ci-gce.sh"
@@ -118,7 +118,7 @@ presubmits:
     max_concurrency: 5
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           args:
             - runner.sh
             - "./images/capi/scripts/ci-goss-populate.sh"
@@ -136,7 +136,7 @@ presubmits:
     max_concurrency: 5
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           args:
             - runner.sh
             - "./images/capi/scripts/ci-container-image.sh"

--- a/config/jobs/kubernetes-sigs/ingress-controller-conformance/ingress-controller-conformance.yaml
+++ b/config/jobs/kubernetes-sigs/ingress-controller-conformance/ingress-controller-conformance.yaml
@@ -12,7 +12,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -32,7 +32,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -53,7 +53,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -73,7 +73,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -93,7 +93,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -113,7 +113,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/kind/kind-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-postsubmits.yaml
@@ -9,7 +9,7 @@ postsubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - make

--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-ci.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-ci.yaml
@@ -9,7 +9,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py

--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
@@ -5,7 +5,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - make
         - test
@@ -22,7 +22,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
@@ -54,7 +54,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
@@ -95,7 +95,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - "./test/e2e/test-kinder.sh"

--- a/config/jobs/kubernetes-sigs/kubebuilder-declarative-pattern/kubebuilder-declarative-pattern-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder-declarative-pattern/kubebuilder-declarative-pattern-presubmits.yaml
@@ -6,6 +6,6 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "./hack/ci/test.sh"

--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
     - ^feature/plugins-.+$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
         - runner.sh
@@ -59,7 +59,7 @@ presubmits:
     - ^feature/plugins-.+$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
         - runner.sh
@@ -89,7 +89,7 @@ presubmits:
     - ^feature/plugins-.+$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
         - runner.sh
@@ -119,7 +119,7 @@ presubmits:
     - ^feature/plugins-.+$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
         - runner.sh
@@ -149,7 +149,7 @@ presubmits:
     - ^feature/plugins-.+$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
         - runner.sh
@@ -179,7 +179,7 @@ presubmits:
     - ^feature/plugins-.+$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
         - runner.sh

--- a/config/jobs/kubernetes-sigs/kubetest2/kubetest2-canaries.yaml
+++ b/config/jobs/kubernetes-sigs/kubetest2/kubetest2-canaries.yaml
@@ -15,7 +15,7 @@ presubmits:
       repo: cloud-provider-gcp
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "runner.sh"
         args:

--- a/config/jobs/kubernetes-sigs/kubetest2/kubetest2-gke-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubetest2/kubetest2-gke-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "runner.sh"
         args:
@@ -23,7 +23,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "runner.sh"
         args:

--- a/config/jobs/kubernetes-sigs/kubetest2/kubetest2-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubetest2/kubetest2-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -22,7 +22,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/kustomize/kustomize-config.yaml
+++ b/config/jobs/kubernetes-sigs/kustomize/kustomize-config.yaml
@@ -6,7 +6,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"

--- a/config/jobs/kubernetes-sigs/metrics-server/metrics-server-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/metrics-server/metrics-server-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - make
@@ -26,7 +26,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - make
@@ -48,7 +48,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - make
@@ -74,7 +74,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
           - runner.sh
           - make

--- a/config/jobs/kubernetes-sigs/node-feature-discovery-operator/node-feature-discovery-operator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery-operator/node-feature-discovery-operator-presubmits.yaml
@@ -42,7 +42,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         securityContext:
           privileged: true
         command:
@@ -62,7 +62,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         securityContext:
           privileged: true
         command:

--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits.yaml
@@ -55,7 +55,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         securityContext:
           privileged: true
         command:
@@ -75,7 +75,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         securityContext:
           privileged: true
         command:

--- a/config/jobs/kubernetes-sigs/poseidon/poseidon-config.yaml
+++ b/config/jobs/kubernetes-sigs/poseidon/poseidon-config.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
@@ -39,7 +39,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"

--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -12,7 +12,7 @@ presubmits:
     labels:
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -35,7 +35,7 @@ presubmits:
     labels:
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -60,7 +60,7 @@ presubmits:
     labels:
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -87,7 +87,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             - runner.sh
           args:
@@ -119,7 +119,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -152,7 +152,7 @@ presubmits:
       preset-azure-secrets-store-creds: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -183,7 +183,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - "./test/scripts/e2e_provider.sh"
@@ -212,7 +212,7 @@ presubmits:
       preset-azure-secrets-store-creds: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -251,7 +251,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -301,7 +301,7 @@ presubmits:
     spec:
       serviceAccountName: secrets-store-csi-driver-gcp
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -335,7 +335,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -362,7 +362,7 @@ presubmits:
     labels:
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -397,7 +397,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -433,7 +433,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -470,7 +470,7 @@ presubmits:
       preset-azure-secrets-store-creds: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -506,7 +506,7 @@ presubmits:
     spec:
       serviceAccountName: secrets-store-csi-driver-gcp
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -542,7 +542,7 @@ postsubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -578,7 +578,7 @@ postsubmits:
       preset-azure-secrets-store-creds: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -613,7 +613,7 @@ postsubmits:
     spec:
       serviceAccountName: secrets-store-csi-driver-gcp
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -650,7 +650,7 @@ postsubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -685,7 +685,7 @@ periodics:
     path_alias: sigs.k8s.io/secrets-store-csi-driver
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
           - runner.sh
         args:
@@ -721,7 +721,7 @@ periodics:
     path_alias: sigs.k8s.io/secrets-store-csi-driver
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
           - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-release-0.1-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-release-0.1-config.yaml
@@ -18,7 +18,7 @@ periodics:
     path_alias: sigs.k8s.io/secrets-store-csi-driver
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
           - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/security-profiles-operator/seccomp-operator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/security-profiles-operator/seccomp-operator-presubmits.yaml
@@ -48,7 +48,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         securityContext:
           privileged: true  # for dind
         resources:
@@ -74,7 +74,7 @@ presubmits:
       hostNetwork: true
       hostPID: true
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         securityContext:
           privileged: true  # for dind
         resources:

--- a/config/jobs/kubernetes-sigs/service-catalog/service-catalog-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/service-catalog/service-catalog-presubmits.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -44,7 +44,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -64,7 +64,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -88,7 +88,7 @@ presubmits:
       - master
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -117,7 +117,7 @@ presubmits:
       - master
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -132,7 +132,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -148,7 +148,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -164,7 +164,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -180,7 +180,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -196,7 +196,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -212,7 +212,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh

--- a/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner-trusted.yaml
+++ b/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner-trusted.yaml
@@ -12,7 +12,7 @@ postsubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -56,7 +56,7 @@ postsubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner.yaml
+++ b/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -22,7 +22,7 @@ presubmits:
     path_alias: sigs.k8s.io/sig-storage-local-static-provisioner
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -36,7 +36,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -55,7 +55,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -74,7 +74,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -106,7 +106,7 @@ periodics:
     path_alias: sigs.k8s.io/sig-storage-local-static-provisioner
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -136,7 +136,7 @@ periodics:
     path_alias: sigs.k8s.io/sig-storage-local-static-provisioner
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes-sigs/sig-windows/generate-presubmits.sh
+++ b/config/jobs/kubernetes-sigs/sig-windows/generate-presubmits.sh
@@ -36,7 +36,7 @@ EOF
 }
 
 # we need to define the full image URL so it can be autobumped
-tmp="gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master"
+tmp="gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master"
 kubekins_e2e_image="${tmp/\-master/}"
 
 readonly ginkgo_focus="\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice"
@@ -260,7 +260,7 @@ $(generate_presubmit_annotations ${branch} pull-kubernetes-e2e-aks-engine-azure-
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.19-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.19-windows-presubmits.yaml
@@ -19,7 +19,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
         command:
         - runner.sh
         - kubetest
@@ -70,7 +70,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
         command:
         - runner.sh
         - kubetest
@@ -125,7 +125,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
         command:
         - runner.sh
         - kubetest
@@ -184,7 +184,7 @@ presubmits:
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.19-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.19-windows.yaml
@@ -18,7 +18,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
       command:
       - runner.sh
       - kubetest
@@ -72,7 +72,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
       command:
       - runner.sh
       - kubetest
@@ -126,7 +126,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
       command:
       - runner.sh
       - kubetest
@@ -180,7 +180,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
       command:
       - runner.sh
       - kubetest

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.20-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.20-windows-presubmits.yaml
@@ -19,7 +19,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
         command:
         - runner.sh
         - kubetest
@@ -70,7 +70,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
         command:
         - runner.sh
         - kubetest
@@ -125,7 +125,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
         command:
         - runner.sh
         - kubetest
@@ -184,7 +184,7 @@ presubmits:
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.20-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.20-windows.yaml
@@ -18,7 +18,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
       command:
       - runner.sh
       - kubetest
@@ -72,7 +72,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
       command:
       - runner.sh
       - kubetest
@@ -126,7 +126,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
       command:
       - runner.sh
       - kubetest
@@ -180,7 +180,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
       command:
       - runner.sh
       - kubetest

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.21-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.21-windows-presubmits.yaml
@@ -20,7 +20,7 @@ presubmits:
       preset-windows-private-registry-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         command:
         - runner.sh
         - kubetest
@@ -72,7 +72,7 @@ presubmits:
       preset-windows-private-registry-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         command:
         - runner.sh
         - kubetest
@@ -127,7 +127,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         command:
         - runner.sh
         - kubetest
@@ -186,7 +186,7 @@ presubmits:
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.21-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.21-windows.yaml
@@ -19,7 +19,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
       - runner.sh
       - kubetest
@@ -73,7 +73,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
       - runner.sh
       - kubetest
@@ -128,7 +128,7 @@ periodics:
 #     path_alias: k8s.io/kubernetes
 #   spec:
 #     containers:
-#     - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+#     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
 #       command:
 #       - runner.sh
 #       - kubetest
@@ -182,7 +182,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
       - runner.sh
       - kubetest

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.22-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.22-windows-presubmits.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-windows-private-registry-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
         command:
         - runner.sh
         - kubetest
@@ -76,7 +76,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
         command:
         - runner.sh
         - kubetest
@@ -135,7 +135,7 @@ presubmits:
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.22-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.22-windows.yaml
@@ -49,7 +49,7 @@ periodics:
       command:
       - runner.sh
       - kubetest
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
       name: ""
       resources: {}
       securityContext:
@@ -73,7 +73,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
       command:
       - runner.sh
       - kubetest
@@ -124,7 +124,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api-provider-azure
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
         command:
           - "runner.sh"
           - "./scripts/ci-conformance.sh"

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
@@ -20,7 +20,7 @@ presubmits:
       preset-windows-private-registry-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -75,7 +75,7 @@ presubmits:
       preset-windows-private-registry-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -133,7 +133,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -195,7 +195,7 @@ presubmits:
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -254,7 +254,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - ./scripts/ci-conformance.sh

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -19,7 +19,7 @@ presubmits:
       preset-windows-private-registry-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -78,7 +78,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -139,7 +139,7 @@ presubmits:
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -199,7 +199,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - kubetest
@@ -250,7 +250,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api-provider-azure
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
           - "runner.sh"
           - "./scripts/ci-conformance.sh"
@@ -294,7 +294,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - kubetest
@@ -349,7 +349,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - kubetest
@@ -405,7 +405,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - kubetest
@@ -462,7 +462,7 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - kubetest
@@ -524,7 +524,7 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - kubetest
@@ -584,7 +584,7 @@ periodics:
     path_alias: sigs.k8s.io/azurefile-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - kubetest
@@ -646,7 +646,7 @@ periodics:
     path_alias: sigs.k8s.io/azurefile-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - kubetest
@@ -704,7 +704,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - kubetest

--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-containerd-hyperv.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-containerd-hyperv.yaml
@@ -19,7 +19,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - kubetest
@@ -74,7 +74,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - kubetest

--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-kubeadm.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-kubeadm.yaml
@@ -21,7 +21,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - "runner.sh"
       - "./kubeadm/hack/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-sac.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-sac.yaml
@@ -19,7 +19,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - kubetest
@@ -75,7 +75,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - kubetest
@@ -131,7 +131,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - kubetest
@@ -186,7 +186,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - kubetest
@@ -242,7 +242,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - kubetest

--- a/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-ci.yaml
+++ b/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-ci.yaml
@@ -11,7 +11,7 @@ periodics:
     path_alias: sigs.k8s.io/structured-merge-diff
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - go
       args:
@@ -33,7 +33,7 @@ periodics:
     path_alias: sigs.k8s.io/structured-merge-diff
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - bash
       - -c

--- a/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
     path_alias: sigs.k8s.io/structured-merge-diff
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - go
         args:
@@ -27,7 +27,7 @@ presubmits:
     path_alias: sigs.k8s.io/structured-merge-diff
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - bash
         - -c

--- a/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
@@ -8,7 +8,7 @@ presubmits:
     path_alias: sigs.k8s.io/vsphere-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - make
         args:
@@ -27,7 +27,7 @@ presubmits:
     path_alias: sigs.k8s.io/vsphere-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - make
         args:
@@ -101,7 +101,7 @@ presubmits:
     path_alias: sigs.k8s.io/vsphere-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - make
         args:
@@ -122,7 +122,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "make"
         args:
@@ -141,7 +141,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "make"
         args:
@@ -167,7 +167,7 @@ postsubmits:
     skip_submodules: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "make"
         args:
@@ -192,7 +192,7 @@ postsubmits:
     skip_submodules: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "make"
         args:

--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-config.yaml
@@ -10,7 +10,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -31,7 +31,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
@@ -20,7 +20,7 @@ periodics:
     path_alias: k8s.io/cloud-provider-gcp
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         limits:
           cpu: 4

--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -37,7 +37,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             - runner.sh
             - ./tools/verify-all.sh
@@ -58,7 +58,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes/cloud-provider-openstack/cloud-provider-openstack-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/cloud-provider-openstack-config.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -26,7 +26,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"

--- a/config/jobs/kubernetes/cloud-provider-openstack/release-master-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/release-master-presubmits.yaml
@@ -18,7 +18,7 @@ presubmits:
       timeout: 3h
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           env:
           - name: "BOSKOS_HOST"
             value: "boskos.test-pods.svc.cluster.local"
@@ -52,7 +52,7 @@ presubmits:
       timeout: 3h
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           env:
           - name: "BOSKOS_HOST"
             value: "boskos.test-pods.svc.cluster.local"
@@ -78,7 +78,7 @@ presubmits:
     path_alias: "k8s.io/cloud-provider-openstack"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - make
         args:
@@ -97,7 +97,7 @@ presubmits:
     path_alias: "k8s.io/cloud-provider-openstack"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - make
         args:

--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
@@ -34,7 +34,7 @@ presubmits:
     path_alias: k8s.io/cloud-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - make
         args:
@@ -52,7 +52,7 @@ presubmits:
     path_alias: k8s.io/cloud-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - make
         args:
@@ -70,7 +70,7 @@ presubmits:
     path_alias: k8s.io/cloud-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - make
         args:
@@ -127,7 +127,7 @@ presubmits:
     path_alias: k8s.io/cloud-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - make
         args:
@@ -150,7 +150,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "make"
         args:
@@ -171,7 +171,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "make"
         args:
@@ -195,7 +195,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "make"
         args:
@@ -226,7 +226,7 @@ postsubmits:
     skip_submodules: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         resources:
           requests:
             cpu: "1000m"
@@ -257,7 +257,7 @@ postsubmits:
     skip_submodules: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         resources:
           requests:
             cpu: "1000m"

--- a/config/jobs/kubernetes/cluster-registry/cluster-registry-config.yaml
+++ b/config/jobs/kubernetes/cluster-registry/cluster-registry-config.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -29,7 +29,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - "--job=$(JOB_NAME)"
         - "--root=/go/src"

--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -28,7 +28,7 @@ periodics:
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Networking-IPv6)\]|csi-hostpath-v0 --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         requests:
           cpu: 1000m
@@ -66,7 +66,7 @@ periodics:
       - --ginkgo-parallel=30
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         requests:
           cpu: 1000m
@@ -109,7 +109,7 @@ periodics:
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         requests:
           cpu: 1000m
@@ -145,7 +145,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         requests:
           cpu: 1000m
@@ -182,7 +182,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         requests:
           cpu: 1000m
@@ -220,7 +220,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         requests:
           cpu: 1000m
@@ -269,7 +269,7 @@ periodics:
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Networking-IPv6)\]|csi-hostpath-v0 --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         requests:
           cpu: 1000m
@@ -307,7 +307,7 @@ periodics:
       - --ginkgo-parallel=30
       - --env=ENABLE_POD_SECURITY_POLICY=true
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         requests:
           cpu: 1000m
@@ -345,7 +345,7 @@ periodics:
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         requests:
           cpu: 1000m
@@ -381,7 +381,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         requests:
           cpu: 1000m
@@ -418,7 +418,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         requests:
           cpu: 1000m
@@ -456,7 +456,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         requests:
           cpu: 1000m
@@ -499,7 +499,7 @@ periodics:
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:(Volumes|SCTPConnectivity) --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         requests:
           cpu: 1000m
@@ -536,7 +536,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         requests:
           cpu: 1000m
@@ -574,7 +574,7 @@ periodics:
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         requests:
           cpu: 1000m
@@ -610,7 +610,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         requests:
           cpu: 1000m
@@ -647,7 +647,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         requests:
           cpu: 1000m
@@ -685,7 +685,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         requests:
           cpu: 1000m
@@ -728,7 +728,7 @@ periodics:
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --runtime-config=api/all=true
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         requests:
           cpu: 1000m
@@ -765,7 +765,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         requests:
           cpu: 1000m
@@ -803,7 +803,7 @@ periodics:
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         requests:
           cpu: 1000m
@@ -839,7 +839,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         requests:
           cpu: 1000m
@@ -876,7 +876,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         requests:
           cpu: 1000m
@@ -914,7 +914,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         requests:
           cpu: 1000m

--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -33,7 +33,7 @@ from helpers import ( # pylint: disable=import-error, no-name-in-module
 skip_jobs = [
 ]
 
-image = "gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master"
+image = "gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master"
 
 ##############
 # Build Test #

--- a/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
@@ -45,7 +45,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -108,7 +108,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -171,7 +171,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -234,7 +234,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -297,7 +297,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -360,7 +360,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -423,7 +423,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: centos
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -486,7 +486,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: centos
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -549,7 +549,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -612,7 +612,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -675,7 +675,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -739,7 +739,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:

--- a/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
@@ -43,7 +43,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: KUBE_SSH_USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -110,7 +110,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: KUBE_SSH_USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -45,7 +45,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -108,7 +108,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -171,7 +171,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -234,7 +234,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -297,7 +297,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -360,7 +360,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -423,7 +423,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -486,7 +486,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -549,7 +549,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -612,7 +612,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -675,7 +675,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -738,7 +738,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -801,7 +801,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -864,7 +864,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -927,7 +927,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -990,7 +990,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1053,7 +1053,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1116,7 +1116,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1179,7 +1179,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1242,7 +1242,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1305,7 +1305,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1369,7 +1369,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1433,7 +1433,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1497,7 +1497,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1561,7 +1561,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1625,7 +1625,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1689,7 +1689,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1753,7 +1753,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1817,7 +1817,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1880,7 +1880,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1943,7 +1943,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2006,7 +2006,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2069,7 +2069,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2132,7 +2132,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2195,7 +2195,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2258,7 +2258,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2321,7 +2321,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2384,7 +2384,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2447,7 +2447,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2510,7 +2510,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2573,7 +2573,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2636,7 +2636,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2699,7 +2699,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2762,7 +2762,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2825,7 +2825,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2888,7 +2888,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -2951,7 +2951,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3014,7 +3014,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3077,7 +3077,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3140,7 +3140,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3203,7 +3203,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3266,7 +3266,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3329,7 +3329,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3392,7 +3392,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3455,7 +3455,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3518,7 +3518,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3581,7 +3581,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3644,7 +3644,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3707,7 +3707,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3770,7 +3770,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3833,7 +3833,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3896,7 +3896,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -3959,7 +3959,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4022,7 +4022,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4085,7 +4085,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4148,7 +4148,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4211,7 +4211,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4274,7 +4274,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4337,7 +4337,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4400,7 +4400,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4463,7 +4463,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4526,7 +4526,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4589,7 +4589,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4652,7 +4652,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4715,7 +4715,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4778,7 +4778,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4842,7 +4842,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4906,7 +4906,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -4970,7 +4970,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5034,7 +5034,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5098,7 +5098,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5162,7 +5162,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5226,7 +5226,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5290,7 +5290,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5353,7 +5353,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5416,7 +5416,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5479,7 +5479,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5542,7 +5542,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5605,7 +5605,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5668,7 +5668,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5731,7 +5731,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5794,7 +5794,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5857,7 +5857,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5920,7 +5920,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -5983,7 +5983,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6046,7 +6046,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6109,7 +6109,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6172,7 +6172,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6235,7 +6235,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6298,7 +6298,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6361,7 +6361,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6424,7 +6424,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6487,7 +6487,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6550,7 +6550,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6613,7 +6613,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6676,7 +6676,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6739,7 +6739,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6802,7 +6802,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6865,7 +6865,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6928,7 +6928,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -6991,7 +6991,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7054,7 +7054,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7117,7 +7117,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7180,7 +7180,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7243,7 +7243,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7306,7 +7306,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7369,7 +7369,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7432,7 +7432,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7495,7 +7495,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7558,7 +7558,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7621,7 +7621,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7684,7 +7684,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7747,7 +7747,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7810,7 +7810,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7873,7 +7873,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7936,7 +7936,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -7999,7 +7999,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -8062,7 +8062,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -8125,7 +8125,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -8188,7 +8188,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -8251,7 +8251,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -8314,7 +8314,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -8377,7 +8377,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -8440,7 +8440,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -8503,7 +8503,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -8566,7 +8566,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -8629,7 +8629,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -8692,7 +8692,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -8755,7 +8755,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -8818,7 +8818,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -8881,7 +8881,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -8944,7 +8944,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9007,7 +9007,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9070,7 +9070,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9133,7 +9133,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9196,7 +9196,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9259,7 +9259,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9322,7 +9322,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9385,7 +9385,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9448,7 +9448,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9511,7 +9511,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9574,7 +9574,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9637,7 +9637,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9700,7 +9700,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9763,7 +9763,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9826,7 +9826,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9889,7 +9889,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -9952,7 +9952,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10015,7 +10015,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10078,7 +10078,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10141,7 +10141,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10204,7 +10204,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10267,7 +10267,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10330,7 +10330,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10393,7 +10393,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10456,7 +10456,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10519,7 +10519,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10582,7 +10582,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10645,7 +10645,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10708,7 +10708,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10771,7 +10771,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10834,7 +10834,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10897,7 +10897,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -10960,7 +10960,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11023,7 +11023,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11086,7 +11086,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11149,7 +11149,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11212,7 +11212,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11275,7 +11275,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11339,7 +11339,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11403,7 +11403,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11467,7 +11467,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11531,7 +11531,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11595,7 +11595,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11659,7 +11659,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11723,7 +11723,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11787,7 +11787,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11850,7 +11850,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11913,7 +11913,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -11976,7 +11976,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12039,7 +12039,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12102,7 +12102,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12165,7 +12165,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12228,7 +12228,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12291,7 +12291,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12354,7 +12354,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12417,7 +12417,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12480,7 +12480,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12543,7 +12543,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12606,7 +12606,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12669,7 +12669,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12732,7 +12732,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12795,7 +12795,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12858,7 +12858,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12921,7 +12921,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -12984,7 +12984,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13047,7 +13047,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13110,7 +13110,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13173,7 +13173,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13236,7 +13236,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13299,7 +13299,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13362,7 +13362,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13425,7 +13425,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13488,7 +13488,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13551,7 +13551,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13614,7 +13614,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13677,7 +13677,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13740,7 +13740,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13803,7 +13803,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13866,7 +13866,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13929,7 +13929,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -13992,7 +13992,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14055,7 +14055,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14118,7 +14118,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14181,7 +14181,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14244,7 +14244,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14307,7 +14307,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14370,7 +14370,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14433,7 +14433,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14496,7 +14496,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14559,7 +14559,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14622,7 +14622,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14685,7 +14685,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14748,7 +14748,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14812,7 +14812,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14876,7 +14876,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -14940,7 +14940,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15004,7 +15004,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15068,7 +15068,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15132,7 +15132,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15196,7 +15196,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15260,7 +15260,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15323,7 +15323,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15386,7 +15386,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15449,7 +15449,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15512,7 +15512,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15575,7 +15575,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15638,7 +15638,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15701,7 +15701,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15764,7 +15764,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15827,7 +15827,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15890,7 +15890,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -15953,7 +15953,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16016,7 +16016,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16079,7 +16079,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16142,7 +16142,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16205,7 +16205,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16268,7 +16268,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16331,7 +16331,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16394,7 +16394,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16457,7 +16457,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16520,7 +16520,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16583,7 +16583,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16646,7 +16646,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16709,7 +16709,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16772,7 +16772,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16835,7 +16835,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16898,7 +16898,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -16961,7 +16961,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17024,7 +17024,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17087,7 +17087,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17150,7 +17150,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17213,7 +17213,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17276,7 +17276,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17339,7 +17339,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17402,7 +17402,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17465,7 +17465,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17528,7 +17528,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17591,7 +17591,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17654,7 +17654,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17717,7 +17717,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17780,7 +17780,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17843,7 +17843,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17906,7 +17906,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -17969,7 +17969,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18032,7 +18032,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18095,7 +18095,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18158,7 +18158,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18221,7 +18221,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18285,7 +18285,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18349,7 +18349,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18413,7 +18413,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18477,7 +18477,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18541,7 +18541,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18605,7 +18605,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18669,7 +18669,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18733,7 +18733,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18796,7 +18796,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18859,7 +18859,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18922,7 +18922,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -18985,7 +18985,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19048,7 +19048,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19111,7 +19111,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19174,7 +19174,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19237,7 +19237,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19300,7 +19300,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19363,7 +19363,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19426,7 +19426,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19489,7 +19489,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19552,7 +19552,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19615,7 +19615,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19678,7 +19678,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19741,7 +19741,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19804,7 +19804,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19867,7 +19867,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19930,7 +19930,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -19993,7 +19993,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20056,7 +20056,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20119,7 +20119,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20182,7 +20182,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20245,7 +20245,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20308,7 +20308,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20371,7 +20371,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20434,7 +20434,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20497,7 +20497,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20560,7 +20560,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20623,7 +20623,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20686,7 +20686,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20749,7 +20749,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20812,7 +20812,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20875,7 +20875,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -20938,7 +20938,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21001,7 +21001,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21064,7 +21064,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21127,7 +21127,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21190,7 +21190,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21253,7 +21253,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21316,7 +21316,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21379,7 +21379,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21442,7 +21442,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21505,7 +21505,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21568,7 +21568,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21631,7 +21631,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21694,7 +21694,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21758,7 +21758,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21822,7 +21822,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21886,7 +21886,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -21950,7 +21950,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22014,7 +22014,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22078,7 +22078,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22142,7 +22142,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22206,7 +22206,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22269,7 +22269,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22332,7 +22332,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22395,7 +22395,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22458,7 +22458,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22521,7 +22521,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22584,7 +22584,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22647,7 +22647,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22710,7 +22710,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22773,7 +22773,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22836,7 +22836,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22899,7 +22899,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -22962,7 +22962,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23025,7 +23025,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23088,7 +23088,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23151,7 +23151,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23214,7 +23214,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23277,7 +23277,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23340,7 +23340,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23403,7 +23403,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23466,7 +23466,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23529,7 +23529,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23592,7 +23592,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23655,7 +23655,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23718,7 +23718,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23781,7 +23781,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23844,7 +23844,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23907,7 +23907,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -23970,7 +23970,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24033,7 +24033,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24096,7 +24096,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24159,7 +24159,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24222,7 +24222,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24285,7 +24285,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24348,7 +24348,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24411,7 +24411,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24474,7 +24474,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24537,7 +24537,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24600,7 +24600,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24663,7 +24663,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24726,7 +24726,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24789,7 +24789,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24852,7 +24852,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24915,7 +24915,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -24978,7 +24978,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25041,7 +25041,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25104,7 +25104,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25167,7 +25167,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25230,7 +25230,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25293,7 +25293,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25356,7 +25356,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25419,7 +25419,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25482,7 +25482,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25545,7 +25545,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25608,7 +25608,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25671,7 +25671,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25734,7 +25734,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25797,7 +25797,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25860,7 +25860,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25923,7 +25923,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -25986,7 +25986,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26049,7 +26049,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26112,7 +26112,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26175,7 +26175,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26238,7 +26238,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26301,7 +26301,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26364,7 +26364,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26427,7 +26427,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26490,7 +26490,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26553,7 +26553,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26616,7 +26616,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26679,7 +26679,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26742,7 +26742,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26805,7 +26805,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26868,7 +26868,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26931,7 +26931,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -26994,7 +26994,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27057,7 +27057,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27120,7 +27120,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27183,7 +27183,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27246,7 +27246,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27309,7 +27309,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27372,7 +27372,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27435,7 +27435,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27498,7 +27498,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27561,7 +27561,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27624,7 +27624,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27687,7 +27687,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27750,7 +27750,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27813,7 +27813,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27876,7 +27876,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -27939,7 +27939,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28002,7 +28002,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28065,7 +28065,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28128,7 +28128,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28191,7 +28191,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28255,7 +28255,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28319,7 +28319,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28383,7 +28383,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28447,7 +28447,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28511,7 +28511,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28575,7 +28575,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28639,7 +28639,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28703,7 +28703,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28766,7 +28766,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28829,7 +28829,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28892,7 +28892,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -28955,7 +28955,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29018,7 +29018,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29081,7 +29081,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29144,7 +29144,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29207,7 +29207,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29270,7 +29270,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29333,7 +29333,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29396,7 +29396,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29459,7 +29459,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29522,7 +29522,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29585,7 +29585,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29648,7 +29648,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29711,7 +29711,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29774,7 +29774,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29837,7 +29837,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29900,7 +29900,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -29963,7 +29963,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30026,7 +30026,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30089,7 +30089,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30152,7 +30152,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30215,7 +30215,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30278,7 +30278,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30341,7 +30341,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30404,7 +30404,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30467,7 +30467,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30530,7 +30530,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30593,7 +30593,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30656,7 +30656,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30719,7 +30719,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30782,7 +30782,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30845,7 +30845,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30908,7 +30908,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -30971,7 +30971,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31034,7 +31034,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31097,7 +31097,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31160,7 +31160,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31223,7 +31223,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31286,7 +31286,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31349,7 +31349,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31412,7 +31412,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31475,7 +31475,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31538,7 +31538,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31601,7 +31601,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31664,7 +31664,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31728,7 +31728,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31792,7 +31792,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31856,7 +31856,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31920,7 +31920,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -31984,7 +31984,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32048,7 +32048,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32112,7 +32112,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32176,7 +32176,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32239,7 +32239,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32302,7 +32302,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32365,7 +32365,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32428,7 +32428,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32491,7 +32491,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32554,7 +32554,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32617,7 +32617,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32680,7 +32680,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32743,7 +32743,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32806,7 +32806,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32869,7 +32869,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32932,7 +32932,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -32995,7 +32995,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -33058,7 +33058,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -33121,7 +33121,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -33184,7 +33184,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -33247,7 +33247,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -33310,7 +33310,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -33373,7 +33373,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -33436,7 +33436,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -33499,7 +33499,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -33562,7 +33562,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -33625,7 +33625,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -33688,7 +33688,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -33751,7 +33751,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -33814,7 +33814,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:

--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -6,7 +6,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-experimental
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-experimental
       args:
       - --repo=k8s.io/kops
       - --repo=k8s.io/release
@@ -45,7 +45,7 @@ periodics:
     path_alias: k8s.io/kops
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-experimental
       imagePullPolicy: Always
       command:
       - runner.sh

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -45,7 +45,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -113,7 +113,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -181,7 +181,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -249,7 +249,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -314,7 +314,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -378,7 +378,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -444,7 +444,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -510,7 +510,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -575,7 +575,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -639,7 +639,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -705,7 +705,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -771,7 +771,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -839,7 +839,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -907,7 +907,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -973,7 +973,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1037,7 +1037,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1101,7 +1101,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1156,7 +1156,7 @@ periodics:
         value: "s3://k8s-kops-prow"
       - name: KUBE_SSH_USER
         value: "ubuntu"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1214,7 +1214,7 @@ periodics:
         value: "s3://k8s-kops-prow"
       - name: KUBE_SSH_USER
         value: "ubuntu"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1271,7 +1271,7 @@ periodics:
         value: "s3://k8s-kops-prow"
       - name: KUBE_SSH_USER
         value: "ubuntu"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1329,7 +1329,7 @@ periodics:
         value: "s3://k8s-kops-prow"
       - name: KUBE_SSH_USER
         value: "ubuntu"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1385,7 +1385,7 @@ periodics:
         value: "s3://k8s-kops-prow"
       - name: KUBE_SSH_USER
         value: "ubuntu"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1441,7 +1441,7 @@ periodics:
         value: "s3://k8s-kops-prow"
       - name: KUBE_SSH_USER
         value: "ubuntu"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1506,7 +1506,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -1570,7 +1570,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:

--- a/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
@@ -45,7 +45,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -109,7 +109,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -173,7 +173,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -237,7 +237,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -301,7 +301,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -365,7 +365,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -429,7 +429,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -493,7 +493,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -557,7 +557,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:

--- a/config/jobs/kubernetes/kops/kops-periodics-pipeline.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-pipeline.yaml
@@ -48,7 +48,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -114,7 +114,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -180,7 +180,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -246,7 +246,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:

--- a/config/jobs/kubernetes/kops/kops-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-upgrades.yaml
@@ -44,7 +44,7 @@ periodics:
         value: "s3://k8s-kops-prow"
       - name: KUBE_SSH_USER
         value: "ubuntu"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -108,7 +108,7 @@ periodics:
         value: "s3://k8s-kops-prow"
       - name: KUBE_SSH_USER
         value: "ubuntu"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -172,7 +172,7 @@ periodics:
         value: "s3://k8s-kops-prow"
       - name: KUBE_SSH_USER
         value: "ubuntu"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -236,7 +236,7 @@ periodics:
         value: "s3://k8s-kops-prow"
       - name: KUBE_SSH_USER
         value: "ubuntu"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -300,7 +300,7 @@ periodics:
         value: "s3://k8s-kops-prow"
       - name: KUBE_SSH_USER
         value: "ubuntu"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:

--- a/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
@@ -48,7 +48,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -111,7 +111,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -174,7 +174,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -237,7 +237,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -300,7 +300,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -363,7 +363,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:

--- a/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
@@ -22,7 +22,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -90,7 +90,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -159,7 +159,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -224,7 +224,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -289,7 +289,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -354,7 +354,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -419,7 +419,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -480,7 +480,7 @@ presubmits:
     spec:
       serviceAccountName: k8s-kops-test
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -548,7 +548,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -616,7 +616,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -684,7 +684,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -752,7 +752,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -823,7 +823,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -878,7 +878,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -934,7 +934,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -989,7 +989,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -1044,7 +1044,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -1099,7 +1099,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -1167,7 +1167,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -1235,7 +1235,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -1301,7 +1301,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh

--- a/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
@@ -23,7 +23,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -90,7 +90,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -157,7 +157,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -224,7 +224,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -290,7 +290,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -357,7 +357,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -424,7 +424,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -491,7 +491,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh

--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-experimental
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-experimental
         command:
         - runner.sh
         args:
@@ -38,7 +38,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-experimental
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-experimental
         command:
         - runner.sh
         args:
@@ -68,7 +68,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-experimental
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -123,7 +123,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -171,7 +171,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -214,7 +214,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-experimental
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-experimental
         command:
         - runner.sh
         args:
@@ -233,7 +233,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-experimental
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-experimental
         command:
         - runner.sh
         args:
@@ -254,7 +254,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-experimental
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-experimental
         command:
         - runner.sh
         args:
@@ -275,7 +275,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
         command:
         - runner.sh
         args:
@@ -296,7 +296,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
         command:
         - runner.sh
         args:
@@ -315,7 +315,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-experimental
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-experimental
         command:
         - runner.sh
         args:
@@ -336,7 +336,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-experimental
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-experimental
         command:
         - runner.sh
         args:
@@ -358,7 +358,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-experimental
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-experimental
         command:
         - runner.sh
         args:
@@ -379,7 +379,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-experimental
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-experimental
         command:
         - runner.sh
         args:
@@ -399,7 +399,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-experimental
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-experimental
         command:
         - runner.sh
         args:
@@ -420,7 +420,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-experimental
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-experimental
         command:
         - runner.sh
         args:
@@ -446,7 +446,7 @@ presubmits:
     - release-1.18
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-experimental
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-experimental
         command:
         - runner.sh
         args:
@@ -473,7 +473,7 @@ postsubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-experimental
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-experimental
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes/kops/kubernetes-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kubernetes-presubmits.yaml
@@ -19,7 +19,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"

--- a/config/jobs/kubernetes/kubeadm/kubeadm-presubmits.yaml
+++ b/config/jobs/kubernetes/kubeadm/kubeadm-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     run_if_changed: '^kinder\/.*$'
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "./kinder/hack/verify-all.sh"
 
@@ -31,7 +31,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -53,7 +53,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - "./operator/hack/verify-all.sh"

--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -12,7 +12,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -39,7 +39,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -75,7 +75,7 @@ periodics:
     path_alias: k8s.io/test-infra
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -113,7 +113,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -150,7 +150,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -187,7 +187,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -224,7 +224,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:
@@ -261,7 +261,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       env:
       - name: ZONE
         value: us-central1-a

--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -38,7 +38,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -72,7 +72,7 @@ presubmits:
       path_alias: k8s.io/test-infra
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -109,7 +109,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -145,7 +145,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -181,7 +181,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -217,7 +217,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -252,7 +252,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         env:
         - name: ZONE
           value: us-central1-a

--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -28,7 +28,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-release-cluster-up
         - --test_args=--ginkgo.focus=definitely-not-a-real-focus
         - --timeout=65m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         resources:
           requests:
             memory: "6Gi"

--- a/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
+++ b/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
@@ -20,7 +20,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gci-gce-proto
@@ -49,7 +49,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=9
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: sig-api-machinery-network-proxy
 - interval: 2h
@@ -76,7 +76,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=9
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: sig-api-machinery-network-proxy
 
@@ -116,7 +116,7 @@ presubmits:
         - --provider=gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=9
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         resources:
           requests:
             cpu: 2
@@ -163,7 +163,7 @@ presubmits:
         - --provider=gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=9
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         resources:
           requests:
             cpu: 4

--- a/config/jobs/kubernetes/sig-apps/sig-apps-config.yaml
+++ b/config/jobs/kubernetes/sig-apps/sig-apps-config.yaml
@@ -7,7 +7,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --repo=github.com/kubernetes-sigs/application=master
       - --upload=gs://kubernetes-jenkins/logs/
@@ -57,7 +57,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:TaintEviction\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
 
 
   annotations:
@@ -81,7 +81,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:StatefulSet\] --minStartupPods=8
       - --timeout=90m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gci-gce-statefulset

--- a/config/jobs/kubernetes/sig-auth/serviceaccount-admission-controller-migration-config.yaml
+++ b/config/jobs/kubernetes/sig-auth/serviceaccount-admission-controller-migration-config.yaml
@@ -12,7 +12,7 @@ periodics:
   interval: 24h
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -7,7 +7,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --repo=k8s.io/autoscaler=master
       - --root=/go/src
@@ -38,7 +38,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --repo=k8s.io/autoscaler=master
       - --root=/go/src
@@ -69,7 +69,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --repo=k8s.io/autoscaler=master
       - --root=/go/src
@@ -100,7 +100,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --repo=k8s.io/autoscaler=master
       - --root=/go/src
@@ -131,7 +131,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --repo=k8s.io/autoscaler=master
       - --root=/go/src
@@ -184,7 +184,7 @@ periodics:
       - --runtime-config=scheduling.k8s.io/v1alpha1=true
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\]|\[Feature:InitialResources\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
 
   annotations:
     testgrid-dashboards: sig-autoscaling-cluster-autoscaler
@@ -209,7 +209,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:CustomMetricsAutoscaling\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
 
   annotations:
     testgrid-dashboards: sig-autoscaling-hpa
@@ -244,7 +244,7 @@ periodics:
       - --runtime-config=scheduling.k8s.io/v1alpha1=true
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
 
   annotations:
     testgrid-dashboards: sig-autoscaling-cluster-autoscaler
@@ -269,7 +269,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:CustomMetricsAutoscaling\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
 
   annotations:
     testgrid-dashboards: sig-autoscaling-hpa
@@ -295,7 +295,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:HPA\]
         --minStartupPods=8
       - --ginkgo-parallel=1
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
 
   annotations:
     # TODO: add to release blocking dashboards once run is successful

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -44,6 +44,6 @@ presubmits:
         - --runtime-config=scheduling.k8s.io/v1alpha1=true
         - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\]|\[Feature:InitialResources\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
         - --timeout=400m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -18,7 +18,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-cli\].*\[Serial\]|\[sig-cli\].*\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
 
   annotations:
     testgrid-dashboards: sig-cli-master
@@ -47,7 +47,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-cli\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
 
   annotations:
     testgrid-dashboards: sig-cli-master
@@ -75,7 +75,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.focus=\[sig-cli\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
 
   # kubectl skew tests
   annotations:
@@ -105,7 +105,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         limits:
           cpu: 1
@@ -139,7 +139,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors, sig-cli-master
@@ -169,7 +169,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         limits:
           cpu: 1
@@ -208,7 +208,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
 
   annotations:
     testgrid-dashboards: sig-cli-master
@@ -236,7 +236,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
 
   annotations:
     testgrid-dashboards: sig-cli-master
@@ -263,7 +263,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
 
   annotations:
     testgrid-dashboards: sig-cli-master
@@ -291,7 +291,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors, sig-cli-master
@@ -317,7 +317,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors, sig-cli-master
@@ -345,7 +345,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors, sig-cli-master
@@ -372,7 +372,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors, sig-cli-master
@@ -399,7 +399,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors, sig-cli-master
@@ -425,7 +425,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors, sig-cli-master

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/generate.sh
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/generate.sh
@@ -38,7 +38,7 @@ EOF
 }
 
 # we need to define the full image URL so it can be autobumped
-tmp="gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master"
+tmp="gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master"
 kubekins_e2e_image="${tmp/\-master/}"
 
 for release in "$@"; do

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.19.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.19.yaml
@@ -26,7 +26,7 @@ presubmits:
         path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -71,7 +71,7 @@ presubmits:
         path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -118,7 +118,7 @@ presubmits:
         path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -164,7 +164,7 @@ presubmits:
         path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -208,7 +208,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - ./scripts/ci-conformance.sh
@@ -246,7 +246,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - ./scripts/ci-conformance.sh
@@ -281,7 +281,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - ./scripts/ci-conformance.sh
@@ -328,7 +328,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh
@@ -380,7 +380,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh
@@ -434,7 +434,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh
@@ -485,7 +485,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.20.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.20.yaml
@@ -26,7 +26,7 @@ presubmits:
         path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -71,7 +71,7 @@ presubmits:
         path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -118,7 +118,7 @@ presubmits:
         path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -164,7 +164,7 @@ presubmits:
         path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -208,7 +208,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - ./scripts/ci-conformance.sh
@@ -246,7 +246,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - ./scripts/ci-conformance.sh
@@ -281,7 +281,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - ./scripts/ci-conformance.sh
@@ -328,7 +328,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh
@@ -380,7 +380,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh
@@ -434,7 +434,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh
@@ -485,7 +485,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.21.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.21.yaml
@@ -26,7 +26,7 @@ presubmits:
         path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -71,7 +71,7 @@ presubmits:
         path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -118,7 +118,7 @@ presubmits:
         path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -164,7 +164,7 @@ presubmits:
         path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -208,7 +208,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - ./scripts/ci-conformance.sh
@@ -246,7 +246,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - ./scripts/ci-conformance.sh
@@ -281,7 +281,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - ./scripts/ci-conformance.sh
@@ -328,7 +328,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh
@@ -380,7 +380,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh
@@ -434,7 +434,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh
@@ -485,7 +485,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.22.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.22.yaml
@@ -26,7 +26,7 @@ presubmits:
         path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -71,7 +71,7 @@ presubmits:
         path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -118,7 +118,7 @@ presubmits:
         path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -164,7 +164,7 @@ presubmits:
         path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -208,7 +208,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - ./scripts/ci-conformance.sh
@@ -246,7 +246,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - ./scripts/ci-conformance.sh
@@ -281,7 +281,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - ./scripts/ci-conformance.sh
@@ -328,7 +328,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh
@@ -380,7 +380,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh
@@ -434,7 +434,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh
@@ -485,7 +485,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
@@ -26,7 +26,7 @@ presubmits:
         path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -76,7 +76,7 @@ presubmits:
         path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -128,7 +128,7 @@ presubmits:
         path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -179,7 +179,7 @@ presubmits:
         path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             - runner.sh
             - ./scripts/ci-entrypoint.sh
@@ -228,7 +228,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - ./scripts/ci-conformance.sh
@@ -270,7 +270,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - ./scripts/ci-conformance.sh
@@ -309,7 +309,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - ./scripts/ci-conformance.sh
@@ -356,7 +356,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh
@@ -409,7 +409,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh
@@ -464,7 +464,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh
@@ -516,7 +516,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
@@ -26,7 +26,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         limits:
           cpu: 1
@@ -59,7 +59,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       securityContext:
         privileged: true
       resources:

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -50,7 +50,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         resources:
           requests:
             cpu: 4
@@ -92,7 +92,7 @@ presubmits:
         - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         resources:
           requests:
             cpu: 4
@@ -119,7 +119,7 @@ presubmits:
       testgrid-tab-name: pull-kubernetes-e2e-gce-kubetest2
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-experimental
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-experimental
         resources:
           requests:
             cpu: 4
@@ -189,7 +189,7 @@ presubmits:
         env:
         - name: BOOTSTRAP_FETCH_TEST_INFRA
           value: "true"
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -245,7 +245,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-ubuntu
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         resources:
           requests:
             memory: "6Gi"
@@ -301,7 +301,7 @@ presubmits:
             - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-ubuntu-containerd
             - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
             - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
-          image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+          image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           resources:
             limits:
               cpu: 4
@@ -361,7 +361,7 @@ presubmits:
             - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-ubuntu-containerd-canary
             - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
             - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
-          image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+          image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           resources:
             limits:
               cpu: 4
@@ -407,7 +407,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-alpha-features
         - --test_args=--ginkgo.focus=\[Feature:(ProbeTerminationGracePeriod|APIServerTracing|ServiceAccountIssuerDiscovery|StorageVersionAPI|Audit|PodPreset|RunAsGroup|TTLAfterFinished|NodeLease|CSIStorageCapacity|GenericEphemeralVolume|StatefulSetMinReadySeconds)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance)\]|IPv6|csi-hostpath-v0 --minStartupPods=8
         - --timeout=180m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         resources:
           requests:
             memory: "6Gi"
@@ -441,7 +441,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         limits:
           cpu: 2
@@ -487,7 +487,7 @@ periodics:
           - --provider=gce
           - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
           - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         resources:
           limits:
             cpu: 2
@@ -537,7 +537,7 @@ periodics:
           - --provider=gce
           - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
           - --timeout=50m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         resources:
           limits:
             cpu: 2
@@ -576,7 +576,7 @@ periodics:
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|csi-hostpath-v0 --minStartupPods=8
       - --timeout=70m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gci-gce-alpha-enabled-default
@@ -606,7 +606,7 @@ periodics:
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(ServiceAccountIssuerDiscovery|StorageVersionAPI|Audit|PodPreset|RunAsGroup|TTLAfterFinished|NodeLease|CSIStorageCapacity|GenericEphemeralVolume|DaemonSetUpdateSurge|CrossNamespacePodAffinity)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance)\]|IPv6|csi-hostpath-v0 --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         limits:
           cpu: 1
@@ -643,7 +643,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         limits:
           cpu: 2
@@ -675,7 +675,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gci-gce-flaky
@@ -701,7 +701,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gci-gce-single-flake-attempt
@@ -728,7 +728,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         limits:
           cpu: 1
@@ -765,7 +765,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         limits:
           cpu: 1
@@ -802,7 +802,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         limits:
           cpu: 1
@@ -842,7 +842,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1400m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: google-soak
     testgrid-tab-name: gce-gci
@@ -872,7 +872,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1400m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: soak-gci-gce-1.15
@@ -901,7 +901,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1400m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: soak-gci-gce-1.14
@@ -930,7 +930,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1400m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: soak-gci-gce-1.13
@@ -959,7 +959,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1400m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: soak-gci-gce-1.12

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
@@ -25,7 +25,7 @@ presubmits:
       preset-pull-gce-device-plugin-gpu: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-upgrade-downgrade.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-upgrade-downgrade.yaml
@@ -24,7 +24,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
 
   annotations:
     testgrid-dashboards: google-gce-upgrade
@@ -55,7 +55,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUMasterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
 
   annotations:
     testgrid-dashboards: google-gce-upgrade
@@ -87,7 +87,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
 
   annotations:
     testgrid-dashboards: google-gce-upgrade
@@ -118,7 +118,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUMasterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
 
   annotations:
     testgrid-dashboards: google-gce-upgrade

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -46,7 +46,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         limits:
           cpu: 1
@@ -83,7 +83,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         limits:
           cpu: 1

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/upgrade-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/upgrade-gce.yaml
@@ -23,7 +23,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-stable1-latest-upgrade-cluster
@@ -53,7 +53,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-stable1-latest-upgrade-cluster-parallel
@@ -83,7 +83,7 @@ periodics:
       - --skew
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-stable1-latest-upgrade-cluster-new
@@ -114,7 +114,7 @@ periodics:
       - --skew
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-stable1-latest-upgrade-cluster-new-parallel
@@ -143,7 +143,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-stable1-latest-upgrade-master
@@ -173,7 +173,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-stable1-latest-upgrade-master-parallel
@@ -202,7 +202,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-stable2-stable1-upgrade-cluster
@@ -231,7 +231,7 @@ periodics:
       - --skew
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-stable2-stable1-upgrade-cluster-new
@@ -260,7 +260,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/k8s-stable1
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-stable2-stable1-upgrade-master

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-addons.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-addons.yaml
@@ -28,7 +28,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
@@ -28,7 +28,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -68,7 +68,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -108,7 +108,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -148,7 +148,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-ca.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-ca.yaml
@@ -28,7 +28,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -68,7 +68,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -108,7 +108,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -148,7 +148,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
@@ -28,7 +28,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -68,7 +68,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -108,7 +108,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -148,7 +148,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kubelet-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kubelet-x-on-y.yaml
@@ -28,7 +28,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -68,7 +68,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -108,7 +108,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -148,7 +148,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -188,7 +188,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -228,7 +228,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -268,7 +268,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-patches.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-patches.yaml
@@ -28,7 +28,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -68,7 +68,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -108,7 +108,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -148,7 +148,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-rootless.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-rootless.yaml
@@ -28,7 +28,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
@@ -28,7 +28,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -68,7 +68,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -108,7 +108,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -148,7 +148,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
@@ -28,7 +28,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -68,7 +68,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -108,7 +108,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
@@ -28,7 +28,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -68,7 +68,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -108,7 +108,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -148,7 +148,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/manifests.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/manifests.yaml
@@ -13,7 +13,7 @@ periodics:
       - --scenario=execute
       - --
       - ./tests/e2e/manifests/verify_manifest_lists.sh
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-all
     testgrid-tab-name: periodic-manifest-lists

--- a/config/jobs/kubernetes/sig-instrumentation/verify-govet-levee.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/verify-govet-levee.yaml
@@ -17,7 +17,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: IfNotPresent
         command:
         - make

--- a/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml
@@ -15,7 +15,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
       command:
       - runner.sh
       - kubetest
@@ -65,7 +65,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
       command:
       - runner.sh
       - kubetest
@@ -118,7 +118,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       command:
       - runner.sh
       - kubetest
@@ -171,7 +171,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
       command:
       - runner.sh
       - kubetest
@@ -224,7 +224,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - kubetest
@@ -277,7 +277,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - kubetest
@@ -334,7 +334,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - kubetest
@@ -390,7 +390,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest
@@ -443,7 +443,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - kubetest

--- a/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
@@ -92,7 +92,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - --repo=k8s.io/ingress-gce=$(PULL_REFS)
         - --root=/go/src/
@@ -114,7 +114,7 @@ postsubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - --repo=k8s.io/ingress-gce=$(PULL_REFS)
         - --root=/go/src/
@@ -142,7 +142,7 @@ periodics:
     preset-ingress-master-yaml: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --timeout=340
       - --bare
@@ -174,7 +174,7 @@ periodics:
     preset-ingress-master-yaml: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --timeout=340
       - --bare
@@ -211,7 +211,7 @@ periodics:
     preset-ingress-master-yaml: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --timeout=340
       - --bare

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -56,7 +56,7 @@ presubmits:
         - --test_args=--ginkgo.focus=\[Feature:Ingress\]|\[Feature:NEG\]|Loadbalancing|LoadBalancers --ginkgo.skip=\[Feature:kubemci\]|\[Disruptive\]|\[Feature:IngressScale\]
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gci-gce-ingress
         - --timeout=320m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         resources:
           requests:
             memory: "6Gi"
@@ -124,7 +124,7 @@ presubmits:
         - --test_args=--ginkgo.focus=\[sig-network\]|\[Conformance\]|\[Feature:NetworkPolicy\]|\[Feature:NetworkPolicyEndPort\] --ginkgo.skip=\[Feature:(Networking-IPv6|Example|Federation|PerformanceDNS|KubeProxyDaemonSetMigration|SCTP)\]|DualStack|GCE|Disruptive|Serial|SNAT|LoadBalancer|ESIPP
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-ubuntu-gce-network-policies
         - --timeout=150m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         resources:
           requests:
             memory: "6Gi"
@@ -172,7 +172,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gci-gce-ipvs
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         resources:
           requests:
             memory: "6Gi"
@@ -191,7 +191,7 @@ presubmits:
     path_alias: k8s.io/dns
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "runner.sh"
         - ./presubmits.sh
@@ -224,7 +224,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GCEAlphaFeature\] --minStartupPods=8
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: google-gce, sig-network-gce
     testgrid-tab-name: gce-alpha-api
@@ -252,7 +252,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:PerformanceDNS\]
       - --timeout=60m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: sig-network-gce
     testgrid-tab-name: gce-coredns-performance
@@ -279,7 +279,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:PerformanceDNS\]
       - --timeout=60m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: sig-network-gce
     testgrid-tab-name: gce-kubedns-performance
@@ -304,7 +304,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
 
 - interval: 6h
   name: ci-kubernetes-e2e-gce-coredns-performance-nodecache
@@ -330,7 +330,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:PerformanceDNS\]
       - --timeout=60m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: sig-network-gce
     testgrid-tab-name: gce-coredns-performance-nodecache
@@ -358,7 +358,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:PerformanceDNS\]
       - --timeout=60m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: sig-network-gce
     testgrid-tab-name: gce-kubedns-performance-nodecache
@@ -384,7 +384,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
 
 - interval: 6h
   name: ci-kubernetes-e2e-gci-gce-ingress
@@ -409,7 +409,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Ingress\]|\[Feature:NEG\]
       - --timeout=320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         limits:
           cpu: 1
@@ -446,7 +446,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Ingress\]|\[Feature:NEG\]
       - --timeout=320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         limits:
           cpu: 1
@@ -480,7 +480,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: sig-network-gce
     testgrid-tab-name: gci-gce-ingress-manual-network
@@ -510,7 +510,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: google-gce, google-gci
     testgrid-tab-name: ip-alias
@@ -537,7 +537,7 @@ periodics:
       # skip ESIPP should work from pods #97081
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|ESIPP.*should.work.from.pods --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-num-failures-to-alert: '6'
     testgrid-alert-stale-results-hours: '24'
@@ -562,7 +562,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
 
 - interval: 6h
   name: ci-kubernetes-e2e-gci-gce-kube-dns-nodecache
@@ -586,7 +586,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
 
 - interval: 6h
   name: ci-kubernetes-e2e-gci-gce-serial-kube-dns
@@ -610,7 +610,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
 
 - interval: 6h
   name: ci-kubernetes-e2e-gci-gce-serial-kube-dns-nodecache
@@ -635,7 +635,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
 
 - interval: 6h
   name: ci-kubernetes-e2e-ubuntu-gce-network-policies
@@ -676,7 +676,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[sig-network\]|\[Conformance\]|\[Feature:NetworkPolicy\]|\[Feature:NetworkPolicyEndPort\] --ginkgo.skip=\[Feature:(Networking-IPv6|Example|Federation|PerformanceDNS|KubeProxyDaemonSetMigration|SCTP)\]|DualStack|GCE|Disruptive|Serial|SNAT|LoadBalancer|ESIPP
       - --extract=ci/latest
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         requests:
           memory: "6Gi"

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -46,7 +46,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --repo=github.com/containerd/containerd=main
       - --root=/go/src
@@ -68,7 +68,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
           - --repo=github.com/containerd/containerd=release/1.4
           - --repo=github.com/containerd/cri=release/1.4
@@ -90,7 +90,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
           - --repo=github.com/containerd/containerd=main
           - --root=/go/src
@@ -132,7 +132,7 @@ periodics:
           - --provider=gce
           - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
           - --timeout=50m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: sig-node-cos
     testgrid-tab-name: containerd-e2e-cos-1.4
@@ -161,7 +161,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-e2e-ubuntu
@@ -172,7 +172,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -203,7 +203,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes=release-1.21
@@ -233,7 +233,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -263,7 +263,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes=release-1.21
@@ -312,7 +312,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1200m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: sig-node-cos
     testgrid-tab-name: soak-cos-gce
@@ -339,7 +339,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-cos-device-plugin-gpu
@@ -368,7 +368,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: sig-node-cos
     testgrid-tab-name: e2e-cos
@@ -397,7 +397,7 @@ periodics:
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandPersistentVolumes|VolumeSubpathEnvExpansion|RunAsGroup|NodeLease)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes|Feature:SCTPConnectivity --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: sig-node-cos
     testgrid-tab-name: e2e-cos-alpha-features
@@ -422,7 +422,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: sig-node-cos
     testgrid-tab-name: e2e-cos-flaky
@@ -450,7 +450,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Ingress\]|\[Feature:NEG\]
       - --timeout=320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: sig-network-gce, sig-node-cos
     testgrid-tab-name: e2e-cos-ingress
@@ -480,7 +480,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: sig-node-cos
     testgrid-tab-name: e2e-cos-ip-alias
@@ -507,7 +507,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: sig-node-cos
     testgrid-tab-name: e2e-cos-proto
@@ -532,7 +532,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: sig-node-cos
     testgrid-tab-name: e2e-cos-reboot
@@ -557,7 +557,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: sig-node-cos
     testgrid-tab-name: e2e-cos-serial
@@ -583,7 +583,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: sig-node-cos
     testgrid-tab-name: e2e-cos-slow
@@ -611,7 +611,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-ubuntu
@@ -622,7 +622,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -652,7 +652,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -682,7 +682,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -729,7 +729,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: image-validation-cos-e2e
@@ -756,7 +756,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: image-validation-ubuntu-e2e
@@ -767,7 +767,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -796,7 +796,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -825,7 +825,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -855,7 +855,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes

--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -6,7 +6,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -38,7 +38,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -70,7 +70,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes

--- a/config/jobs/kubernetes/sig-node/node-docker.yaml
+++ b/config/jobs/kubernetes/sig-node/node-docker.yaml
@@ -6,7 +6,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -35,7 +35,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=200
@@ -64,7 +64,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=200

--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -14,7 +14,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -47,7 +47,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -84,7 +84,7 @@ periodics:
     testgrid-alert-email: kubernetes-sig-node+testgrid@googlegroups.com,kubernetes-sig-node-test-failures@googlegroups.com
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -117,7 +117,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -147,7 +147,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=400
@@ -178,7 +178,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=260
@@ -215,7 +215,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=260
@@ -254,7 +254,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=320
@@ -284,7 +284,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=240
@@ -315,7 +315,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
           - --repo=k8s.io/kubernetes=master
           - --timeout=240
@@ -346,7 +346,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
           - --repo=k8s.io/kubernetes=master
           - --timeout=240
@@ -377,7 +377,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
           - --repo=k8s.io/kubernetes=master
           - --timeout=240
@@ -409,7 +409,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
           - --repo=k8s.io/kubernetes=master
           - --timeout=240
@@ -441,7 +441,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
           - --repo=k8s.io/kubernetes=master
           - --timeout=240
@@ -471,7 +471,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
           - --repo=k8s.io/kubernetes=master
           - --timeout=240
@@ -506,7 +506,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
           - --repo=k8s.io/kubernetes=master
           - --timeout=240
@@ -542,7 +542,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
           - --repo=k8s.io/kubernetes=master
           - --timeout=90

--- a/config/jobs/kubernetes/sig-node/sig-node-config.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-config.yaml
@@ -23,7 +23,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: google-gce, sig-storage-kubernetes
     testgrid-tab-name: gce-containerd

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -66,7 +66,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
@@ -122,7 +122,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-containerd-gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
         - --timeout=80m     # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         resources:
           requests:
             memory: "6Gi"
@@ -145,7 +145,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - --root=/go/src
         - --job=$(JOB_NAME)
@@ -184,7 +184,7 @@ presubmits:
       testgrid-create-test-group: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - --root=/go/src
         - --repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)
@@ -223,7 +223,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -262,7 +262,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - --timeout=260
@@ -305,7 +305,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - --timeout=260
@@ -346,7 +346,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - --timeout=440
@@ -380,7 +380,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           args:
             - --repo=k8s.io/kubernetes=$(PULL_REFS)
             - --repo=k8s.io/release
@@ -414,7 +414,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           args:
             - --repo=k8s.io/kubernetes=$(PULL_REFS)
             - --repo=k8s.io/release
@@ -448,7 +448,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           args:
             - --repo=k8s.io/kubernetes=$(PULL_REFS)
             - --repo=k8s.io/release
@@ -484,7 +484,7 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -522,7 +522,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -560,7 +560,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -600,7 +600,7 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -639,7 +639,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           args:
             - --repo=k8s.io/kubernetes=$(PULL_REFS)
             - --repo=k8s.io/release
@@ -676,7 +676,7 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -713,7 +713,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           args:
             - --root=/go/src
             - "--job=$(JOB_NAME)"
@@ -756,7 +756,7 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"

--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -104,7 +104,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -143,7 +143,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -213,7 +213,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "make"
         args:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -27,7 +27,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
       name: ""
       resources:
         limits:
@@ -68,7 +68,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
       name: ""
       resources:
         limits:
@@ -107,7 +107,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
       name: ""
       resources:
         limits:
@@ -144,7 +144,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
       name: ""
       resources:
         limits:
@@ -295,7 +295,7 @@ periodics:
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
       name: ""
       resources: {}
       securityContext:
@@ -371,7 +371,7 @@ periodics:
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
       name: ""
       resources:
         limits:
@@ -420,7 +420,7 @@ periodics:
             --version-suffix=-bazel
       command:
       - bash
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
       name: ""
       resources:
         limits:
@@ -492,7 +492,7 @@ periodics:
       - ./hack/jenkins/test-dockerized.sh
       command:
       - runner.sh
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
       name: ""
       resources:
         limits:
@@ -535,7 +535,7 @@ periodics:
         value: release-1.19
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
       imagePullPolicy: Always
       name: ""
       resources:
@@ -588,7 +588,7 @@ periodics:
         value: win2019
       - name: PREPULL_YAML
         value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
       name: ""
       resources: {}
 - annotations:
@@ -723,7 +723,7 @@ postsubmits:
         - --release=//build/release-tars
         - --gcs=gs://k8s-release-dev/ci
         - --version-suffix=-bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
         name: ""
         resources:
           requests:
@@ -802,7 +802,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
         name: ""
         resources:
           requests:
@@ -841,7 +841,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
         name: ""
         resources:
           limits:
@@ -883,7 +883,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
         name: ""
         resources:
           requests:
@@ -929,7 +929,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
         name: ""
         resources:
           requests:
@@ -980,7 +980,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
         name: ""
         resources:
           limits:
@@ -1026,7 +1026,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
         name: ""
         resources:
           requests:
@@ -1059,7 +1059,7 @@ presubmits:
         - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
         name: ""
         resources:
           limits:
@@ -1103,7 +1103,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
         name: ""
         resources:
           requests:
@@ -1168,7 +1168,7 @@ presubmits:
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
         name: ""
         resources:
           limits:
@@ -1243,7 +1243,7 @@ presubmits:
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
         name: ""
         resources:
           limits:
@@ -1337,7 +1337,7 @@ presubmits:
         env:
         - name: WHAT
           value: external-dependencies-version vendor vendor-licenses
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
         name: main
         resources:
           limits:
@@ -1365,7 +1365,7 @@ presubmits:
         env:
         - name: WHAT
           value: generated-files-remake
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
         name: main
         resources:
           limits:
@@ -1390,7 +1390,7 @@ presubmits:
         - ./hack/jenkins/test-dockerized.sh
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
         name: ""
         resources:
           limits:
@@ -1460,7 +1460,7 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck typecheck-providerless typecheck-dockerless
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
         name: main
         resources:
           limits:
@@ -1496,7 +1496,7 @@ presubmits:
           value: release-1.19
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
         imagePullPolicy: Always
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
@@ -27,7 +27,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
       name: ""
       resources:
         limits:
@@ -67,7 +67,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
       name: ""
       resources:
         limits:
@@ -106,7 +106,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
       name: ""
       resources:
         limits:
@@ -143,7 +143,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
       name: ""
       resources:
         limits:
@@ -290,7 +290,7 @@ periodics:
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
       name: ""
       resources:
         limits:
@@ -368,7 +368,7 @@ periodics:
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
       name: ""
       resources:
         limits:
@@ -417,7 +417,7 @@ periodics:
             --version-suffix=-bazel
       command:
       - bash
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
       name: ""
       resources:
         limits:
@@ -491,7 +491,7 @@ periodics:
       env:
       - name: SHORT
         value: --short=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
       name: ""
       resources:
         limits:
@@ -533,7 +533,7 @@ periodics:
         value: release-1.20
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
       imagePullPolicy: Always
       name: ""
       resources:
@@ -589,7 +589,7 @@ periodics:
         value: win2019
       - name: PREPULL_YAML
         value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
       name: ""
       resources: {}
 - annotations:
@@ -724,7 +724,7 @@ postsubmits:
         - --release=//build/release-tars
         - --gcs=gs://k8s-release-dev/ci
         - --version-suffix=-bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
         name: ""
         resources:
           requests:
@@ -775,7 +775,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
         name: ""
         resources:
           requests:
@@ -814,7 +814,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
         name: ""
         resources:
           limits:
@@ -856,7 +856,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
         name: ""
         resources:
           limits:
@@ -906,7 +906,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
         name: ""
         resources:
           requests:
@@ -957,7 +957,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
         name: ""
         resources:
           limits:
@@ -1012,7 +1012,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
         name: ""
         resources:
           limits:
@@ -1058,7 +1058,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
         name: ""
         resources:
           requests:
@@ -1091,7 +1091,7 @@ presubmits:
         - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
         name: ""
         resources:
           limits:
@@ -1135,7 +1135,7 @@ presubmits:
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
         name: ""
         resources:
           limits:
@@ -1179,7 +1179,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
         name: ""
         resources:
           requests:
@@ -1241,7 +1241,7 @@ presubmits:
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
         name: ""
         resources:
           limits:
@@ -1314,7 +1314,7 @@ presubmits:
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
         name: ""
         resources:
           limits:
@@ -1420,7 +1420,7 @@ presubmits:
         env:
         - name: WHAT
           value: external-dependencies-version vendor vendor-licenses
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
         name: main
         resources:
           limits:
@@ -1448,7 +1448,7 @@ presubmits:
         env:
         - name: WHAT
           value: generated-files-remake
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
         name: main
         resources:
           limits:
@@ -1473,7 +1473,7 @@ presubmits:
         - ./hack/jenkins/test-dockerized.sh
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
         name: ""
         resources:
           limits:
@@ -1543,7 +1543,7 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck typecheck-providerless typecheck-dockerless
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
         name: main
         resources:
           limits:
@@ -1579,7 +1579,7 @@ presubmits:
           value: release-1.20
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
         imagePullPolicy: Always
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.21.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.21.yaml
@@ -23,7 +23,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       name: ""
       resources:
         limits:
@@ -63,7 +63,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       name: ""
       resources:
         limits:
@@ -150,7 +150,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       name: ""
       resources:
         limits:
@@ -187,7 +187,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       name: ""
       resources:
         limits:
@@ -335,7 +335,7 @@ periodics:
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       name: ""
       resources:
         limits:
@@ -413,7 +413,7 @@ periodics:
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       name: ""
       resources:
         limits:
@@ -452,7 +452,7 @@ periodics:
       env:
       - name: SHORT
         value: --short=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       name: ""
       resources:
         limits:
@@ -485,7 +485,7 @@ periodics:
       - test
       - KUBE_RACE=-race
       - KUBE_TIMEOUT=--timeout=240s
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       name: ""
       resources:
         limits:
@@ -525,7 +525,7 @@ periodics:
         value: release-1.21
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       imagePullPolicy: Always
       name: ""
       resources:
@@ -586,7 +586,7 @@ periodics:
         value: win2019
       - name: PREPULL_YAML
         value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       name: ""
       resources: {}
 - annotations:
@@ -638,7 +638,7 @@ periodics:
         value: win20h2
       - name: PREPULL_YAML
         value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       name: ""
       resources: {}
 - annotations:
@@ -690,7 +690,7 @@ periodics:
         value: win2004
       - name: PREPULL_YAML
         value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       name: ""
       resources: {}
 - annotations:
@@ -839,7 +839,7 @@ periodics:
       command:
       - runner.sh
       - kubetest
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
       name: ""
       resources: {}
       securityContext:
@@ -889,7 +889,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         name: ""
         resources:
           requests:
@@ -929,7 +929,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         name: ""
         resources:
           limits:
@@ -977,7 +977,7 @@ presubmits:
         env:
         - name: BOOTSTRAP_FETCH_TEST_INFRA
           value: "true"
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         name: ""
         resources:
           limits:
@@ -1026,7 +1026,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         name: ""
         resources:
           requests:
@@ -1078,7 +1078,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         name: ""
         resources:
           limits:
@@ -1133,7 +1133,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         name: ""
         resources:
           limits:
@@ -1180,7 +1180,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         name: ""
         resources:
           requests:
@@ -1215,7 +1215,7 @@ presubmits:
         - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         name: ""
         resources:
           limits:
@@ -1257,7 +1257,7 @@ presubmits:
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         name: ""
         resources:
           limits:
@@ -1300,7 +1300,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         name: ""
         resources:
           requests:
@@ -1363,7 +1363,7 @@ presubmits:
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         name: ""
         resources:
           limits:
@@ -1437,7 +1437,7 @@ presubmits:
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         name: ""
         resources:
           limits:
@@ -1468,7 +1468,7 @@ presubmits:
         env:
         - name: WHAT
           value: external-dependencies-version vendor vendor-licenses
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         name: main
         resources:
           limits:
@@ -1496,7 +1496,7 @@ presubmits:
         env:
         - name: WHAT
           value: generated-files-remake
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         name: main
         resources:
           limits:
@@ -1521,7 +1521,7 @@ presubmits:
         - ./hack/jenkins/test-dockerized.sh
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         name: ""
         resources:
           limits:
@@ -1587,7 +1587,7 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck typecheck-providerless typecheck-dockerless
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         name: main
         resources:
           limits:
@@ -1623,7 +1623,7 @@ presubmits:
           value: release-1.21
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         imagePullPolicy: Always
         name: ""
         resources:
@@ -1664,7 +1664,7 @@ presubmits:
           value: release-1.21
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         imagePullPolicy: IfNotPresent
         name: ""
         resources:
@@ -1809,7 +1809,7 @@ presubmits:
         - runner.sh
         - bash
         - -c
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
         name: ""
         resources:
           limits:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml
@@ -23,7 +23,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
       name: ""
       resources:
         limits:
@@ -63,7 +63,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
       name: ""
       resources:
         limits:
@@ -150,7 +150,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
       name: ""
       resources:
         limits:
@@ -187,7 +187,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
       name: ""
       resources:
         limits:
@@ -336,7 +336,7 @@ periodics:
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
       name: ""
       resources:
         limits:
@@ -416,7 +416,7 @@ periodics:
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
       name: ""
       resources:
         limits:
@@ -455,7 +455,7 @@ periodics:
       env:
       - name: SHORT
         value: --short=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
       name: ""
       resources:
         limits:
@@ -487,7 +487,7 @@ periodics:
     - command:
       - make
       - test
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
       name: ""
       resources:
         limits:
@@ -529,7 +529,7 @@ periodics:
         value: release-1.22
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
       imagePullPolicy: Always
       name: ""
       resources:
@@ -590,7 +590,7 @@ periodics:
         value: win2019
       - name: PREPULL_YAML
         value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
       name: ""
       resources: {}
 - annotations:
@@ -643,7 +643,7 @@ periodics:
         value: win2019
       - name: PREPULL_YAML
         value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
       name: ""
       resources: {}
 - annotations:
@@ -698,7 +698,7 @@ periodics:
         value: "true"
       - name: PREPULL_YAML
         value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
       name: ""
       resources: {}
 - annotations:
@@ -752,7 +752,7 @@ periodics:
         value: win20h2
       - name: PREPULL_YAML
         value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
       name: ""
       resources: {}
 - annotations:
@@ -807,7 +807,7 @@ periodics:
         value: "true"
       - name: PREPULL_YAML
         value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
       name: ""
       resources: {}
 - annotations:
@@ -870,7 +870,7 @@ periodics:
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
       name: ""
       resources:
         limits:
@@ -1026,7 +1026,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
         name: ""
         resources:
           requests:
@@ -1067,7 +1067,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
         name: ""
         resources:
           limits:
@@ -1116,7 +1116,7 @@ presubmits:
         env:
         - name: BOOTSTRAP_FETCH_TEST_INFRA
           value: "true"
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
         name: ""
         resources:
           limits:
@@ -1167,7 +1167,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
         name: ""
         resources:
           requests:
@@ -1219,7 +1219,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
         name: ""
         resources:
           limits:
@@ -1274,7 +1274,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
         name: ""
         resources:
           limits:
@@ -1322,7 +1322,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
         name: ""
         resources:
           requests:
@@ -1359,7 +1359,7 @@ presubmits:
           value: release-1.22
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
         imagePullPolicy: IfNotPresent
         name: ""
         resources:
@@ -1405,7 +1405,7 @@ presubmits:
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
         name: ""
         resources:
           limits:
@@ -1449,7 +1449,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
         name: ""
         resources:
           requests:
@@ -1488,7 +1488,7 @@ presubmits:
         - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/image-config.yaml
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
         name: ""
         resources:
           limits:
@@ -1555,7 +1555,7 @@ presubmits:
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
         name: ""
         resources:
           limits:
@@ -1631,7 +1631,7 @@ presubmits:
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
         name: ""
         resources:
           limits:
@@ -1700,7 +1700,7 @@ presubmits:
         env:
         - name: WHAT
           value: external-dependencies-version vendor vendor-licenses
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
         name: main
         resources:
           limits:
@@ -1729,7 +1729,7 @@ presubmits:
         env:
         - name: WHAT
           value: generated-files-remake
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
         name: main
         resources:
           limits:
@@ -1755,7 +1755,7 @@ presubmits:
         - ./hack/jenkins/test-dockerized.sh
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
         name: ""
         resources:
           limits:
@@ -1903,7 +1903,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
         name: ""
         resources:
           limits:
@@ -1931,7 +1931,7 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck typecheck-providerless typecheck-dockerless
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
         name: main
         resources:
           limits:
@@ -1968,7 +1968,7 @@ presubmits:
           value: release-1.22
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
         imagePullPolicy: Always
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-adhoc.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-adhoc.yaml
@@ -34,7 +34,7 @@ presubmits:
       testgrid-tab-name: pull-perf-tests-100-adhoc
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-cleanup.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-cleanup.yaml
@@ -16,7 +16,7 @@ periodics:
     testgrid-tab-name: snapshots-cleanup
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - /workspace/scenarios/execute.py

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
@@ -27,7 +27,7 @@ periodics:
     testgrid-tab-name: storage
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
@@ -78,7 +78,7 @@ periodics:
     testgrid-tab-name: calico
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
@@ -144,7 +144,7 @@ periodics:
     testgrid-tab-name: gce-cos-master-scalability-100-nodekiller
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
@@ -84,7 +84,7 @@ periodics:
     testgrid-tab-name: golang-tip-k8s-1-18
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -27,7 +27,7 @@ periodics:
     testgrid-tab-name: node-throughput
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
@@ -86,7 +86,7 @@ periodics:
     testgrid-tab-name: node-containerd-throughput
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
@@ -151,7 +151,7 @@ periodics:
     testgrid-num-failures-to-alert: '2'
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
@@ -228,7 +228,7 @@ periodics:
     testgrid-num-failures-to-alert: '1'
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
@@ -303,7 +303,7 @@ periodics:
     testgrid-num-failures-to-alert: '1'
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
@@ -384,7 +384,7 @@ periodics:
     testgrid-num-failures-to-alert: '2'
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
@@ -464,7 +464,7 @@ periodics:
     testgrid-num-columns-recent: '3'
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
@@ -548,7 +548,7 @@ periodics:
     testgrid-num-columns-recent: '3'
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
@@ -621,7 +621,7 @@ periodics:
     testgrid-num-failures-to-alert: '1'
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
@@ -684,7 +684,7 @@ periodics:
     testgrid-tab-name: kubemark-100-benchmark
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - /workspace/scenarios/execute.py
@@ -716,7 +716,7 @@ periodics:
     timeout: 1h55m
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - ./hack/jenkins/benchmark-dockerized.sh
       args:
@@ -752,7 +752,7 @@ periodics:
     timeout: 1h55m
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - ./hack/jenkins/benchmark-dockerized.sh
       args:
@@ -805,7 +805,7 @@ periodics:
     testgrid-tab-name: kube-dns
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
@@ -859,7 +859,7 @@ periodics:
     testgrid-tab-name: node-local-dns
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
@@ -940,7 +940,7 @@ periodics:
     testgrid-tab-name: metric-measurement
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -32,7 +32,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
@@ -100,7 +100,7 @@ presubmits:
       preset-e2e-scalability-presubmits: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
@@ -166,7 +166,7 @@ presubmits:
       testgrid-tab-name: pull-kubernetes-e2e-gce-correctness
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
@@ -226,7 +226,7 @@ presubmits:
       preset-e2e-scalability-presubmits: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
@@ -299,7 +299,7 @@ presubmits:
       testgrid-create-test-group: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
@@ -378,7 +378,7 @@ presubmits:
       preset-e2e-scalability-presubmits: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
@@ -449,7 +449,7 @@ presubmits:
     run_if_changed: ^dns/.*$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
@@ -491,7 +491,7 @@ presubmits:
     run_if_changed: ^clusterloader2/.*$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
@@ -556,7 +556,7 @@ presubmits:
     run_if_changed: ^clusterloader2/.*$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -19,7 +19,7 @@ periodics:
     description: "Uses kubetest to run correctness tests against a 5000-node cluster created with cluster/kube-up.sh"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
@@ -85,7 +85,7 @@ periodics:
     description: "Uses kubetest to run k8s.io/perf-tests/run-e2e.sh against a 5000-node cluster created with cluster/kube-up.sh"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
@@ -174,7 +174,7 @@ periodics:
     testgrid-num-failures-to-alert: '2'
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py

--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -43,7 +43,7 @@ presubmits:
         - --timeout=80m
         securityContext:
           privileged: true
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         resources:
           requests:
             memory: "6Gi"
@@ -91,7 +91,7 @@ presubmits:
         - --timeout=120m
         securityContext:
           privileged: true
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         resources:
           requests:
             memory: "6Gi"
@@ -137,7 +137,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-csi-serial
         - --test_args=--ginkgo.focus=CSI.*(\[Serial\]|\[Disruptive\]) --ginkgo.skip=\[Flaky\]|\[Feature:.+\]|\[Slow\] --minStartupPods=8
         - --timeout=150m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         resources:
           requests:
             memory: "6Gi"
@@ -180,7 +180,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-iscsi
         - --test_args=--ginkgo.focus=\[Driver:.iscsi\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
         - --timeout=120m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         resources:
           requests:
             memory: "6Gi"
@@ -222,7 +222,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-iscsi-serial
         - --test_args=--ginkgo.focus=\[Driver:.iscsi\].*(\[Serial\]|\[Disruptive\]) --ginkgo.skip=\[Flaky\] --minStartupPods=8
         - --timeout=120m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         resources:
           requests:
             memory: "6Gi"
@@ -260,7 +260,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-storage-disruptive
         - --test_args=--ginkgo.focus=\[sig-storage\].*\[Disruptive\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
         - --timeout=240m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         resources:
           requests:
             memory: "6Gi"
@@ -292,7 +292,7 @@ periodics:
       - --ginkgo-parallel=30
       - --test_args=--ginkgo.focus=\[Driver:.iscsi\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-num-columns-recent: '20'
 - interval: 24h
@@ -317,7 +317,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Driver:.iscsi\].*(\[Serial\]|\[Disruptive\]) --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-num-columns-recent: '20'
 - interval: 24h
@@ -339,7 +339,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:VolumeSnapshotDataSource\] --ginkgo.skip=\[Disruptive\]|\[Flaky\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-num-columns-recent: '20'
     testgrid-num-failures-to-alert: '6'

--- a/config/jobs/kubernetes/sig-storage/sig-storage-kops-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-kops-config.yaml
@@ -30,7 +30,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.focus=\[sig-storage\].*\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
   annotations:
     testgrid-num-columns-recent: '20'

--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -15,7 +15,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - "--job=$(JOB_NAME)"
         - "--root=/go/src"
@@ -104,7 +104,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"

--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -23,7 +23,7 @@ periodics:
     timeout: 6h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - bash
@@ -84,7 +84,7 @@ periodics:
     timeout: 3h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - bash
@@ -138,7 +138,7 @@ periodics:
     path_alias: k8s.io/test-infra
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - bash

--- a/config/jobs/kubernetes/sig-testing/dependencies.yaml
+++ b/config/jobs/kubernetes/sig-testing/dependencies.yaml
@@ -21,7 +21,7 @@ presubmits:
       - name: main
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - make
         - verify
@@ -60,7 +60,7 @@ presubmits:
       - name: main
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-go-canary
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-go-canary
         args:
         - make
         - verify

--- a/config/jobs/kubernetes/sig-testing/files-remake.yaml
+++ b/config/jobs/kubernetes/sig-testing/files-remake.yaml
@@ -21,7 +21,7 @@ presubmits:
       - name: main
         command:
         - make
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - verify
         env:

--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -18,7 +18,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         args:
@@ -88,7 +88,7 @@ periodics:
     description: "Ends up running: make test-cmd test-integration"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -77,7 +77,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-experimental
         imagePullPolicy: Always
         args:
         - "--job=$(JOB_NAME)"
@@ -177,7 +177,7 @@ periodics:
       - --timeout=120m
       - --use-logexporter
       - --logexporter-gcs-path=gs://sig-scalability-logs/$(JOB_NAME)/$(BUILD_ID)
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: sig-testing-canaries
@@ -206,7 +206,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-gke, sig-testing-canaries
@@ -225,7 +225,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master
       imagePullPolicy: Always
       command:
       - runner.sh
@@ -258,7 +258,7 @@ periodics:
     timeout: 260m
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master
       imagePullPolicy: Always
       command:
       - runner.sh

--- a/config/jobs/kubernetes/sig-testing/local-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/local-e2e.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -54,7 +54,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - "--timeout=140"
       - "--bare"

--- a/config/jobs/kubernetes/sig-testing/make-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/make-test.yaml
@@ -19,7 +19,7 @@ presubmits:
         runAsUser: 2000
         allowPrivilegeEscalation: false
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             - make
             - test
@@ -53,7 +53,7 @@ presubmits:
         runAsUser: 2001
         runAsGroup: 2010
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master
           imagePullPolicy: Always
           command:
             - make
@@ -128,7 +128,7 @@ periodics:
         runAsUser: 2000
         allowPrivilegeEscalation: false
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             - make
             - test
@@ -158,7 +158,7 @@ periodics:
         runAsUser: 2000
         allowPrivilegeEscalation: false
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             - runner.sh
             - bash
@@ -219,7 +219,7 @@ periodics:
         runAsUser: 2000
         allowPrivilegeEscalation: false
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
           command:
             - runner.sh
             - bash

--- a/config/jobs/kubernetes/sig-testing/typecheck.yaml
+++ b/config/jobs/kubernetes/sig-testing/typecheck.yaml
@@ -19,7 +19,7 @@ presubmits:
       - name: main
         command:
         - make
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         resources:
           limits:
             cpu: 5

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -17,7 +17,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -65,7 +65,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-go-canary
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-go-canary
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -117,7 +117,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       command:
       - runner.sh

--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -97,7 +97,7 @@ periodics:
         value: "win2019"
       - name: PREPULL_YAML
         value: "prepull-head.yaml"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     fork-per-release: "true"
     fork-per-release-replacements: "--extract=ci/latest -> --extract=ci/latest-{{.Version}}"
@@ -149,7 +149,7 @@ periodics:
         value: "true"
       - name: PREPULL_YAML
         value: "prepull-head.yaml"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     fork-per-release: "true"
     fork-per-release-replacements: "--extract=ci/latest -> --extract=ci/latest-{{.Version}}"
@@ -200,7 +200,7 @@ periodics:
         value: "win20h2"
       - name: PREPULL_YAML
         value: "prepull-head.yaml"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     fork-per-release: "true"
     fork-per-release-replacements: "--extract=ci/latest -> --extract=ci/latest-{{.Version}}"
@@ -252,7 +252,7 @@ periodics:
         value: "true"
       - name: PREPULL_YAML
         value: "prepull-head.yaml"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     fork-per-release: "true"
     fork-per-release-replacements: "--extract=ci/latest -> --extract=ci/latest-{{.Version}}"
@@ -304,7 +304,7 @@ periodics:
         value: "prepull-head.yaml"
       - name: KUBE_FEATURE_GATES
         value: "WindowsGMSA=true"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: google-windows, sig-windows-gce
     testgrid-tab-name: gce-windows-2019-master-alpha-features
@@ -352,7 +352,7 @@ periodics:
         value: "win2019"
       - name: PREPULL_YAML
         value: "prepull-head.yaml"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: google-windows, sig-windows-gce
     testgrid-tab-name: gce-windows-2019-serial
@@ -400,7 +400,7 @@ periodics:
         value: "win2019"
       - name: PREPULL_YAML
         value: "prepull-head.yaml"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   annotations:
     testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-master-release
     testgrid-tab-name: gce-windows-2019-containerd-master
@@ -449,7 +449,7 @@ periodics:
         value: "win2019"
       - name: PREPULL_YAML
         value: "prepull-head.yaml"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
   annotations:
     testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-1.21-release
     testgrid-tab-name: gce-windows-2019-containerd-1.21
@@ -498,7 +498,7 @@ periodics:
         value: "win20h2"
       - name: PREPULL_YAML
         value: "prepull-head.yaml"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
   annotations:
     testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-1.21-release
     testgrid-tab-name: gce-windows-20h2-containerd-1.21
@@ -531,7 +531,7 @@ periodics:
     - command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       env:
       - name: CL2_CONTAINER_IMAGE
         value: "k8s.gcr.io/pause:3.4.1"
@@ -585,7 +585,7 @@ periodics:
     - command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       env:
       - name: CL2_CONTAINER_IMAGE
         value: "mcr.microsoft.com/windows/servercore/iis"
@@ -671,7 +671,7 @@ presubmits:
           value: "win2019"
         - name: PREPULL_YAML
           value: "prepull-head.yaml"
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes/system-validators/system-validators-presubmits.yaml
+++ b/config/jobs/kubernetes/system-validators/system-validators-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - "./hack/verify-all.sh"
     annotations:

--- a/config/jobs/kubernetes/test-infra/janitors.yaml
+++ b/config/jobs/kubernetes/test-infra/janitors.yaml
@@ -40,7 +40,7 @@ periodics:
       - --config-path=config/prow/config.yaml
       - --job-config-path=config/jobs
       - --janitor-path=boskos/cmd/janitor/gcp_janitor.py
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         requests:
           cpu: 5
@@ -65,7 +65,7 @@ periodics:
       - --
       - --mode=pr
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-experimental
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-experimental
       resources:
         requests:
           cpu: 5
@@ -91,7 +91,7 @@ periodics:
       - --mode=scale
       - --ratelimit=5
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-experimental
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-experimental
       resources:
         requests:
           cpu: 5

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -53,7 +53,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-experimental
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-experimental
         command:
         - ./hack/verify-file-perms.sh
     annotations:
@@ -112,7 +112,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-test-infra
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-test-infra
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -430,7 +430,7 @@ postsubmits:
         - --project=k8s-testimages
         - --build-dir=.
         - images/gcloud/
-  - name: post-test-infra-push-kubekins-e2e
+  - name: post-test-infra-push-kubekins-e2e-deprecated
     cluster: test-infra-trusted
     run_if_changed: '^(images/kubekins-e2e|kubetest|boskos)/'
     annotations:

--- a/config/jobs/kubernetes/wg-k8s-infra/canaries/kops-periodics-pipeline-canary.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/canaries/kops-periodics-pipeline-canary.yaml
@@ -48,7 +48,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -116,7 +116,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -184,7 +184,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:
@@ -252,7 +252,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       imagePullPolicy: Always
       resources:
         limits:

--- a/config/jobs/kubernetes/wg-k8s-infra/canaries/sig-node-containerd.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/canaries/sig-node-containerd.yaml
@@ -7,7 +7,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --repo=github.com/containerd/containerd=main
       - --root=/go/src
@@ -37,7 +37,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
           - --repo=github.com/containerd/containerd=release/1.4
           - --repo=github.com/containerd/cri=release/1.4
@@ -67,7 +67,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
           - --repo=github.com/containerd/containerd=main
           - --root=/go/src
@@ -114,7 +114,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         limits:
           cpu: 4
@@ -152,7 +152,7 @@ periodics:
           - --provider=gce
           - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
           - --timeout=50m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         resources:
           limits:
             cpu: 4
@@ -188,7 +188,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         limits:
           cpu: 4
@@ -207,7 +207,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -245,7 +245,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes=release-1.21
@@ -283,7 +283,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -321,7 +321,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes=release-1.21
@@ -375,7 +375,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         limits:
           cpu: 4
@@ -411,7 +411,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         limits:
           cpu: 4
@@ -448,7 +448,7 @@ periodics:
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandPersistentVolumes|VolumeSubpathEnvExpansion|RunAsGroup|NodeLease)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes|Feature:SCTPConnectivity --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         limits:
           cpu: 4
@@ -481,7 +481,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         limits:
           cpu: 4
@@ -518,7 +518,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         limits:
           cpu: 4
@@ -553,7 +553,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         limits:
           cpu: 4
@@ -586,7 +586,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         limits:
           cpu: 4
@@ -620,7 +620,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         limits:
           cpu: 4
@@ -656,7 +656,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         limits:
           cpu: 4
@@ -675,7 +675,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -713,7 +713,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -751,7 +751,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -805,7 +805,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         limits:
           cpu: 4
@@ -840,7 +840,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       resources:
         limits:
           cpu: 4
@@ -859,7 +859,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -896,7 +896,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -933,7 +933,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes

--- a/config/jobs/kubernetes/wg-k8s-infra/canaries/sig-scalability.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/canaries/sig-scalability.yaml
@@ -17,7 +17,7 @@ periodics:
     description: "Uses kubetest to run correctness tests against a 5000-node cluster created with cluster/kube-up.sh"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
@@ -80,7 +80,7 @@ periodics:
     testgrid-tab-name: gce-master-scale-performance-canary
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
@@ -165,7 +165,7 @@ periodics:
     testgrid-num-failures-to-alert: '2'
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
@@ -243,7 +243,7 @@ periodics:
     testgrid-num-columns-recent: '3'
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
@@ -326,7 +326,7 @@ periodics:
     testgrid-num-columns-recent: '3'
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
@@ -454,7 +454,7 @@ periodics:
     testgrid-tab-name: ci-golang-tip-k8s-1-18-canary
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
@@ -535,7 +535,7 @@ presubmits:
       testgrid-tab-name: pull-kubernetes-e2e-gce-large-performance-canary
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/image-builder/image-builder-periodics.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/image-builder/image-builder-periodics.yaml
@@ -11,7 +11,7 @@ periodics:
   spec:
     serviceAccountName: gcb-builder-cluster-api-gcp
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         args:
           - runner.sh
           - "./images/capi/scripts/ci-gce-nightly.sh"

--- a/experiment/bump_e2e_image.sh
+++ b/experiment/bump_e2e_image.sh
@@ -21,11 +21,11 @@ set -o pipefail
 
 TREE="$(git rev-parse --show-toplevel)"
 
-bazel run //experiment/image-bumper -- --image-regex gcr.io/k8s-testimages/kubekins-e2e "${TREE}/experiment/generate_tests.py" "${TREE}/experiment/test_config.yaml" "${TREE}/config/prow/config.yaml"
-find "${TREE}/config/jobs/" . -name "*.yaml" | xargs bazel run //experiment/image-bumper -- --image-regex gcr.io/k8s-testimages/kubekins-e2e
+bazel run //experiment/image-bumper -- --image-regex gcr.io/k8s-staging-test-infra/kubekins-e2e "${TREE}/experiment/generate_tests.py" "${TREE}/experiment/test_config.yaml" "${TREE}/config/prow/config.yaml"
+find "${TREE}/config/jobs/" . -name "*.yaml" | xargs bazel run //experiment/image-bumper -- --image-regex gcr.io/k8s-staging-test-infra/kubekins-e2e
 
 bazel run //experiment:generate_tests -- \
   "--yaml-config-path=${TREE}/experiment/test_config.yaml" \
   "--output-dir=${TREE}/config/jobs/kubernetes/generated/"
 
-git commit -am "Bump gcr.io/k8s-testimages/kubekins-e2e (using generate_tests and manual)"
+git commit -am "Bump gcr.io/k8s-staging-test-infra/kubekins-e2e (using generate_tests and manual)"

--- a/images/kubemci/Dockerfile
+++ b/images/kubemci/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:latest-master
+FROM gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master
 
 RUN apt-get update && apt-get install -y \
     git && \

--- a/prow/spyglass/lenses/metadata/lens_test.go
+++ b/prow/spyglass/lenses/metadata/lens_test.go
@@ -120,7 +120,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						Containers: []v1.Container{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
+								Image: "gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master",
 							},
 						},
 					},
@@ -129,7 +129,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						ContainerStatuses: []v1.ContainerStatus{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
+								Image: "gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master",
 								Ready: false,
 								State: v1.ContainerState{
 									Terminated: &v1.ContainerStateTerminated{
@@ -145,7 +145,7 @@ func TestHintFromPodInfo(t *testing.T) {
 		},
 		{
 			name:     "stuck images are reported by name",
-			expected: `The test container could not start because it could not pull "gcr.io/k8s-testimages/kubekins-e2e:latest-master". Check your images. Full message: "rpc error: code = Unknown desc"`,
+			expected: `The test container could not start because it could not pull "gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master". Check your images. Full message: "rpc error: code = Unknown desc"`,
 			info: k8sreporter.PodReport{
 				Pod: &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -155,7 +155,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						Containers: []v1.Container{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
+								Image: "gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master",
 							},
 						},
 					},
@@ -164,7 +164,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						ContainerStatuses: []v1.ContainerStatus{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
+								Image: "gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master",
 								Ready: false,
 								State: v1.ContainerState{
 									Waiting: &v1.ContainerStateWaiting{
@@ -180,7 +180,7 @@ func TestHintFromPodInfo(t *testing.T) {
 		},
 		{
 			name:     "stuck images are reported by name - errimagepull",
-			expected: `The test container could not start because it could not pull "gcr.io/k8s-testimages/kubekins-e2e:latest-master". Check your images. Full message: "rpc error: code = Unknown desc"`,
+			expected: `The test container could not start because it could not pull "gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master". Check your images. Full message: "rpc error: code = Unknown desc"`,
 			info: k8sreporter.PodReport{
 				Pod: &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -190,7 +190,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						Containers: []v1.Container{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
+								Image: "gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master",
 							},
 						},
 					},
@@ -199,7 +199,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						ContainerStatuses: []v1.ContainerStatus{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
+								Image: "gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master",
 								Ready: false,
 								State: v1.ContainerState{
 									Waiting: &v1.ContainerStateWaiting{
@@ -225,7 +225,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						Containers: []v1.Container{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
+								Image: "gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master",
 								VolumeMounts: []v1.VolumeMount{
 									{
 										Name:      "some-volume",
@@ -250,7 +250,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						ContainerStatuses: []v1.ContainerStatus{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
+								Image: "gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master",
 								Ready: false,
 								State: v1.ContainerState{
 									Waiting: &v1.ContainerStateWaiting{
@@ -282,7 +282,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						Containers: []v1.Container{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
+								Image: "gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master",
 							},
 						},
 					},
@@ -305,7 +305,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						Containers: []v1.Container{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
+								Image: "gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master",
 							},
 						},
 					},
@@ -334,7 +334,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						Containers: []v1.Container{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
+								Image: "gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master",
 							},
 						},
 					},
@@ -343,7 +343,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						ContainerStatuses: []v1.ContainerStatus{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
+								Image: "gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master",
 								Ready: false,
 								State: v1.ContainerState{
 									Waiting: &v1.ContainerStateWaiting{
@@ -374,7 +374,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						Containers: []v1.Container{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
+								Image: "gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master",
 							},
 						},
 					},
@@ -395,7 +395,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						ContainerStatuses: []v1.ContainerStatus{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
+								Image: "gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master",
 								Ready: false,
 								State: v1.ContainerState{
 									Waiting: &v1.ContainerStateWaiting{
@@ -420,7 +420,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						Containers: []v1.Container{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
+								Image: "gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master",
 							},
 						},
 					},
@@ -438,7 +438,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						ContainerStatuses: []v1.ContainerStatus{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
+								Image: "gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master",
 								Ready: false,
 								State: v1.ContainerState{
 									Waiting: &v1.ContainerStateWaiting{
@@ -463,7 +463,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						Containers: []v1.Container{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
+								Image: "gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master",
 							},
 						},
 					},
@@ -494,7 +494,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						ContainerStatuses: []v1.ContainerStatus{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:latest-master",
+								Image: "gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master",
 								Ready: false,
 								State: v1.ContainerState{
 									Waiting: &v1.ContainerStateWaiting{

--- a/releng/config-forker/main_test.go
+++ b/releng/config-forker/main_test.go
@@ -535,7 +535,7 @@ func TestGeneratePresubmits(t *testing.T) {
 					Spec: &v1.PodSpec{
 						Containers: []v1.Container{
 							{
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:blahblahblah-master",
+								Image: "gcr.io/k8s-staging-test-infra/kubekins-e2e:blahblahblah-master",
 								Args:  []string{"--repo=k8s.io/kubernetes", "--something=foo"},
 								Env:   []v1.EnvVar{{Name: "BRANCH", Value: "master"}},
 							},
@@ -614,7 +614,7 @@ func TestGeneratePresubmits(t *testing.T) {
 					Spec: &v1.PodSpec{
 						Containers: []v1.Container{
 							{
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:blahblahblah-1.15",
+								Image: "gcr.io/k8s-staging-test-infra/kubekins-e2e:blahblahblah-1.15",
 								Args:  []string{"--repo=k8s.io/kubernetes", "--something=1.15"},
 								Env:   []v1.EnvVar{{Name: "BRANCH", Value: "release-1.15"}},
 							},
@@ -831,7 +831,7 @@ func TestGeneratePostsubmits(t *testing.T) {
 					Spec: &v1.PodSpec{
 						Containers: []v1.Container{
 							{
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:blahblahblah-master",
+								Image: "gcr.io/k8s-staging-test-infra/kubekins-e2e:blahblahblah-master",
 								Args:  []string{"--repo=k8s.io/kubernetes", "--something=foo"},
 								Env:   []v1.EnvVar{{Name: "BRANCH", Value: "master"}},
 							},
@@ -896,7 +896,7 @@ func TestGeneratePostsubmits(t *testing.T) {
 					Spec: &v1.PodSpec{
 						Containers: []v1.Container{
 							{
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:blahblahblah-1.15",
+								Image: "gcr.io/k8s-staging-test-infra/kubekins-e2e:blahblahblah-1.15",
 								Args:  []string{"--repo=k8s.io/kubernetes", "--something=1.15"},
 								Env:   []v1.EnvVar{{Name: "BRANCH", Value: "release-1.15"}},
 							},

--- a/releng/generate_tests.py
+++ b/releng/generate_tests.py
@@ -45,7 +45,7 @@ PROW_CONFIG_TEMPLATE = """
       containers:
       - args:
         env:
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
         resources:
           requests:
             cpu: 1000m

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -388,23 +388,23 @@ nodeK8sVersions:
   dev:
     args:
     - --repo=k8s.io/kubernetes=master
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-master
+    prowImage: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-master
   beta:
     args:
     - --repo=k8s.io/kubernetes=release-1.22
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.22
+    prowImage: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.22
   stable1:
     args:
     - --repo=k8s.io/kubernetes=release-1.21
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.21
+    prowImage: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.21
   stable2:
     args:
     - --repo=k8s.io/kubernetes=release-1.20
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.20
+    prowImage: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.20
   stable3:
     args:
     - --repo=k8s.io/kubernetes=release-1.19
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20210902-e4567b8-1.19
+    prowImage: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210902-e4567b8-1.19
 
 nodeTestSuites:
   default:

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -113,7 +113,7 @@ def check_env(env, *cmd):
 
 def kubekins(tag):
     """Return full path to kubekins-e2e:tag."""
-    return 'gcr.io/k8s-testimages/kubekins-e2e:%s' % tag
+    return 'gcr.io/k8s-staging-test-infra/kubekins-e2e:%s' % tag
 
 def parse_env(env):
     """Returns (FOO, BAR=MORE) for FOO=BAR=MORE."""


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1523#issuecomment-912031929
- Followup to: https://github.com/kubernetes/test-infra/pull/23543

Broken up into three commits:
- The first two contain changes generated via this script
```bash
#!/usr/bin/env bash

export old=gcr.io/k8s-testimages/kubekins-e2e
export new=gcr.io/k8s-staging-test-infra/kubekins-e2e
for f in $(rg -l $old | grep -v foo.sh); do
  sed -i.bak -e "s|$old|$new|g" $f;
  rm $f.bak;
done
```
- The first commit is everything in config/jobs/
- The second commit is everything else
- The final commit renames the jobs that push kubekins images, making the old job -deprecated, the new job the default, and updating testgrid dashboards + alerts to follow suit