### PR TITLE
releng: Add presubmits for sigs.k8s.io/release-sdk

### DIFF
--- a/config/jobs/kubernetes-sigs/release-sdk/OWNERS
+++ b/config/jobs/kubernetes-sigs/release-sdk/OWNERS
@@ -1,0 +1,11 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- release-engineering-approvers
+
+reviewers:
+- release-engineering-reviewers
+
+labels:
+- sig/release
+- area/release-eng

--- a/config/jobs/kubernetes-sigs/release-sdk/release-sdk-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/release-sdk/release-sdk-presubmits.yaml
@@ -1,0 +1,40 @@
+presubmits:
+  kubernetes-sigs/release-sdk:
+  - name: pull-release-sdk-test
+    always_run: true
+    decorate: true
+    path_alias: "sigs.k8s.io/release-sdk"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
+        imagePullPolicy: Always
+        command:
+        - go
+        args:
+        - run
+        - mage.go
+        - Test
+    annotations:
+      testgrid-dashboards: sig-release-releng-presubmits
+      testgrid-tab-name: release-sdk-test
+      testgrid-alert-email: release-managers+alerts@kubernetes.io
+      testgrid-num-columns-recent: '30'
+  - name: pull-release-sdk-verify
+    always_run: true
+    decorate: true
+    path_alias: "sigs.k8s.io/release-sdk"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
+        imagePullPolicy: Always
+        command:
+        - go
+        args:
+        - run
+        - mage.go
+        - Verify
+    annotations:
+      testgrid-dashboards: sig-release-releng-presubmits
+      testgrid-tab-name: release-sdk-verify
+      testgrid-alert-email: release-managers+alerts@kubernetes.io
+      testgrid-num-columns-recent: '30'


### PR DESCRIPTION
The repo was missing presubmits because it had no code in it... but it does now, so let's remedy that!
(noticed in https://github.com/kubernetes-sigs/release-sdk/pull/3)

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @puerco @cpanato @ameukam @Verolop 
cc: @kubernetes/release-engineering 