### PR TITLE
capdo: lock the images in the 1.21 tag that uses go 1.16.x

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics.yaml
@@ -15,7 +15,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210913-82aac5659f-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210913-82aac5659f-1.21
       command:
         - "runner.sh"
         - "./scripts/ci-conformance.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210913-82aac5659f-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210913-82aac5659f-1.21
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -24,7 +24,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210913-82aac5659f-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210913-82aac5659f-1.21
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -39,7 +39,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210913-82aac5659f-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210913-82aac5659f-1.21
         command:
         - make
         args:
@@ -80,7 +80,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210913-82aac5659f-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210913-82aac5659f-1.21
         command:
           - "runner.sh"
           - "./scripts/ci-e2e.sh"
@@ -109,7 +109,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210913-82aac5659f-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210913-82aac5659f-1.21
         command:
           - "runner.sh"
           - "./scripts/ci-e2e.sh"
@@ -141,7 +141,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210913-82aac5659f-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210913-82aac5659f-1.21
         command:
           - "runner.sh"
           - "./scripts/ci-conformance.sh"


### PR DESCRIPTION
the current images are pointing to the master tag that uses go 1.17, but we are using go 1.16.x for now

this PR update the images to use 1.21 tags, similar to that have for CAPZ

needed for https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/pull/271

/assign @timoreimann 