### PR TITLE
bugzilla: handle slightly incorrect external PRs better

### DIFF
--- a/prow/bugzilla/client.go
+++ b/prow/bugzilla/client.go
@@ -945,7 +945,7 @@ func IdentifierForPull(org, repo string, num int) string {
 
 func PullFromIdentifier(identifier string) (org, repo string, num int, err error) {
 	parts := strings.Split(identifier, "/")
-	if len(parts) != 4 {
+	if len(parts) != 4 && !(len(parts) == 5 && (parts[4] == "" || parts[4] == "files")) && !(len(parts) == 6 && (parts[4] == "files" && parts[5] == "")) {
 		return "", "", 0, fmt.Errorf("invalid pull identifier with %d parts: %q", len(parts), identifier)
 	}
 	if parts[2] != "pull" {

--- a/prow/bugzilla/client_test.go
+++ b/prow/bugzilla/client_test.go
@@ -907,6 +907,27 @@ func TestPullFromIdentifier(t *testing.T) {
 			expectedNum:  1234,
 		},
 		{
+			name:         "extra `/` at end works correctly",
+			identifier:   "organization/repository/pull/1234/",
+			expectedOrg:  "organization",
+			expectedRepo: "repository",
+			expectedNum:  1234,
+		},
+		{
+			name:         "extra `/files` included works correctly",
+			identifier:   "organization/repository/pull/1234/files",
+			expectedOrg:  "organization",
+			expectedRepo: "repository",
+			expectedNum:  1234,
+		},
+		{
+			name:         "extra `/files/` included works correctly",
+			identifier:   "organization/repository/pull/1234/files/",
+			expectedOrg:  "organization",
+			expectedRepo: "repository",
+			expectedNum:  1234,
+		},
+		{
 			name:        "wrong number of parts fails",
 			identifier:  "organization/repository",
 			expectedErr: true,


### PR DESCRIPTION
A few times, a user has decided to manually add a PR to a bugzilla bug
and either included an unnecessary `/`, `/files`, or `/files/` at the
end of the URL, which causes the client to throw an error. These are
minor issues but they can break some automation quite easily and require
someone to manually remove the offending PR to fix the problem and
unblock bugzilla automation. It's simpler to just handle these
situations directly in the client, as these extra parts don't affect the
rest of the URL and still work fine.

/cc @stevekuznetsov