### PR TITLE
config/jobs: add ci-test-infra-autobump-prowjobs-for-auto-deploy

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-test-infra.yaml
@@ -113,8 +113,8 @@ periodics:
           cpu: 6
           memory: 32Gi
 
-- cron: "06 14-22 * * 1-5"  # Run every hour at 7:06-15:06 PST (14:06 UTC) Mon-Fri
-  name: ci-test-infra-autobump-prowjobs
+- name: ci-test-infra-autobump-prowjobs
+  cron: "06 14-23 * * 1-5"  # Run every hour at 7:06 - 16:06 PDT (in UTC) Mon-Fri
   cluster: k8s-infra-prow-build-trusted
   decorate: true
   extra_refs:
@@ -139,6 +139,38 @@ periodics:
   annotations:
     testgrid-dashboards: sig-testing-prow
     testgrid-tab-name: autobump-prowjobs
-    description: runs experiment/autobumper to create/update a PR that bumps prowjobs to the latest RC
+    description: runs experiment/autobumper to create/update a PR that bumps prowjob images to latest published version
     testgrid-alert-email: k8s-infra-oncall@google.com
     testgrid-num-failures-to-alert: '3'
+- name: ci-test-infra-autobump-prowjobs-for-auto-deploy
+  # This 1h after ci-k8sio-autobump-prow-build-clusters, 2h before ci-test-infra-autobump-prow-for-auto-deploy
+  cron: "30 15-20/5 * * 1-5"  # Bump with label `skip-review`. Run at 08:30 and 13:30 PDT (in UTC) Mon-Fri
+  cluster: k8s-infra-prow-build-trusted
+  decorate: true
+  extra_refs:
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/generic-autobumper:v20210914-d9fade61b4
+      command:
+      - /app/prow/cmd/generic-autobumper/app.binary
+      args:
+      - --config=config/prow/autobump-config/prow-job-autobump-config.yaml
+      - --labels-override=skip-review # This label is used by tide for identifying trusted PR
+      - --skip-if-no-oncall # Only apply `skip-review` label when oncall is active
+      volumeMounts:
+      - name: github
+        mountPath: /etc/github-token
+        readOnly: true
+    volumes:
+    - name: github
+      secret:
+        secretName: k8s-infra-ci-robot-github-token
+  annotations:
+    testgrid-dashboards: sig-testing-prow
+    testgrid-tab-name: autobump-prowjobs-for-auto-deploy
+    testgrid-alert-email: k8s-infra-oncall@google.com
+    testgrid-num-failures-to-alert: '2' # This could fail when it runs right in the middle of prow push, tolerate it once
+    description: runs autobumper to create/update a PR that bumps prowjob images to latest published version with label 'skip-review'


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1523
- Part of: https://github.com/kubernetes/test-infra/issues/21137
- Related to: https://github.com/kubernetes/enhancements/issues/2539
- Followup to: https://github.com/kubernetes/test-infra/pull/23597

We've been autobumping jobs separately from prow for a while now without incident. Let's start auto-deploying them.

This adopts a similar pattern that's used for prow's auto-deploys:
- 2 auto-deploy runs per day, during on-call hours
- hourly autobumps for humans to approve during on-call hours

See the comments on the jobs to see the rationale for scheduling