### PR TITLE
images: README update to trigger image builds

### DIFF
--- a/images/bigquery/README.md
+++ b/images/bigquery/README.md
@@ -1,4 +1,4 @@
-# bigquery
+# bigquery image
 
 The `gcr.io/k8s-staging-test-infra/bigquery` image is used to run [`/metrics/bigquery.py`] and [`/kettle/monitor.py`]
 

--- a/images/bootstrap/README.md
+++ b/images/bootstrap/README.md
@@ -6,7 +6,7 @@ Critical bugfies or security updates may be accepted, but approached with heavy 
 
 New dependencies or features will very likely not be accepted.
 
-# bootstrap
+# bootstrap image
 
 This image is used as the base layer for the kubekins-e2e image, with a focus
 on the deprecated bootstrap.py tooling that was used during Kubernetes' early

--- a/images/builder/README.md
+++ b/images/builder/README.md
@@ -52,12 +52,17 @@ bazel run //images/builder -- [options] path/to/build-directory/
 
 ### A note about logging in Prow
 
-Prow job logs can be viewed at a URI constructed as follows: `https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/<job-name>/<job-number>` e.g., https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-prototype-build/1187171788975509509
+Prow job logs can be viewed at a URI constructed as follows:
+`https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/<job-name>/<job-number>` e.g.,
+https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-prototype-build/1187171788975509509
 
-When `--log-dir` is specified (which is the default case when running in Prow), the GCB build logs will be written to a set of log files, based on the variant(s).
+When `--log-dir` is specified (which is the default case when running in Prow),
+the GCB build logs will be written to a set of log files, based on the variant(s).
 
 For example:
 - No variant --> `build.log` (https://storage.googleapis.com/kubernetes-jenkins/logs/post-release-push-image-k8s-cloud-builder/1186437931728900096/artifacts/build.log)
 - Variant: `build-ci` --> `build-ci.log` (https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-prototype-build/1187156434249322500/artifacts/build-ci.log)
 
-For single-variant jobs where the preference is to log directly to stdout (so that the log is instead visible in `https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/<job-name>/<job-number>`), `LOG_TO_STDOUT="y"` can be specified.
+For single-variant jobs where the preference is to log directly to stdout (so
+that the log is instead visible in `https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/<job-name>/<job-number>`),
+`LOG_TO_STDOUT="y"` can be specified.

--- a/images/gcloud/README.md
+++ b/images/gcloud/README.md
@@ -1,4 +1,4 @@
-# gcloud-in-go
+# gcloud-in-go image
 
 Use this image when you want to use `go` and `gcloud` in the same job
 

--- a/images/krte/README.md
+++ b/images/krte/README.md
@@ -1,4 +1,4 @@
-# krte
+# krte image
 
 krte - [KIND](https://sigs.k8s.io/kind) RunTime Environment
 


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1523
- Followup to: https://github.com/kubernetes/test-infra/pull/23580

Here's another README-only update to trigger image builds now that the jobs have been updated via autobump to use the latest image-builder