### PR TITLE
descheduler: alter kindest/node:version based on docker hub

### DIFF
--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
@@ -73,7 +73,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBERNETES_VERSION
-          value: "v1.22.0"
+          value: "v1.22.1"
         - name: KIND_E2E
           value: "true"
         args:
@@ -103,7 +103,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBERNETES_VERSION
-          value: "v1.21.1"
+          value: "v1.21.2"
         - name: KIND_E2E
           value: "true"
         args:

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.21.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.21.yaml
@@ -64,7 +64,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     branches:
-    - master
+    - ^release-1.21$
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210910-f5a7052457-master
@@ -73,7 +73,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBERNETES_VERSION
-          value: "v1.21.4"
+          value: "v1.21.2"
         - name: KIND_E2E
           value: "true"
         args:

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.22.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.22.yaml
@@ -73,7 +73,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBERNETES_VERSION
-          value: "v1.22.0"
+          value: "v1.22.1"
         - name: KIND_E2E
           value: "true"
         args:
@@ -103,7 +103,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBERNETES_VERSION
-          value: "v1.21.4"
+          value: "v1.21.2"
         - name: KIND_E2E
           value: "true"
         args:


### PR DESCRIPTION
Follow up for https://github.com/kubernetes/test-infra/pull/23514

1.22: https://hub.docker.com/r/kindest/node/tags?page=1&ordering=last_updated&name=1.22
1.21: https://hub.docker.com/r/kindest/node/tags?page=1&ordering=last_updated&name=1.21