### PR TITLE
releng(promo-tools): Update OWNERS for presubmits 

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -298,3 +298,19 @@ aliases:
   - pwittrock
 
   # end sigs.k8s.io/kubebuilder/OWNERS_ALIASES
+
+  # copied from sigs.k8s.io/k8s-container-image-promoter/OWNERS_ALIASES
+  promo-tools-approvers:
+    - cpanato
+    - jeremyrickard
+    - justaugustus
+    - listx
+    - puerco
+    - saschagrunert
+  promo-tools-reviewers:
+    - cpanato
+    - jeremyrickard
+    - justaugustus
+    - listx
+    - puerco
+    - saschagrunert

--- a/config/jobs/kubernetes/sig-release/cip/OWNERS
+++ b/config/jobs/kubernetes/sig-release/cip/OWNERS
@@ -1,12 +1,19 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
-reviewers:
-- dims
-- hh
-- listx
-- tpepper
 approvers:
-- dims
-- hh
-- listx
-- tpepper
+- release-engineering-approvers
+- promo-tools-approvers
+# TODO(releng): Distill down to SIG K8s Infra leads, once the proposal to
+#               convert to a SIG is approved.
+#               ref: https://github.com/kubernetes/community/pull/5928
+- wg-k8s-infra-leads
+- thockin
+
+reviewers:
+- release-engineering-reviewers
+- promo-tools-reviewers
+
+labels:
+- sig/release
+- area/release-eng
+- area/artifacts


### PR DESCRIPTION
- OWNERS(releng): Add aliases for promotion tools reviews
- releng(promo-tools): Update OWNERS for presubmits
  - Drop:
    - @hh
    - @tpepper
  - Add RelEng aliases
  - Consolidate WG K8s Infra reviewers to alias (+ @thockin)
  - Add labels:
    - sig/release
    - area/release-eng
    - area/artifacts

/assign @cpanato @ameukam @puerco @Verolop 
cc: @kubernetes/release-engineering @kubernetes/wg-k8s-infra-leads 

Closes https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/266