### PR TITLE
[Bugzilla] Allow the bugzilla client to use a Bearer Authorization token

### DIFF
--- a/prow/bugzilla/client.go
+++ b/prow/bugzilla/client.go
@@ -677,8 +677,10 @@ func (c *client) GetComments(bugID int) ([]Comment, error) {
 func (c *client) request(req *http.Request, logger *logrus.Entry) ([]byte, error) {
 	if apiKey := c.getAPIKey(); len(apiKey) > 0 {
 		// some BugZilla servers are too old and can't handle the header.
-		// some don't want the query parameter. We can set both and keep
+		// some don't want the query parameter and some need Bearer Authorization instead.
+		// We can set all of them and keep
 		// everyone happy without negotiating on versions
+		req.Header.Set("Authorization", "Bearer "+string(apiKey))
 		req.Header.Set("X-BUGZILLA-API-KEY", string(apiKey))
 		values := req.URL.Query()
 		values.Add("api_key", string(apiKey))


### PR DESCRIPTION
/cc @stevekuznetsov @alvaroaleman 

Some of the Bugzilla instances support only Bearer Authorization headers. This change only adds the extra header to be used.

NOTE: I have tested the co-existence of the `X-BUGZILLA-API-KEY` and `Authorization header and it seems ok.

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>