### PR TITLE
Fetch the validate branch before checkout

### DIFF
--- a/config/jobs/kubernetes/sig-security/cvelist-public.yaml
+++ b/config/jobs/kubernetes/sig-security/cvelist-public.yaml
@@ -15,7 +15,7 @@ presubmits:
         - |
           set -euo pipefail; \
           apt update && apt -y install jq; \
-          [[ -f validate-k8s.sh ]] || git checkout validate -- validate-k8s.sh; \
+          [[ -f validate-k8s.sh ]] || (git fetch https://github.com/kubernetes-security/cvelist-public.git validate && git checkout FETCH_HEAD -- validate-k8s.sh); \
           git diff --name-only --diff-filter=d $PULL_BASE_SHA...$PULL_PULL_SHA | grep "\/CVE.*json$" | xargs ./validate-k8s.sh
     annotations:
       testgrid-create-test-group: "true"


### PR DESCRIPTION
Tests were failing with
```
fatal: invalid reference: validate
```
(https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-security_cvelist-public/8/validate-cve-files/1438352771689484288)

/cc @cjcullen 