### PR TITLE
Add configuration to allow opting out of PJ failure comments created by Crier on GitHub.

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -791,6 +791,9 @@ type GitHubReporter struct {
 	//
 	// defaults to both presubmit and postsubmit jobs.
 	JobTypesToReport []prowapi.ProwJobType `json:"job_types_to_report,omitempty"`
+	// NoCommentRepos is a list of orgs and org/repos for which failure report
+	// comments should not be maintained. Status contexts will still be written.
+	NoCommentRepos []string `json:"no_comment_repos,omitempty"`
 }
 
 // Sinker is config for the sinker controller.

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -440,6 +440,11 @@ github_reporter:
     # defaults to both presubmit and postsubmit jobs.
     job_types_to_report:
       - ""
+
+    # NoCommentRepos is a list of orgs and org/repos for which failure report
+    # comments should not be maintained. Status contexts will still be written.
+    no_comment_repos:
+      - ""
 horologium:
     # TickInterval is the interval in which we check if new jobs need to be
     # created. Defaults to one minute.

--- a/prow/crier/reporters/github/reporter.go
+++ b/prow/crier/reporters/github/reporter.go
@@ -163,7 +163,7 @@ func (c *Client) Report(ctx context.Context, log *logrus.Entry, pj *v1.ProwJob) 
 	}
 
 	// TODO(krzyzacy): ditch ReportTemplate, and we can drop reference to config.Getter
-	err := report.Report(ctx, c.gc, c.config().Plank.ReportTemplateForRepo(pj.Spec.Refs), *pj, c.config().GitHubReporter.JobTypesToReport)
+	err := report.Report(ctx, c.gc, c.config().Plank.ReportTemplateForRepo(pj.Spec.Refs), *pj, c.config().GitHubReporter)
 	if err != nil {
 		if strings.Contains(err.Error(), "This SHA and context has reached the maximum number of statuses") {
 			// This is completely unrecoverable, so just swallow the error to make sure we wont retry, even when crier gets restarted.

--- a/prow/external-plugins/refresh/server.go
+++ b/prow/external-plugins/refresh/server.go
@@ -169,7 +169,7 @@ func (s *server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent
 
 	jenkinsConfig := s.configAgent.Config().JenkinsOperators
 	kubeReport := s.configAgent.Config().Plank.ReportTemplateForRepo(&prowapi.Refs{Org: org, Repo: repo})
-	reportTypes := s.configAgent.Config().GitHubReporter.JobTypesToReport
+	reportConfig := s.configAgent.Config().GitHubReporter
 	for _, pj := range pjutil.GetLatestProwJobs(presubmits, prowapi.PresubmitJob) {
 		var reportTemplate *template.Template
 		switch pj.Spec.Agent {
@@ -183,7 +183,7 @@ func (s *server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent
 		}
 
 		s.log.WithFields(l.Data).Infof("Refreshing the status of job %q (pj: %s)", pj.Spec.Job, pj.ObjectMeta.Name)
-		if err := report.Report(context.Background(), s.ghc, reportTemplate, pj, reportTypes); err != nil {
+		if err := report.Report(context.Background(), s.ghc, reportTemplate, pj, reportConfig); err != nil {
 			s.log.WithError(err).WithFields(l.Data).Info("Failed report.")
 		}
 	}

--- a/prow/jenkins/controller.go
+++ b/prow/jenkins/controller.go
@@ -220,11 +220,11 @@ func (c *Controller) Sync() error {
 
 	var reportErrs []error
 	if !c.skipReport {
-		reportTypes := c.cfg().GitHubReporter.JobTypesToReport
+		reportConfig := c.cfg().GitHubReporter
 		jConfig := c.config()
 		for report := range reportCh {
 			reportTemplate := jConfig.ReportTemplateForRepo(report.Spec.Refs)
-			if err := reportlib.Report(context.Background(), c.ghc, reportTemplate, report, reportTypes); err != nil {
+			if err := reportlib.Report(context.Background(), c.ghc, reportTemplate, report, reportConfig); err != nil {
 				reportErrs = append(reportErrs, err)
 				c.log.WithFields(pjutil.ProwJobFields(&report)).WithError(err).Warn("Failed to report ProwJob status")
 			}


### PR DESCRIPTION
We need this to address a load issue on one of our instances. Crier is consuming too much GH rate limit listing issue comments and is the overwhelming source of rate limit usage for the instance.

/assign @chaodaiG 
/cc @alvaroaleman 