### PR TITLE
config/jobs: add pull-enhancements-test

### DIFF
--- a/config/jobs/kubernetes/enhancements/enhancements-presubmit.yaml
+++ b/config/jobs/kubernetes/enhancements/enhancements-presubmit.yaml
@@ -10,3 +10,13 @@ presubmits:
               - sh
               - "-c"
               - "export PATH=$PATH:$GOPATH/bin && ./hack/verify.sh"
+    - name: pull-enhancements-test
+      always_run: true
+      decorate: true
+      spec:
+        containers:
+          - image: golang:1.17
+            command:
+              - make
+              - test
+              - tools


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/enhancements/issues/2276
- Followup to: https://github.com/kubernetes/enhancements/pull/2927

Let's prevent `make test` and `make tools` from breaking again by running them as a blocking presubmit