### PR TITLE
config/jobs: push more k8s-testimages to k8s-infra

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-test-infra.yaml
+++ b/config/jobs/image-pushing/k8s-staging-test-infra.yaml
@@ -1,9 +1,160 @@
 postsubmits:
   kubernetes/test-infra:
+    #
+    # job images, e.g. images/*
+    #
+    - name: post-test-infra-push-bigquery-canary
+      cluster: k8s-infra-prow-build-trusted
+      run_if_changed: '^(images/bigquery|scenarios)/'
+      annotations:
+        testgrid-dashboards: sig-testing-canaries, wg-k8s-infra-canaries, wg-k8s-infra-gcb
+        testgrid-tab-name: bigquery-canary
+        testgrid-alert-email: k8s-infra-alerts@kubernetes.io
+        testgrid-num-failures-to-alert: '1'
+        description: builds and pushes the bigquery image
+      decorate: true
+      branches:
+      - ^master$
+      max_concurrency: 1
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+        - image: gcr.io/k8s-testimages/image-builder:v20210622-762366a
+          command:
+          - ./run.sh
+          args:
+          - --scratch-bucket=gs://k8s-staging-test-infra-gcb
+          - --project=k8s-staging-test-infra
+          - --build-dir=.
+          - images/bigquery/
+    - name: post-test-infra-push-bootstrap-canary
+      cluster: k8s-infra-prow-build-trusted
+      run_if_changed: '^(images/bootstrap|scenarios)/'
+      annotations:
+        testgrid-dashboards: sig-testing-canaries, wg-k8s-infra-canaries, wg-k8s-infra-gcb
+        testgrid-tab-name: bootstrap-canary
+        testgrid-alert-email: k8s-infra-alerts@kubernetes.io
+        testgrid-num-failures-to-alert: '1'
+        description: builds and pushes the bootstrap image
+      decorate: true
+      branches:
+      - ^master$
+      max_concurrency: 1
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+        - image: gcr.io/k8s-testimages/image-builder:v20210622-762366a
+          command:
+          - ./run.sh
+          args:
+          - --scratch-bucket=gs://k8s-staging-test-infra-gcb
+          - --project=k8s-staging-test-infra
+          - --build-dir=.
+          - images/bootstrap/
+    - name: post-test-infra-push-gcloud-in-go-canary
+      cluster: k8s-infra-prow-build-trusted
+      run_if_changed: '^images/gcloud/'
+      annotations:
+        testgrid-dashboards: sig-testing-canaries, wg-k8s-infra-canaries, wg-k8s-infra-gcb
+        testgrid-tab-name: gcloud-in-go-canary
+        testgrid-alert-email: k8s-infra-alerts@kubernetes.io
+        testgrid-num-failures-to-alert: '1'
+        description: builds and pushes the gcloud-in-go image
+      decorate: true
+      branches:
+      - ^master$
+      max_concurrency: 1
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+        - image: gcr.io/k8s-testimages/image-builder:v20210622-762366a
+          command:
+          - ./run.sh
+          args:
+          - --scratch-bucket=gs://k8s-staging-test-infra-gcb
+          - --project=k8s-staging-test-infra
+          - --build-dir=.
+          - images/gcloud/
+    - name: post-test-infra-push-image-builder-canary
+      cluster: k8s-infra-prow-build-trusted
+      run_if_changed: '^images/builder/'
+      annotations:
+        testgrid-dashboards: sig-testing-canaries, wg-k8s-infra-canaries, wg-k8s-infra-gcb
+        testgrid-tab-name: image-builder-canary
+        testgrid-alert-email: k8s-infra-alerts@kubernetes.io
+        testgrid-num-failures-to-alert: '1'
+        description: builds and pushes the image builder's own image
+      decorate: true
+      branches:
+      - ^master$
+      max_concurrency: 1
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+        - image: gcr.io/k8s-testimages/image-builder:v20210622-762366a
+          command:
+          - ./run.sh
+          args:
+          - --scratch-bucket=gs://k8s-staging-test-infra-gcb
+          - --project=k8s-staging-test-infra
+          - --build-dir=.
+          - images/builder/
+    - name: post-test-infra-push-krte-canary
+      cluster: k8s-infra-prow-build-trusted
+      run_if_changed: '^images/(krte/|kubekins-e2e/variants.yaml)'
+      annotations:
+        testgrid-dashboards: sig-testing-canaries, wg-k8s-infra-canaries, wg-k8s-infra-gcb
+        testgrid-tab-name: krte-canary
+        testgrid-alert-email: k8s-infra-alerts@kubernetes.io
+        testgrid-num-failures-to-alert: '1'
+        description: builds and pushes the krte image
+      decorate: true
+      branches:
+      - ^master$
+      max_concurrency: 1
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+        - image: gcr.io/k8s-testimages/image-builder:v20210622-762366a
+          command:
+          - ./run.sh
+          args:
+          - --scratch-bucket=gs://k8s-staging-test-infra-gcb
+          - --project=k8s-staging-test-infra
+          - --build-dir=.
+          - images/krte/
+    - name: post-test-infra-push-kubekins-e2e
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-testing-images, wg-k8s-infra-gcb
+        testgrid-tab-name: kubekins-e2e
+        testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com, k8s-infra-alerts@kubernetes.io
+        testgrid-num-failures-to-alert: '1'
+        description: builds and pushes the kubekins-e2e image
+      run_if_changed: '^(images/kubekins-e2e|kubetest|boskos)/'
+      decorate: true
+      branches:
+      - ^master$
+      max_concurrency: 1
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+        - image: gcr.io/k8s-testimages/image-builder:v20210622-762366a
+          command:
+          - /run.sh
+          args:
+          - --scratch-bucket=gs://k8s-staging-test-infra-gcb
+          - --project=k8s-staging-test-infra
+          - --build-dir=.
+          - images/kubekins-e2e/
+    #
+    # components, e.g. kettle/, triage/
+    #
     - name: post-test-infra-push-kettle-canary
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-canaries, wg-k8s-infra-canaries, wg-k8s-infra-gcb
+        testgrid-tab-name: kettle-canary
         testgrid-alert-email: k8s-infra-alerts@kubernetes.io
         testgrid-num-failures-to-alert: '1'
         description: builds and pushes the kettle image
@@ -26,29 +177,6 @@ postsubmits:
           - --project=k8s-staging-test-infra
           - --build-dir=.
           - kettle/
-    - name: post-test-infra-push-kubekins-e2e
-      cluster: k8s-infra-prow-build-trusted
-      annotations:
-        testgrid-dashboards: sig-testing-images, wg-k8s-infra-gcb
-        testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com, k8s-infra-alerts@kubernetes.io
-        testgrid-num-failures-to-alert: '1'
-        description: builds and pushes the kubekins-e2e image
-      run_if_changed: '^(images/kubekins-e2e|kubetest|boskos)/'
-      decorate: true
-      branches:
-      - ^master$
-      max_concurrency: 1
-      spec:
-        serviceAccountName: gcb-builder
-        containers:
-        - image: gcr.io/k8s-testimages/image-builder:v20210622-762366a
-          command:
-          - /run.sh
-          args:
-          - --scratch-bucket=gs://k8s-staging-test-infra-gcb
-          - --project=k8s-staging-test-infra
-          - --build-dir=.
-          - images/kubekins-e2e/
     - name: post-test-infra-push-triage
       cluster: k8s-infra-prow-build-trusted
       run_if_changed: '^triage/'

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -435,7 +435,7 @@ postsubmits:
     run_if_changed: '^(images/kubekins-e2e|kubetest|boskos)/'
     annotations:
       testgrid-dashboards: "sig-testing-images"
-      testgrid-tab-name: "kubekins-e2e"
+      testgrid-tab-name: kubekins-e2e-deprecated
       testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
       testgrid-num-failures-to-alert: '1'
       description: builds and pushes the kubekins-e2e image


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1523
- Followup to: https://github.com/kubernetes/test-infra/pull/23544

Specifically, add canary jobs to push the following to
gcr.io/k8s-staging-test-infra

- bigquery
- bootstrap
- gcloud-in-go
- image-builder
- krte

This will need to be followed up by PRs to trigger image builds