### PR TITLE
Move prow image push job to run on tainted high cpu nodes

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -203,6 +203,16 @@ postsubmits:
       - image: gcr.io/k8s-testimages/bazelbuild:v20210806-7bef894-test-infra
         command:
         - prow/push.sh
+      tolerations:
+      - key: "highcpu"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+      nodeSelector:
+        highcpu: "true"
+      resources:
+        requests:
+          cpu: "15"
     annotations:
       testgrid-dashboards: sig-testing-prow
       testgrid-tab-name: push-prow


### PR DESCRIPTION
This job is currently running on default nodes with 8 CPUs in total, I have inspected a running job and found out that it uses 8 CPUs at peak, which might be bounded by the VM. This also affects other jobs running on the same node, including prow components. Make it running on tainted node should help.

I have already created the nodepool with 16 CPUs each and tainted with corresponding key:val