### PR TITLE
Crier github reporter uses cached git client for reporting to github

### DIFF
--- a/prow/cmd/crier/main.go
+++ b/prow/cmd/crier/main.go
@@ -287,7 +287,9 @@ func main() {
 		if err != nil {
 			logrus.WithError(err).Fatal("Error getting Git client.")
 		}
-		gitClient := git.ClientFactoryFrom(g)
+		// This git client is only used for inrepoconfig, updating it to use the cached
+		// version of git client for improved performance of inrepoconfig
+		gitClient := config.NewInRepoConfigGitCache(git.ClientFactoryFrom(g))
 
 		hasReporter = true
 		githubReporter := githubreporter.NewReporter(gitClient, githubClient, cfg, prowapi.ProwJobAgent(o.reportAgent))


### PR DESCRIPTION
We are seeing huge backlog in crier when a large repo configures lots of prow jobs via inrepoconfig, this is bottlenecked by the git client performs local cloning, which as we observed takes ~12 seconds per clone, and all reports were queued because this clone is mutex locked.

This PR makes crier use the git cache client. This cached git client reserved cloned repos more aggressively, it updates caches by fetch refs instead of local cloning, saves disk I/O, as well as more time efficient.

This git cache client had been pioneered in pubsub component and had been performing really well. Since the git client in crier only does repo checkout for inrepoconfig, I believe it will work equally well