### PR TITLE
[scheduler-plugins] Add a presubmit CI job to verify crd manifests

### DIFF
--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-master.yaml
@@ -53,3 +53,16 @@ presubmits:
         - make
         args:
         - integration-test
+  - name: pull-scheduler-plugins-verify-crdgen-master
+    decorate: true
+    path_alias: sigs.k8s.io/scheduler-plugins
+    branches:
+    - ^master$
+    always_run: true
+    spec:
+      containers:
+      - image: golang:1.16.7
+        command:
+        - make
+        args:
+        - verify-crdgen


### PR DESCRIPTION
This PRs adds a presubmit CI job to verify crd manifests in scheduler-plugins.