### PR TITLE
config/jobs: migrate some straggling k8s-testimages/kubekins jobs

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.21-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.21-config.yaml
@@ -9,7 +9,7 @@ presubmits:
     path_alias: "k8s.io/cloud-provider-openstack"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210915-5dbaf53-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210915-5dbaf53458-master
         command:
         - make
         args:

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.22-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.22-config.yaml
@@ -9,7 +9,7 @@ presubmits:
     path_alias: "k8s.io/cloud-provider-openstack"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210915-5dbaf53-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210915-5dbaf53458-master
         command:
         - make
         args:


### PR DESCRIPTION
Related:
- Part of https://github.com/kubernetes/k8s.io/issues/1523
- Followup to: https://github.com/kubernetes/test-infra/pull/23544

I think these were from PRs that sat open while https://github.com/kubernetes/test-infra/pull/23544 merged