### PR TITLE
ghproxy unit tests: avoid using time.Sleep for synchronization of goroutines

### DIFF
--- a/ghproxy/ghcache/coalesce.go
+++ b/ghproxy/ghcache/coalesce.go
@@ -32,22 +32,43 @@ import (
 )
 
 // requestCoalescer allows concurrent requests for the same URI to share a
-// single upstream request and response.
+// single upstream request and response. Once a request comes in for processing
+// for the first time, it is processed and a response is received (via
+// "requestExecutor"). Meanwhile, if there are any other requests for the same URI,
+// those threads Wait(). Then when the first request is done processing (we
+// receive a real request), we copy the original request's response into the
+// subscribed threads, before letting them all finish. The "cache" map is there
+// for our own short-term memory of knowing which request is the "first" one of
+// its kind.
 type requestCoalescer struct {
 	sync.Mutex
-	keys map[string]*responseWaiter
+	cache map[string]*firstRequest
 
-	delegate http.RoundTripper
+	// requestExecutor is anything that can resolve a request by executing a single
+	// HTTP transaction, returning a Response for the provided Request. Using an
+	// interface here allows us to mock this out with a fake non-HTTP transport
+	// in unit tests.
+	requestExecutor http.RoundTripper
 
 	hasher ghmetrics.Hasher
 }
 
-type responseWaiter struct {
+// firstRequest is where we store the coalesced requests's actual response. It
+// is named firstRequest because only the first one (which also creates the
+// entry in the cache) will actually be resolved by being processed over the
+// network; all subsequent requests that match the first request's URL will end
+// up waiting for this first request to finish. After the first request is
+// processed, the "resp" field will be populated, and subsequent requests will
+// simply reuse the same "resp" body. Note that if the first request fails, then
+// all subsequent requests will fail together.
+type firstRequest struct {
 	*sync.Cond
 
-	waiting bool
-	resp    []byte
-	err     error
+	// Are there any threads that are "subscribed" to this first request's
+	// response?
+	subscribers bool
+	resp        []byte
+	err         error
 }
 
 // RoundTrip coalesces concurrent GET requests for the same URI by blocking
@@ -55,18 +76,18 @@ type responseWaiter struct {
 // response between all requests.
 //
 // Notes: Deadlock shouldn't be possible because the map lock is always
-// acquired before responseWaiter lock if both locks are to be held and we
-// never hold multiple responseWaiter locks.
-func (r *requestCoalescer) RoundTrip(req *http.Request) (*http.Response, error) {
+// acquired before firstRequest lock if both locks are to be held and we
+// never hold multiple firstRequest locks.
+func (coalescer *requestCoalescer) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Only coalesce GET requests
 	if req.Method != http.MethodGet {
-		resp, err := r.delegate.RoundTrip(req)
+		resp, err := coalescer.requestExecutor.RoundTrip(req)
 		if strings.HasPrefix(req.URL.Path, "graphql") || strings.HasPrefix(req.URL.Path, "/graphql") {
 			var tokenBudgetName string
 			if val := req.Header.Get(TokenBudgetIdentifierHeader); val != "" {
 				tokenBudgetName = val
 			} else {
-				tokenBudgetName = r.hasher.Hash(req)
+				tokenBudgetName = coalescer.hasher.Hash(req)
 			}
 			collectMetrics(ModeNoStore, req, resp, tokenBudgetName)
 		}
@@ -76,16 +97,37 @@ func (r *requestCoalescer) RoundTrip(req *http.Request) (*http.Response, error) 
 	var cacheMode = ModeError
 	resp, err := func() (*http.Response, error) {
 		key := req.URL.String()
-		r.Lock()
-		waiter, ok := r.keys[key]
+		coalescer.Lock()
+		firstReq, ok := coalescer.cache[key]
+
+		// Earlier request in flight (common case). Wait for its response, which
+		// will be received by a different thread (specifically, the original
+		// thread that created the firstReq object --- let's call this the
+		// "main" thread for simplicity).
 		if ok {
-			// Earlier request in flight. Wait for it's response.
+			// If the request that we're trying to process has a body, don't
+			// forget to close it. Normally if we're performing the HTTP
+			// roundtrip ourselves, we won't need to do this because the
+			// RoundTripper will do it on its own. However we'll never call
+			// RoundTrip() on this request ourselves because we're going to be
+			// lazy and just wait for the main thread to do it for us. So we
+			// need to close the body directly. See
+			// https://cs.opensource.google/go/go/+/refs/tags/go1.17.1:src/net/http/transport.go;l=510
+			// and
+			// https://cs.opensource.google/go/go/+/refs/tags/go1.17.1:src/net/http/request.go;drc=refs%2Ftags%2Fgo1.17.1;l=1408
+			// for an example.
 			if req.Body != nil {
-				defer req.Body.Close() // Since we won't pass the request we must close it.
+				defer req.Body.Close()
 			}
-			waiter.L.Lock()
-			r.Unlock()
-			waiter.waiting = true
+
+			// Let the main thread know that there is at least one subscriber (us).
+			firstReq.L.Lock()
+			// Unlock the coalescer, so that other threads can read from it.
+			// That is, the coalescer itself should never be blocked by
+			// subscribed threads.
+			coalescer.Unlock()
+			firstReq.subscribers = true
+
 			// The documentation for Wait() says:
 			// "Because c.L is not locked when Wait first resumes, the caller typically
 			// cannot assume that the condition is true when Wait returns. Instead, the
@@ -94,15 +136,28 @@ func (r *requestCoalescer) RoundTrip(req *http.Request) (*http.Response, error) 
 			// waiting for remains true once it becomes true. This lets us avoid the
 			// normal check to see if the condition has switched back to false between
 			// the signal being sent and this thread acquiring the lock.
-			waiter.Wait()
-			waiter.L.Unlock()
-			// Earlier request completed.
 
-			if waiter.err != nil {
-				// Don't log the error, it will be logged by requester.
-				return nil, waiter.err
+			// Unlock firstReq.L variable (so that the thread that __did__ create
+			// the first request can actually process it). Suspend execution of
+			// this thread until that is done.
+			firstReq.Wait()
+
+			// Because firstReq.Wait() will lock firstReq.L before returning,
+			// release the lock now because we won't be modifying anything
+			// inside firstRequest. Anyway, firstRequest has now completed and
+			// we can read from it.
+			firstReq.L.Unlock()
+
+			if firstReq.err != nil {
+				// Don't log the error ourselves, because it will be logged once
+				// by the main thread. This avoids spamming the logs with the
+				// same error.
+				return nil, firstReq.err
 			}
-			resp, err := http.ReadResponse(bufio.NewReader(bytes.NewBuffer(waiter.resp)), nil)
+
+			// Copy in firstReq's response into our own response. We didn't have
+			// to process the request ourselves! Wasn't that easy?
+			resp, err := http.ReadResponse(bufio.NewReader(bytes.NewBuffer(firstReq.resp)), nil)
 			if err != nil {
 				logrus.WithField("cache-key", key).WithError(err).Error("Error loading response.")
 				return nil, err
@@ -111,31 +166,55 @@ func (r *requestCoalescer) RoundTrip(req *http.Request) (*http.Response, error) 
 			cacheMode = ModeCoalesced
 			return resp, nil
 		}
-		// No earlier request in flight (common case).
-		// Register a new responseWaiter and make the request ourself.
-		waiter = &responseWaiter{Cond: sync.NewCond(&sync.Mutex{})}
-		r.keys[key] = waiter
-		r.Unlock()
 
-		resp, err := r.delegate.RoundTrip(req)
-		// Real response received. Remove this responseWaiter from the map THEN
-		// wake any requesters that were waiting on this response.
-		r.Lock()
-		delete(r.keys, key)
-		r.Unlock()
+		// No earlier (first) request in flight yet. Create a new firstRequest
+		// object and process it ourselves.
+		firstReq = &firstRequest{Cond: sync.NewCond(&sync.Mutex{})}
+		coalescer.cache[key] = firstReq
 
-		waiter.L.Lock()
-		if waiter.waiting {
+		// Unlock the coalescer so that it doesn't block on this particular request.
+		coalescer.Unlock()
+
+		// Actually process the request and get a response.
+		resp, err := coalescer.requestExecutor.RoundTrip(req)
+
+		// Real response received. Remove this firstRequest from the cache first
+		// __before__ waking any subscribed threads to let them copy the
+		// response we got. This order is important. If delete the cache entry
+		// __after__ waking the subscribed threads, then the following race
+		// condition can happen:
+		//
+		//  1. firstReq creator thread wakes subscribed threads
+		//  2. subscribed threads begin copying data from firstReq struct
+		//  3. *NEW* subscribers get created, because the cached key is still there
+		//  4. cached key is finally deleted
+		//  5. firstReq creator thread from Step 1 dies
+		//  6. subscribed threads from Step 3 will wait forever (memory leak, not to mention request timeout for all of these)
+		coalescer.Lock()
+		delete(coalescer.cache, key)
+		coalescer.Unlock()
+
+		// Write response data into firstReq for all subscribers to see. But
+		// only bother with writing into firstReq if we have subscribers at all
+		// (because otherwise no other thread will use it anyway).
+		firstReq.L.Lock()
+		if firstReq.subscribers {
 			if err != nil {
-				waiter.resp, waiter.err = nil, err
+				firstReq.resp, firstReq.err = nil, err
 			} else {
-				// Copy the response before releasing to waiter(s).
-				waiter.resp, waiter.err = httputil.DumpResponse(resp, true)
+				// Copy the response into firstReq.resp before letting
+				// subscribers know about it.
+				firstReq.resp, firstReq.err = httputil.DumpResponse(resp, true)
 			}
-			waiter.Broadcast()
-		}
-		waiter.L.Unlock()
 
+			// Wake up all subscribed threads. They will all read firstReq.resp
+			// to construct their own (identical) HTTP Responses, based on the
+			// contents of firstReq.
+			firstReq.Broadcast()
+		}
+		firstReq.L.Unlock()
+
+		// The RoundTrip() encountered an error. Log it.
 		if err != nil {
 			logrus.WithField("cache-key", key).WithError(err).Warn("Error from cache transport layer.")
 			return nil, err
@@ -148,7 +227,7 @@ func (r *requestCoalescer) RoundTrip(req *http.Request) (*http.Response, error) 
 	if val := req.Header.Get(TokenBudgetIdentifierHeader); val != "" {
 		tokenBudgetName = val
 	} else {
-		tokenBudgetName = r.hasher.Hash(req)
+		tokenBudgetName = coalescer.hasher.Hash(req)
 	}
 
 	collectMetrics(cacheMode, req, resp, tokenBudgetName)

--- a/ghproxy/ghcache/coalesce_test.go
+++ b/ghproxy/ghcache/coalesce_test.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"k8s.io/test-infra/ghproxy/ghmetrics"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -29,13 +28,16 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/test-infra/ghproxy/ghmetrics"
+
 	"k8s.io/apimachinery/pkg/util/diff"
 )
 
-// testDelegate is a fake upstream transport delegate that logs hits by URI and
-// will wait to respond to requests until signaled unless the request has
-// a header specifying it should be responded to immediately.
-type testDelegate struct {
+// fakeRequestExecutor is a fake upstream transport RoundTripper that logs hits by
+// URI. It will wait to respond to requests until signaled, or respond
+// immediately if the request has a header specifying it should be responded to
+// immediately.
+type fakeRequestExecutor struct {
 	beginResponding *sync.Cond
 
 	hitsLock sync.Mutex
@@ -44,17 +46,17 @@ type testDelegate struct {
 	responseHeader http.Header
 }
 
-func (t *testDelegate) RoundTrip(req *http.Request) (*http.Response, error) {
-	t.hitsLock.Lock()
-	t.hits[req.URL.Path] += 1
-	t.hitsLock.Unlock()
+func (fre *fakeRequestExecutor) RoundTrip(req *http.Request) (*http.Response, error) {
+	fre.hitsLock.Lock()
+	fre.hits[req.URL.Path] += 1
+	fre.hitsLock.Unlock()
 
 	if req.Header.Get("test-immediate-response") == "" {
-		t.beginResponding.L.Lock()
-		t.beginResponding.Wait()
-		t.beginResponding.L.Unlock()
+		fre.beginResponding.L.Lock()
+		fre.beginResponding.Wait()
+		fre.beginResponding.L.Unlock()
 	}
-	header := t.responseHeader
+	header := fre.responseHeader
 	if header == nil {
 		header = http.Header{}
 	}
@@ -68,20 +70,20 @@ func (t *testDelegate) RoundTrip(req *http.Request) (*http.Response, error) {
 func TestRoundTrip(t *testing.T) {
 	// Check that only 1 request goes to upstream if there are concurrent requests.
 	t.Parallel()
-	delegate := &testDelegate{
+	fre := &fakeRequestExecutor{
 		hits:            make(map[string]int),
 		beginResponding: sync.NewCond(&sync.Mutex{}),
 	}
-	coalesce := &requestCoalescer{
-		keys:     make(map[string]*responseWaiter),
-		delegate: delegate,
-		hasher:   ghmetrics.NewCachingHasher(),
+	coalescer := &requestCoalescer{
+		cache:           make(map[string]*firstRequest),
+		requestExecutor: fre,
+		hasher:          ghmetrics.NewCachingHasher(),
 	}
 	wg := sync.WaitGroup{}
 	wg.Add(100)
 	for i := 0; i < 100; i++ {
 		go func() {
-			if _, err := runRequest(coalesce, "/resource1", false); err != nil {
+			if _, err := runRequest(coalescer, "/resource1", false); err != nil {
 				t.Errorf("Failed to run request: %v.", err)
 			}
 			wg.Done()
@@ -94,34 +96,34 @@ func TestRoundTrip(t *testing.T) {
 	time.Sleep(time.Second * 5)
 
 	// Check that requests for different resources are not blocked.
-	if _, err := runRequest(coalesce, "/resource2", true); err != nil {
+	if _, err := runRequest(coalescer, "/resource2", true); err != nil {
 		t.Errorf("Failed to run request: %v.", err)
 	} // Doesn't return until timeout or success.
-	delegate.beginResponding.Broadcast()
+	fre.beginResponding.Broadcast()
 
 	// Check that non concurrent requests all hit upstream.
-	if _, err := runRequest(coalesce, "/resource2", true); err != nil {
+	if _, err := runRequest(coalescer, "/resource2", true); err != nil {
 		t.Errorf("Failed to run request: %v.", err)
 	}
 
 	wg.Wait()
 	expectedHits := map[string]int{"/resource1": 1, "/resource2": 2}
-	if !reflect.DeepEqual(delegate.hits, expectedHits) {
-		t.Errorf("Unexpected hit count(s). Diff: %v.", diff.ObjectReflectDiff(expectedHits, delegate.hits))
+	if !reflect.DeepEqual(fre.hits, expectedHits) {
+		t.Errorf("Unexpected hit count(s). Diff: %v.", diff.ObjectReflectDiff(expectedHits, fre.hits))
 	}
 }
 
 func TestCacheModeHeader(t *testing.T) {
 	t.Parallel()
 	wg := sync.WaitGroup{}
-	delegate := &testDelegate{
+	fre := &fakeRequestExecutor{
 		hits:            make(map[string]int),
 		beginResponding: sync.NewCond(&sync.Mutex{}),
 	}
-	coalesce := &requestCoalescer{
-		keys:     make(map[string]*responseWaiter),
-		delegate: delegate,
-		hasher:   ghmetrics.NewCachingHasher(),
+	coalescer := &requestCoalescer{
+		cache:           make(map[string]*firstRequest),
+		requestExecutor: fre,
+		hasher:          ghmetrics.NewCachingHasher(),
 	}
 
 	checkMode := func(resp *http.Response, expected CacheResponseMode) {
@@ -135,7 +137,7 @@ func TestCacheModeHeader(t *testing.T) {
 	// This should eventually return ModeMiss.
 	wg.Add(1)
 	go func() {
-		if resp, err := runRequest(coalesce, "/resource1", false); err != nil {
+		if resp, err := runRequest(coalescer, "/resource1", false); err != nil {
 			t.Errorf("Failed to run request: %v.", err)
 		} else {
 			checkMode(resp, ModeMiss)
@@ -150,10 +152,10 @@ func TestCacheModeHeader(t *testing.T) {
 	time.Sleep(time.Second * 3)
 
 	// Queue a second request for resource1.
-	// This should coalesce and eventually return ModeCoalesced.
+	// This should coalescer and eventually return ModeCoalesced.
 	wg.Add(1)
 	go func() {
-		if resp, err := runRequest(coalesce, "/resource1", false); err != nil {
+		if resp, err := runRequest(coalescer, "/resource1", false); err != nil {
 			t.Errorf("Failed to run request: %v.", err)
 		} else {
 			checkMode(resp, ModeCoalesced)
@@ -164,15 +166,15 @@ func TestCacheModeHeader(t *testing.T) {
 
 	// Requests should be waiting now. Start responding and wait for all
 	// downstream responses to return.
-	delegate.beginResponding.Broadcast()
+	fre.beginResponding.Broadcast()
 	wg.Wait()
 
 	// A later request for resource1 revalidates cached response.
 	// This should return ModeRevalidated.
 	header := http.Header{}
 	header.Set("Status", "304 Not Modified")
-	delegate.responseHeader = header
-	if resp, err := runRequest(coalesce, "/resource1", true); err != nil {
+	fre.responseHeader = header
+	if resp, err := runRequest(coalescer, "/resource1", true); err != nil {
 		t.Errorf("Failed to run request: %v.", err)
 	} else {
 		checkMode(resp, ModeRevalidated)
@@ -182,8 +184,8 @@ func TestCacheModeHeader(t *testing.T) {
 	// This should return ModeChanged.
 	header = http.Header{}
 	header.Set("X-Conditional-Request", "I am an E-Tag.")
-	delegate.responseHeader = header
-	if resp, err := runRequest(coalesce, "/resource1", true); err != nil {
+	fre.responseHeader = header
+	if resp, err := runRequest(coalescer, "/resource1", true); err != nil {
 		t.Errorf("Failed to run request: %v.", err)
 	} else {
 		checkMode(resp, ModeChanged)
@@ -191,8 +193,8 @@ func TestCacheModeHeader(t *testing.T) {
 
 	// Request for new resource2 with no concurrent requests.
 	// This should return ModeMiss.
-	delegate.responseHeader = nil
-	if resp, err := runRequest(coalesce, "/resource2", true); err != nil {
+	fre.responseHeader = nil
+	if resp, err := runRequest(coalescer, "/resource2", true); err != nil {
 		t.Errorf("Failed to run request: %v.", err)
 	} else {
 		checkMode(resp, ModeMiss)
@@ -202,8 +204,8 @@ func TestCacheModeHeader(t *testing.T) {
 	// This should return ModeNoStore.
 	header = http.Header{}
 	header.Set("Cache-Control", "no-store")
-	delegate.responseHeader = header
-	if resp, err := runRequest(coalesce, "/resource3", true); err != nil {
+	fre.responseHeader = header
+	if resp, err := runRequest(coalescer, "/resource3", true); err != nil {
 		t.Errorf("Failed to run request: %v.", err)
 	} else {
 		checkMode(resp, ModeNoStore)
@@ -214,8 +216,8 @@ func TestCacheModeHeader(t *testing.T) {
 
 	// Might as well mind the hit count in this test too.
 	expectedHits := map[string]int{"/resource1": 3, "/resource2": 1, "/resource3": 1}
-	if !reflect.DeepEqual(delegate.hits, expectedHits) {
-		t.Errorf("Unexpected hit count(s). Diff: %v.", diff.ObjectReflectDiff(expectedHits, delegate.hits))
+	if !reflect.DeepEqual(fre.hits, expectedHits) {
+		t.Errorf("Unexpected hit count(s). Diff: %v.", diff.ObjectReflectDiff(expectedHits, fre.hits))
 	}
 }
 

--- a/ghproxy/ghcache/coalesce_test.go
+++ b/ghproxy/ghcache/coalesce_test.go
@@ -19,8 +19,8 @@ package ghcache
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -28,38 +28,43 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"k8s.io/test-infra/ghproxy/ghmetrics"
 
 	"k8s.io/apimachinery/pkg/util/diff"
 )
 
+const fakeGitHubDomain string = "http://fake-github.com"
+
 // fakeRequestExecutor is a fake upstream transport RoundTripper that logs hits by
-// URI. It will wait to respond to requests until signaled, or respond
+// endpoint. It will wait to respond to requests until signaled, or respond
 // immediately if the request has a header specifying it should be responded to
 // immediately.
 type fakeRequestExecutor struct {
-	beginResponding *sync.Cond
-
 	hitsLock sync.Mutex
 	hits     map[string]int
 
-	responseHeader http.Header
+	responseHeader     http.Header
+	finishFirstRequest chan bool
 }
 
+// RoundTrip can generate a fake HTTP response, and can also record the response
+// by keeping state in the fakeRequestExecutor.
 func (fre *fakeRequestExecutor) RoundTrip(req *http.Request) (*http.Response, error) {
 	fre.hitsLock.Lock()
 	fre.hits[req.URL.Path] += 1
 	fre.hitsLock.Unlock()
 
-	if req.Header.Get("test-immediate-response") == "" {
-		fre.beginResponding.L.Lock()
-		fre.beginResponding.Wait()
-		fre.beginResponding.L.Unlock()
-	}
+	// Construct the fake HTTP response.
 	header := fre.responseHeader
 	if header == nil {
 		header = http.Header{}
 	}
+
+	// Block until we're told to finish creating the first request's response.
+	// We rely on the requestCoalescer to only call us for the
+	// first request.
+	<-fre.finishFirstRequest
 	return &http.Response{
 			Body:   ioutil.NopCloser(bytes.NewBufferString("Response")),
 			Header: header,
@@ -67,58 +72,372 @@ func (fre *fakeRequestExecutor) RoundTrip(req *http.Request) (*http.Response, er
 		nil
 }
 
+// concurrentRequestGroup describes a single URL path endpoint (minus the
+// domain) and how many total concurrent requests should be made against it.
+type concurrentRequestGroup struct {
+	endpoint string
+	size     int
+}
+
+// spawn creates a sudden burst of multiple concurrent requests for multiple
+// endpoints.
+func spawnGroups(
+	crgs []concurrentRequestGroup,
+	t *testing.T,
+	coalescer *requestCoalescer,
+	wg *sync.WaitGroup) {
+
+	for _, concurrentRequestGroup := range crgs {
+		concurrentRequestGroup.spawn(t, coalescer, wg)
+	}
+}
+
+// spawn creates a burst of multiple concurrent requets for a single endpoint.
+func (crg concurrentRequestGroup) spawn(
+	t *testing.T,
+	coalescer *requestCoalescer,
+	wg *sync.WaitGroup) {
+
+	wg.Add(crg.size)
+	for i := 0; i < crg.size; i++ {
+		go func() {
+			if _, err := runRequest(coalescer, crg.endpoint); err != nil {
+				t.Errorf("Failed to run request: %v.", err)
+			}
+			wg.Done()
+		}()
+	}
+}
+
+// runRequest creates an HTTP Request, and resolves it using the given HTTP
+// RoundTripper and finally returns an HTTP Response. In production we use the
+// requestCoalescer to essentially cache multiple requests to GitHub into a
+// single request. The runRequest function acts as a "fake GitHub" because we
+// can get responses back immediately without going over the network.
+func runRequest(coalescer *requestCoalescer, endpoint string) (*http.Response, error) {
+
+	// Construct an HTTP request.
+	u, err := url.Parse(fakeGitHubDomain + endpoint)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	// Squelch missing Authorization header warning from requestCoalescer.hasher.
+	req.Header.Set("Authorization", "unknown")
+
+	// Construct an HTTP response for the given request.
+	var resp *http.Response
+
+	resp, err = coalescer.RoundTrip(req)
+	if err == nil {
+		if b, readErr := ioutil.ReadAll(resp.Body); readErr != nil {
+			err = readErr
+		} else if string(b) != "Response" {
+			err = errors.New("unexpected response value")
+		}
+	}
+
+	return resp, err
+}
+
+// waitUntilCacheIsFull waits until all concurrentRequestGroups are full.
+func waitUntilCacheIsFull(
+	concurrentRequestGroups []concurrentRequestGroup,
+	coalescer *requestCoalescer) {
+
+	// Look at each concurrentRequestGroup, and only check it off if we see
+	// size-1 subscribed goroutines for it in the coalescer.
+	for _, concurrentRequestGroup := range concurrentRequestGroups {
+		waitUntilCacheIsFullForGroup(concurrentRequestGroup, coalescer)
+	}
+}
+
+func waitUntilCacheIsFullForGroup(
+	concurrentRequestGroup concurrentRequestGroup,
+	coalescer *requestCoalescer) {
+
+	// Wait for the cache entry for this group's endpoint to appear in the
+	// coalescer.
+	firstReq := waitUntilCacheKeyCreation(fakeGitHubDomain+concurrentRequestGroup.endpoint, coalescer)
+
+	// Wait for this concurrentRequestGroup's requests to be fully loaded
+	// into the coalescer's cache. Notice that we never hold both the outer
+	// coalescer lock and the inner firstReq lock at the same time. If we do
+	// hold both locks, we may deadlock because the requestCoalescer's main
+	// thread (which does the actual HTTP round trip) may get stuck trying
+	// to lock both locks one after the other (which will never complete if
+	// both locks are held by this thread).
+	waitingForSubscribers := true
+	for waitingForSubscribers {
+		// If we only want to create a single request, we don't expect
+		// there to be any subscribers.
+		if concurrentRequestGroup.size == 1 {
+			break
+		}
+
+		// There are some pending requests being handled by the coalescer
+		// for this particular URL. Watch subscribers in a busy loop until
+		// we see the expected number of subscribed threads.
+		for {
+			firstReq.L.Lock()
+			subscribers := firstReq.subscribers
+			firstReq.L.Unlock()
+			// If there are size - 1 subscribed threads, then the coalescer's
+			// cache is fully loaded because there are no more subscribers that
+			// are scheduled to arrive.
+			if subscribers == (concurrentRequestGroup.size - 1) {
+				waitingForSubscribers = false
+				break
+			}
+		}
+	}
+}
+
+// waitUntilCacheKeyCreation waits until the coalescer has created a cache
+// entry. The cache entry is only created by the first thread that reaches the
+// coalescer (reverse proxy, in this case, to the fake GitHub server). This is
+// useful for waiting until a goroutine has been officially "promoted" to be the
+// first thread that has reached the coalescer, responsible for invoking the
+// RoundTripper.
+func waitUntilCacheKeyCreation(
+	key string,
+	coalescer *requestCoalescer) *firstRequest {
+
+	for {
+		coalescer.Lock()
+		firstReq, keyExists := coalescer.cache[key]
+		if keyExists {
+			coalescer.Unlock()
+			return firstReq
+		}
+		coalescer.Unlock()
+	}
+}
+
+// waitUntilCacheKeyDeletion waits until the coalescer has deleted the given
+// cache entry. This is useful for detecting when an initial burst of concurrent
+// requests to a single endpoint has subsided.
+func waitUntilCacheKeyDeletion(
+	key string,
+	coalescer *requestCoalescer) {
+
+	for {
+		coalescer.Lock()
+		_, keyExists := coalescer.cache[key]
+		if !keyExists {
+			coalescer.Unlock()
+			break
+		}
+		coalescer.Unlock()
+	}
+}
+
+// TestRoundTrip checks that only 1 request goes to upstream if there are
+// concurrent requests for the same URL.
 func TestRoundTrip(t *testing.T) {
-	// Check that only 1 request goes to upstream if there are concurrent requests.
-	t.Parallel()
 	fre := &fakeRequestExecutor{
-		hits:            make(map[string]int),
-		beginResponding: sync.NewCond(&sync.Mutex{}),
+		hits:               make(map[string]int),
+		finishFirstRequest: make(chan bool),
 	}
 	coalescer := &requestCoalescer{
 		cache:           make(map[string]*firstRequest),
 		requestExecutor: fre,
 		hasher:          ghmetrics.NewCachingHasher(),
 	}
+
+	// Create 500 fake requests, 100 for each unique URL. For each group, we
+	// expect 1 of them to be the first one, and 99 of them to be "subscribed"
+	// to the first one (for the first one to finish). For 99 of these
+	// goroutines, we expect them to wait because of the coalescer.
+	concurrentRequestGroups := []concurrentRequestGroup{
+		{"/resource1",
+			100,
+		},
+		{"/resource2",
+			100,
+		},
+		{"/resource3",
+			100,
+		},
+		{"/resource4",
+			100,
+		},
+		{"/resource5",
+			100,
+		},
+	}
+
 	wg := sync.WaitGroup{}
-	wg.Add(100)
-	for i := 0; i < 100; i++ {
-		go func() {
-			if _, err := runRequest(coalescer, "/resource1", false); err != nil {
-				t.Errorf("Failed to run request: %v.", err)
-			}
-			wg.Done()
-		}()
+
+	// We need to wait for all requests to be made to the coalescer. The calls
+	// to spawnGroups() and waitUntilCacheIsFull() establish a state where the
+	// coalescer is still holding onto __all__ pending concurrent requests. None
+	// of the requests we've made above have finished yet because we have not
+	// told the fake GitHub server to actually respond yet. That's what we do
+	// below.
+	spawnGroups(concurrentRequestGroups, t, coalescer, &wg)
+	waitUntilCacheIsFull(concurrentRequestGroups, coalescer)
+
+	// We only made 5 unique requests to the fake GitHub server. Tell the fake
+	// GitHub to finally respond to these 5 requests. This triggers a chain
+	// reaction where:
+	//
+	//  1. (inside requestCoalescer) the lucky threads that got the firstRequest
+	//  finally receive (through our fakeRequestExecutor) a response from the
+	//  fake GitHub server, and
+	//
+	//  2. (inside requestCoalescer) the subscribed threads that were waiting
+	//  for firstRequest to finish being populated also get to finish
+	//  constructing their own HTTP Response bodies and return.
+	//
+	// The above 2 steps happen concurrently for all 5 coalesced requests.
+	for i := 0; i < len(concurrentRequestGroups); i++ {
+		fre.finishFirstRequest <- true
 	}
-	// There is a race here. We need to wait for all requests to be made to the
-	// coalescer before letting upstream respond, but we don't have a way of
-	// knowing when all requests have actually started waiting on the
-	// responseWaiter...
-	time.Sleep(time.Second * 5)
 
-	// Check that requests for different resources are not blocked.
-	if _, err := runRequest(coalescer, "/resource2", true); err != nil {
-		t.Errorf("Failed to run request: %v.", err)
-	} // Doesn't return until timeout or success.
-	fre.beginResponding.Broadcast()
-
-	// Check that non concurrent requests all hit upstream.
-	if _, err := runRequest(coalescer, "/resource2", true); err != nil {
-		t.Errorf("Failed to run request: %v.", err)
+	// Check that non-concurrent requests all hit upstream. We simulate this by
+	// creating another round of concurrent requests, but with size 1.
+	concurrentRequestGroups2 := []concurrentRequestGroup{
+		{"/resource2",
+			1,
+		},
 	}
-
+	// Wait until the lucky thread that handled the "/resource2" endpoint in the
+	// first group of concurrent requests has finished running (deleted the
+	// cache entry). This is important because otherwise the thread spawned
+	// below might (due to a race) get wrongly categorized as another
+	// "subscriber" thread as part of the concurrent requests above. Forcing
+	// this main thread to wait until the original cached entry is deleted
+	// guarantees that the request below will be handled as a new key.
+	waitUntilCacheKeyDeletion(fakeGitHubDomain+"/resource2", coalescer)
+	spawnGroups(concurrentRequestGroups2, t, coalescer, &wg)
+	fre.finishFirstRequest <- true
 	wg.Wait()
-	expectedHits := map[string]int{"/resource1": 1, "/resource2": 2}
+
+	expectedHits := map[string]int{
+		"/resource1": 1,
+		"/resource2": 2,
+		"/resource3": 1,
+		"/resource4": 1,
+		"/resource5": 1,
+	}
 	if !reflect.DeepEqual(fre.hits, expectedHits) {
 		t.Errorf("Unexpected hit count(s). Diff: %v.", diff.ObjectReflectDiff(expectedHits, fre.hits))
 	}
 }
 
+// TestRoundTripSynthetic runs until we've processed 100,000 requests. During
+// this time, we create an upper limit of 1000 concurrent requests to 10
+// different URL endpoints in flight at any given time. Meanwhile, the fake
+// GitHub server randomly takes between 1 or 5 milliseconds to respond to each
+// proxied request. We simply expect this test to finish, and that all requests
+// are served (no timeouts).
+func TestRoundTripSynthetic(t *testing.T) {
+	// Detect deadlocks. We should be able to finish this test in 10 seconds.
+	timeout := time.After(10 * time.Second)
+	done := make(chan bool)
+	shutdownFakeGitHub := make(chan bool)
+
+	go func() {
+		fre := &fakeRequestExecutor{
+			hits:               make(map[string]int),
+			finishFirstRequest: make(chan bool),
+		}
+		coalescer := &requestCoalescer{
+			cache:           make(map[string]*firstRequest),
+			requestExecutor: fre,
+			hasher:          ghmetrics.NewCachingHasher(),
+		}
+
+		synthetic := sync.Mutex{}
+
+		const maxConcurrentRequests = 1_000
+		concurrentRequests := 0
+
+		const maxStartedRequests = 100_000
+		startedRequests := 0
+
+		rand.Seed(time.Now().Unix())
+		endpoints := []string{
+			"/resource/1",
+			"/resource/2",
+			"/resource/3",
+			"/resource/4",
+			"/resource/5",
+			"/resource/6",
+			"/resource/7",
+			"/resource/8",
+			"/resource/9",
+			"/resource/10",
+		}
+
+		// From the fake GitHub server side, complete requests after sleeping a
+		// random interval. Stop responding when we know that we've processed
+		// 100,000 requests in total.
+		go func() {
+			fakeGitHubOnline := true
+			for fakeGitHubOnline {
+				select {
+				case <-shutdownFakeGitHub:
+					close(fre.finishFirstRequest)
+					fakeGitHubOnline = false
+				default:
+					time.Sleep(time.Duration(rand.Intn(5)+1) * time.Millisecond)
+					fre.finishFirstRequest <- true
+				}
+			}
+		}()
+
+		for {
+			synthetic.Lock()
+			// We've created all 100,000 requests we wanted to create so far, so
+			// we're done with this test.
+			if startedRequests == maxStartedRequests {
+				synthetic.Unlock()
+				shutdownFakeGitHub <- true
+				break
+			}
+			if concurrentRequests == maxConcurrentRequests {
+				synthetic.Unlock()
+				continue
+			}
+
+			startedRequests++
+			concurrentRequests++
+			synthetic.Unlock()
+
+			go func() {
+				randomEndpoint := endpoints[rand.Intn(len(endpoints))]
+				if _, err := runRequest(coalescer, randomEndpoint); err != nil {
+					t.Errorf("Failed to run request: %v.", err)
+				}
+				synthetic.Lock()
+				concurrentRequests--
+				synthetic.Unlock()
+			}()
+		}
+
+		// Show some diagnostics.
+		logrus.Infof("TestRoundTripSyntehtic: fre.hits: '%v'", fre.hits)
+
+		done <- true
+	}()
+
+	select {
+	case <-timeout:
+		t.Fatal("Deadlocked")
+	case <-done:
+	}
+}
+
 func TestCacheModeHeader(t *testing.T) {
-	t.Parallel()
 	wg := sync.WaitGroup{}
 	fre := &fakeRequestExecutor{
-		hits:            make(map[string]int),
-		beginResponding: sync.NewCond(&sync.Mutex{}),
+		hits:               make(map[string]int),
+		finishFirstRequest: make(chan bool),
 	}
 	coalescer := &requestCoalescer{
 		cache:           make(map[string]*firstRequest),
@@ -137,36 +456,44 @@ func TestCacheModeHeader(t *testing.T) {
 	// This should eventually return ModeMiss.
 	wg.Add(1)
 	go func() {
-		if resp, err := runRequest(coalescer, "/resource1", false); err != nil {
+		if resp, err := runRequest(coalescer, "/resource1"); err != nil {
 			t.Errorf("Failed to run request: %v.", err)
 		} else {
 			checkMode(resp, ModeMiss)
 		}
 		wg.Done()
 	}()
-	// There is a race here and where sleeps are used below.
-	// We need to wait for the initial request to be made
-	// to the coalescer before letting upstream respond, but we don't have a way
-	// of knowing when the requests has actually started waiting on the
-	// responseWaiter...
-	time.Sleep(time.Second * 3)
+
+	// Wait until a cache entry is created. This ensures that the goroutine
+	// above will end up as the one performing the RoundTrip.
+	waitUntilCacheKeyCreation(fakeGitHubDomain+"/resource1", coalescer)
 
 	// Queue a second request for resource1.
 	// This should coalescer and eventually return ModeCoalesced.
+	crg := []concurrentRequestGroup{
+		{"/resource1",
+			2,
+		},
+	}
 	wg.Add(1)
 	go func() {
-		if resp, err := runRequest(coalescer, "/resource1", false); err != nil {
+		if resp, err := runRequest(coalescer, "/resource1"); err != nil {
 			t.Errorf("Failed to run request: %v.", err)
 		} else {
 			checkMode(resp, ModeCoalesced)
 		}
 		wg.Done()
 	}()
-	time.Sleep(time.Second * 3)
+	// Now there are 2 requests pending --- the first one that received
+	// "/resource1", and the second one that is also reqeusting "/resource1".
+	// Wait to ensure that they are both in flight the requestCoalescer.
+	waitUntilCacheIsFull(crg, coalescer)
 
-	// Requests should be waiting now. Start responding and wait for all
-	// downstream responses to return.
-	fre.beginResponding.Broadcast()
+	// Requests should be waiting now. Make fake GitHub finally respond. We only
+	// created 1 unique URL, so we only need to unblock 1 thread that will
+	// perform the actual RoundTrip; and so we only pass in a single boolean to
+	// fre.finishFirstRequest.
+	fre.finishFirstRequest <- true
 	wg.Wait()
 
 	// A later request for resource1 revalidates cached response.
@@ -174,42 +501,66 @@ func TestCacheModeHeader(t *testing.T) {
 	header := http.Header{}
 	header.Set("Status", "304 Not Modified")
 	fre.responseHeader = header
-	if resp, err := runRequest(coalescer, "/resource1", true); err != nil {
-		t.Errorf("Failed to run request: %v.", err)
-	} else {
-		checkMode(resp, ModeRevalidated)
-	}
+	wg.Add(1)
+	go func() {
+		if resp, err := runRequest(coalescer, "/resource1"); err != nil {
+			t.Errorf("Failed to run request: %v.", err)
+		} else {
+			checkMode(resp, ModeRevalidated)
+		}
+		wg.Done()
+	}()
+	fre.finishFirstRequest <- true
+	wg.Wait()
 
 	// Another request for resource1 after the resource has changed.
 	// This should return ModeChanged.
 	header = http.Header{}
 	header.Set("X-Conditional-Request", "I am an E-Tag.")
 	fre.responseHeader = header
-	if resp, err := runRequest(coalescer, "/resource1", true); err != nil {
-		t.Errorf("Failed to run request: %v.", err)
-	} else {
-		checkMode(resp, ModeChanged)
-	}
+	wg.Add(1)
+	go func() {
+		if resp, err := runRequest(coalescer, "/resource1"); err != nil {
+			t.Errorf("Failed to run request: %v.", err)
+		} else {
+			checkMode(resp, ModeChanged)
+		}
+		wg.Done()
+	}()
+	fre.finishFirstRequest <- true
+	wg.Wait()
 
 	// Request for new resource2 with no concurrent requests.
 	// This should return ModeMiss.
 	fre.responseHeader = nil
-	if resp, err := runRequest(coalescer, "/resource2", true); err != nil {
-		t.Errorf("Failed to run request: %v.", err)
-	} else {
-		checkMode(resp, ModeMiss)
-	}
+	wg.Add(1)
+	go func() {
+		if resp, err := runRequest(coalescer, "/resource2"); err != nil {
+			t.Errorf("Failed to run request: %v.", err)
+		} else {
+			checkMode(resp, ModeMiss)
+		}
+		wg.Done()
+	}()
+	fre.finishFirstRequest <- true
+	wg.Wait()
 
 	// Request for uncacheable resource3.
 	// This should return ModeNoStore.
 	header = http.Header{}
 	header.Set("Cache-Control", "no-store")
 	fre.responseHeader = header
-	if resp, err := runRequest(coalescer, "/resource3", true); err != nil {
-		t.Errorf("Failed to run request: %v.", err)
-	} else {
-		checkMode(resp, ModeNoStore)
-	}
+	wg.Add(1)
+	go func() {
+		if resp, err := runRequest(coalescer, "/resource3"); err != nil {
+			t.Errorf("Failed to run request: %v.", err)
+		} else {
+			checkMode(resp, ModeNoStore)
+		}
+		wg.Done()
+	}()
+	fre.finishFirstRequest <- true
+	wg.Wait()
 
 	// We never send a ModeError mode in a header because we never return a
 	// http.Response if there is an error. ModeError is only for metrics.
@@ -221,37 +572,13 @@ func TestCacheModeHeader(t *testing.T) {
 	}
 }
 
-func runRequest(rt http.RoundTripper, uri string, immediate bool) (*http.Response, error) {
-	u, err := url.Parse("http://foo.com" + uri)
-	if err != nil {
-		return nil, err
-	}
-	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	if immediate {
-		req.Header.Set("test-immediate-response", "true")
-	}
-
-	waitChan := make(chan struct{})
-	var resp *http.Response
-	go func() {
-		defer close(waitChan)
-		resp, err = rt.RoundTrip(req)
-		if err == nil {
-			if b, readErr := ioutil.ReadAll(resp.Body); readErr != nil {
-				err = readErr
-			} else if string(b) != "Response" {
-				err = errors.New("unexpected response value")
-			}
-		}
-	}()
-
-	select {
-	case <-time.After(time.Second * 10):
-		return nil, fmt.Errorf("Request for %q timed out.", uri)
-	case <-waitChan:
-		return resp, err
+// TestStress runs tests multiple times, to attempt to detect any
+// races in our own test code (along with the code being tested). This is
+// important as subtle concurrency bugs can only be observed after multiple
+// runs.
+func TestStress(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		TestRoundTrip(t)
+		TestCacheModeHeader(t)
 	}
 }

--- a/ghproxy/ghcache/ghcache.go
+++ b/ghproxy/ghcache/ghcache.go
@@ -125,14 +125,14 @@ func cacheResponseMode(headers http.Header) CacheResponseMode {
 	return ModeMiss
 }
 
-func newThrottlingTransport(maxConcurrency int, delegate http.RoundTripper) http.RoundTripper {
-	return &throttlingTransport{sem: semaphore.NewWeighted(int64(maxConcurrency)), delegate: delegate}
+func newThrottlingTransport(maxConcurrency int, roundTripper http.RoundTripper) http.RoundTripper {
+	return &throttlingTransport{sem: semaphore.NewWeighted(int64(maxConcurrency)), roundTripper: roundTripper}
 }
 
 // throttlingTransport throttles outbound concurrency from the proxy
 type throttlingTransport struct {
-	sem      *semaphore.Weighted
-	delegate http.RoundTripper
+	sem          *semaphore.Weighted
+	roundTripper http.RoundTripper
 }
 
 func (c *throttlingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -145,7 +145,7 @@ func (c *throttlingTransport) RoundTrip(req *http.Request) (*http.Response, erro
 	pendingOutboundConnectionsGauge.Dec()
 	outboundConcurrencyGauge.Inc()
 	defer outboundConcurrencyGauge.Dec()
-	return c.delegate.RoundTrip(req)
+	return c.roundTripper.RoundTrip(req)
 }
 
 // upstreamTransport changes response headers from upstream before they
@@ -159,8 +159,8 @@ func (c *throttlingTransport) RoundTrip(req *http.Request) (*http.Response, erro
 //    Cache-Control: no-cache
 // This instructs the cache to store the response, but always consider it stale.
 type upstreamTransport struct {
-	delegate http.RoundTripper
-	hasher   ghmetrics.Hasher
+	roundTripper http.RoundTripper
+	hasher       ghmetrics.Hasher
 }
 
 func (u upstreamTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -173,8 +173,8 @@ func (u upstreamTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	}
 
 	reqStartTime := time.Now()
-	// Don't modify request, just pass to delegate.
-	resp, err := u.delegate.RoundTrip(req)
+	// Don't modify request, just pass to roundTripper.
+	resp, err := u.roundTripper.RoundTrip(req)
 	if err != nil {
 		ghmetrics.CollectRequestTimeoutMetrics(tokenBudgetName, req.URL.Path, req.Header.Get("User-Agent"), reqStartTime, time.Now())
 		logrus.WithField("cache-key", req.URL.String()).WithError(err).Warn("Error from upstream (GitHub).")
@@ -214,7 +214,7 @@ const LogMessageWithDiskPartitionFields = "Not using a partitioned cache because
 // NewDiskCache creates a GitHub cache RoundTripper that is backed by a disk
 // cache.
 // It supports a partitioned cache.
-func NewDiskCache(delegate http.RoundTripper, cacheDir string, cacheSizeGB, maxConcurrency int, legacyDisablePartitioningByAuthHeader bool) http.RoundTripper {
+func NewDiskCache(roundTripper http.RoundTripper, cacheDir string, cacheSizeGB, maxConcurrency int, legacyDisablePartitioningByAuthHeader bool) http.RoundTripper {
 	if legacyDisablePartitioningByAuthHeader {
 		diskCache := diskcache.NewWithDiskv(
 			diskv.New(diskv.Options{
@@ -222,7 +222,7 @@ func NewDiskCache(delegate http.RoundTripper, cacheDir string, cacheSizeGB, maxC
 				TempDir:      path.Join(cacheDir, "temp"),
 				CacheSizeMax: uint64(cacheSizeGB) * uint64(1000000000), // convert G to B
 			}))
-		return NewFromCache(delegate,
+		return NewFromCache(roundTripper,
 			func(partitionKey string) httpcache.Cache {
 				logrus.WithField("cache-base-path", path.Join(cacheDir, "data", partitionKey)).
 					WithField("cache-temp-path", path.Join(cacheDir, "temp", partitionKey)).
@@ -232,7 +232,7 @@ func NewDiskCache(delegate http.RoundTripper, cacheDir string, cacheSizeGB, maxC
 			maxConcurrency,
 		)
 	}
-	return NewFromCache(delegate,
+	return NewFromCache(roundTripper,
 		func(partitionKey string) httpcache.Cache {
 			return diskcache.NewWithDiskv(
 				diskv.New(diskv.Options{
@@ -248,8 +248,8 @@ func NewDiskCache(delegate http.RoundTripper, cacheDir string, cacheSizeGB, maxC
 // NewMemCache creates a GitHub cache RoundTripper that is backed by a memory
 // cache.
 // It supports a partitioned cache.
-func NewMemCache(delegate http.RoundTripper, maxConcurrency int) http.RoundTripper {
-	return NewFromCache(delegate,
+func NewMemCache(roundTripper http.RoundTripper, maxConcurrency int) http.RoundTripper {
+	return NewFromCache(roundTripper,
 		func(_ string) httpcache.Cache { return httpcache.NewMemoryCache() },
 		maxConcurrency)
 }
@@ -259,15 +259,15 @@ type CachePartitionCreator func(partitionKey string) httpcache.Cache
 
 // NewFromCache creates a GitHub cache RoundTripper that is backed by the
 // specified httpcache.Cache implementation.
-func NewFromCache(delegate http.RoundTripper, cache CachePartitionCreator, maxConcurrency int) http.RoundTripper {
+func NewFromCache(roundTripper http.RoundTripper, cache CachePartitionCreator, maxConcurrency int) http.RoundTripper {
 	hasher := ghmetrics.NewCachingHasher()
 	return newPartitioningRoundTripper(func(partitionKey string) http.RoundTripper {
 		cacheTransport := httpcache.NewTransport(cache(partitionKey))
-		cacheTransport.Transport = newThrottlingTransport(maxConcurrency, upstreamTransport{delegate: delegate, hasher: hasher})
+		cacheTransport.Transport = newThrottlingTransport(maxConcurrency, upstreamTransport{roundTripper: roundTripper, hasher: hasher})
 		return &requestCoalescer{
-			keys:     make(map[string]*responseWaiter),
-			delegate: cacheTransport,
-			hasher:   hasher,
+			cache:           make(map[string]*firstRequest),
+			requestExecutor: cacheTransport,
+			hasher:          hasher,
 		}
 	})
 }
@@ -277,13 +277,13 @@ func NewFromCache(delegate http.RoundTripper, cache CachePartitionCreator, maxCo
 // Important note: The redis implementation does not support partitioning the cache
 // which means that requests to the same path from different tokens will invalidate
 // each other.
-func NewRedisCache(delegate http.RoundTripper, redisAddress string, maxConcurrency int) http.RoundTripper {
+func NewRedisCache(roundTripper http.RoundTripper, redisAddress string, maxConcurrency int) http.RoundTripper {
 	conn, err := redis.Dial("tcp", redisAddress)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error connecting to Redis")
 	}
 	redisCache := rediscache.NewWithClient(conn)
-	return NewFromCache(delegate,
+	return NewFromCache(roundTripper,
 		func(_ string) httpcache.Cache { return redisCache },
 		maxConcurrency)
 }

--- a/prow/pubsub/subscriber/subscriber.go
+++ b/prow/pubsub/subscriber/subscriber.go
@@ -44,10 +44,13 @@ const (
 	postsubmitProwJobEvent = "prow.k8s.io/pubsub.PostsubmitProwJobEvent"
 )
 
-// Ensure interface is intact
+// Ensure interface is intact. I.e., this declaration ensures that the type
+// "*config.Config" implements the "prowCfgClient" interface. See
+// https://golang.org/doc/faq#guarantee_satisfies_interface.
 var _ prowCfgClient = (*config.Config)(nil)
 
-// prowCfgClient is for unit test purpose
+// prowCfgClient is a subset of all the various behaviors that the
+// "*config.Config" type implements, which we will test here.
 type prowCfgClient interface {
 	AllPeriodics() []config.Periodic
 	GetPresubmits(gc git.ClientFactory, identifier string, baseSHAGetter config.RefGetter, headSHAGetters ...config.RefGetter) ([]config.Presubmit, error)


### PR DESCRIPTION
This builds on #23568.

I made the changes in this PR because I needed to closely understand how/why ghproxy's request coalescer worked, in order to implement it for #23500. I wanted to get to the bottom of why we were using time.Sleep() in the unit tests, and realized that it was unnecessary (at least the way they were being used). There are a large amount of test helper functions that allow us to get rid of time.Sleep() calls, but on the other hand we can now run the tests hundreds of times in less time than before, which gives us high confidence.

There are only a handful (3 to be exact) changes to the underlying business logic in coalesce.go, which seem to have been overlooked previously and should be NOP changes.

Anyway, using the knowledge I have learned here, I will implement similar unit tests for #23500, without relying on time.Sleep() for synchronization.

/assign @cjwagner 