### PR TITLE
config/prow: slack warnings for k/k go to github-management

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -268,7 +268,7 @@ slack:
   - repos:
     - kubernetes/kubernetes
     channels:
-    - kubernetes-dev
+    - github-management
     exempt_users:
     - k8s-ci-robot # future home of tide
     - k8s-release-robot # anago

--- a/prow/plugins/slackevents/slackevents_test.go
+++ b/prow/plugins/slackevents/slackevents_test.go
@@ -110,19 +110,19 @@ func TestPush(t *testing.T) {
 	noMessages := map[string][]string{}
 	stdWarningMessages := map[string][]string{
 		"sig-contribex":  {"*Warning:* tester (<@tester>) manually merged 2 commit(s) into master: https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...045a6dca0784"},
-		"kubernetes-dev": {"*Warning:* tester (<@tester>) manually merged 2 commit(s) into master: https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...045a6dca0784"}}
+		"kubernetes-foo": {"*Warning:* tester (<@tester>) manually merged 2 commit(s) into master: https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...045a6dca0784"}}
 
 	createdWarningMessages := map[string][]string{
 		"sig-contribex":  {"*Warning:* tester (<@tester>) pushed a new branch (release-1.99): https://github.com/kubernetes/kubernetes/compare/045a6dca0784"},
-		"kubernetes-dev": {"*Warning:* tester (<@tester>) pushed a new branch (release-1.99): https://github.com/kubernetes/kubernetes/compare/045a6dca0784"}}
+		"kubernetes-foo": {"*Warning:* tester (<@tester>) pushed a new branch (release-1.99): https://github.com/kubernetes/kubernetes/compare/045a6dca0784"}}
 
 	deletedWarningMessages := map[string][]string{
 		"sig-contribex":  {"*Warning:* tester (<@tester>) deleted a branch (release-1.99): https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...000000000000"},
-		"kubernetes-dev": {"*Warning:* tester (<@tester>) deleted a branch (release-1.99): https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...000000000000"}}
+		"kubernetes-foo": {"*Warning:* tester (<@tester>) deleted a branch (release-1.99): https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...000000000000"}}
 
 	forcedWarningMessages := map[string][]string{
 		"sig-contribex":  {"*Warning:* tester (<@tester>) *force* merged 2 commit(s) into master: https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...045a6dca0784"},
-		"kubernetes-dev": {"*Warning:* tester (<@tester>) *force* merged 2 commit(s) into master: https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...045a6dca0784"}}
+		"kubernetes-foo": {"*Warning:* tester (<@tester>) *force* merged 2 commit(s) into master: https://github.com/kubernetes/kubernetes/compare/d73a75b4b1dd...045a6dca0784"}}
 
 	type testCase struct {
 		name             string
@@ -132,37 +132,37 @@ func TestPush(t *testing.T) {
 
 	testcases := []testCase{
 		{
-			name:             "If PR merged manually by a user, we send message to sig-contribex and kubernetes-dev.",
+			name:             "If PR merged manually by a user, we send message to sig-contribex and kubernetes-foo.",
 			pushReq:          pushEvManual,
 			expectedMessages: stdWarningMessages,
 		},
 		{
-			name:             "If PR force merged by a user, we send message to sig-contribex and kubernetes-dev with force merge message.",
+			name:             "If PR force merged by a user, we send message to sig-contribex and kubernetes-foo with force merge message.",
 			pushReq:          pushEvManualForced,
 			expectedMessages: forcedWarningMessages,
 		},
 		{
-			name:             "If PR merged by k8s merge bot we should NOT send message to sig-contribex and kubernetes-dev.",
+			name:             "If PR merged by k8s merge bot we should NOT send message to sig-contribex and kubernetes-foo.",
 			pushReq:          pushEv,
 			expectedMessages: noMessages,
 		},
 		{
-			name:             "If PR merged by a user not in the exemption list but in THIS branch exemption list, we should NOT send a message to sig-contribex and kubernetes-dev.",
+			name:             "If PR merged by a user not in the exemption list but in THIS branch exemption list, we should NOT send a message to sig-contribex and kubernetes-foo.",
 			pushReq:          pushEvManualBranchExempted,
 			expectedMessages: noMessages,
 		},
 		{
-			name:             "If PR merged by a user not in the exemption list, in a branch exemption list, but not THIS branch exemption list, we should send a message to sig-contribex and kubernetes-dev.",
+			name:             "If PR merged by a user not in the exemption list, in a branch exemption list, but not THIS branch exemption list, we should send a message to sig-contribex and kubernetes-foo.",
 			pushReq:          pushEvManualBranchExempted,
 			expectedMessages: noMessages,
 		},
 		{
-			name:             "If a branch is created by a non-exempted user, we send message to sig-contribex and kubernetes-dev with branch created message.",
+			name:             "If a branch is created by a non-exempted user, we send message to sig-contribex and kubernetes-foo with branch created message.",
 			pushReq:          pushEvManualCreated,
 			expectedMessages: createdWarningMessages,
 		},
 		{
-			name:             "If a branch is deleted by a non-exempted user, we send message to sig-contribex and kubernetes-dev with branch deleted message.",
+			name:             "If a branch is deleted by a non-exempted user, we send message to sig-contribex and kubernetes-foo with branch deleted message.",
 			pushReq:          pushEvManualDeleted,
 			expectedMessages: deletedWarningMessages,
 		},
@@ -173,7 +173,7 @@ func TestPush(t *testing.T) {
 			MergeWarnings: []plugins.MergeWarning{
 				{
 					Repos:       []string{"kubernetes/kubernetes"},
-					Channels:    []string{"kubernetes-dev", "sig-contribex"},
+					Channels:    []string{"kubernetes-foo", "sig-contribex"},
 					ExemptUsers: []string{"k8s-merge-robot"},
 					ExemptBranches: map[string][]string{
 						"warrens-branch": {"wteened"},


### PR DESCRIPTION
Related:
- Prompted by: https://github.com/kubernetes/kubernetes/pull/104763#issuecomment-918479336

kubernetes-dev was renamed to kubernetes-contributors a while ago, and the
slack plugin config for kubernetes/kubernetes was never updated to follow
suit, so notifications about unexpected branch creations, deletions or
merges have effectively been going to /dev/null

Rather than follow suit, change to github-management as a higher 
signal/noise ratio channel, with more members who have permissions that 
will allow them to address stray branches

Drop kubernetes-dev from the plugin test data to avoid having to rename test data again if we decide to change our mind.

/sig release
/sig contributor-experience
/area github-management
/kind bug
/priority important-soon