### PR TITLE
config/prow: fix prow job autobump config

### DIFF
--- a/config/prow/autobump-config/prow-job-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-job-autobump-config.yaml
@@ -1,8 +1,8 @@
 ---
-gitHubLogin: "k8s-ci-robot"
-gitHubToken: "/etc/github-token/oauth"
+gitHubLogin: "k8s-infra-ci-robot"
+gitHubToken: "/etc/github-token/token"
 gitName: "Kubernetes Prow Robot"
-gitEmail: "k8s.ci.robot@gmail.com"
+gitEmail: "k8s-infra-ci-robot@kubernetes.io"
 onCallAddress: "https://storage.googleapis.com/kubernetes-jenkins/oncall.json"
 skipPullRequest: false
 gitHubOrg: "kubernetes"


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1523
- Followup to: https://github.com/kubernetes/test-infra/pull/23581
The job was moved to use credentials for k8s-infra-ci-robot, I forgot
that autobump doesn't parse out who it's PR'ing as from the token