### PR TITLE
Revert "Change retest help message to indicate optional jobs #23484"

### DIFF
--- a/prow/cmd/crier/BUILD.bazel
+++ b/prow/cmd/crier/BUILD.bazel
@@ -20,7 +20,6 @@ go_library(
         "//prow/flagutil:go_default_library",
         "//prow/flagutil/config:go_default_library",
         "//prow/gerrit/client:go_default_library",
-        "//prow/git/v2:go_default_library",
         "//prow/interrupts:go_default_library",
         "//prow/io:go_default_library",
         "//prow/logrusutil:go_default_library",

--- a/prow/cmd/crier/README.md
+++ b/prow/cmd/crier/README.md
@@ -205,9 +205,9 @@ Each crier controller takes in a reporter.
 Each reporter will implement the following interface:
 ```go
 type reportClient interface {
-	Report(ctx context.Context, log *logrus.Entry, pj *prowv1.ProwJob) ([]*prowv1.ProwJob, *reconcile.Result, error)
+	Report(pj *v1.ProwJob) error
 	GetName() string
-	ShouldReport(ctx context.Context, log *logrus.Entry, pj *prowv1.ProwJob) bool
+	ShouldReport(pj *v1.ProwJob) bool
 }
 ```
 

--- a/prow/cmd/crier/main.go
+++ b/prow/cmd/crier/main.go
@@ -23,7 +23,6 @@ import (
 	"os"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/test-infra/prow/git/v2"
 	"k8s.io/test-infra/prow/pjutil/pprof"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -283,14 +282,9 @@ func main() {
 		if err != nil {
 			logrus.WithError(err).Fatal("Error getting GitHub client.")
 		}
-		g, err := o.github.GitClient(o.dryrun)
-		if err != nil {
-			logrus.WithError(err).Fatal("Error getting Git client.")
-		}
-		gitClient := git.ClientFactoryFrom(g)
 
 		hasReporter = true
-		githubReporter := githubreporter.NewReporter(gitClient, githubClient, cfg, prowapi.ProwJobAgent(o.reportAgent))
+		githubReporter := githubreporter.NewReporter(githubClient, cfg, prowapi.ProwJobAgent(o.reportAgent))
 		if err := crier.New(mgr, githubReporter, o.githubWorkers, o.githubEnablement.EnablementChecker()); err != nil {
 			logrus.WithError(err).Fatal("failed to construct github reporter controller")
 		}

--- a/prow/cmd/crier/main.go
+++ b/prow/cmd/crier/main.go
@@ -287,9 +287,7 @@ func main() {
 		if err != nil {
 			logrus.WithError(err).Fatal("Error getting Git client.")
 		}
-		// This git client is only used for inrepoconfig, updating it to use the cached
-		// version of git client for improved performance of inrepoconfig
-		gitClient := config.NewInRepoConfigGitCache(git.ClientFactoryFrom(g))
+		gitClient := git.ClientFactoryFrom(g)
 
 		hasReporter = true
 		githubReporter := githubreporter.NewReporter(gitClient, githubClient, cfg, prowapi.ProwJobAgent(o.reportAgent))

--- a/prow/cmd/jenkins-operator/BUILD.bazel
+++ b/prow/cmd/jenkins-operator/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "//prow/config/secret:go_default_library",
         "//prow/flagutil:go_default_library",
         "//prow/flagutil/config:go_default_library",
-        "//prow/git/v2:go_default_library",
         "//prow/interrupts:go_default_library",
         "//prow/jenkins:go_default_library",
         "//prow/logrusutil:go_default_library",

--- a/prow/cmd/jenkins-operator/main.go
+++ b/prow/cmd/jenkins-operator/main.go
@@ -31,7 +31,6 @@ import (
 	"github.com/NYTimes/gziphandler"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/test-infra/prow/git/v2"
 	"k8s.io/test-infra/prow/pjutil/pprof"
 
 	"k8s.io/test-infra/pkg/flagutil"
@@ -197,13 +196,8 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting GitHub client.")
 	}
-	g, err := o.github.GitClient(o.dryRun)
-	if err != nil {
-		logrus.WithError(err).Fatal("Error getting Git client.")
-	}
-	gitClient := git.ClientFactoryFrom(g)
 
-	c, err := jenkins.NewController(prowJobClient, jc, gitClient, githubClient, nil, cfg, o.totURL, o.selector, o.skipReport)
+	c, err := jenkins.NewController(prowJobClient, jc, githubClient, nil, cfg, o.totURL, o.selector, o.skipReport)
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to instantiate Jenkins controller.")
 	}

--- a/prow/crier/reporters/github/BUILD.bazel
+++ b/prow/crier/reporters/github/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
         "//prow/gerrit/client:go_default_library",
-        "//prow/git/v2:go_default_library",
         "//prow/github/report:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/reconcile:go_default_library",

--- a/prow/crier/reporters/github/reporter.go
+++ b/prow/crier/reporters/github/reporter.go
@@ -32,7 +32,6 @@ import (
 	v1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/gerrit/client"
-	"k8s.io/test-infra/prow/git/v2"
 	"k8s.io/test-infra/prow/github/report"
 )
 
@@ -43,8 +42,7 @@ const (
 
 // Client is a github reporter client
 type Client struct {
-	gitClient   git.ClientFactory
-	ghc         report.GitHubClient
+	gc          report.GitHubClient
 	config      config.Getter
 	reportAgent v1.ProwJobAgent
 	prLocks     *shardedLock
@@ -104,10 +102,9 @@ func (s *shardedLock) runCleanup() {
 }
 
 // NewReporter returns a reporter client
-func NewReporter(gitClient git.ClientFactory, ghc report.GitHubClient, cfg config.Getter, reportAgent v1.ProwJobAgent) *Client {
+func NewReporter(gc report.GitHubClient, cfg config.Getter, reportAgent v1.ProwJobAgent) *Client {
 	c := &Client{
-		gitClient:   gitClient,
-		ghc:         ghc,
+		gc:          gc,
 		config:      cfg,
 		reportAgent: reportAgent,
 		prLocks: &shardedLock{
@@ -162,12 +159,11 @@ func (c *Client) Report(ctx context.Context, log *logrus.Entry, pj *v1.ProwJob) 
 		if err := lock.Acquire(ctx, 1); err != nil {
 			return nil, nil, err
 		}
-
 		defer lock.Release(1)
 	}
 
 	// TODO(krzyzacy): ditch ReportTemplate, and we can drop reference to config.Getter
-	err := report.Report(ctx, c.config(), c.gitClient, c.ghc, c.config().Plank.ReportTemplateForRepo(pj.Spec.Refs), *pj, c.config().GitHubReporter.JobTypesToReport)
+	err := report.Report(ctx, c.gc, c.config().Plank.ReportTemplateForRepo(pj.Spec.Refs), *pj, c.config().GitHubReporter.JobTypesToReport)
 	if err != nil {
 		if strings.Contains(err.Error(), "This SHA and context has reached the maximum number of statuses") {
 			// This is completely unrecoverable, so just swallow the error to make sure we wont retry, even when crier gets restarted.

--- a/prow/crier/reporters/github/reporter_test.go
+++ b/prow/crier/reporters/github/reporter_test.go
@@ -97,7 +97,7 @@ func TestShouldReport(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			c := NewReporter(nil, nil, nil, tc.reportAgent)
+			c := NewReporter(nil, nil, tc.reportAgent)
 			if r := c.ShouldReport(context.Background(), logrus.NewEntry(logrus.StandardLogger()), &tc.pj); r == tc.report {
 				return
 			}
@@ -116,7 +116,6 @@ func TestShouldReport(t *testing.T) {
 // threadsafe.
 func TestPresumitReportingLocks(t *testing.T) {
 	reporter := NewReporter(
-		nil,
 		fakegithub.NewFakeClient(),
 		func() *config.Config {
 			return &config.Config{
@@ -210,7 +209,7 @@ func TestReport(t *testing.T) {
 			fghc := fakegithub.NewFakeClient()
 			fghc.Error = tc.githubError
 			c := Client{
-				ghc: fghc,
+				gc: fghc,
 				config: func() *config.Config {
 					return &config.Config{
 						ProwConfig: config.ProwConfig{

--- a/prow/external-plugins/refresh/BUILD.bazel
+++ b/prow/external-plugins/refresh/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "//prow/config/secret:go_default_library",
         "//prow/flagutil:go_default_library",
         "//prow/flagutil/config:go_default_library",
-        "//prow/git/v2:go_default_library",
         "//prow/github:go_default_library",
         "//prow/github/report:go_default_library",
         "//prow/interrupts:go_default_library",

--- a/prow/external-plugins/refresh/main.go
+++ b/prow/external-plugins/refresh/main.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/test-infra/prow/git/v2"
 	"k8s.io/test-infra/prow/interrupts"
 	"k8s.io/test-infra/prow/logrusutil"
 	"k8s.io/test-infra/prow/pjutil"
@@ -101,17 +100,11 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting GitHub client.")
 	}
-	g, err := o.github.GitClient(o.dryRun)
-	if err != nil {
-		logrus.WithError(err).Fatal("Error getting Git client.")
-	}
-	gitClient := git.ClientFactoryFrom(g)
 
 	serv := &server{
 		tokenGenerator: secret.GetTokenGenerator(o.webhookSecretFile),
 		prowURL:        o.prowURL,
 		configAgent:    configAgent,
-		gitClient:      gitClient,
 		ghc:            githubClient,
 		log:            log,
 	}

--- a/prow/external-plugins/refresh/server.go
+++ b/prow/external-plugins/refresh/server.go
@@ -30,7 +30,6 @@ import (
 
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
-	"k8s.io/test-infra/prow/git/v2"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/github/report"
 	"k8s.io/test-infra/prow/pjutil"
@@ -58,7 +57,6 @@ type server struct {
 	tokenGenerator func() []byte
 	prowURL        string
 	configAgent    *config.Agent
-	gitClient      git.ClientFactory
 	ghc            github.Client
 	log            *logrus.Entry
 }
@@ -185,7 +183,7 @@ func (s *server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent
 		}
 
 		s.log.WithFields(l.Data).Infof("Refreshing the status of job %q (pj: %s)", pj.Spec.Job, pj.ObjectMeta.Name)
-		if err := report.Report(context.Background(), s.configAgent.Config(), s.gitClient, s.ghc, reportTemplate, pj, reportTypes); err != nil {
+		if err := report.Report(context.Background(), s.ghc, reportTemplate, pj, reportTypes); err != nil {
 			s.log.WithError(err).WithFields(l.Data).Info("Failed report.")
 		}
 	}

--- a/prow/github/report/BUILD.bazel
+++ b/prow/github/report/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
-        "//prow/git/v2:go_default_library",
         "//prow/github:go_default_library",
         "//prow/plugins:go_default_library",
     ],

--- a/prow/jenkins/BUILD.bazel
+++ b/prow/jenkins/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/client/clientset/versioned/typed/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
-        "//prow/git/v2:go_default_library",
         "//prow/github:go_default_library",
         "//prow/github/report:go_default_library",
         "//prow/kube:go_default_library",

--- a/prow/jenkins/controller_test.go
+++ b/prow/jenkins/controller_test.go
@@ -185,16 +185,6 @@ func (f *fghc) EditCommentWithContext(_ context.Context, org, repo string, ID in
 	defer f.Unlock()
 	return nil
 }
-func (f *fghc) GetPullRequest(org, repo string, number int) (*github.PullRequest, error) {
-	f.Lock()
-	defer f.Unlock()
-	return nil, nil
-}
-func (f *fghc) GetRef(org, repo, ref string) (string, error) {
-	f.Lock()
-	defer f.Unlock()
-	return "", nil
-}
 
 func TestSyncTriggeredJobs(t *testing.T) {
 	fakeClock := clock.NewFakeClock(time.Now().Truncate(1 * time.Second))


### PR DESCRIPTION
As discussed in https://github.com/kubernetes/test-infra/pull/23484, reverting #23484 to remove the dependence of crier on inrepoconfig. 

We can discuss how to move forward via idea from https://github.com/kubernetes/test-infra/pull/23484#issuecomment-919412357