### PR TITLE
releng(kpromo): Switch to `k8s-infra-promoter` svc acct for prod jobs

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -11,7 +11,7 @@ postsubmits:
     branches:
     - ^main$
     spec:
-      serviceAccountName: k8s-infra-gcr-promoter
+      serviceAccountName: k8s-infra-promoter
       containers:
       - image: k8s.gcr.io/artifact-promoter/kpromo:v0.2.1-2
         command:
@@ -61,9 +61,7 @@ periodics:
     repo: k8s.io
     base_ref: main
   spec:
-    # TODO(releng): Should we use a different service account or change this
-    #               one's name to 'k8s-infra-artifact-promoter'?
-    serviceAccountName: k8s-infra-gcr-promoter
+    serviceAccountName: k8s-infra-promoter
     containers:
     - image: k8s.gcr.io/artifact-promoter/kpromo:v0.2.1-2
       command:


### PR DESCRIPTION
(Part of https://github.com/kubernetes/k8s.io/issues/2624, https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/413.)

Utilizing the service account created for file promotion in https://github.com/kubernetes/k8s.io/pull/2700.
/hold until https://github.com/kubernetes/k8s.io/pull/2700 is actuated.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @ameukam @puerco @saschagrunert @cpanato 
cc: @spiffxp @kubernetes/release-engineering 