### PR TITLE
releng(kpromo): Bump images to v0.2.4-1

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -78,7 +78,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v0.2.3-1
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v0.2.4-1
         command:
         - /kpromo
         args:

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -13,7 +13,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-promoter
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v0.2.3-1
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v0.2.4-1
         command:
         - /kpromo
         args:
@@ -63,7 +63,7 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-promoter
     containers:
-    - image: k8s.gcr.io/artifact-promoter/kpromo:v0.2.3-1
+    - image: k8s.gcr.io/artifact-promoter/kpromo:v0.2.4-1
       command:
       - /kpromo
       args:


### PR DESCRIPTION
Image bump for https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/422.
(Part of https://github.com/kubernetes/k8s.io/issues/2624, https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/413.)

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @puerco @ameukam @Verolop @cpanato @saschagrunert
cc: @kubernetes/release-engineering

(Image promotion PR is inbound: https://github.com/kubernetes/k8s.io/pull/2709)