### PR TITLE
jenkins-operator: use git-base image

### DIFF
--- a/prow/cmd/jenkins-operator/BUILD.bazel
+++ b/prow/cmd/jenkins-operator/BUILD.bazel
@@ -9,7 +9,7 @@ NAME = "jenkins-operator"
 
 prow_image(
     name = "image",
-    base = "@alpine-base//image",
+    base = "@git-base//image",
     component = NAME,
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
To avoid:

```
{"component":"jenkins-operator","error":"exec: \"git\": executable file not found in $PATH","file":"prow/cmd/jenkins-operator/main.go:202","func":"main.main","level":"fatal","msg":"Error getting Git client.","severity":"fatal","time":"2021-09-13T12:20:12Z"}
```

/cc @alvaroaleman @stevekuznetsov 