### PR TITLE
config/jobs: fix k8s-infra canary image build jobs

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-test-infra.yaml
+++ b/config/jobs/image-pushing/k8s-staging-test-infra.yaml
@@ -21,7 +21,7 @@ postsubmits:
         containers:
         - image: gcr.io/k8s-testimages/image-builder:v20210910-b5a7cb2
           command:
-          - ./run.sh
+          - /run.sh
           args:
           - --scratch-bucket=gs://k8s-staging-test-infra-gcb
           - --project=k8s-staging-test-infra
@@ -45,7 +45,7 @@ postsubmits:
         containers:
         - image: gcr.io/k8s-testimages/image-builder:v20210910-b5a7cb2
           command:
-          - ./run.sh
+          - /run.sh
           args:
           - --scratch-bucket=gs://k8s-staging-test-infra-gcb
           - --project=k8s-staging-test-infra
@@ -69,7 +69,7 @@ postsubmits:
         containers:
         - image: gcr.io/k8s-testimages/image-builder:v20210910-b5a7cb2
           command:
-          - ./run.sh
+          - /run.sh
           args:
           - --scratch-bucket=gs://k8s-staging-test-infra-gcb
           - --project=k8s-staging-test-infra
@@ -93,7 +93,7 @@ postsubmits:
         containers:
         - image: gcr.io/k8s-testimages/image-builder:v20210910-b5a7cb2
           command:
-          - ./run.sh
+          - /run.sh
           args:
           - --scratch-bucket=gs://k8s-staging-test-infra-gcb
           - --project=k8s-staging-test-infra
@@ -117,7 +117,7 @@ postsubmits:
         containers:
         - image: gcr.io/k8s-testimages/image-builder:v20210910-b5a7cb2
           command:
-          - ./run.sh
+          - /run.sh
           args:
           - --scratch-bucket=gs://k8s-staging-test-infra-gcb
           - --project=k8s-staging-test-infra


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1523
- Followup to: https://github.com/kubernetes/test-infra/pull/23552

Fix a copy-paste typo in the job definitions, everything triggered from https://github.com/kubernetes/test-infra/pull/23555 failed with `./run.sh` not found