### PR TITLE
config/prow/cluster: fix typo in cherrypicker secret

### DIFF
--- a/config/prow/cluster/cherrypicker_deployment.yaml
+++ b/config/prow/cluster/cherrypicker_deployment.yaml
@@ -66,4 +66,4 @@ spec:
           secretName: hmac-token
       - name: github-token
         secret:
-          secretName: k8s-infra-cherrypicker-robot-github-token
+          secretName: k8s-infra-cherrypick-robot-github-token


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/test-infra/issues/23469
- Followup to: https://github.com/kubernetes/k8s.io/pull/2702