### PR TITLE
releng(kubekins, krte): Update Golang versions to go1.16.8

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.16.7
+    GO_VERSION: 1.16.8
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
@@ -28,13 +28,13 @@ variants:
     OLD_BAZEL_VERSION: 2.2.0
   '1.22':
     CONFIG: '1.22'
-    GO_VERSION: 1.16.7
+    GO_VERSION: 1.16.8
     K8S_RELEASE: stable-1.22
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.21':
     CONFIG: '1.21'
-    GO_VERSION: 1.16.7
+    GO_VERSION: 1.16.8
     K8S_RELEASE: stable-1.21
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
Part of https://github.com/kubernetes/release/issues/2238
Ready to land, now that the k/k go1.16.8 PRs are merged: https://github.com/kubernetes/kubernetes/pull/104906 / https://github.com/kubernetes/kubernetes/pull/104905


/assign @justaugustus @puerco @xmudrii @Verolop @BenTheElder 
cc: @kubernetes/release-engineering
