### PR TITLE
Enable image preloading in all scalability tests.

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -99,6 +99,8 @@ presets:
   # TODO(https://github.com/kubernetes/perf-tests/issues/1828): Use konnectivity in kubemark.
   - name: KUBE_ENABLE_KONNECTIVITY_SERVICE
     value: false
+  - name: NODE_PRELOAD_IMAGES
+    value: k8s.gcr.io/pause:3.1
 
 ### kubemark-gce-scale
 - labels:
@@ -236,6 +238,8 @@ presets:
     value: "containerd"
   - name: DUMP_TO_GCS_ONLY
     value: true
+  - name: NODE_PRELOAD_IMAGES
+    value: k8s.gcr.io/pause:3.1
 
   ###### Scalability Envs
   ### Common env variables for containerd scalability-related suites.
@@ -309,8 +313,6 @@ presets:
 - labels:
     preset-e2e-scalability-periodics: "true"
   env:
-  - name: NODE_PRELOAD_IMAGES
-    value: k8s.gcr.io/pause:3.1
 
 - labels:
     preset-e2e-scalability-periodics-master: "true"


### PR DESCRIPTION
As described in https://github.com/kubernetes/test-infra/pull/19710#issue-510849500

After having few green runs in periodics for each minor, let's move NODE_PRELOAD_IMAGES to `preset-e2e-scalability-common` and `preset-e2e-kubemark-common`.

The expected diff is: adding this env to presubmits (which should be safe as we already tested in CI).

/assign @wojtek-t 