### PR TITLE
releng(test-infra): Bump image promoter to v3.2.0

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -680,12 +680,13 @@ postsubmits:
     spec:
       serviceAccountName: pusher
       containers:
-      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v2.4.1
+      - image: k8s.gcr.io/artifact-promoter/cip:v3.2.0
         command:
         - cip
         args:
-        - -manifest=prow/cip-manifest.yaml
-        - -dry-run=false
+        - run
+        - --manifest=prow/cip-manifest.yaml
+        - --confirm
     annotations:
       testgrid-dashboards: sig-testing-prow
       testgrid-tab-name: cip-prow


### PR DESCRIPTION
Image bump for CIP release v3.2.0: https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/426
v3.2.0: https://github.com/kubernetes-sigs/k8s-container-image-promoter/releases/tag/v3.2.0
Image promotion PR: https://github.com/kubernetes/k8s.io/pull/2720
Follow-up to https://github.com/kubernetes/test-infra/pull/23591.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @spiffxp @dims 
cc: @kubernetes/release-engineering @kubernetes/wg-k8s-infra-leads @kubernetes/sig-testing-leads 