### PR TITLE
releng(kubekins, krte): Update Golang versions to go1.17.1

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -9,7 +9,7 @@ variants:
     UPGRADE_DOCKER: 'true'
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.17
+    GO_VERSION: 1.17.1
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
@@ -22,7 +22,7 @@ variants:
     KIND_VERSION: 0.10.0
   master:
     CONFIG: master
-    GO_VERSION: 1.17
+    GO_VERSION: 1.17.1
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
Part of https://github.com/kubernetes/release/issues/2238
Ready to land, now that the k/k go1.17.1 PR has merged https://github.com/kubernetes/kubernetes/pull/104904

/assign @justaugustus @puerco @xmudrii @Verolop @BenTheElder 
cc: @kubernetes/release-engineering
