### PR TITLE
Use %w when wrapping errors

### DIFF
--- a/def/configmap/main.go
+++ b/def/configmap/main.go
@@ -94,7 +94,7 @@ func buildConfigMap(name, namespace string, labels map[string]string, data map[s
 			buf, err := ioutil.ReadFile(value)
 			if err != nil {
 				wd, _ := os.Getwd()
-				return nil, fmt.Errorf("could not read %s/%s: %v", wd, value, err)
+				return nil, fmt.Errorf("could not read %s/%s: %w", wd, value, err)
 			}
 			cm.Data[key] = string(buf)
 		}

--- a/experiment/aws-stockout/main.go
+++ b/experiment/aws-stockout/main.go
@@ -72,7 +72,7 @@ func run() error {
 
 	o, err := json.MarshalIndent(avail, "", "  ")
 	if err != nil {
-		return fmt.Errorf("error marshaling json: %v", err)
+		return fmt.Errorf("error marshaling json: %w", err)
 	}
 
 	fmt.Printf("\n%s\n", string(o))
@@ -84,7 +84,7 @@ func findRegions() ([]string, error) {
 	config := &aws.Config{}
 	sess, err := session.NewSession(config)
 	if err != nil {
-		return nil, fmt.Errorf("error creating aws session: %v", err)
+		return nil, fmt.Errorf("error creating aws session: %w", err)
 	}
 
 	svc := ec2.New(sess)
@@ -93,7 +93,7 @@ func findRegions() ([]string, error) {
 	{
 		response, err := svc.DescribeRegions(&ec2.DescribeRegionsInput{})
 		if err != nil {
-			return nil, fmt.Errorf("error from DescribeRegions: %v", err)
+			return nil, fmt.Errorf("error from DescribeRegions: %w", err)
 		}
 		for _, r := range response.Regions {
 			regions = append(regions, aws.StringValue(r.RegionName))
@@ -139,7 +139,7 @@ func cleanupInstances(region string) error {
 	config := &aws.Config{Region: aws.String(region)}
 	sess, err := session.NewSession(config)
 	if err != nil {
-		return fmt.Errorf("error creating aws session: %v", err)
+		return fmt.Errorf("error creating aws session: %w", err)
 	}
 
 	svc := ec2.New(sess)
@@ -150,7 +150,7 @@ func cleanupInstances(region string) error {
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("error from DescribeInstances: %v", err)
+		return fmt.Errorf("error from DescribeInstances: %w", err)
 	}
 
 	for _, r := range instancesResponse.Reservations {
@@ -184,7 +184,7 @@ func launchInstance(region string, instanceType string) (string, error) {
 	config := &aws.Config{Region: aws.String(region)}
 	sess, err := session.NewSession(config)
 	if err != nil {
-		return "", fmt.Errorf("error creating aws session: %v", err)
+		return "", fmt.Errorf("error creating aws session: %w", err)
 	}
 
 	svc := ec2.New(sess)
@@ -196,7 +196,7 @@ func launchInstance(region string, instanceType string) (string, error) {
 		},
 	})
 	if err != nil {
-		return "", fmt.Errorf("error describing images: %v", err)
+		return "", fmt.Errorf("error describing images: %w", err)
 	}
 
 	if len(images.Images) == 0 {
@@ -233,7 +233,7 @@ func launchInstance(region string, instanceType string) (string, error) {
 			return "", nil
 		}
 
-		return "", fmt.Errorf("error from RunInstances: %v", err)
+		return "", fmt.Errorf("error from RunInstances: %w", err)
 	}
 
 	zone := aws.StringValue(createResponse.Instances[0].Placement.AvailabilityZone)

--- a/experiment/bumpmonitoring/main.go
+++ b/experiment/bumpmonitoring/main.go
@@ -138,7 +138,7 @@ func (c *client) findConfigToUpdate() error {
 
 		if _, err := os.Stat(fullPath); err != nil {
 			if !os.IsNotExist(err) {
-				return fmt.Errorf("failed to get the file info for %q: %v", fullPath, err)
+				return fmt.Errorf("failed to get the file info for %q: %w", fullPath, err)
 			}
 			logrus.Infof("Skipping %s as it doesn't exist from dst", fullPath)
 		}

--- a/experiment/clustersecretbackup/secretmanager/secretmanager.go
+++ b/experiment/clustersecretbackup/secretmanager/secretmanager.go
@@ -50,7 +50,7 @@ func NewClient(projectID string, dryrun bool) (*Client, error) {
 	ctx := context.Background()
 	client, err := secretmanager.NewClient(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to setup client: %v", err)
+		return nil, fmt.Errorf("failed to setup client: %w", err)
 	}
 	return &Client{ProjectID: projectID, client: client, dryrun: dryrun}, nil
 }
@@ -168,7 +168,7 @@ func (c *Client) GetSecretValue(ctx context.Context, secretName, versionName str
 	// Call the API.
 	result, err := c.client.AccessSecretVersion(ctx, accessRequest)
 	if err != nil {
-		return nil, fmt.Errorf("failed to access secret version: %v", err)
+		return nil, fmt.Errorf("failed to access secret version: %w", err)
 	}
 	return result.Payload.Data, nil
 }

--- a/experiment/image-bumper/bumper/bumper.go
+++ b/experiment/image-bumper/bumper/bumper.go
@@ -106,7 +106,7 @@ func DeconstructTag(tag string) (date, commit, variant string) {
 func (cli *Client) getManifest(imageHost, imageName string) (manifest, error) {
 	resp, err := cli.httpClient.Get("https://" + imageHost + "/v2/" + imageName + "/tags/list")
 	if err != nil {
-		return nil, fmt.Errorf("couldn't fetch tag list: %v", err)
+		return nil, fmt.Errorf("couldn't fetch tag list: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -115,7 +115,7 @@ func (cli *Client) getManifest(imageHost, imageName string) (manifest, error) {
 	}{}
 
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("couldn't parse tag information from registry: %v", err)
+		return nil, fmt.Errorf("couldn't parse tag information from registry: %w", err)
 	}
 
 	return result.Manifest, nil
@@ -198,7 +198,7 @@ func pickBestTag(currentTagParts []string, manifest manifest) (string, error) {
 		}
 		t, err := strconv.ParseInt(v.TimeCreatedMs, 10, 64)
 		if err != nil {
-			return "", fmt.Errorf("couldn't parse timestamp %q: %v", v.TimeCreatedMs, err)
+			return "", fmt.Errorf("couldn't parse timestamp %q: %w", v.TimeCreatedMs, err)
 		}
 		if override || t > latestTime {
 			latestTime = t
@@ -260,13 +260,13 @@ func (cli *Client) UpdateFile(tagPicker func(imageHost, imageName, currentTag st
 	path string, imageFilter *regexp.Regexp) error {
 	content, err := ioutil.ReadFile(path)
 	if err != nil {
-		return fmt.Errorf("failed to read %s: %v", path, err)
+		return fmt.Errorf("failed to read %s: %w", path, err)
 	}
 
 	newContent := updateAllTags(tagPicker, content, imageFilter)
 
 	if err := ioutil.WriteFile(path, newContent, 0644); err != nil {
-		return fmt.Errorf("failed to write %s: %v", path, err)
+		return fmt.Errorf("failed to write %s: %w", path, err)
 	}
 	return nil
 }

--- a/experiment/manual-trigger/manual-trigger.go
+++ b/experiment/manual-trigger/manual-trigger.go
@@ -92,19 +92,19 @@ func sanityCheckFlags(o options) error {
 	if o.githubEndpoint == "" {
 		return fmt.Errorf("empty --github-endpoint")
 	} else if _, err := url.Parse(o.githubEndpoint); err != nil {
-		return fmt.Errorf("bad --github-endpoint provided: %v", err)
+		return fmt.Errorf("bad --github-endpoint provided: %w", err)
 	}
 
 	if o.graphqlEndpoint == "" {
 		return fmt.Errorf("empty --graphql-endpoint")
 	} else if _, err := url.Parse(o.graphqlEndpoint); err != nil {
-		return fmt.Errorf("bad --graphql-endpoint provided: %v", err)
+		return fmt.Errorf("bad --graphql-endpoint provided: %w", err)
 	}
 
 	if o.jenkinsURL == "" {
 		return fmt.Errorf("empty --jenkins-url")
 	} else if _, err := url.Parse(o.jenkinsURL); err != nil {
-		return fmt.Errorf("bad --jenkins-url provided: %v", err)
+		return fmt.Errorf("bad --jenkins-url provided: %w", err)
 	}
 
 	return nil

--- a/experiment/service-account-creator/main.go
+++ b/experiment/service-account-creator/main.go
@@ -92,7 +92,7 @@ func create(project, prefix string) error {
 	create := exec.Command("gcloud", "iam", "service-accounts", "create", "-f", "--project="+project, prefix)
 	create.Stderr = os.Stderr
 	if err := create.Start(); err != nil {
-		return fmt.Errorf("start: %v", err)
+		return fmt.Errorf("start: %w", err)
 	}
 	return create.Wait()
 }
@@ -102,7 +102,7 @@ func describe(user string) error {
 	desc := exec.Command("gcloud", "iam", "service-accounts", "describe", user)
 	desc.Stderr = os.Stderr
 	if err := desc.Start(); err != nil {
-		return fmt.Errorf("start: %v", err)
+		return fmt.Errorf("start: %w", err)
 	}
 	return desc.Wait()
 }
@@ -112,7 +112,7 @@ func addPolicy(project, member, role string) error {
 	add := exec.Command("gcloud", "projects", project, "add-iam-policy-binding", "--member="+member, "--role="+role)
 	add.Stderr = os.Stderr
 	if err := add.Start(); err != nil {
-		return fmt.Errorf("start: %v", err)
+		return fmt.Errorf("start: %w", err)
 	}
 	return add.Wait()
 }
@@ -122,7 +122,7 @@ func removePolicy(project, member, role string) error {
 	remove := exec.Command("gcloud", "projects", project, "remove-iam-policy-binding", "--member="+member, "--role="+role)
 	remove.Stderr = os.Stderr
 	if err := remove.Start(); err != nil {
-		return fmt.Errorf("start: %v", err)
+		return fmt.Errorf("start: %w", err)
 	}
 	return remove.Wait()
 }
@@ -150,14 +150,14 @@ func run(o options) error {
 	if err := describe(user); err != nil {
 		if o.serviceAccountProject == "" {
 			logrus.WithField("serviceAccount", user).Warn("Cannot parse prefix and project from service account")
-			return fmt.Errorf("validate account pre-existence: %v", err)
+			return fmt.Errorf("validate account pre-existence: %w", err)
 		}
 		if cerr := create(o.serviceAccountProject, o.serviceAccountPrefix); err != nil {
-			return fmt.Errorf("create account: %v", cerr)
+			return fmt.Errorf("create account: %w", cerr)
 		}
 	}
 	if err := describe(user); err != nil {
-		return fmt.Errorf("validate account: %v", err)
+		return fmt.Errorf("validate account: %w", err)
 	}
 
 	member := "serviceAccount:" + user

--- a/experiment/slack-oncall-updater/main.go
+++ b/experiment/slack-oncall-updater/main.go
@@ -59,13 +59,13 @@ var rotationToSlackGroup = map[string]string{
 func getJSON(url string, v interface{}) error {
 	resp, err := http.Get(url)
 	if err != nil {
-		return fmt.Errorf("failed to fetch %q: %v", url, err)
+		return fmt.Errorf("failed to fetch %q: %w", url, err)
 	}
 	defer resp.Body.Close()
 	decoder := json.NewDecoder(resp.Body)
 	err = decoder.Decode(v)
 	if err != nil {
-		return fmt.Errorf("failed to decode json from %q: %v", url, err)
+		return fmt.Errorf("failed to decode json from %q: %w", url, err)
 	}
 	return nil
 }
@@ -91,7 +91,7 @@ func updateGroupMembership(token, groupID, userID string) error {
 
 	err := getJSON("https://slack.com/api/usergroups.users.update?token="+token+"&users="+userID+"&usergroup="+groupID, &result)
 	if err != nil {
-		return fmt.Errorf("couldn't make membership request: %v", err)
+		return fmt.Errorf("couldn't make membership request: %w", err)
 	}
 
 	if !result.Ok {
@@ -104,7 +104,7 @@ func updateGroupMembership(token, groupID, userID string) error {
 func getTokenFromPath(path string) (string, error) {
 	content, err := ioutil.ReadFile(path)
 	if err != nil {
-		return "", fmt.Errorf("couldn't open file: %v", err)
+		return "", fmt.Errorf("couldn't open file: %w", err)
 	}
 	return strings.TrimSpace(string(content)), nil
 }

--- a/gcsweb/cmd/gcsweb/gcsweb.go
+++ b/gcsweb/cmd/gcsweb/gcsweb.go
@@ -140,7 +140,7 @@ func getStorageClient(o options) (*storage.Client, error) {
 	if o.oauthTokenFile != "" {
 		b, err := ioutil.ReadFile(o.oauthTokenFile)
 		if err != nil {
-			return nil, fmt.Errorf("error reading oauth token file %s: %v", o.oauthTokenFile, err)
+			return nil, fmt.Errorf("error reading oauth token file %s: %w", o.oauthTokenFile, err)
 		}
 		clientOption = option.WithAPIKey(string(bytes.TrimSpace(b)))
 	}
@@ -151,7 +151,7 @@ func getStorageClient(o options) (*storage.Client, error) {
 
 	storageClient, err := storage.NewClient(ctx, clientOption)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't create the gcs storage client: %v", err)
+		return nil, fmt.Errorf("couldn't create the gcs storage client: %w", err)
 	}
 
 	return storageClient, nil
@@ -294,7 +294,7 @@ func (s *server) handleObject(w http.ResponseWriter, bucket, object string, head
 
 	objReader, err := obj.NewReader(context.Background())
 	if err != nil {
-		return fmt.Errorf("couldn't create the object reader: %v", err)
+		return fmt.Errorf("couldn't create the object reader: %w", err)
 	}
 	defer objReader.Close()
 
@@ -314,7 +314,7 @@ func (s *server) handleObject(w http.ResponseWriter, bucket, object string, head
 	}
 
 	if _, err := io.Copy(w, objReader); err != nil {
-		return fmt.Errorf("coudln't copy data to the response writer: %v", err)
+		return fmt.Errorf("coudln't copy data to the response writer: %w", err)
 	}
 
 	return nil
@@ -338,7 +338,7 @@ func (s *server) handleDirectory(w http.ResponseWriter, bucket, object, path str
 			break
 		}
 		if err != nil {
-			return fmt.Errorf("error while processing object: %v", err)
+			return fmt.Errorf("error while processing object: %w", err)
 		}
 
 		// That means that the object is a file

--- a/gencred/pkg/certificate/certificate.go
+++ b/gencred/pkg/certificate/certificate.go
@@ -54,13 +54,13 @@ func generateCSR() (*certificates.CertificateSigningRequest, []byte, error) {
 	// Generate a new private key.
 	pk, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
-		return nil, nil, fmt.Errorf("generate key: %v", err)
+		return nil, nil, fmt.Errorf("generate key: %w", err)
 	}
 
 	// Marshal pk -> der.
 	der, err := x509.MarshalECPrivateKey(pk)
 	if err != nil {
-		return nil, nil, fmt.Errorf("marshal key to DER: %v", err)
+		return nil, nil, fmt.Errorf("marshal key to DER: %w", err)
 	}
 
 	// Generate PEM key.
@@ -69,7 +69,7 @@ func generateCSR() (*certificates.CertificateSigningRequest, []byte, error) {
 	// Generate a x509 certificate signing request.
 	csrPEM, err := cert.MakeCSR(pk, &pkix.Name{CommonName: "client", Organization: []string{systemPrivilegedGroup}}, nil, nil)
 	if err != nil {
-		return nil, nil, fmt.Errorf("create CSR from key: %v", err)
+		return nil, nil, fmt.Errorf("create CSR from key: %w", err)
 	}
 
 	// Generate a Kubernetes CSR object.
@@ -99,7 +99,7 @@ func requestCSR(clientset kubernetes.Interface, csrObj *certificates.Certificate
 	// Create CSR.
 	csrObj, err := client.Create(context.TODO(), csrObj, metav1.CreateOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("create CSR: %v", err)
+		return nil, fmt.Errorf("create CSR: %w", err)
 	}
 
 	csrName := csrObj.Name
@@ -115,7 +115,7 @@ func requestCSR(clientset kubernetes.Interface, csrObj *certificates.Certificate
 		return true, nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("approve CSR: %v", err)
+		return nil, fmt.Errorf("approve CSR: %w", err)
 	}
 
 	// Get CSR.
@@ -128,7 +128,7 @@ func requestCSR(clientset kubernetes.Interface, csrObj *certificates.Certificate
 		return true, nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("get CSR: %v", err)
+		return nil, fmt.Errorf("get CSR: %w", err)
 	}
 
 	return csrObj.Status.Certificate, nil
@@ -166,17 +166,17 @@ func appendApprovalCondition(csr *certificates.CertificateSigningRequest) {
 func CreateClusterCertificateCredentials(clientset kubernetes.Interface) (certPEM []byte, keyPEM []byte, caPEM []byte, err error) {
 	csrObj, keyPEM, err := generateCSR()
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("generate CSR: %v", err)
+		return nil, nil, nil, fmt.Errorf("generate CSR: %w", err)
 	}
 
 	certPEM, err = requestCSR(clientset, csrObj)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("request CSR: %v", err)
+		return nil, nil, nil, fmt.Errorf("request CSR: %w", err)
 	}
 
 	caPEM, err = getRootCA(clientset)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("get root CA: %v", err)
+		return nil, nil, nil, fmt.Errorf("get root CA: %w", err)
 	}
 
 	return certPEM, keyPEM, caPEM, nil

--- a/gencred/pkg/serviceaccount/serviceaccount.go
+++ b/gencred/pkg/serviceaccount/serviceaccount.go
@@ -57,7 +57,7 @@ func checkSAAuth(clientset kubernetes.Interface) error {
 			},
 		},
 		metav1.CreateOptions{}); err != nil {
-		return fmt.Errorf("bind %s: %v", clusterRole, err)
+		return fmt.Errorf("bind %s: %w", clusterRole, err)
 	} else if !sar.Status.Allowed {
 		return fmt.Errorf("not authorized to bind %s: %s", clusterRole, sar.Status.Reason)
 	}
@@ -86,20 +86,20 @@ func getOrCreateSA(clientset kubernetes.Interface) ([]byte, []byte, error) {
 		// Create ServiceAccount.
 		_, err := client.Create(context.TODO(), saObj, metav1.CreateOptions{})
 		if err != nil {
-			return nil, nil, fmt.Errorf("create SA: %v", err)
+			return nil, nil, fmt.Errorf("create SA: %w", err)
 		}
 	}
 
 	// Get/Create ClusterRoleBinding.
 	err := getOrCreateCRB(clientset)
 	if err != nil {
-		return nil, nil, fmt.Errorf("get or create CRB: %v", err)
+		return nil, nil, fmt.Errorf("get or create CRB: %w", err)
 	}
 
 	// Get ServiceAccount.
 	saObj, err := client.Get(context.TODO(), serviceAccountName, metav1.GetOptions{})
 	if err != nil {
-		return nil, nil, fmt.Errorf("get SA: %v", err)
+		return nil, nil, fmt.Errorf("get SA: %w", err)
 	}
 
 	return getSASecrets(clientset, saObj)
@@ -124,7 +124,7 @@ func getOrCreateCRB(clientset kubernetes.Interface) error {
 	// Create ClusterRoleBinding.
 	_, err := client.Create(context.TODO(), crbObj, metav1.CreateOptions{})
 	if err != nil {
-		return fmt.Errorf("create CRB: %v", err)
+		return fmt.Errorf("create CRB: %w", err)
 	}
 
 	return nil
@@ -141,7 +141,7 @@ func getSASecrets(clientset kubernetes.Interface, saObj *corev1.ServiceAccount) 
 	// Get Secret.
 	secretObj, err := client.Get(context.TODO(), saObj.Secrets[0].Name, metav1.GetOptions{})
 	if err != nil {
-		return nil, nil, fmt.Errorf("get secret: %v", err)
+		return nil, nil, fmt.Errorf("get secret: %w", err)
 	}
 
 	token, ok := secretObj.Data[corev1.ServiceAccountTokenKey]
@@ -161,7 +161,7 @@ func getSASecrets(clientset kubernetes.Interface, saObj *corev1.ServiceAccount) 
 func CreateClusterServiceAccountCredentials(clientset kubernetes.Interface) (token []byte, caPEM []byte, err error) {
 	token, caPEM, err = getOrCreateSA(clientset)
 	if err != nil {
-		return nil, nil, fmt.Errorf("get or create SA: %v", err)
+		return nil, nil, fmt.Errorf("get or create SA: %w", err)
 	}
 
 	return token, caPEM, nil

--- a/ghproxy/ghproxy.go
+++ b/ghproxy/ghproxy.go
@@ -115,7 +115,7 @@ type options struct {
 func (o *options) validate() error {
 	level, err := logrus.ParseLevel(o.logLevel)
 	if err != nil {
-		return fmt.Errorf("invalid log level specified: %v", err)
+		return fmt.Errorf("invalid log level specified: %w", err)
 	}
 	logrus.SetLevel(level)
 
@@ -124,7 +124,7 @@ func (o *options) validate() error {
 	}
 	upstreamURL, err := url.Parse(o.upstream)
 	if err != nil {
-		return fmt.Errorf("failed to parse upstream URL: %v", err)
+		return fmt.Errorf("failed to parse upstream URL: %w", err)
 	}
 	o.upstreamParsed = upstreamURL
 	return nil

--- a/gopherage/pkg/cov/diff.go
+++ b/gopherage/pkg/cov/diff.go
@@ -32,7 +32,7 @@ func DiffProfiles(before []*cover.Profile, after []*cover.Profile) ([]*cover.Pro
 	for i, beforeProfile := range before {
 		afterProfile := after[i]
 		if err := ensureProfilesMatch(beforeProfile, afterProfile); err != nil {
-			return nil, fmt.Errorf("error on profile #%d: %v", i, err)
+			return nil, fmt.Errorf("error on profile #%d: %w", i, err)
 		}
 		diffProfile := cover.Profile{FileName: beforeProfile.FileName, Mode: beforeProfile.Mode}
 		for j, beforeBlock := range beforeProfile.Blocks {

--- a/gopherage/pkg/cov/merge.go
+++ b/gopherage/pkg/cov/merge.go
@@ -46,7 +46,7 @@ func MergeProfiles(a []*cover.Profile, b []*cover.Profile) ([]*cover.Profile, er
 		dest, ok := files[profile.FileName]
 		if ok {
 			if err := ensureProfilesMatch(profile, dest); err != nil {
-				return nil, fmt.Errorf("error merging %s: %v", profile.FileName, err)
+				return nil, fmt.Errorf("error merging %s: %w", profile.FileName, err)
 			}
 			for i, block := range profile.Blocks {
 				db := &dest.Blocks[i]

--- a/gopherage/pkg/util/util.go
+++ b/gopherage/pkg/util/util.go
@@ -34,14 +34,14 @@ func DumpProfile(destination string, profile []*cover.Profile) error {
 	} else {
 		f, err := os.Create(destination)
 		if err != nil {
-			return fmt.Errorf("failed to open %s: %v", destination, err)
+			return fmt.Errorf("failed to open %s: %w", destination, err)
 		}
 		defer f.Close()
 		output = f
 	}
 	err := cov.DumpProfile(profile, output)
 	if err != nil {
-		return fmt.Errorf("failed to dump profile: %v", err)
+		return fmt.Errorf("failed to dump profile: %w", err)
 	}
 	return nil
 }
@@ -56,12 +56,12 @@ func LoadProfile(origin string) ([]*cover.Profile, error) {
 		// We could probably also just give it /dev/stdin, but that'll break on Windows.
 		tf, err := ioutil.TempFile("", "")
 		if err != nil {
-			return nil, fmt.Errorf("failed to create temp file: %v", err)
+			return nil, fmt.Errorf("failed to create temp file: %w", err)
 		}
 		defer tf.Close()
 		defer os.Remove(tf.Name())
 		if _, err := io.Copy(tf, os.Stdin); err != nil {
-			return nil, fmt.Errorf("failed to copy stdin to temp file: %v", err)
+			return nil, fmt.Errorf("failed to copy stdin to temp file: %w", err)
 		}
 		filename = tf.Name()
 	}

--- a/greenhouse/diskcache/cache.go
+++ b/greenhouse/diskcache/cache.go
@@ -102,7 +102,7 @@ func (c *Cache) Put(key string, content io.Reader, contentSHA256 string) error {
 	// create a temp file to get the content on disk
 	temp, err := ioutil.TempFile(dir, "temp-put")
 	if err != nil {
-		return fmt.Errorf("failed to create cache entry: %v", err)
+		return fmt.Errorf("failed to create cache entry: %w", err)
 	}
 
 	// fast path copying when not hashing content,s
@@ -110,7 +110,7 @@ func (c *Cache) Put(key string, content io.Reader, contentSHA256 string) error {
 		_, err = io.Copy(temp, content)
 		if err != nil {
 			removeTemp(temp.Name())
-			return fmt.Errorf("failed to copy into cache entry: %v", err)
+			return fmt.Errorf("failed to copy into cache entry: %w", err)
 		}
 
 	} else {
@@ -118,7 +118,7 @@ func (c *Cache) Put(key string, content io.Reader, contentSHA256 string) error {
 		_, err = io.Copy(io.MultiWriter(temp, hasher), content)
 		if err != nil {
 			removeTemp(temp.Name())
-			return fmt.Errorf("failed to copy into cache entry: %v", err)
+			return fmt.Errorf("failed to copy into cache entry: %w", err)
 		}
 		actualContentSHA256 := hex.EncodeToString(hasher.Sum(nil))
 		if actualContentSHA256 != contentSHA256 {
@@ -133,13 +133,13 @@ func (c *Cache) Put(key string, content io.Reader, contentSHA256 string) error {
 	err = temp.Sync()
 	if err != nil {
 		removeTemp(temp.Name())
-		return fmt.Errorf("failed to sync cache entry: %v", err)
+		return fmt.Errorf("failed to sync cache entry: %w", err)
 	}
 	temp.Close()
 	err = os.Rename(temp.Name(), path)
 	if err != nil {
 		removeTemp(temp.Name())
-		return fmt.Errorf("failed to insert contents into cache: %v", err)
+		return fmt.Errorf("failed to insert contents into cache: %w", err)
 	}
 	return nil
 }
@@ -152,7 +152,7 @@ func (c *Cache) Get(key string, readHandler ReadHandler) error {
 		if os.IsNotExist(err) {
 			return readHandler(false, nil)
 		}
-		return fmt.Errorf("failed to get key: %v", err)
+		return fmt.Errorf("failed to get key: %w", err)
 	}
 	return readHandler(true, f)
 }

--- a/images/builder/main.go
+++ b/images/builder/main.go
@@ -56,7 +56,7 @@ func getProjectID() (string, error) {
 	cmd := exec.Command("gcloud", "config", "get-value", "project")
 	projectID, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("failed to get project_id: %v", err)
+		return "", fmt.Errorf("failed to get project_id: %w", err)
 	}
 	return string(projectID), nil
 }
@@ -65,7 +65,7 @@ func getImageName(o options, tag string, config string) (string, error) {
 	var cloudbuildyamlFile CloudBuildYAMLFile
 	buf, _ := ioutil.ReadFile(o.cloudbuildFile)
 	if err := yaml.Unmarshal(buf, &cloudbuildyamlFile); err != nil {
-		return "", fmt.Errorf("failed to get image name: %v", err)
+		return "", fmt.Errorf("failed to get image name: %w", err)
 	}
 	projectID := o.project
 	// if projectID wasn't set explicitly, discover it
@@ -129,7 +129,7 @@ func (o *options) validateConfigDir() error {
 func (o *options) uploadBuildDir(targetBucket string) (string, error) {
 	f, err := ioutil.TempFile("", "")
 	if err != nil {
-		return "", fmt.Errorf("failed to create temp file: %v", err)
+		return "", fmt.Errorf("failed to create temp file: %w", err)
 	}
 	name := f.Name()
 	_ = f.Close()
@@ -208,7 +208,7 @@ func runSingleJob(o options, jobName, uploaded, version string, subs map[string]
 		f, err := os.Create(logFilePath)
 
 		if err != nil {
-			return fmt.Errorf("couldn't create %s: %v", logFilePath, err)
+			return fmt.Errorf("couldn't create %s: %w", logFilePath, err)
 		}
 
 		defer f.Sync()
@@ -226,7 +226,7 @@ func runSingleJob(o options, jobName, uploaded, version string, subs map[string]
 			buildLog, _ := ioutil.ReadFile(logFilePath)
 			fmt.Println(string(buildLog))
 		}
-		return fmt.Errorf("error running %s: %v", cmd.Args, err)
+		return fmt.Errorf("error running %s: %w", cmd.Args, err)
 	}
 
 	return nil
@@ -238,7 +238,7 @@ func getVariants(o options) (variants, error) {
 	content, err := ioutil.ReadFile(path.Join(o.configDir, "variants.yaml"))
 	if err != nil {
 		if !os.IsNotExist(err) {
-			return nil, fmt.Errorf("failed to load variants.yaml: %v", err)
+			return nil, fmt.Errorf("failed to load variants.yaml: %w", err)
 		}
 		if o.variant != "" {
 			return nil, fmt.Errorf("no variants.yaml found, but a build variant (%q) was specified", o.variant)
@@ -249,7 +249,7 @@ func getVariants(o options) (variants, error) {
 		Variants variants `json:"variants"`
 	}{}
 	if err := yaml.UnmarshalStrict(content, &v); err != nil {
-		return nil, fmt.Errorf("failed to read variants.yaml: %v", err)
+		return nil, fmt.Errorf("failed to read variants.yaml: %w", err)
 	}
 	if o.variant != "" {
 		va, ok := v.Variants[o.variant]
@@ -268,7 +268,7 @@ func runBuildJobs(o options) []error {
 			var err error
 			uploaded, err = o.uploadBuildDir(o.scratchBucket + gcsSourceDir)
 			if err != nil {
-				return []error{fmt.Errorf("failed to upload source: %v", err)}
+				return []error{fmt.Errorf("failed to upload source: %w", err)}
 			}
 		}
 	} else {
@@ -278,7 +278,7 @@ func runBuildJobs(o options) []error {
 	log.Println("Running build jobs...")
 	tag, err := getVersion()
 	if err != nil {
-		return []error{fmt.Errorf("failed to get current tag: %v", err)}
+		return []error{fmt.Errorf("failed to get current tag: %w", err)}
 	}
 
 	if !o.allowDirty && strings.HasSuffix(tag, "-dirty") {
@@ -311,7 +311,7 @@ func runBuildJobs(o options) []error {
 			defer w.Done()
 			log.Printf("Starting job %q...\n", job)
 			if err := runSingleJob(o, job, uploaded, tag, mergeMaps(extraSubs, vc)); err != nil {
-				errors = append(errors, fmt.Errorf("job %q failed: %v", job, err))
+				errors = append(errors, fmt.Errorf("job %q failed: %w", job, err))
 				log.Printf("Job %q failed: %v\n", job, err)
 			} else {
 				var imageName, _ = getImageName(o, tag, job)

--- a/kubetest/aksengine.go
+++ b/kubetest/aksengine.go
@@ -354,7 +354,7 @@ func checkParams() error {
 
 func newAKSEngine() (*aksEngineDeployer, error) {
 	if err := checkParams(); err != nil {
-		return nil, fmt.Errorf("error creating Azure K8S cluster: %v", err)
+		return nil, fmt.Errorf("error creating Azure K8S cluster: %w", err)
 	}
 
 	sshKey, err := ioutil.ReadFile(*aksSSHPublicKeyPath)
@@ -362,13 +362,13 @@ func newAKSEngine() (*aksEngineDeployer, error) {
 		if os.IsNotExist(err) {
 			sshKey = []byte{}
 		} else {
-			return nil, fmt.Errorf("error reading SSH Key %v %v", *aksSSHPublicKeyPath, err)
+			return nil, fmt.Errorf("error reading SSH Key %v %w", *aksSSHPublicKeyPath, err)
 		}
 	}
 
 	outputDir, err := ioutil.TempDir(os.Getenv("HOME"), "tmp")
 	if err != nil {
-		return nil, fmt.Errorf("error creating tempdir: %v", err)
+		return nil, fmt.Errorf("error creating tempdir: %w", err)
 	}
 
 	c := aksEngineDeployer{
@@ -406,7 +406,7 @@ func newAKSEngine() (*aksEngineDeployer, error) {
 	}
 	creds, err := getAzCredentials()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get azure credentials: %v", err)
+		return nil, fmt.Errorf("failed to get azure credentials: %w", err)
 	}
 	c.credentials = creds
 	c.azureBlobContainerURL = fmt.Sprintf(azureBlobContainerURLTemplate, c.credentials.StorageAccountName, os.Getenv("AZ_STORAGE_CONTAINER_NAME"))
@@ -415,11 +415,11 @@ func newAKSEngine() (*aksEngineDeployer, error) {
 
 	err = c.SetCustomCloudProfileEnvironment()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create custom cloud profile file: %v", err)
+		return nil, fmt.Errorf("failed to create custom cloud profile file: %w", err)
 	}
 	err = c.getAzureClient(c.ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate ARM client: %v", err)
+		return nil, fmt.Errorf("failed to generate ARM client: %w", err)
 	}
 	// like kops and gke set KUBERNETES_CONFORMANCE_TEST so the auth is picked up
 	// from kubectl instead of bash inference.
@@ -471,10 +471,10 @@ func (c *aksEngineDeployer) populateAPIModelTemplate() error {
 		// Enforce strict JSON
 		dec.DisallowUnknownFields()
 		if err := dec.Decode(&v); err != nil {
-			return fmt.Errorf("error unmarshaling ApiModel template file: %v", err)
+			return fmt.Errorf("error unmarshaling ApiModel template file: %w", err)
 		}
 	} else {
-		return fmt.Errorf("No template file specified %v", err)
+		return fmt.Errorf("No template file specified %w", err)
 	}
 
 	// replace APIModel template properties from flags
@@ -615,7 +615,7 @@ func (c *aksEngineDeployer) populateAPIModelTemplate() error {
 	c.apiModelPath = path.Join(c.outputDir, "kubernetes.json")
 	err = ioutil.WriteFile(c.apiModelPath, apiModel, 0644)
 	if err != nil {
-		return fmt.Errorf("cannot write apimodel to file: %v", err)
+		return fmt.Errorf("cannot write apimodel to file: %w", err)
 	}
 	return nil
 }
@@ -697,16 +697,16 @@ func (c *aksEngineDeployer) loadARMTemplates() error {
 	c.templateJSON = make(map[string]interface{})
 	err = json.Unmarshal(template, &c.templateJSON)
 	if err != nil {
-		return fmt.Errorf("error unmarshall template %v", err.Error())
+		return fmt.Errorf("error unmarshall template %w", err)
 	}
 	parameters, err := ioutil.ReadFile(path.Join(c.outputDir, "azuredeploy.parameters.json"))
 	if err != nil {
-		return fmt.Errorf("error reading ARM parameters file: %v", err)
+		return fmt.Errorf("error reading ARM parameters file: %w", err)
 	}
 	c.parametersJSON = make(map[string]interface{})
 	err = json.Unmarshal(parameters, &c.parametersJSON)
 	if err != nil {
-		return fmt.Errorf("error unmarshall parameters %v", err.Error())
+		return fmt.Errorf("error unmarshall parameters %w", err)
 	}
 	c.parametersJSON = c.parametersJSON["parameters"].(map[string]interface{})
 
@@ -726,7 +726,7 @@ func (c *aksEngineDeployer) getAzureClient(ctx context.Context) error {
 			c.credentials.ClientID,
 			c.azureIdentitySystem,
 			c.credentials.ClientSecret); err != nil {
-			return fmt.Errorf("error trying to get ADFS Azure Client: %v", err)
+			return fmt.Errorf("error trying to get ADFS Azure Client: %w", err)
 		}
 	} else {
 		if client, err = getAzureClient(env,
@@ -734,7 +734,7 @@ func (c *aksEngineDeployer) getAzureClient(ctx context.Context) error {
 			c.credentials.ClientID,
 			c.credentials.TenantID,
 			c.credentials.ClientSecret); err != nil {
-			return fmt.Errorf("error trying to get Azure Client: %v", err)
+			return fmt.Errorf("error trying to get Azure Client: %w", err)
 		}
 	}
 	c.azureClient = client
@@ -752,21 +752,21 @@ func (c *aksEngineDeployer) createCluster() error {
 	log.Printf("Creating Azure resource group: %v for cluster deployment.", c.resourceGroup)
 	_, err = c.azureClient.EnsureResourceGroup(c.ctx, c.resourceGroup, c.location, nil)
 	if err != nil {
-		return fmt.Errorf("could not ensure resource group: %v", err)
+		return fmt.Errorf("could not ensure resource group: %w", err)
 	}
 
 	log.Printf("Validating deployment ARM templates.")
 	if _, err := c.azureClient.ValidateDeployment(
 		c.ctx, c.resourceGroup, c.name, &c.templateJSON, &c.parametersJSON,
 	); err != nil {
-		return fmt.Errorf("ARM template invalid: %v", err)
+		return fmt.Errorf("ARM template invalid: %w", err)
 	}
 
 	log.Printf("Deploying cluster %v in resource group %v.", c.name, c.resourceGroup)
 	if _, err := c.azureClient.DeployTemplate(
 		c.ctx, c.resourceGroup, c.name, &c.templateJSON, &c.parametersJSON,
 	); err != nil {
-		return fmt.Errorf("cannot deploy: %v", err)
+		return fmt.Errorf("cannot deploy: %w", err)
 	}
 
 	if c.useManagedIdentity && c.identityName != "" {
@@ -793,7 +793,7 @@ func (c *aksEngineDeployer) dockerLogin() error {
 		passwordFile := os.Getenv("DOCKER_PASSWORD_FILE")
 		password, err := ioutil.ReadFile(passwordFile)
 		if err != nil {
-			return fmt.Errorf("error reading docker password file %v: %v", passwordFile, err)
+			return fmt.Errorf("error reading docker password file %v: %w", passwordFile, err)
 		}
 		pwd = strings.TrimSuffix(string(password), "\n")
 	} else {
@@ -805,7 +805,7 @@ func (c *aksEngineDeployer) dockerLogin() error {
 	}
 	cmd := exec.Command("docker", "login", fmt.Sprintf("--username=%s", username), fmt.Sprintf("--password=%s", pwd), server)
 	if err = cmd.Run(); err != nil {
-		return fmt.Errorf("failed Docker login with error: %v", err)
+		return fmt.Errorf("failed Docker login with error: %w", err)
 	}
 	log.Println("Docker login success.")
 	return nil
@@ -817,7 +817,7 @@ func dockerPush(images ...string) error {
 
 		cmd := exec.Command("docker", "push", image)
 		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("failed to push %s: %v", image, err)
+			return fmt.Errorf("failed to push %s: %w", image, err)
 		}
 	}
 
@@ -924,7 +924,7 @@ func (c *aksEngineDeployer) buildHyperkube() error {
 func (c *aksEngineDeployer) uploadToAzureStorage(filePath string) (string, error) {
 	credential, err := azblob.NewSharedKeyCredential(c.credentials.StorageAccountName, c.credentials.StorageAccountKey)
 	if err != nil {
-		return "", fmt.Errorf("new shared key credential: %v", err)
+		return "", fmt.Errorf("new shared key credential: %w", err)
 	}
 	p := azblob.NewPipeline(credential, azblob.PipelineOptions{})
 	URL, _ := url.Parse(c.azureBlobContainerURL)
@@ -932,7 +932,7 @@ func (c *aksEngineDeployer) uploadToAzureStorage(filePath string) (string, error
 	containerURL := azblob.NewContainerURL(*URL, p)
 	file, err := os.Open(filePath)
 	if err != nil {
-		return "", fmt.Errorf("failed to open file %v . Error %v", filePath, err)
+		return "", fmt.Errorf("failed to open file %v . Error %w", filePath, err)
 	}
 	defer file.Close()
 
@@ -1005,7 +1005,7 @@ func (c *aksEngineDeployer) Up() error {
 
 		cmd := exec.Command("curl", "-o", "build-kubemark.sh", *kubemarkBuildScriptURL)
 		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("failed to get build-kubemark.sh from %v: %v", *kubemarkBuildScriptURL, err)
+			return fmt.Errorf("failed to get build-kubemark.sh from %v: %w", *kubemarkBuildScriptURL, err)
 		}
 
 		cmd = exec.Command("bash", "build-kubemark.sh",
@@ -1017,7 +1017,7 @@ func (c *aksEngineDeployer) Up() error {
 			"--location", *kubemarkLocation)
 
 		if err := control.FinishRunning(cmd); err != nil {
-			return fmt.Errorf("failed to build up kubemark environment: %v", err)
+			return fmt.Errorf("failed to build up kubemark environment: %w", err)
 		}
 
 		log.Println("kubemark test finished")
@@ -1028,33 +1028,33 @@ func (c *aksEngineDeployer) Up() error {
 	if c.apiModelPath != "" {
 		templateFile, err := downloadFromURL(c.apiModelPath, path.Join(c.outputDir, "kubernetes.json"), 2)
 		if err != nil {
-			return fmt.Errorf("error downloading ApiModel template: %v with error %v", c.apiModelPath, err)
+			return fmt.Errorf("error downloading ApiModel template: %v with error %w", c.apiModelPath, err)
 		}
 		c.apiModelPath = templateFile
 	}
 
 	err = c.populateAPIModelTemplate()
 	if err != nil {
-		return fmt.Errorf("failed to populate aks-engine apimodel template: %v", err)
+		return fmt.Errorf("failed to populate aks-engine apimodel template: %w", err)
 	}
 
 	if *aksEngineURL != "" {
 		err = c.getAKSEngine(2)
 		if err != nil {
-			return fmt.Errorf("failed to get AKS Engine binary: %v", err)
+			return fmt.Errorf("failed to get AKS Engine binary: %w", err)
 		}
 	}
 	err = c.generateARMTemplates()
 	if err != nil {
-		return fmt.Errorf("failed to generate ARM templates: %v", err)
+		return fmt.Errorf("failed to generate ARM templates: %w", err)
 	}
 	err = c.loadARMTemplates()
 	if err != nil {
-		return fmt.Errorf("error loading ARM templates: %v", err)
+		return fmt.Errorf("error loading ARM templates: %w", err)
 	}
 	err = c.createCluster()
 	if err != nil {
-		return fmt.Errorf("error creating cluster: %v", err)
+		return fmt.Errorf("error creating cluster: %w", err)
 	}
 
 	return nil
@@ -1067,7 +1067,7 @@ func (c *aksEngineDeployer) Build(b buildStrategy) error {
 			return err
 		}
 		if err := c.buildHyperkube(); err != nil {
-			return fmt.Errorf("error building hyperkube %v", err)
+			return fmt.Errorf("error building hyperkube %w", err)
 		}
 	} else if c.aksDeploymentMethod == customK8sComponents &&
 		(!areAllDockerImagesExist(c.customKubeAPIServerImage,
@@ -1104,7 +1104,7 @@ func (c *aksEngineDeployer) Build(b buildStrategy) error {
 		newK8sNodeTarball := filepath.Join(k8sNodeTarballDir, fmt.Sprintf(k8sNodeTarballTemplate, k8sVersion))
 		log.Printf("Renaming %s to %s", oldK8sNodeTarball, newK8sNodeTarball)
 		if err := os.Rename(oldK8sNodeTarball, newK8sNodeTarball); err != nil {
-			return fmt.Errorf("error renaming %s to %s: %v", oldK8sNodeTarball, newK8sNodeTarball, err)
+			return fmt.Errorf("error renaming %s to %s: %w", oldK8sNodeTarball, newK8sNodeTarball, err)
 		}
 
 		var err error
@@ -1125,12 +1125,12 @@ func (c *aksEngineDeployer) Build(b buildStrategy) error {
 
 	if *aksCcm && !areAllDockerImagesExist(c.customCcmImage, c.customCnmImage) {
 		if err := c.buildAzureCloudComponents(); err != nil {
-			return fmt.Errorf("error building Azure cloud components: %v", err)
+			return fmt.Errorf("error building Azure cloud components: %w", err)
 		}
 	}
 	if *aksWinBinaries && !isURLExist(c.aksCustomWinBinariesURL) {
 		if err := c.buildWinZip(); err != nil {
-			return fmt.Errorf("error building windowsZipFile %v", err)
+			return fmt.Errorf("error building windowsZipFile %w", err)
 		}
 	}
 
@@ -1157,17 +1157,17 @@ func (c *aksEngineDeployer) DumpClusterLogs(localPath, gcsPath string) error {
 		const logDumpURLPrefix string = "https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/hack/log-dump/"
 		logDumpScript, err := downloadFromURL(logDumpURLPrefix+"log-dump.sh", path.Join(c.outputDir, "log-dump.sh"), 2)
 		if err != nil {
-			return fmt.Errorf("error downloading log dump script: %v", err)
+			return fmt.Errorf("error downloading log dump script: %w", err)
 		}
 		if err := control.FinishRunning(exec.Command("chmod", "+x", logDumpScript)); err != nil {
-			return fmt.Errorf("error changing access permission for %s: %v", logDumpScript, err)
+			return fmt.Errorf("error changing access permission for %s: %w", logDumpScript, err)
 		}
 		if _, err := downloadFromURL(logDumpURLPrefix+"log-dump-daemonset.yaml", path.Join(c.outputDir, "log-dump-daemonset.yaml"), 2); err != nil {
-			return fmt.Errorf("error downloading log dump manifest: %v", err)
+			return fmt.Errorf("error downloading log dump manifest: %w", err)
 		}
 
 		if err := control.FinishRunning(exec.Command("bash", "-c", logDumpScript)); err != nil {
-			return fmt.Errorf("error running log collection script %s: %v", logDumpScript, err)
+			return fmt.Errorf("error running log collection script %s: %w", logDumpScript, err)
 		}
 		return nil
 	}
@@ -1178,13 +1178,13 @@ func (c *aksEngineDeployer) DumpClusterLogs(localPath, gcsPath string) error {
 
 		masterFQDN := fmt.Sprintf("%s.%s.cloudapp.azure.com", c.dnsPrefix, c.location)
 		if err != nil {
-			return fmt.Errorf("error downloading windows logs dump script: %v", err)
+			return fmt.Errorf("error downloading windows logs dump script: %w", err)
 		}
 		if err := control.FinishRunning(exec.Command("chmod", "+x", winLogDumpScript)); err != nil {
-			return fmt.Errorf("error changing permission for script %s: %v", winLogDumpScript, err)
+			return fmt.Errorf("error changing permission for script %s: %w", winLogDumpScript, err)
 		}
 		if err := control.FinishRunning(exec.Command("bash", "-c", fmt.Sprintf("%s %s %s %s", winLogDumpScript, masterFQDN, c.outputDir, c.sshPrivateKeyPath))); err != nil {
-			return fmt.Errorf("error while running Windows log collector script: %v", err)
+			return fmt.Errorf("error while running Windows log collector script: %w", err)
 		}
 		return nil
 	}

--- a/kubetest/aksengine_helpers.go
+++ b/kubetest/aksengine_helpers.go
@@ -275,12 +275,12 @@ func (az *AzureClient) DeployTemplate(ctx context.Context, resourceGroupName, de
 			},
 		})
 	if err != nil {
-		return de, fmt.Errorf("cannot create deployment: %v", err)
+		return de, fmt.Errorf("cannot create deployment: %w", err)
 	}
 
 	err = future.WaitForCompletionRef(ctx, az.deploymentsClient.Client)
 	if err != nil {
-		return de, fmt.Errorf("cannot get the create deployment future response: %v", err)
+		return de, fmt.Errorf("cannot get the create deployment future response: %w", err)
 	}
 
 	return future.Result(az.deploymentsClient)
@@ -317,7 +317,7 @@ func (az *AzureClient) DeleteResourceGroup(ctx context.Context, groupName string
 	if err == nil {
 		future, err := az.groupsClient.Delete(ctx, groupName)
 		if err != nil {
-			return fmt.Errorf("cannot delete resource group %v: %v", groupName, err)
+			return fmt.Errorf("cannot delete resource group %v: %w", groupName, err)
 		}
 		err = future.WaitForCompletionRef(ctx, az.groupsClient.Client)
 		if err != nil {
@@ -332,7 +332,7 @@ func (az *AzureClient) DeleteResourceGroup(ctx context.Context, groupName string
 func (az *AzureClient) AssignOwnerRoleToIdentity(ctx context.Context, resourceGroupName, identityName string) error {
 	identity, err := az.msiClient.Get(ctx, resourceGroupName, identityName)
 	if err != nil {
-		return fmt.Errorf("failed to get identity's client ID: %v", err)
+		return fmt.Errorf("failed to get identity's client ID: %w", err)
 	}
 
 	identityPrincipalID := identity.PrincipalID.String()
@@ -348,7 +348,7 @@ func (az *AzureClient) AssignOwnerRoleToIdentity(ctx context.Context, resourceGr
 	}
 
 	if _, err := az.authorizationClient.Create(ctx, scope, uuid.NewV1().String(), roleAssignmentParameters); err != nil {
-		return fmt.Errorf("failed to assign 'Owner' role to user assigned identity: %v", err)
+		return fmt.Errorf("failed to assign 'Owner' role to user assigned identity: %w", err)
 	}
 
 	return nil
@@ -368,12 +368,12 @@ func getAzCredentials() (*Creds, error) {
 	content, err := ioutil.ReadFile(*aksCredentialsFile)
 	log.Printf("Reading credentials file %v", *aksCredentialsFile)
 	if err != nil {
-		return nil, fmt.Errorf("error reading credentials file %v %v", *aksCredentialsFile, err)
+		return nil, fmt.Errorf("error reading credentials file %v %w", *aksCredentialsFile, err)
 	}
 	config := Config{}
 	err = toml.Unmarshal(content, &config)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing credentials file %v %v", *aksCredentialsFile, err)
+		return nil, fmt.Errorf("error parsing credentials file %v %w", *aksCredentialsFile, err)
 	}
 	return &config.Creds, nil
 }
@@ -426,7 +426,7 @@ func downloadFromURL(url string, destination string, retry int) (string, error) 
 		if err := httpRead(url, f); err == nil {
 			break
 		}
-		err = fmt.Errorf("url=%s failed get %v: %v", url, destination, err)
+		err = fmt.Errorf("url=%s failed get %v: %w", url, destination, err)
 		if i == retry-1 {
 			return "", err
 		}
@@ -457,15 +457,15 @@ func populateAzureCloudConfig(isVMSS bool, credentials Creds, azureEnvironment, 
 
 	cloudConfig, err := json.MarshalIndent(cc, "", "    ")
 	if err != nil {
-		return fmt.Errorf("error creating Azure cloud config: %v", err)
+		return fmt.Errorf("error creating Azure cloud config: %w", err)
 	}
 
 	cloudConfigPath := path.Join(outputDir, "azure.json")
 	if err := ioutil.WriteFile(cloudConfigPath, cloudConfig, 0644); err != nil {
-		return fmt.Errorf("cannot write Azure cloud config to file: %v", err)
+		return fmt.Errorf("cannot write Azure cloud config to file: %w", err)
 	}
 	if err := os.Setenv("CLOUD_CONFIG", cloudConfigPath); err != nil {
-		return fmt.Errorf("error setting CLOUD_CONFIG=%s: %v", cloudConfigPath, err)
+		return fmt.Errorf("error setting CLOUD_CONFIG=%s: %w", cloudConfigPath, err)
 	}
 
 	return nil

--- a/kubetest/bash.go
+++ b/kubetest/bash.go
@@ -89,12 +89,12 @@ func (b *bashDeployer) GetClusterCreated(gcpProject string) (time.Time, error) {
 		"--project="+gcpProject,
 		"--format=json(name,creationTimestamp)"))
 	if err != nil {
-		return time.Time{}, fmt.Errorf("list instance-group failed : %v", err)
+		return time.Time{}, fmt.Errorf("list instance-group failed : %w", err)
 	}
 
 	created, err := getLatestClusterUpTime(string(res))
 	if err != nil {
-		return time.Time{}, fmt.Errorf("parse time failed : got gcloud res %s, err %v", string(res), err)
+		return time.Time{}, fmt.Errorf("parse time failed : got gcloud res %s, err %w", string(res), err)
 	}
 	return created, nil
 }

--- a/kubetest/dump_test.go
+++ b/kubetest/dump_test.go
@@ -373,10 +373,10 @@ func (m *mockSSHClient) ExecPiped(ctx context.Context, command string, stdout io
 		}
 		if c.command == command {
 			if _, err := stdout.Write(c.stdout); err != nil {
-				return fmt.Errorf("error writing to stdout: %v", err)
+				return fmt.Errorf("error writing to stdout: %w", err)
 			}
 			if _, err := stderr.Write(c.stderr); err != nil {
-				return fmt.Errorf("error writing to stderr: %v", err)
+				return fmt.Errorf("error writing to stderr: %w", err)
 			}
 			m.commands[i] = nil
 			return c.err

--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -67,12 +67,12 @@ func run(deploy deployer, o options) error {
 
 	dump, err := util.OptionalAbsPath(o.dump)
 	if err != nil {
-		return fmt.Errorf("failed handling --dump path: %v", err)
+		return fmt.Errorf("failed handling --dump path: %w", err)
 	}
 
 	dumpPreTestLogs, err := util.OptionalAbsPath(o.dumpPreTestLogs)
 	if err != nil {
-		return fmt.Errorf("failed handling --dump-pre-test-logs path: %v", err)
+		return fmt.Errorf("failed handling --dump-pre-test-logs path: %w", err)
 	}
 
 	if o.up {
@@ -583,7 +583,7 @@ func nodeTest(nodeArgs []string, testArgs, nodeTestArgs, project, zone, runtimeC
 
 	sshKeyPath := os.Getenv("JENKINS_GCE_SSH_PRIVATE_KEY_FILE")
 	if _, err := os.Stat(sshKeyPath); err != nil {
-		return fmt.Errorf("Cannot find ssh key from: %v, err : %v", sshKeyPath, err)
+		return fmt.Errorf("Cannot find ssh key from: %v, err : %w", sshKeyPath, err)
 	}
 
 	artifactsDir, ok := os.LookupEnv("ARTIFACTS")
@@ -635,7 +635,7 @@ func kubemarkUp(dump string, o options, deploy deployer) error {
 	// Stop previously running kubemark cluster (if any).
 	if err := control.XMLWrap(&suite, "Kubemark TearDown Previous", func() error {
 		if err := control.FinishRunning(exec.Command("./test/kubemark/stop-kubemark.sh")); err != nil {
-			return fmt.Errorf("failed to stop kubemark cluster, err: %v", err)
+			return fmt.Errorf("failed to stop kubemark cluster, err: %w", err)
 		}
 		return nil
 	}); err != nil {
@@ -678,7 +678,7 @@ func kubemarkUp(dump string, o options, deploy deployer) error {
 			"--region="+o.gcpZone[:len(o.gcpZone)-2],
 			"--format=value(address)"))
 		if err != nil {
-			return fmt.Errorf("failed to get masterIP: %v", err)
+			return fmt.Errorf("failed to get masterIP: %w", err)
 		}
 
 		masterInternalIP, err = control.Output(exec.Command(
@@ -688,7 +688,7 @@ func kubemarkUp(dump string, o options, deploy deployer) error {
 			"--zone="+o.gcpZone,
 			"--format=value(networkInterfaces[0].networkIP)"))
 		if err != nil {
-			return fmt.Errorf("failed to get masterInternalIP: %v", err)
+			return fmt.Errorf("failed to get masterInternalIP: %w", err)
 		}
 	} else if o.deployment == "aks" {
 		var err error
@@ -698,7 +698,7 @@ func kubemarkUp(dump string, o options, deploy deployer) error {
 			"-n", *aksResourceName,
 			"--query", "fqdn", "-o", "tsv"))
 		if err != nil {
-			return fmt.Errorf("failed to get masterIP: %v", err)
+			return fmt.Errorf("failed to get masterIP: %w", err)
 		}
 		masterInternalIP = masterIP
 	}

--- a/kubetest/e2e/runner.go
+++ b/kubetest/e2e/runner.go
@@ -124,7 +124,7 @@ func (t *GinkgoTester) validate() error {
 	// Check that our files and folders exist.
 	if t.ReportDir != "" {
 		if _, err := os.Stat(t.ReportDir); err != nil {
-			return fmt.Errorf("ReportDir %s must exist before tests are run: %v", t.ReportDir, err)
+			return fmt.Errorf("ReportDir %s must exist before tests are run: %w", t.ReportDir, err)
 		}
 	}
 
@@ -134,7 +134,7 @@ func (t *GinkgoTester) validate() error {
 // Run executes the test (calling ginkgo)
 func (t *GinkgoTester) Run(control *process.Control, extraArgs []string) error {
 	if err := t.validate(); err != nil {
-		return fmt.Errorf("configuration error in GinkgoTester: %v", err)
+		return fmt.Errorf("configuration error in GinkgoTester: %w", err)
 	}
 
 	ginkgoPath, err := t.findBinary("ginkgo")
@@ -225,7 +225,7 @@ func (t *GinkgoTester) findBinary(name string) (string, error) {
 	if bazelBinExists {
 		err := filepath.Walk(bazelBin, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
-				return fmt.Errorf("error from walk: %v", err)
+				return fmt.Errorf("error from walk: %w", err)
 			}
 			if info.Name() != name {
 				return nil
@@ -249,7 +249,7 @@ func (t *GinkgoTester) findBinary(name string) (string, error) {
 			if os.IsNotExist(err) {
 				continue
 			}
-			return "", fmt.Errorf("error from stat %s: %v", loc, err)
+			return "", fmt.Errorf("error from stat %s: %w", loc, err)
 		}
 		if newestLocation == "" || stat.ModTime().After(newestModTime) {
 			newestModTime = stat.ModTime()

--- a/kubetest/extract_k8s.go
+++ b/kubetest/extract_k8s.go
@@ -88,7 +88,7 @@ func (l *extractStrategies) Set(value string) error {
 	}
 
 	if len(*l) == 2 {
-		return fmt.Errorf("May only define at most 2 --extract strategies: %v %v", *l, value)
+		return fmt.Errorf("May only define at most 2 --extract strategies: %v %s", *l, value)
 	}
 	for search, mode := range strategies {
 		re := regexp.MustCompile(search)
@@ -112,7 +112,7 @@ func (l *extractStrategies) Set(value string) error {
 		log.Printf("Matched extraction strategy: %s", search)
 		return nil
 	}
-	return fmt.Errorf("Unknown extraction strategy: %v", value)
+	return fmt.Errorf("Unknown extraction strategy: %s", value)
 
 }
 
@@ -208,7 +208,7 @@ func getNamedBinaries(url, version, tarball string, retry int) error {
 		if err := httpRead(full, f); err == nil {
 			break
 		}
-		err = fmt.Errorf("url=%s version=%s failed get %v: %v", url, version, tarball, err)
+		err = fmt.Errorf("url=%s version=%s failed get %v: %w", url, version, tarball, err)
 		if i == retry-1 {
 			return err
 		}
@@ -225,7 +225,7 @@ func getNamedBinaries(url, version, tarball string, retry int) error {
 
 	cwd, err := os.Getwd()
 	if err != nil {
-		return fmt.Errorf("unable to get current directory: %v", err)
+		return fmt.Errorf("unable to get current directory: %w", err)
 	}
 	log.Printf("Extracting tar file %v into directory %v", f.Name(), cwd)
 
@@ -298,7 +298,7 @@ var getKube = func(url, version string, getSrc bool) error {
 		if err == nil {
 			break
 		}
-		err = fmt.Errorf("U=%s R=%s get-kube.sh failed: %v", url, version, err)
+		err = fmt.Errorf("U=%s R=%s get-kube.sh failed: %w", url, version, err)
 		log.Println(err)
 		sleep(time.Duration(i) * time.Second)
 	}
@@ -458,7 +458,7 @@ func (e extractStrategy) Extract(project, zone, region, ciBucket, releaseBucket 
 			}
 		}
 		if len(release) == 0 {
-			return fmt.Errorf("No releases found in %v", url)
+			return fmt.Errorf("No releases found in %s", url)
 		}
 		return getKube(fmt.Sprintf("file://%s", url), release, extractSrc)
 	case gci, gciCi:
@@ -583,7 +583,7 @@ func (e extractStrategy) Extract(project, zone, region, ciBucket, releaseBucket 
 func loadKubeconfig(save string) error {
 	cURL, err := util.JoinURL(save, "kube-config")
 	if err != nil {
-		return fmt.Errorf("bad load url %s: %v", save, err)
+		return fmt.Errorf("bad load url %s: %w", save, err)
 	}
 	if err := os.MkdirAll(util.Home(".kube"), 0775); err != nil {
 		return err
@@ -596,15 +596,15 @@ func loadState(save string, getSrc bool) error {
 
 	uURL, err := util.JoinURL(save, "release-url.txt")
 	if err != nil {
-		return fmt.Errorf("bad load url %s: %v", save, err)
+		return fmt.Errorf("bad load url %s: %w", save, err)
 	}
 	rURL, err := util.JoinURL(save, "release.txt")
 	if err != nil {
-		return fmt.Errorf("bad load url %s: %v", save, err)
+		return fmt.Errorf("bad load url %s: %w", save, err)
 	}
 
 	if err := loadKubeconfig(save); err != nil {
-		return fmt.Errorf("failed loading kubeconfig: %v", err)
+		return fmt.Errorf("failed loading kubeconfig: %w", err)
 	}
 
 	url, err := gsutilCat(uURL)
@@ -624,30 +624,30 @@ func saveState(save string) error {
 	log.Printf("Save U=%s R=%s to %s", url, version, save)
 	cURL, err := util.JoinURL(save, "kube-config")
 	if err != nil {
-		return fmt.Errorf("bad save url %s: %v", save, err)
+		return fmt.Errorf("bad save url %s: %w", save, err)
 	}
 	uURL, err := util.JoinURL(save, "release-url.txt")
 	if err != nil {
-		return fmt.Errorf("bad save url %s: %v", save, err)
+		return fmt.Errorf("bad save url %s: %w", save, err)
 	}
 	rURL, err := util.JoinURL(save, "release.txt")
 	if err != nil {
-		return fmt.Errorf("bad save url %s: %v", save, err)
+		return fmt.Errorf("bad save url %s: %w", save, err)
 	}
 
 	if err := control.FinishRunning(exec.Command("gsutil", "cp", util.Home(".kube", "config"), cURL)); err != nil {
-		return fmt.Errorf("failed to save .kube/config to %s: %v", cURL, err)
+		return fmt.Errorf("failed to save .kube/config to %s: %w", cURL, err)
 	}
 	if cmd, err := control.InputCommand(url, "gsutil", "cp", "-", uURL); err != nil {
-		return fmt.Errorf("failed to write url %s to %s: %v", url, uURL, err)
+		return fmt.Errorf("failed to write url %s to %s: %w", url, uURL, err)
 	} else if err = control.FinishRunning(cmd); err != nil {
-		return fmt.Errorf("failed to upload url %s to %s: %v", url, uURL, err)
+		return fmt.Errorf("failed to upload url %s to %s: %w", url, uURL, err)
 	}
 
 	if cmd, err := control.InputCommand(version, "gsutil", "cp", "-", rURL); err != nil {
-		return fmt.Errorf("failed to write release %s to %s: %v", version, rURL, err)
+		return fmt.Errorf("failed to write release %s to %s: %w", version, rURL, err)
 	} else if err = control.FinishRunning(cmd); err != nil {
-		return fmt.Errorf("failed to upload release %s to %s: %v", version, rURL, err)
+		return fmt.Errorf("failed to upload release %s to %s: %w", version, rURL, err)
 	}
 	return nil
 }

--- a/kubetest/kops.go
+++ b/kubetest/kops.go
@@ -341,7 +341,7 @@ func newKops(provider, gcpProject, cluster string) (*kops, error) {
 		kopsBin := filepath.Join(tmpdir, "kops")
 		f, err := os.Create(kopsBin)
 		if err != nil {
-			return nil, fmt.Errorf("error creating file %q: %v", kopsBin, err)
+			return nil, fmt.Errorf("error creating file %q: %w", kopsBin, err)
 		}
 		defer f.Close()
 		if err := httpRead(kopsBinURL, f); err != nil {
@@ -433,7 +433,7 @@ func (k kops) Up() error {
 	if k.adminAccess == "" {
 		externalIPRange, err := getExternalIPRange()
 		if err != nil {
-			return fmt.Errorf("external IP cannot be retrieved: %v", err)
+			return fmt.Errorf("external IP cannot be retrieved: %w", err)
 		}
 
 		log.Printf("Using external IP for admin access: %v", externalIPRange)
@@ -480,12 +480,12 @@ func (k kops) Up() error {
 	createArgs = append(createArgs, "--yes")
 
 	if err := control.FinishRunning(exec.Command(k.path, createArgs...)); err != nil {
-		return fmt.Errorf("kops create cluster failed: %v", err)
+		return fmt.Errorf("kops create cluster failed: %w", err)
 	}
 
 	// TODO: Once this gets support for N checks in a row, it can replace the above node readiness check
 	if err := control.FinishRunning(exec.Command(k.path, "validate", "cluster", k.cluster, "--wait", "15m")); err != nil {
-		return fmt.Errorf("kops validate cluster failed: %v", err)
+		return fmt.Errorf("kops validate cluster failed: %w", err)
 	}
 
 	// We require repeated successes, so we know that the cluster is stable
@@ -496,7 +496,7 @@ func (k kops) Up() error {
 
 	// Wait for nodes to become ready
 	if err := waitForReadyNodes(k.nodes+1, *kopsUpTimeout, requiredConsecutiveSuccesses); err != nil {
-		return fmt.Errorf("kops nodes not ready: %v", err)
+		return fmt.Errorf("kops nodes not ready: %w", err)
 	}
 
 	return nil
@@ -549,12 +549,12 @@ func (k kops) DumpClusterLogs(localPath, gcsPath string) error {
 	}
 	key, err := ioutil.ReadFile(privateKeyPath)
 	if err != nil {
-		return fmt.Errorf("error reading private key %q: %v", k.sshPrivateKey, err)
+		return fmt.Errorf("error reading private key %q: %w", k.sshPrivateKey, err)
 	}
 
 	signer, err := ssh.ParsePrivateKey(key)
 	if err != nil {
-		return fmt.Errorf("error parsing private key %q: %v", k.sshPrivateKey, err)
+		return fmt.Errorf("error parsing private key %q: %w", k.sshPrivateKey, err)
 	}
 
 	sshConfig := &ssh.ClientConfig{
@@ -600,7 +600,7 @@ func (k kops) DumpClusterLogs(localPath, gcsPath string) error {
 func (k *kops) dumpAllNodes(ctx context.Context, d *logDumper) error {
 	// Make sure kubeconfig is set, in particular before calling DumpAllNodes, which calls kubectlGetNodes
 	if err := k.TestSetup(); err != nil {
-		return fmt.Errorf("error setting up kubeconfig: %v", err)
+		return fmt.Errorf("error setting up kubeconfig: %w", err)
 	}
 
 	var additionalIPs []string
@@ -641,7 +641,7 @@ func (k kops) TestSetup() error {
 	}
 
 	if err := control.FinishRunning(exec.Command(k.path, "export", "kubecfg", k.cluster)); err != nil {
-		return fmt.Errorf("failure from 'kops export kubecfg %s': %v", k.cluster, err)
+		return fmt.Errorf("failure from 'kops export kubecfg %s': %w", k.cluster, err)
 	}
 
 	// Double-check that the file was exported
@@ -660,7 +660,7 @@ func (k kops) TestSetup() error {
 func (k kops) BuildTester(o *e2e.BuildTesterOptions) (e2e.Tester, error) {
 	kubecfg, err := parseKubeconfig(k.kubecfg)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing kubeconfig %q: %v", k.kubecfg, err)
+		return nil, fmt.Errorf("error parsing kubeconfig %q: %w", k.kubecfg, err)
 	}
 
 	log.Printf("running ginkgo tests directly")
@@ -722,7 +722,7 @@ func (k kops) Down() error {
 		ctx := context.Background()
 		client, err := storage.NewClient(ctx)
 		if err != nil {
-			return fmt.Errorf("error building storage API client: %v", err)
+			return fmt.Errorf("error building storage API client: %w", err)
 		}
 		bkt := client.Bucket(*kopsState)
 		if err := bkt.Delete(ctx); err != nil {
@@ -767,7 +767,7 @@ func (k *kops) runKopsDump() (*kopsDump, error) {
 
 	dump := &kopsDump{}
 	if err := json.Unmarshal(o, dump); err != nil {
-		return nil, fmt.Errorf("error parsing kops toolbox dump output: %v", err)
+		return nil, fmt.Errorf("error parsing kops toolbox dump output: %w", err)
 	}
 
 	return dump, nil
@@ -813,7 +813,7 @@ func getRandomAWSZones(masterCount int, multipleZones bool) ([]string, error) {
 		// az for a region. AWS Go API does not allow us to make a single call
 		zoneResults, err := ec2Session.DescribeAvailabilityZones(&ec2.DescribeAvailabilityZonesInput{})
 		if err != nil {
-			return nil, fmt.Errorf("unable to call aws api DescribeAvailabilityZones for %q: %v", awsRegions[i], err)
+			return nil, fmt.Errorf("unable to call aws api DescribeAvailabilityZones for %q: %w", awsRegions[i], err)
 		}
 
 		var selectedZones []string
@@ -844,7 +844,7 @@ func getAWSEC2Session(region string) (*ec2.EC2, error) {
 
 	s, err := session.NewSession(config)
 	if err != nil {
-		return nil, fmt.Errorf("unable to build aws API session with region: %q: %v", region, err)
+		return nil, fmt.Errorf("unable to build aws API session with region: %q: %w", region, err)
 	}
 
 	return ec2.New(s, config), nil
@@ -871,7 +871,7 @@ func parseKubeconfig(kubeconfigPath string) (*kubeconfig, error) {
 
 	cfg := &kubeconfig{}
 	if err := json.Unmarshal(o, cfg); err != nil {
-		return nil, fmt.Errorf("error parsing kubectl config view output: %v", err)
+		return nil, fmt.Errorf("error parsing kubectl config view output: %w", err)
 	}
 
 	return cfg, nil
@@ -882,7 +882,7 @@ func setupGCEStateStore(projectId string) (*string, error) {
 	ctx := context.Background()
 	client, err := storage.NewClient(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("error building storage API client: %v", err)
+		return nil, fmt.Errorf("error building storage API client: %w", err)
 	}
 	name := gceBucketName(projectId)
 	bkt := client.Bucket(name)

--- a/kubetest/kubernetes.go
+++ b/kubetest/kubernetes.go
@@ -38,7 +38,7 @@ func kubectlGetNodes(cmd string) (*nodeList, error) {
 
 	nodes := &nodeList{}
 	if err := json.Unmarshal(o, nodes); err != nil {
-		return nil, fmt.Errorf("error parsing kubectl get nodes output: %v", err)
+		return nil, fmt.Errorf("error parsing kubectl get nodes output: %w", err)
 	}
 
 	return nodes, nil
@@ -120,7 +120,7 @@ func kubectlGetPods(ctx context.Context, namespace string, labelSelector []strin
 
 	pods := &podList{}
 	if err := json.Unmarshal(o, pods); err != nil {
-		return nil, fmt.Errorf("error parsing kubectl get pods output: %v", err)
+		return nil, fmt.Errorf("error parsing kubectl get pods output: %w", err)
 	}
 
 	return pods, nil

--- a/kubetest/local.go
+++ b/kubetest/local.go
@@ -63,7 +63,7 @@ func (n localCluster) getScript(scriptPath string) (string, error) {
 	if _, err := os.Stat(path); err == nil {
 		return path, nil
 	}
-	return "", fmt.Errorf("unable to find script %v in directory %v", scriptPath, cwd)
+	return "", fmt.Errorf("unable to find script %v in directory %s", scriptPath, cwd)
 }
 
 func (n localCluster) Up() error {

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -216,15 +216,15 @@ var suite util.TestSuite = util.TestSuite{Name: "kubetest"}
 func validWorkingDirectory() error {
 	cwd, err := os.Getwd()
 	if err != nil {
-		return fmt.Errorf("could not get pwd: %v", err)
+		return fmt.Errorf("could not get pwd: %w", err)
 	}
 	acwd, err := filepath.Abs(cwd)
 	if err != nil {
-		return fmt.Errorf("failed to convert %s to an absolute path: %v", cwd, err)
+		return fmt.Errorf("failed to convert %s to an absolute path: %w", cwd, err)
 	}
 	// This also matches "kubernetes_skew" for upgrades.
 	if !strings.Contains(filepath.Base(acwd), "kubernetes") {
-		return fmt.Errorf("must run from kubernetes directory root. current: %v", acwd)
+		return fmt.Errorf("must run from kubernetes directory root. current: %s", acwd)
 	}
 	return nil
 }
@@ -353,13 +353,13 @@ func complete(o *options) error {
 		o.testArgs += fmt.Sprintf(" --logexporter-gcs-path=%s", o.logexporterGCSPath)
 	}
 	if err := prepare(o); err != nil {
-		return fmt.Errorf("failed to prepare test environment: %v", err)
+		return fmt.Errorf("failed to prepare test environment: %w", err)
 	}
 	// Get the deployer before we acquire k8s so any additional flag
 	// verifications happen early.
 	deploy, err := getDeployer(o)
 	if err != nil {
-		return fmt.Errorf("error creating deployer: %v", err)
+		return fmt.Errorf("error creating deployer: %w", err)
 	}
 
 	// Check soaking before run tests
@@ -377,18 +377,18 @@ func complete(o *options) error {
 	}
 
 	if err := acquireKubernetes(o, deploy); err != nil {
-		return fmt.Errorf("failed to acquire k8s binaries: %v", err)
+		return fmt.Errorf("failed to acquire k8s binaries: %w", err)
 	}
 	if o.extract.Enabled() {
 		// If we specified `--extract-source` we will already be in the correct directory
 		if !o.extractSource {
 			if err := os.Chdir("kubernetes"); err != nil {
-				return fmt.Errorf("failed to chdir to kubernetes dir: %v", err)
+				return fmt.Errorf("failed to chdir to kubernetes dir: %w", err)
 			}
 		}
 	}
 	if err := validWorkingDirectory(); err != nil {
-		return fmt.Errorf("called from invalid working directory: %v", err)
+		return fmt.Errorf("called from invalid working directory: %w", err)
 	}
 
 	if o.down {
@@ -669,10 +669,10 @@ func prepareGcp(o *options) error {
 			o.gcpNodeImage = distro
 			o.gcpMasterImage = distro
 			if err := os.Setenv("KUBE_NODE_OS_DISTRIBUTION", distro); err != nil {
-				return fmt.Errorf("could not set KUBE_NODE_OS_DISTRIBUTION=%s: %v", distro, err)
+				return fmt.Errorf("could not set KUBE_NODE_OS_DISTRIBUTION=%s: %w", distro, err)
 			}
 			if err := os.Setenv("KUBE_MASTER_OS_DISTRIBUTION", distro); err != nil {
-				return fmt.Errorf("could not set KUBE_MASTER_OS_DISTRIBUTION=%s: %v", distro, err)
+				return fmt.Errorf("could not set KUBE_MASTER_OS_DISTRIBUTION=%s: %w", distro, err)
 			}
 		}
 
@@ -760,7 +760,7 @@ func prepareGcp(o *options) error {
 		defer cancel()
 		p, err := boskos.AcquireWait(ctx, resType, "free", "busy")
 		if err != nil {
-			return fmt.Errorf("--provider=%s boskos failed to acquire project: %v", o.provider, err)
+			return fmt.Errorf("--provider=%s boskos failed to acquire project: %w", o.provider, err)
 		}
 
 		if p == nil {
@@ -778,17 +778,17 @@ func prepareGcp(o *options) error {
 	}
 
 	if err := os.Setenv("CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS", "1"); err != nil {
-		return fmt.Errorf("could not set CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS=1: %v", err)
+		return fmt.Errorf("could not set CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS=1: %w", err)
 	}
 
 	if err := control.FinishRunning(exec.Command("gcloud", "config", "set", "project", o.gcpProject)); err != nil {
-		return fmt.Errorf("fail to set project %s : err %v", o.gcpProject, err)
+		return fmt.Errorf("fail to set project %s : err %w", o.gcpProject, err)
 	}
 
 	// TODO(krzyzacy):Remove this when we retire migrateGcpEnvAndOptions
 	// Note that a lot of scripts are still depend on this env in k/k repo.
 	if err := os.Setenv("PROJECT", o.gcpProject); err != nil {
-		return fmt.Errorf("fail to set env var PROJECT %s : err %v", o.gcpProject, err)
+		return fmt.Errorf("fail to set env var PROJECT %s : err %w", o.gcpProject, err)
 	}
 
 	// Ensure ssh keys exist

--- a/kubetest/process/process.go
+++ b/kubetest/process/process.go
@@ -157,7 +157,7 @@ func (c *Control) FinishRunning(cmd *exec.Cmd) error {
 
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("error starting %v: %v", stepName, err)
+		return fmt.Errorf("error starting %v: %w", stepName, err)
 	}
 
 	finished := make(chan error)
@@ -212,7 +212,7 @@ func (c *Control) FinishRunning(cmd *exec.Cmd) error {
 				} else if c.isInterrupted() {
 					suffix = " (interrupted)"
 				}
-				return fmt.Errorf("error during %s%s: %v", stepName, suffix, err)
+				return fmt.Errorf("error during %s%s: %w", stepName, suffix, err)
 			}
 			return err
 		}
@@ -243,7 +243,7 @@ func (c *Control) executeParallelCommand(cmd *exec.Cmd, resChan chan cmdExecResu
 
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	if err := cmd.Start(); err != nil {
-		resChan <- cmdExecResult{stepName: stepName, output: stdout.String(), execTime: time.Since(start), err: fmt.Errorf("error starting %v: %v", stepName, err)}
+		resChan <- cmdExecResult{stepName: stepName, output: stdout.String(), execTime: time.Since(start), err: fmt.Errorf("error starting %v: %w", stepName, err)}
 		return
 	}
 
@@ -262,7 +262,7 @@ func (c *Control) executeParallelCommand(cmd *exec.Cmd, resChan chan cmdExecResu
 				} else if c.isInterrupted() {
 					suffix = " (interrupted)"
 				}
-				err = fmt.Errorf("error during %s%s: %v", stepName, suffix, err)
+				err = fmt.Errorf("error during %s%s: %w", stepName, suffix, err)
 			}
 			resChan <- cmdExecResult{stepName: stepName, output: stdout.String(), execTime: time.Since(start), err: err}
 			return

--- a/kubetest/util.go
+++ b/kubetest/util.go
@@ -91,7 +91,7 @@ type instanceGroup struct {
 func getLatestClusterUpTime(gcloudJSON string) (time.Time, error) {
 	igs := []instanceGroup{}
 	if err := json.Unmarshal([]byte(gcloudJSON), &igs); err != nil {
-		return time.Time{}, fmt.Errorf("error when unmarshal json: %v", err)
+		return time.Time{}, fmt.Errorf("error when unmarshal json: %w", err)
 	}
 
 	latest := time.Time{}
@@ -99,7 +99,7 @@ func getLatestClusterUpTime(gcloudJSON string) (time.Time, error) {
 	for _, ig := range igs {
 		created, err := time.Parse(time.RFC3339, ig.CreationTimestamp)
 		if err != nil {
-			return time.Time{}, fmt.Errorf("error when parse time from %s: %v", ig.CreationTimestamp, err)
+			return time.Time{}, fmt.Errorf("error when parse time from %s: %w", ig.CreationTimestamp, err)
 		}
 
 		if created.After(latest) {
@@ -228,7 +228,7 @@ func getChannelGKEVersion(project, zone, region, gkeChannel string) (string, err
 func gcsWrite(dest string, contents []byte) error {
 	f, err := ioutil.TempFile("", "")
 	if err != nil {
-		return fmt.Errorf("error creating temp file: %v", err)
+		return fmt.Errorf("error creating temp file: %w", err)
 	}
 
 	defer func() {
@@ -238,11 +238,11 @@ func gcsWrite(dest string, contents []byte) error {
 	}()
 
 	if _, err := f.Write(contents); err != nil {
-		return fmt.Errorf("error writing temp file: %v", err)
+		return fmt.Errorf("error writing temp file: %w", err)
 	}
 
 	if err := f.Close(); err != nil {
-		return fmt.Errorf("error closing temp file: %v", err)
+		return fmt.Errorf("error closing temp file: %w", err)
 	}
 
 	return control.FinishRunning(exec.Command("gsutil", "cp", f.Name(), dest))
@@ -256,7 +256,7 @@ func setKubeShhBastionEnv(gcpProject, gcpZone, sshProxyInstanceName string) erro
 		"--zone="+gcpZone,
 		"--format=get(networkInterfaces[0].accessConfigs[0].natIP)"))
 	if err != nil {
-		return fmt.Errorf("failed to get the external IP address of the '%s' instance: %v",
+		return fmt.Errorf("failed to get the external IP address of the '%s' instance: %w",
 			sshProxyInstanceName, err)
 	}
 	address := strings.TrimSpace(string(value))

--- a/kubetest/util/util.go
+++ b/kubetest/util/util.go
@@ -106,7 +106,7 @@ func JoinURL(urlPath, path string) (string, error) {
 func Pushd(dir string) (func() error, error) {
 	old, err := os.Getwd()
 	if err != nil {
-		return nil, fmt.Errorf("failed to os.Getwd(): %v", err)
+		return nil, fmt.Errorf("failed to os.Getwd(): %w", err)
 	}
 	if err = os.Chdir(dir); err != nil {
 		return nil, err
@@ -120,7 +120,7 @@ func Pushd(dir string) (func() error, error) {
 func PushEnv(env, value string) (func() error, error) {
 	prev, present := os.LookupEnv(env)
 	if err := os.Setenv(env, value); err != nil {
-		return nil, fmt.Errorf("could not set %s: %v", env, err)
+		return nil, fmt.Errorf("could not set %s: %w", env, err)
 	}
 	return func() error {
 		if present {
@@ -160,7 +160,7 @@ func MigrateOptions(m []MigratedOption) error {
 			continue
 		}
 		if err := os.Setenv(s.Env, *s.Option); err != nil {
-			return fmt.Errorf("could not set %s=%s: %v", s.Env, *s.Option, err)
+			return fmt.Errorf("could not set %s=%s: %w", s.Env, *s.Option, err)
 		}
 	}
 	return nil
@@ -236,10 +236,10 @@ func ExecError(err error) string {
 func EnsureExecutable(p string) error {
 	s, err := os.Stat(p)
 	if err != nil {
-		return fmt.Errorf("error doing stat on %q: %v", p, err)
+		return fmt.Errorf("error doing stat on %q: %w", p, err)
 	}
 	if err := os.Chmod(p, s.Mode()|0111); err != nil {
-		return fmt.Errorf("error doing chmod on %q: %v", p, err)
+		return fmt.Errorf("error doing chmod on %q: %w", p, err)
 	}
 	return nil
 }

--- a/label_sync/main.go
+++ b/label_sync/main.go
@@ -271,7 +271,7 @@ func (c Configuration) validate(orgs string) error {
 	// Check default labels
 	defaultSeen, err := validate(c.Default.Labels, "default", make(map[string]string))
 	if err != nil {
-		return fmt.Errorf("invalid config: %v", err)
+		return fmt.Errorf("invalid config: %w", err)
 	}
 
 	// Generate list of orgs
@@ -282,7 +282,7 @@ func (c Configuration) validate(orgs string) error {
 	orgSeen := map[string]map[string]string{}
 	for org, orgConfig := range c.Orgs {
 		if orgSeen[org], err = validate(orgConfig.Labels, org, defaultSeen); err != nil {
-			return fmt.Errorf("invalid config: %v", err)
+			return fmt.Errorf("invalid config: %w", err)
 		}
 	}
 
@@ -298,7 +298,7 @@ func (c Configuration) validate(orgs string) error {
 
 		// Check repo labels for duplicities with default and org-level labels
 		if _, err := validate(repoconfig.Labels, repo, orgSeen[org]); err != nil {
-			return fmt.Errorf("invalid config: %v", err)
+			return fmt.Errorf("invalid config: %w", err)
 		}
 		// If orgs have been specified, warn if repo isn't under orgs
 		if len(orgs) > 0 && !stringInSortedSlice(org, sortedOrgs) {
@@ -515,7 +515,7 @@ func syncLabels(config Configuration, org string, repos RepoLabels) (RepoUpdates
 		}
 		// Check for any duplicate labels
 		if _, err := validate(labels, "", make(map[string]string)); err != nil {
-			validationErrors = append(validationErrors, fmt.Errorf("invalid labels in %s: %v", repo, err))
+			validationErrors = append(validationErrors, fmt.Errorf("invalid labels in %s: %w", repo, err))
 			continue
 		}
 		// Create lowercase map of current labels, checking for dead labels to delete.

--- a/logexporter/cmd/main.go
+++ b/logexporter/cmd/main.go
@@ -81,9 +81,9 @@ func checkConfigValidity() error {
 		return fmt.Errorf("Flag --gcs-path has its value unspecified")
 	}
 	if _, err := os.Stat(*gcloudAuthFilePath); err != nil {
-		return fmt.Errorf("Could not find the gcloud service account file: %v", err)
+		return fmt.Errorf("Could not find the gcloud service account file: %w", err)
 	} else if err := runCommand("gcloud", "auth", "activate-service-account", "--key-file="+*gcloudAuthFilePath); err != nil {
-		return fmt.Errorf("Failed to activate gcloud service account: %v", err)
+		return fmt.Errorf("Failed to activate gcloud service account: %w", err)
 	}
 	return nil
 }
@@ -102,11 +102,11 @@ func createSystemdLogfile(service string, outputMode string, outputDir string) e
 	// Run the command and record the output to a file.
 	output, err := cmd.Output()
 	if err != nil {
-		return fmt.Errorf("Journalctl command for '%v' service failed: %v", service, err)
+		return fmt.Errorf("Journalctl command for '%v' service failed: %w", service, err)
 	}
 	logfile := filepath.Join(outputDir, service+".log")
 	if err := ioutil.WriteFile(logfile, output, 0444); err != nil {
-		return fmt.Errorf("Writing to file of journalctl logs for '%v' service failed: %v", service, err)
+		return fmt.Errorf("Writing to file of journalctl logs for '%v' service failed: %w", service, err)
 	}
 	return nil
 }
@@ -117,11 +117,11 @@ func createFullSystemdLogfile(outputDir string) error {
 	// Run the command and record the output to a file.
 	output, err := cmd.Output()
 	if err != nil {
-		return fmt.Errorf("Journalctl command failed: %v", err)
+		return fmt.Errorf("Journalctl command failed: %w", err)
 	}
 	logfile := filepath.Join(outputDir, "systemd.log")
 	if err := ioutil.WriteFile(logfile, output, 0444); err != nil {
-		return fmt.Errorf("Writing full journalctl logs to file failed: %v", err)
+		return fmt.Errorf("Writing full journalctl logs to file failed: %w", err)
 	}
 	return nil
 }
@@ -195,7 +195,7 @@ func uploadLogfilesToGCS(logDir string) error {
 	cmd := exec.Command("/bin/sh", "-c", fmt.Sprintf("ls %v/*", logDir))
 	output, err := cmd.Output()
 	if err != nil {
-		return fmt.Errorf("Could not list any logfiles: %v", err)
+		return fmt.Errorf("Could not list any logfiles: %w", err)
 	}
 	klog.Infof("List of logfiles available: %v", string(output))
 
@@ -210,7 +210,7 @@ func uploadLogfilesToGCS(logDir string) error {
 		}
 		return writeSuccessMarkerFile()
 	}
-	return fmt.Errorf("Multiple attempts of gsutil failed, the final one due to: %v", err)
+	return fmt.Errorf("Multiple attempts of gsutil failed, the final one due to: %w", err)
 }
 
 // Write a marker file to GCS named after this node to indicate logexporter's success.
@@ -221,12 +221,12 @@ func writeSuccessMarkerFile() error {
 	cmd := exec.Command("gsutil", "-q", "cp", "-", markerFilePath)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		return fmt.Errorf("Failed to get stdin pipe to write marker file: %v", err)
+		return fmt.Errorf("Failed to get stdin pipe to write marker file: %w", err)
 	}
 	io.WriteString(stdin, "")
 	stdin.Close()
 	if err = cmd.Run(); err != nil {
-		return fmt.Errorf("Failed to write marker file to GCS: %v", err)
+		return fmt.Errorf("Failed to write marker file to GCS: %w", err)
 	}
 	return nil
 }

--- a/maintenance/migratestatus/migratestatus.go
+++ b/maintenance/migratestatus/migratestatus.go
@@ -78,7 +78,7 @@ func (o *options) Validate() error {
 	if o.descriptionURL != "" {
 		_, err := url.ParseRequestURI(o.descriptionURL)
 		if err != nil {
-			return fmt.Errorf("'--description' URL '%s' is not valid: %v", o.descriptionURL, err)
+			return fmt.Errorf("'--description' URL '%s' is not valid: %w", o.descriptionURL, err)
 		}
 	}
 
@@ -106,7 +106,7 @@ func (o *options) Validate() error {
 
 	expr, err := regexp.Compile(o.branchFilterRaw)
 	if err != nil {
-		return fmt.Errorf("invalid --branch-filter regular expression: %v", err)
+		return fmt.Errorf("invalid --branch-filter regular expression: %w", err)
 	}
 	o.branchFilter = expr
 

--- a/pkg/benchmarkjunit/integration_test.go
+++ b/pkg/benchmarkjunit/integration_test.go
@@ -35,10 +35,10 @@ import (
 func createTempFile() (string, error) {
 	outFile, err := ioutil.TempFile("", "dummybenchmarks")
 	if err != nil {
-		return "", fmt.Errorf("create error: %v", err)
+		return "", fmt.Errorf("create error: %w", err)
 	}
 	if err := outFile.Close(); err != nil {
-		return "", fmt.Errorf("close error: %v", err)
+		return "", fmt.Errorf("close error: %w", err)
 	}
 	return outFile.Name(), nil
 }

--- a/pkg/benchmarkjunit/parse.go
+++ b/pkg/benchmarkjunit/parse.go
@@ -87,11 +87,11 @@ func recordLogText(s *junit.Suite, text string) {
 func applyPropertiesFromMatch(result *junit.Result, match []string) error {
 	opCount, err := strconv.ParseFloat(match[2], 64)
 	if err != nil {
-		return fmt.Errorf("error parsing opcount %q: %v", match[2], err)
+		return fmt.Errorf("error parsing opcount %q: %w", match[2], err)
 	}
 	opDuration, err := strconv.ParseFloat(match[3], 64)
 	if err != nil {
-		return fmt.Errorf("error parsing ns/op %q: %v", match[3], err)
+		return fmt.Errorf("error parsing ns/op %q: %w", match[3], err)
 	}
 	result.Time = opCount * opDuration / 1000000000 // convert from ns to s.
 	result.SetProperty("op count", match[2])
@@ -142,7 +142,7 @@ func parse(raw []byte) (*junit.Suites, error) {
 			}
 			duration, err := time.ParseDuration(match[3])
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse package test time %q: %v", match[3], err)
+				return nil, fmt.Errorf("failed to parse package test time %q: %w", match[3], err)
 			}
 			suite.Time = duration.Seconds()
 			suites.Suites = append(suites.Suites, suite)
@@ -155,7 +155,7 @@ func parse(raw []byte) (*junit.Suites, error) {
 				Name:      match[1],
 			}
 			if err := applyPropertiesFromMatch(&result, match); err != nil {
-				return nil, fmt.Errorf("error parsing benchmark metric values: %v", err)
+				return nil, fmt.Errorf("error parsing benchmark metric values: %w", err)
 			}
 			suite.Results = append(suite.Results, result)
 			suite.Tests += 1

--- a/pkg/genyaml/genyaml.go
+++ b/pkg/genyaml/genyaml.go
@@ -130,12 +130,12 @@ type Comment struct {
 func marshal(o interface{}) ([]byte, error) {
 	j, err := json.Marshal(o)
 	if err != nil {
-		return nil, fmt.Errorf("error marshaling into JSON: %v", err)
+		return nil, fmt.Errorf("error marshaling into JSON: %w", err)
 	}
 
 	y, err := jsonToYaml(j)
 	if err != nil {
-		return nil, fmt.Errorf("error converting JSON to YAML: %v", err)
+		return nil, fmt.Errorf("error converting JSON to YAML: %w", err)
 	}
 
 	return y, nil
@@ -432,7 +432,7 @@ func (cm *CommentMap) GenYaml(config interface{}) (string, error) {
 
 	err := cm.EncodeYaml(config, encoder)
 	if err != nil {
-		return "", fmt.Errorf("failed to encode config as YAML: %v", err)
+		return "", fmt.Errorf("failed to encode config as YAML: %w", err)
 	}
 
 	return buffer.String(), nil

--- a/pkg/ghclient/core.go
+++ b/pkg/ghclient/core.go
@@ -153,7 +153,7 @@ func (c *Client) depaginate(action string, opts *github.ListOptions, call func()
 	for ; opts.Page <= lastPage; opts.Page++ {
 		resp, err := c.retry(action, wrapper)
 		if err != nil {
-			return allItems, fmt.Errorf("error while depaginating page %d/%d: %v", opts.Page, lastPage, err)
+			return allItems, fmt.Errorf("error while depaginating page %d/%d: %w", opts.Page, lastPage, err)
 		}
 		if resp.LastPage > 0 {
 			lastPage = resp.LastPage

--- a/pkg/ghclient/wrappers.go
+++ b/pkg/ghclient/wrappers.go
@@ -120,9 +120,9 @@ func (c *Client) ForEachPR(owner, repo string, opts *github.PullRequestListOptio
 					}
 					if mungeErr := mungePR(pr); mungeErr != nil {
 						if pr.Number == nil {
-							mungeErr = fmt.Errorf("error munging pull request with nil Number field: %v", mungeErr)
+							mungeErr = fmt.Errorf("error munging pull request with nil Number field: %w", mungeErr)
 						} else {
-							mungeErr = fmt.Errorf("error munging pull request #%d: %v", *pr.Number, mungeErr)
+							mungeErr = fmt.Errorf("error munging pull request #%d: %w", *pr.Number, mungeErr)
 						}
 						if !continueOnError {
 							return nil, resp, &retryAbort{mungeErr}

--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -229,7 +229,7 @@ func (rac *RerunAuthConfig) IsAuthorized(org, user string, cli prowgithub.RerunC
 	for _, gho := range rac.GitHubOrgs {
 		isOrgMember, err := cli.IsMember(gho, user)
 		if err != nil {
-			return false, fmt.Errorf("GitHub failed to fetch members of org %v: %v", gho, err)
+			return false, fmt.Errorf("GitHub failed to fetch members of org %v: %w", gho, err)
 		}
 		if isOrgMember {
 			return true, nil
@@ -238,7 +238,7 @@ func (rac *RerunAuthConfig) IsAuthorized(org, user string, cli prowgithub.RerunC
 	for _, ght := range rac.GitHubTeamIDs {
 		member, err := cli.TeamHasMember(org, ght, user)
 		if err != nil {
-			return false, fmt.Errorf("GitHub failed to fetch members of team %v, verify that you have the correct team number and access token: %v", ght, err)
+			return false, fmt.Errorf("GitHub failed to fetch members of team %v, verify that you have the correct team number and access token: %w", ght, err)
 		}
 		if member {
 			return true, nil
@@ -247,11 +247,11 @@ func (rac *RerunAuthConfig) IsAuthorized(org, user string, cli prowgithub.RerunC
 	for _, ghts := range rac.GitHubTeamSlugs {
 		team, err := cli.GetTeamBySlug(ghts.Slug, ghts.Org)
 		if err != nil {
-			return false, fmt.Errorf("GitHub failed to fetch team with slug %s and org %s: %v", ghts.Slug, ghts.Org, err)
+			return false, fmt.Errorf("GitHub failed to fetch team with slug %s and org %s: %w", ghts.Slug, ghts.Org, err)
 		}
 		member, err := cli.TeamHasMember(org, team.ID, user)
 		if err != nil {
-			return false, fmt.Errorf("GitHub failed to fetch members of team %v: %v", team, err)
+			return false, fmt.Errorf("GitHub failed to fetch members of team %v: %w", team, err)
 		}
 		if member {
 			return true, nil
@@ -638,7 +638,7 @@ func (d *DecorationConfig) Validate() error {
 	// Workload Identity: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
 
 	if err := d.GCSConfiguration.Validate(); err != nil {
-		return fmt.Errorf("GCS configuration is invalid: %v", err)
+		return fmt.Errorf("GCS configuration is invalid: %w", err)
 	}
 	if d.OauthTokenSecret != nil && len(d.SSHKeySecrets) > 0 {
 		return errors.New("both OAuth token and SSH key secrets are specified")
@@ -789,7 +789,7 @@ func (g *GCSConfiguration) Validate() error {
 	}
 	for _, mediaType := range g.MediaTypes {
 		if _, _, err := mime.ParseMediaType(mediaType); err != nil {
-			return fmt.Errorf("invalid extension media type %q: %v", mediaType, err)
+			return fmt.Errorf("invalid extension media type %q: %w", mediaType, err)
 		}
 	}
 	if g.PathStrategy != PathStrategyLegacy && g.PathStrategy != PathStrategyExplicit && g.PathStrategy != PathStrategySingle {

--- a/prow/clonerefs/parse.go
+++ b/prow/clonerefs/parse.go
@@ -73,7 +73,7 @@ func ParseRefs(value string) (*prowapi.Refs, error) {
 		}
 		pullNumber, err := strconv.Atoi(refParts[0])
 		if err != nil {
-			return gitRef, fmt.Errorf("refspec %s invalid: pull request identifier not a number: %v", refValue, err)
+			return gitRef, fmt.Errorf("refspec %s invalid: pull request identifier not a number: %w", refValue, err)
 		}
 		pullRef := prowapi.Pull{
 			Number: pullNumber,

--- a/prow/clonerefs/run.go
+++ b/prow/clonerefs/run.go
@@ -145,11 +145,11 @@ func (o Options) Run() error {
 	results := o.createRecords()
 	logData, err := json.Marshal(results)
 	if err != nil {
-		return fmt.Errorf("marshal clone records: %v", err)
+		return fmt.Errorf("marshal clone records: %w", err)
 	}
 
 	if err := ioutil.WriteFile(o.Log, logData, 0755); err != nil {
-		return fmt.Errorf("write clone records: %v", err)
+		return fmt.Errorf("write clone records: %w", err)
 	}
 
 	var failed int
@@ -208,7 +208,7 @@ func addHostFingerprints(fingerprints []string) (string, []clone.Command, error)
 		}
 		cmds = append(cmds, cmd)
 		if err != nil {
-			return "", cmds, fmt.Errorf("create sshDir %s: %v", sshDir, err)
+			return "", cmds, fmt.Errorf("create sshDir %s: %w", sshDir, err)
 		}
 	}
 
@@ -220,18 +220,18 @@ func addHostFingerprints(fingerprints []string) (string, []clone.Command, error)
 	if err != nil {
 		cmd.Error = err.Error()
 		cmds = append(cmds, cmd)
-		return "", cmds, fmt.Errorf("append %s: %v", knownHostsFile, err)
+		return "", cmds, fmt.Errorf("append %s: %w", knownHostsFile, err)
 	}
 
 	if _, err := f.Write([]byte(strings.Join(fingerprints, "\n"))); err != nil {
 		cmd.Error = err.Error()
 		cmds = append(cmds, cmd)
-		return "", cmds, fmt.Errorf("write fingerprints to %s: %v", knownHostsFile, err)
+		return "", cmds, fmt.Errorf("write fingerprints to %s: %w", knownHostsFile, err)
 	}
 	if err := f.Close(); err != nil {
 		cmd.Error = err.Error()
 		cmds = append(cmds, cmd)
-		return "", cmds, fmt.Errorf("close %s: %v", knownHostsFile, err)
+		return "", cmds, fmt.Errorf("close %s: %w", knownHostsFile, err)
 	}
 	cmds = append(cmds, cmd)
 	logrus.Infof("Updated known_hosts in file: %s", knownHostsFile)
@@ -244,7 +244,7 @@ func addHostFingerprints(fingerprints []string) (string, []clone.Command, error)
 	if err != nil {
 		cmd.Error = err.Error()
 		cmds = append(cmds, cmd)
-		return "", cmds, fmt.Errorf("lookup ssh path: %v", err)
+		return "", cmds, fmt.Errorf("lookup ssh path: %w", err)
 	}
 	cmds = append(cmds, cmd)
 	return fmt.Sprintf("GIT_SSH_COMMAND=%s -o UserKnownHostsFile=%s", ssh, knownHostsFile), cmds, nil
@@ -264,7 +264,7 @@ func addSSHKeys(paths []string) ([]string, []clone.Command, error) {
 	}
 	cmds = append(cmds, cmd)
 	if err != nil {
-		return []string{}, cmds, fmt.Errorf("start ssh-agent: %v", err)
+		return []string{}, cmds, fmt.Errorf("start ssh-agent: %w", err)
 	}
 	logrus.Info("Started SSH agent")
 	// ssh-agent will output three lines of text, in the form:
@@ -311,7 +311,7 @@ func addSSHKeys(paths []string) ([]string, []clone.Command, error) {
 			logrus.Infof("Added SSH key at %s", path)
 			return nil
 		}); err != nil {
-			return env, cmds, fmt.Errorf("walking path %q: %v", keyPath, err)
+			return env, cmds, fmt.Errorf("walking path %q: %w", keyPath, err)
 		}
 	}
 	return env, cmds, nil

--- a/prow/cmd/admission/admission.go
+++ b/prow/cmd/admission/admission.go
@@ -67,14 +67,14 @@ func readRequest(r io.Reader, contentType string) (*admissionapi.AdmissionReques
 	}
 	body, err := ioutil.ReadAll(r)
 	if err != nil {
-		return nil, fmt.Errorf("read body: %v", err)
+		return nil, fmt.Errorf("read body: %w", err)
 	}
 
 	// Can we convert the body into an AdmissionReview?
 	var ar admissionapi.AdmissionReview
 	deserializer := codecs.UniversalDeserializer()
 	if _, _, err := deserializer.Decode(body, nil, &ar); err != nil {
-		return nil, fmt.Errorf("decode body: %v", err)
+		return nil, fmt.Errorf("decode body: %w", err)
 	}
 	return ar.Request, nil
 }
@@ -109,10 +109,10 @@ func writeResponse(ar admissionapi.AdmissionRequest, w io.Writer, decide decider
 	result.Response.UID = ar.UID
 	out, err := json.Marshal(result)
 	if err != nil {
-		return fmt.Errorf("encode response: %v", err)
+		return fmt.Errorf("encode response: %w", err)
 	}
 	if _, err := w.Write(out); err != nil {
-		return fmt.Errorf("write response: %v", err)
+		return fmt.Errorf("write response: %w", err)
 	}
 	return nil
 }
@@ -148,11 +148,11 @@ func onlyUpdateStatus(req admissionapi.AdmissionRequest) (*admissionapi.Admissio
 	// Otherwise, do the specs match?
 	var new prowjobv1.ProwJob
 	if _, _, err := codecs.UniversalDeserializer().Decode(req.Object.Raw, nil, &new); err != nil {
-		return nil, fmt.Errorf("decode new: %v", err)
+		return nil, fmt.Errorf("decode new: %w", err)
 	}
 	var old prowjobv1.ProwJob
 	if _, _, err := codecs.UniversalDeserializer().Decode(req.OldObject.Raw, nil, &old); err != nil {
-		return nil, fmt.Errorf("decode old: %v", err)
+		return nil, fmt.Errorf("decode old: %w", err)
 	}
 	if equality.Semantic.DeepEqual(old.Spec, new.Spec) {
 		logrus.Info("accept update with equivalent spec")

--- a/prow/cmd/admission/main.go
+++ b/prow/cmd/admission/main.go
@@ -53,7 +53,7 @@ func (o *options) parse(flags *flag.FlagSet, args []string) error {
 	flags.StringVar(&o.privateKey, "tls-private-key-file", "", "Path to matching x509 private key.")
 	o.instrumentationOptions.AddFlags(flags)
 	if err := flags.Parse(args); err != nil {
-		return fmt.Errorf("parse flags: %v", err)
+		return fmt.Errorf("parse flags: %w", err)
 	}
 	if len(o.cert) == 0 || len(o.privateKey) == 0 {
 		return errors.New("Both --tls-cert-file and --tls-private-key-file are required for HTTPS")

--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -207,10 +207,10 @@ func (o *options) gatherOptions(flag *flag.FlagSet, args []string) error {
 	o.pluginsConfig.AddFlags(flag)
 	o.storage.AddFlags(flag)
 	if err := flag.Parse(args); err != nil {
-		return fmt.Errorf("parse flags: %v", err)
+		return fmt.Errorf("parse flags: %w", err)
 	}
 	if err := o.DefaultAndValidate(); err != nil {
-		return fmt.Errorf("invalid options: %v", err)
+		return fmt.Errorf("invalid options: %w", err)
 	}
 	return nil
 }
@@ -510,7 +510,7 @@ func validateURLs(c config.ProwConfig) error {
 func validateUnknownFields(cfg interface{}, cfgBytes []byte, filePath string) error {
 	err := yaml.Unmarshal(cfgBytes, &cfg, yaml.DisallowUnknownFields)
 	if err != nil {
-		return fmt.Errorf("unknown fields or bad config in %s: %v", filePath, err)
+		return fmt.Errorf("unknown fields or bad config in %s: %w", filePath, err)
 	}
 	return nil
 }
@@ -985,7 +985,7 @@ func verifyOwnersPresence(cfg *plugins.Configuration, rc FileInRepoExistsChecker
 				if _, nf := err.(*github.FileNotFound); nf {
 					missing = append(missing, repo.FullName)
 				} else {
-					return fmt.Errorf("got error: %v", err)
+					return fmt.Errorf("got error: %w", err)
 				}
 			}
 		}
@@ -1000,7 +1000,7 @@ func verifyOwnersPresence(cfg *plugins.Configuration, rc FileInRepoExistsChecker
 			if _, nf := err.(*github.FileNotFound); nf {
 				missing = append(missing, repo)
 			} else {
-				return fmt.Errorf("got error: %v", err)
+				return fmt.Errorf("got error: %w", err)
 			}
 		}
 	}
@@ -1050,18 +1050,18 @@ func validateInRepoConfig(cfg *config.Config, filePath, repoIdentifier string) e
 	data, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		if !os.IsNotExist(err) {
-			return fmt.Errorf("failed to read file %q: %v", filePath, err)
+			return fmt.Errorf("failed to read file %q: %w", filePath, err)
 		}
 		return nil
 	}
 
 	prowYAML := &config.ProwYAML{}
 	if err := yaml.Unmarshal(data, prowYAML); err != nil {
-		return fmt.Errorf("failed to deserialize content of %q: %v", filePath, err)
+		return fmt.Errorf("failed to deserialize content of %q: %w", filePath, err)
 	}
 
 	if err := config.DefaultAndValidateProwYAML(cfg, prowYAML, repoIdentifier); err != nil {
-		return fmt.Errorf("failed to validate .prow.yaml: %v", err)
+		return fmt.Errorf("failed to validate .prow.yaml: %w", err)
 	}
 
 	return nil

--- a/prow/cmd/deck/job_history.go
+++ b/prow/cmd/deck/job_history.go
@@ -89,7 +89,7 @@ type blobStorageBucket struct {
 // newBlobStorageBucket validates the bucketName and returns a new instance of blobStorageBucket.
 func newBlobStorageBucket(bucketName, storageProvider string, config *config.Config, opener pkgio.Opener) (blobStorageBucket, error) {
 	if err := config.ValidateStorageBucket(bucketName); err != nil {
-		return blobStorageBucket{}, fmt.Errorf("could not instantiate storage bucket: %v", err)
+		return blobStorageBucket{}, fmt.Errorf("could not instantiate storage bucket: %w", err)
 	}
 	return blobStorageBucket{bucketName, storageProvider, opener}, nil
 }
@@ -129,7 +129,7 @@ func readLatestBuild(ctx context.Context, bucket storageBucket, root string) (ui
 	}
 	n, err := strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
 	if err != nil {
-		return emptyID, fmt.Errorf("failed to parse %s: %v", key, err)
+		return emptyID, fmt.Errorf("failed to parse %s: %w", key, err)
 	}
 	return n, nil
 }
@@ -154,7 +154,7 @@ func (bucket blobStorageBucket) resolveSymLink(ctx context.Context, symLink stri
 func (bucket blobStorageBucket) spyglassLink(ctx context.Context, root, id string) (string, error) {
 	p, err := bucket.getPath(ctx, root, id, "")
 	if err != nil {
-		return "", fmt.Errorf("failed to get path: %v", err)
+		return "", fmt.Errorf("failed to get path: %w", err)
 	}
 	return path.Join(spyglassPrefix, bucket.storageProvider, bucket.name, p), nil
 }
@@ -175,11 +175,11 @@ func (bucket blobStorageBucket) getPath(ctx context.Context, root, id, fname str
 func readJSON(ctx context.Context, bucket storageBucket, key string, data interface{}) error {
 	rawData, err := bucket.readObject(ctx, key)
 	if err != nil {
-		return fmt.Errorf("failed to read %s: %v", key, err)
+		return fmt.Errorf("failed to read %s: %w", key, err)
 	}
 	err = json.Unmarshal(rawData, &data)
 	if err != nil {
-		return fmt.Errorf("failed to parse %s: %v", key, err)
+		return fmt.Errorf("failed to parse %s: %w", key, err)
 	}
 	return nil
 }
@@ -316,7 +316,7 @@ func parseJobHistURL(url *url.URL) (storageProvider, bucketName, root string, bu
 	if idVals := url.Query()[idParam]; len(idVals) >= 1 && idVals[0] != "" {
 		buildID, err = strconv.ParseUint(idVals[0], 10, 64)
 		if err != nil {
-			err = fmt.Errorf("invalid value for %s: %v", idParam, err)
+			err = fmt.Errorf("invalid value for %s: %w", idParam, err)
 			return
 		}
 		if buildID < 1 {

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -952,12 +952,12 @@ func renderSpyglass(ctx context.Context, sg *spyglass.Spyglass, cfg config.Gette
 	src = strings.TrimSuffix(src, "/")
 	realPath, err := sg.ResolveSymlink(src)
 	if err != nil {
-		return "", fmt.Errorf("error when resolving real path %s: %v", src, err)
+		return "", fmt.Errorf("error when resolving real path %s: %w", src, err)
 	}
 	src = realPath
 	artifactNames, err := sg.ListArtifacts(ctx, src)
 	if err != nil {
-		return "", fmt.Errorf("error listing artifacts: %v", err)
+		return "", fmt.Errorf("error listing artifacts: %w", err)
 	}
 	if len(artifactNames) == 0 {
 		log.Infof("found no artifacts for %s", src)
@@ -1008,7 +1008,7 @@ lensesLoop:
 		if prowJobName != "" {
 			u, err := url.Parse("/prowjob")
 			if err != nil {
-				return "", fmt.Errorf("error parsing prowjob path: %v", err)
+				return "", fmt.Errorf("error parsing prowjob path: %w", err)
 			}
 			query := url.Values{}
 			query.Set("prowjob", prowJobName)
@@ -1040,7 +1040,7 @@ lensesLoop:
 
 	jobName, buildID, err := common.KeyToJob(src)
 	if err != nil {
-		return "", fmt.Errorf("error determining jobName / buildID: %v", err)
+		return "", fmt.Errorf("error determining jobName / buildID: %w", err)
 	}
 
 	prLink := ""
@@ -1053,7 +1053,7 @@ lensesLoop:
 	if cfg().Deck.Spyglass.Announcement != "" {
 		announcementTmpl, err := template.New("announcement").Parse(cfg().Deck.Spyglass.Announcement)
 		if err != nil {
-			return "", fmt.Errorf("error parsing announcement template: %v", err)
+			return "", fmt.Errorf("error parsing announcement template: %w", err)
 		}
 		runPath, err := sg.RunPath(src)
 		if err != nil {
@@ -1066,7 +1066,7 @@ lensesLoop:
 			ArtifactPath: runPath,
 		})
 		if err != nil {
-			return "", fmt.Errorf("error executing announcement template: %v", err)
+			return "", fmt.Errorf("error executing announcement template: %w", err)
 		}
 		announcement = announcementBuf.String()
 	}
@@ -1122,15 +1122,15 @@ lensesLoop:
 	t := template.New("spyglass.html")
 
 	if _, err := prepareBaseTemplate(o, cfg, csrfToken, t); err != nil {
-		return "", fmt.Errorf("error preparing base template: %v", err)
+		return "", fmt.Errorf("error preparing base template: %w", err)
 	}
 	t, err = t.ParseFiles(path.Join(o.templateFilesLocation, "spyglass.html"))
 	if err != nil {
-		return "", fmt.Errorf("error parsing template: %v", err)
+		return "", fmt.Errorf("error parsing template: %w", err)
 	}
 
 	if err = t.Execute(&viewBuf, sTmpl); err != nil {
-		return "", fmt.Errorf("error rendering template: %v", err)
+		return "", fmt.Errorf("error rendering template: %w", err)
 	}
 	renderElapsed := time.Since(renderStart)
 	log.WithFields(logrus.Fields{

--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -1117,7 +1117,7 @@ func TestSpyglassConfigDefaulting(t *testing.T) {
 			verify: func(_ *config.Config, err error) error {
 				expectedErrMsg := `lens "undef" has no remote_config and could not get default: invalid lens name`
 				if err == nil || err.Error() != expectedErrMsg {
-					return fmt.Errorf("expected err to be %q, was %v", expectedErrMsg, err)
+					return fmt.Errorf("expected err to be %q, was %w", expectedErrMsg, err)
 				}
 				return nil
 			},

--- a/prow/cmd/deck/pluginhelp.go
+++ b/prow/cmd/deck/pluginhelp.go
@@ -54,14 +54,14 @@ func (ha *helpAgent) getHelp() (*pluginhelp.Help, error) {
 	var help pluginhelp.Help
 	resp, err := http.Get(ha.path)
 	if err != nil {
-		return nil, fmt.Errorf("error Getting plugin help: %v", err)
+		return nil, fmt.Errorf("error Getting plugin help: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return nil, fmt.Errorf("response has status code %d", resp.StatusCode)
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&help); err != nil {
-		return nil, fmt.Errorf("error decoding json plugin help: %v", err)
+		return nil, fmt.Errorf("error decoding json plugin help: %w", err)
 	}
 
 	ha.help = &help

--- a/prow/cmd/generic-autobumper/bumper/bumper.go
+++ b/prow/cmd/generic-autobumper/bumper/bumper.go
@@ -299,16 +299,16 @@ func processGerrit(o *Options, prh PRHandler) error {
 	stderr := HideSecretsWriter{Delegate: os.Stderr, Censor: secret.Censor}
 
 	if err := Call(stdout, stderr, gitCmd, "config", "http.cookiefile", o.Gerrit.CookieFile); err != nil {
-		return fmt.Errorf("unable to load cookiefile: %v", err)
+		return fmt.Errorf("unable to load cookiefile: %w", err)
 	}
 	if err := Call(stdout, stderr, gitCmd, "config", "user.name", o.Gerrit.Author); err != nil {
-		return fmt.Errorf("unable to set username: %v", err)
+		return fmt.Errorf("unable to set username: %w", err)
 	}
 	if err := Call(stdout, stderr, gitCmd, "config", "user.email", o.Gerrit.Email); err != nil {
-		return fmt.Errorf("unable to set password: %v", err)
+		return fmt.Errorf("unable to set password: %w", err)
 	}
 	if err := Call(stdout, stderr, gitCmd, "remote", "add", "upstream", o.Gerrit.HostRepo); err != nil {
-		return fmt.Errorf("unable to add upstream remote: %v", err)
+		return fmt.Errorf("unable to add upstream remote: %w", err)
 	}
 	changeId, err := getChangeId(o.Gerrit.Author, o.Gerrit.AutobumpPRIdentifier, "")
 	if err != nil {
@@ -344,7 +344,7 @@ func processGerrit(o *Options, prh PRHandler) error {
 				return err
 			}
 			if err := Call(stdout, stderr, gitCmd, "reset", "HEAD^"); err != nil {
-				return fmt.Errorf("unable to call git reset: %v", err)
+				return fmt.Errorf("unable to call git reset: %w", err)
 			}
 			return gerritCommitandPush(msg, o.Gerrit.AutobumpPRIdentifier, changeId, nil, nil, stdout, stderr)
 		}
@@ -611,7 +611,7 @@ func gerritNoOpChange(changeID string) (bool, error) {
 	}
 	// Get PR with same ChangeID for this bump
 	if err := Call(&outBuf, &garbageBuf, gitCmd, "log", "--all", fmt.Sprintf("--grep=Change-Id: %s", changeID), "-1", "--format=%H"); err != nil {
-		return false, fmt.Errorf("getting previous bump: %v", err)
+		return false, fmt.Errorf("getting previous bump: %w", err)
 	}
 	prevCommit := strings.TrimSpace(outBuf.String())
 	// No current CRs with cur ChangeID means this is not a noOp change
@@ -632,7 +632,7 @@ func gerritNoOpChange(changeID string) (bool, error) {
 func createCR(msg, branch, changeID string, reviewers, cc []string, stdout, stderr io.Writer) error {
 	noOp, err := gerritNoOpChange(changeID)
 	if err != nil {
-		return fmt.Errorf("diffing previous bump: %v", err)
+		return fmt.Errorf("diffing previous bump: %w", err)
 	}
 	if noOp {
 		logrus.Info("CR is a no-op change. Returning without pushing update")
@@ -641,10 +641,10 @@ func createCR(msg, branch, changeID string, reviewers, cc []string, stdout, stde
 
 	pushRef := buildPushRef(branch, reviewers, cc)
 	if err := Call(stdout, stderr, gitCmd, "commit", "-a", "-v", "-m", msg); err != nil {
-		return fmt.Errorf("unable to commit: %v", err)
+		return fmt.Errorf("unable to commit: %w", err)
 	}
 	if err := Call(stdout, stderr, gitCmd, "push", "upstream", pushRef); err != nil {
-		return fmt.Errorf("unable to push: %v", err)
+		return fmt.Errorf("unable to push: %w", err)
 	}
 	return nil
 }

--- a/prow/cmd/gerrit/main.go
+++ b/prow/cmd/gerrit/main.go
@@ -167,12 +167,12 @@ func (st *syncTime) currentState() (client.LastSyncState, error) {
 		logrus.Warnf("lastSyncFallback not found at %q", st.path)
 		return nil, nil
 	} else if err != nil {
-		return nil, fmt.Errorf("open: %v", err)
+		return nil, fmt.Errorf("open: %w", err)
 	}
 	defer io.LogClose(r)
 	buf, err := ioutil.ReadAll(r)
 	if err != nil {
-		return nil, fmt.Errorf("read: %v", err)
+		return nil, fmt.Errorf("read: %w", err)
 	}
 	var state client.LastSyncState
 	if err := json.Unmarshal(buf, &state); err != nil {
@@ -215,18 +215,18 @@ func (st *syncTime) Update(newState client.LastSyncState) error {
 
 	w, err := st.opener.Writer(st.ctx, st.path)
 	if err != nil {
-		return fmt.Errorf("open for write %q: %v", st.path, err)
+		return fmt.Errorf("open for write %q: %w", st.path, err)
 	}
 	stateBytes, err := json.Marshal(targetState)
 	if err != nil {
-		return fmt.Errorf("marshall state: %v", err)
+		return fmt.Errorf("marshall state: %w", err)
 	}
 	if _, err := fmt.Fprint(w, string(stateBytes)); err != nil {
 		io.LogClose(w)
-		return fmt.Errorf("write %q: %v", st.path, err)
+		return fmt.Errorf("write %q: %w", st.path, err)
 	}
 	if err := w.Close(); err != nil {
-		return fmt.Errorf("close %q: %v", st.path, err)
+		return fmt.Errorf("close %q: %w", st.path, err)
 	}
 	st.val = targetState
 	return nil

--- a/prow/cmd/hmac/main.go
+++ b/prow/cmd/hmac/main.go
@@ -260,20 +260,20 @@ func (c *client) handleConfigUpdate() error {
 
 	// Remove the webhooks for the given repos, as well as removing the tokens from the current hmac map.
 	if err := c.handleRemovedRepo(repoRemoved); err != nil {
-		return fmt.Errorf("error handling hmac update for removed repos: %v", err)
+		return fmt.Errorf("error handling hmac update for removed repos: %w", err)
 	}
 
 	// Generate new hmac token for required repos, do batch update for the hmac token secret,
 	// and then iteratively update the webhook for each repo.
 	if err := c.handleAddedRepo(repoAdded); err != nil {
-		return fmt.Errorf("error handling hmac update for new repos: %v", err)
+		return fmt.Errorf("error handling hmac update for new repos: %w", err)
 	}
 	if err := c.handledRotatedRepo(repoRotated); err != nil {
-		return fmt.Errorf("error handling hmac rotations for the repos: %v", err)
+		return fmt.Errorf("error handling hmac rotations for the repos: %w", err)
 	}
 	// Update the hmac token secret first, to guarantee the new tokens are available to hook.
 	if err := c.updateHMACTokenSecret(); err != nil {
-		return fmt.Errorf("error updating hmac tokens: %v", err)
+		return fmt.Errorf("error updating hmac tokens: %w", err)
 	}
 	// HACK: waiting for the hmac k8s secret update to propagate to the pods that are using the secret,
 	// so that components like hook can start respecting the new hmac values.
@@ -282,7 +282,7 @@ func (c *client) handleConfigUpdate() error {
 
 	// Do necessary cleanups after the token and webhook updates are done.
 	if err := c.cleanup(); err != nil {
-		errs = append(errs, fmt.Errorf("error cleaning up %v", err))
+		errs = append(errs, fmt.Errorf("error cleaning up %w", err))
 	}
 
 	return utilerrors.NewAggregate(errs)
@@ -310,12 +310,12 @@ func (c *client) handleRemovedRepo(removed map[string]bool) error {
 			Confirm:          true,
 		}
 		if err := o.Validate(); err != nil {
-			return fmt.Errorf("error validating the options: %v", err)
+			return fmt.Errorf("error validating the options: %w", err)
 		}
 
 		logrus.WithField("repos", repos).Debugf("Deleting webhooks for %q", c.options.hookUrl)
 		if err := o.HandleWebhookConfigChange(); err != nil {
-			return fmt.Errorf("error deleting webhook for repos %q: %v", repos, err)
+			return fmt.Errorf("error deleting webhook for repos %q: %w", repos, err)
 		}
 
 		for _, repo := range repos {
@@ -363,7 +363,7 @@ func (c *client) handledRotatedRepo(rotated map[string]config.ManagedWebhookInfo
 func (c *client) addRepoToBatchUpdate(repo string) error {
 	generatedToken, err := generateNewHMACToken()
 	if err != nil {
-		return fmt.Errorf("error generating a new hmac token for %q: %v", repo, err)
+		return fmt.Errorf("error generating a new hmac token for %q: %w", repo, err)
 	}
 
 	updatedTokenList := github.HMACsForRepo{}
@@ -402,7 +402,7 @@ func (c *client) onboardNewTokenForRepo(repo, generatedToken string) error {
 		Confirm: true,
 	}
 	if err := o.Validate(); err != nil {
-		return fmt.Errorf("error validating the options: %v", err)
+		return fmt.Errorf("error validating the options: %w", err)
 	}
 
 	logrus.WithField("repo", repo).Debugf("Updating the webhook for %q", c.options.hookUrl)
@@ -433,7 +433,7 @@ func (c *client) cleanup() error {
 	}
 	// Update the secret.
 	if err := c.updateHMACTokenSecret(); err != nil {
-		return fmt.Errorf("error updating hmac tokens: %v", err)
+		return fmt.Errorf("error updating hmac tokens: %w", err)
 	}
 	return nil
 }
@@ -447,14 +447,14 @@ func (c *client) updateHMACTokenSecret() error {
 
 	secretContent, err := yaml.Marshal(&c.currentHMACMap)
 	if err != nil {
-		return fmt.Errorf("error converting hmac map to yaml: %v", err)
+		return fmt.Errorf("error converting hmac map to yaml: %w", err)
 	}
 	sec := &corev1.Secret{}
 	sec.Name = c.options.hmacTokenSecretName
 	sec.Namespace = c.options.hmacTokenSecretNamespace
 	sec.StringData = map[string]string{c.options.hmacTokenKey: string(secretContent)}
 	if _, err = c.kubernetesClient.CoreV1().Secrets(c.options.hmacTokenSecretNamespace).Update(context.TODO(), sec, metav1.UpdateOptions{}); err != nil {
-		return fmt.Errorf("error updating the secret: %v", err)
+		return fmt.Errorf("error updating the secret: %w", err)
 	}
 	return nil
 }
@@ -487,7 +487,7 @@ func generateNewHMACToken() (string, error) {
 func getCurrentHMACTokens(kc kubernetes.Interface, ns, secName, key string) ([]byte, error) {
 	sec, err := kc.CoreV1().Secrets(ns).Get(context.TODO(), secName, metav1.GetOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
-		return nil, fmt.Errorf("error getting hmac secret %q: %v", secName, err)
+		return nil, fmt.Errorf("error getting hmac secret %q: %w", secName, err)
 	}
 	if err == nil {
 		buf, ok := sec.Data[key]
@@ -496,5 +496,5 @@ func getCurrentHMACTokens(kc kubernetes.Interface, ns, secName, key string) ([]b
 		}
 		return nil, fmt.Errorf("error getting key %q from the hmac secret %q", key, secName)
 	}
-	return nil, fmt.Errorf("error getting hmac token values: %v", err)
+	return nil, fmt.Errorf("error getting hmac token values: %w", err)
 }

--- a/prow/cmd/invitations-accepter/main.go
+++ b/prow/cmd/invitations-accepter/main.go
@@ -83,7 +83,7 @@ func acceptInvitations(gc githubClient, dryRun bool) error {
 
 	botUser, err := gc.BotUser()
 	if err != nil {
-		return fmt.Errorf("couldn't get bot's user name: %v", err)
+		return fmt.Errorf("couldn't get bot's user name: %w", err)
 	}
 
 	logger := logrus.WithField("bot-user", botUser.Login)
@@ -104,7 +104,7 @@ func acceptOrgInvitations(gc githubClient, dryRun bool, logger *logrus.Entry) er
 
 	orgInvitations, err := gc.ListCurrentUserOrgInvitations()
 	if err != nil {
-		return fmt.Errorf("couldn't get org invitations for the authenticated user: %v", err)
+		return fmt.Errorf("couldn't get org invitations for the authenticated user: %w", err)
 	}
 
 	for _, inv := range orgInvitations {
@@ -126,7 +126,7 @@ func acceptRepoInvitations(gc githubClient, dryRun bool, logger *logrus.Entry) e
 
 	repoInvitations, err := gc.ListCurrentUserRepoInvitations()
 	if err != nil {
-		return fmt.Errorf("couldn't get repo invitations for the authenticated user: %v", err)
+		return fmt.Errorf("couldn't get repo invitations for the authenticated user: %w", err)
 	}
 
 	for _, inv := range repoInvitations {

--- a/prow/cmd/mkpj/main.go
+++ b/prow/cmd/mkpj/main.go
@@ -109,7 +109,7 @@ func (o *options) getPullRequest() (*github.PullRequest, error) {
 	}
 	pr, err := o.githubClient.GetPullRequest(o.org, o.repo, o.pullNumber)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch PullRequest from GitHub: %v", err)
+		return nil, fmt.Errorf("failed to fetch PullRequest from GitHub: %w", err)
 	}
 	o.pullRequest = pr
 	return pr, nil

--- a/prow/cmd/peribolos/main.go
+++ b/prow/cmd/peribolos/main.go
@@ -155,7 +155,7 @@ func (o *options) parseArgs(flags *flag.FlagSet, args []string) error {
 
 	level, err := logrus.ParseLevel(o.logLevel)
 	if err != nil {
-		return fmt.Errorf("--log-level invalid: %v", err)
+		return fmt.Errorf("--log-level invalid: %w", err)
 	}
 	logrus.SetLevel(level)
 
@@ -227,7 +227,7 @@ func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool) (*
 	out := org.Config{}
 	meta, err := client.GetOrg(orgName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get org: %v", err)
+		return nil, fmt.Errorf("failed to get org: %w", err)
 	}
 	out.Metadata.BillingEmail = &meta.BillingEmail
 	out.Metadata.Company = &meta.Company
@@ -248,7 +248,7 @@ func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool) (*
 	}
 	admins, err := client.ListOrgMembers(orgName, github.RoleAdmin)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list org admins: %v", err)
+		return nil, fmt.Errorf("failed to list org admins: %w", err)
 	}
 	logrus.Debugf("Found %d admins", len(admins))
 	for _, m := range admins {
@@ -265,7 +265,7 @@ func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool) (*
 
 	orgMembers, err := client.ListOrgMembers(orgName, github.RoleMember)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list org members: %v", err)
+		return nil, fmt.Errorf("failed to list org members: %w", err)
 	}
 	logrus.Debugf("Found %d members", len(orgMembers))
 	for _, m := range orgMembers {
@@ -275,7 +275,7 @@ func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool) (*
 
 	teams, err := client.ListTeams(orgName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list teams: %v", err)
+		return nil, fmt.Errorf("failed to list teams: %w", err)
 	}
 	logrus.Debugf("Found %d teams", len(teams))
 
@@ -304,7 +304,7 @@ func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool) (*
 		}
 		maintainers, err := client.ListTeamMembers(orgName, t.ID, github.RoleMaintainer)
 		if err != nil {
-			return nil, fmt.Errorf("failed to list team %d(%s) maintainers: %v", t.ID, t.Name, err)
+			return nil, fmt.Errorf("failed to list team %d(%s) maintainers: %w", t.ID, t.Name, err)
 		}
 		logger.Debugf("Found %d maintainers.", len(maintainers))
 		for _, m := range maintainers {
@@ -313,7 +313,7 @@ func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool) (*
 		}
 		teamMembers, err := client.ListTeamMembers(orgName, t.ID, github.RoleMember)
 		if err != nil {
-			return nil, fmt.Errorf("failed to list team %d(%s) members: %v", t.ID, t.Name, err)
+			return nil, fmt.Errorf("failed to list team %d(%s) members: %w", t.ID, t.Name, err)
 		}
 		logger.Debugf("Found %d members.", len(teamMembers))
 		for _, m := range teamMembers {
@@ -334,7 +334,7 @@ func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool) (*
 
 		repos, err := client.ListTeamRepos(orgName, t.ID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to list team %d(%s) repos: %v", t.ID, t.Name, err)
+			return nil, fmt.Errorf("failed to list team %d(%s) repos: %w", t.ID, t.Name, err)
 		}
 		logger.Debugf("Found %d repo permissions.", len(repos))
 		for _, repo := range repos {
@@ -361,14 +361,14 @@ func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool) (*
 
 	repos, err := client.GetRepos(orgName, false)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list org repos: %v", err)
+		return nil, fmt.Errorf("failed to list org repos: %w", err)
 	}
 	logrus.Debugf("Found %d repos", len(repos))
 	out.Repos = make(map[string]org.Repo, len(repos))
 	for _, repo := range repos {
 		full, err := client.GetRepo(orgName, repo.Name)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get repo: %v", err)
+			return nil, fmt.Errorf("failed to get repo: %w", err)
 		}
 		logrus.WithField("repo", full.FullName).Debug("Recording repo.")
 		out.Repos[full.Name] = org.PruneRepoDefaults(org.Repo{
@@ -427,13 +427,13 @@ func configureOrgMembers(opt options, client orgClient, orgName string, orgConfi
 	haveMembers := sets.String{}
 	ms, err := client.ListOrgMembers(orgName, github.RoleAdmin)
 	if err != nil {
-		return fmt.Errorf("failed to list %s admins: %v", orgName, err)
+		return fmt.Errorf("failed to list %s admins: %w", orgName, err)
 	}
 	for _, m := range ms {
 		haveAdmins.Insert(m.Login)
 	}
 	if ms, err = client.ListOrgMembers(orgName, github.RoleMember); err != nil {
-		return fmt.Errorf("failed to list %s members: %v", orgName, err)
+		return fmt.Errorf("failed to list %s members: %w", orgName, err)
 	}
 	for _, m := range ms {
 		haveMembers.Insert(m.Login)
@@ -623,7 +623,7 @@ func configureTeams(client teamClient, orgName string, orgConfig org.Config, max
 	ints := sets.Int{}
 	teamList, err := client.ListTeams(orgName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list teams: %v", err)
+		return nil, fmt.Errorf("failed to list teams: %w", err)
 	}
 	logrus.Debugf("Found %d teams", len(teamList))
 	for _, t := range teamList {
@@ -771,7 +771,7 @@ type orgMetadataClient interface {
 func configureOrgMeta(client orgMetadataClient, orgName string, want org.Metadata) error {
 	cur, err := client.GetOrg(orgName)
 	if err != nil {
-		return fmt.Errorf("failed to get %s metadata: %v", orgName, err)
+		return fmt.Errorf("failed to get %s metadata: %w", orgName, err)
 	}
 	change := false
 	change = updateString(&cur.BillingEmail, want.BillingEmail) || change
@@ -789,7 +789,7 @@ func configureOrgMeta(client orgMetadataClient, orgName string, want org.Metadat
 	change = updateBool(&cur.MembersCanCreateRepositories, want.MembersCanCreateRepositories) || change
 	if change {
 		if _, err := client.EditOrg(orgName, *cur); err != nil {
-			return fmt.Errorf("failed to edit %s metadata: %v", orgName, err)
+			return fmt.Errorf("failed to edit %s metadata: %w", orgName, err)
 		}
 	}
 	return nil
@@ -827,21 +827,21 @@ func configureOrg(opt options, client github.Client, orgName string, orgConfig o
 
 	invitees, err := orgInvitations(opt, client, orgName)
 	if err != nil {
-		return fmt.Errorf("failed to list %s invitations: %v", orgName, err)
+		return fmt.Errorf("failed to list %s invitations: %w", orgName, err)
 	}
 
 	// Invite/remove/update members to the org.
 	if !opt.fixOrgMembers {
 		logrus.Infof("Skipping org member configuration")
 	} else if err := configureOrgMembers(opt, client, orgName, orgConfig, invitees); err != nil {
-		return fmt.Errorf("failed to configure %s members: %v", orgName, err)
+		return fmt.Errorf("failed to configure %s members: %w", orgName, err)
 	}
 
 	// Create repositories in the org
 	if !opt.fixRepos {
 		logrus.Info("Skipping org repositories configuration")
 	} else if err := configureRepos(opt, client, orgName, orgConfig); err != nil {
-		return fmt.Errorf("failed to configure %s repos: %v", orgName, err)
+		return fmt.Errorf("failed to configure %s repos: %w", orgName, err)
 	}
 
 	if !opt.fixTeams {
@@ -852,13 +852,13 @@ func configureOrg(opt options, client github.Client, orgName string, orgConfig o
 	// Find the id and current state of each declared team (create/delete as necessary)
 	githubTeams, err := configureTeams(client, orgName, orgConfig, opt.maximumDelta, opt.ignoreSecretTeams)
 	if err != nil {
-		return fmt.Errorf("failed to configure %s teams: %v", orgName, err)
+		return fmt.Errorf("failed to configure %s teams: %w", orgName, err)
 	}
 
 	for name, team := range orgConfig.Teams {
 		err := configureTeamAndMembers(opt, client, githubTeams, name, orgName, team, nil)
 		if err != nil {
-			return fmt.Errorf("failed to configure %s teams: %v", orgName, err)
+			return fmt.Errorf("failed to configure %s teams: %w", orgName, err)
 		}
 
 		if !opt.fixTeamRepos {
@@ -866,7 +866,7 @@ func configureOrg(opt options, client github.Client, orgName string, orgConfig o
 			continue
 		}
 		if err := configureTeamRepos(client, githubTeams, name, orgName, team); err != nil {
-			return fmt.Errorf("failed to configure %s team %s repos: %v", orgName, name, err)
+			return fmt.Errorf("failed to configure %s team %s repos: %w", orgName, name, err)
 		}
 	}
 	return nil
@@ -991,7 +991,7 @@ func configureRepos(opt options, client repoClient, orgName string, orgConfig or
 
 	repoList, err := client.GetRepos(orgName, false)
 	if err != nil {
-		return fmt.Errorf("failed to get repos: %v", err)
+		return fmt.Errorf("failed to get repos: %w", err)
 	}
 	logrus.Debugf("Found %d repositories", len(repoList))
 	byName := make(map[string]github.Repo, len(repoList))
@@ -1079,20 +1079,20 @@ func configureTeamAndMembers(opt options, client github.Client, githubTeams map[
 	// Configure team metadata
 	err := configureTeam(client, orgName, name, team, gt, parent)
 	if err != nil {
-		return fmt.Errorf("failed to update %s metadata: %v", name, err)
+		return fmt.Errorf("failed to update %s metadata: %w", name, err)
 	}
 
 	// Configure team members
 	if !opt.fixTeamMembers {
 		logrus.Infof("Skipping %s member configuration", name)
 	} else if err = configureTeamMembers(client, orgName, gt, team); err != nil {
-		return fmt.Errorf("failed to update %s members: %v", name, err)
+		return fmt.Errorf("failed to update %s members: %w", name, err)
 	}
 
 	for childName, childTeam := range team.Children {
 		err = configureTeamAndMembers(opt, client, githubTeams, childName, orgName, childTeam, &gt.ID)
 		if err != nil {
-			return fmt.Errorf("failed to update %s child teams: %v", name, err)
+			return fmt.Errorf("failed to update %s child teams: %w", name, err)
 		}
 	}
 
@@ -1145,7 +1145,7 @@ func configureTeam(client editTeamClient, orgName, teamName string, team org.Tea
 
 	if patch { // yes we need to patch
 		if _, err := client.EditTeam(orgName, gt); err != nil {
-			return fmt.Errorf("failed to edit %s team %d(%s): %v", orgName, gt.ID, gt.Name, err)
+			return fmt.Errorf("failed to edit %s team %d(%s): %w", orgName, gt.ID, gt.Name, err)
 		}
 	}
 	return nil
@@ -1168,7 +1168,7 @@ func configureTeamRepos(client teamRepoClient, githubTeams map[string]github.Tea
 	have := map[string]github.RepoPermissionLevel{}
 	repos, err := client.ListTeamRepos(orgName, gt.ID)
 	if err != nil {
-		return fmt.Errorf("failed to list team %d(%s) repos: %v", gt.ID, name, err)
+		return fmt.Errorf("failed to list team %d(%s) repos: %w", gt.ID, name, err)
 	}
 	for _, repo := range repos {
 		have[repo.Name] = github.LevelFromPermissions(repo.Permissions)
@@ -1210,13 +1210,13 @@ func configureTeamRepos(client teamRepoClient, githubTeams map[string]github.Tea
 		}
 
 		if err != nil {
-			updateErrors = append(updateErrors, fmt.Errorf("failed to update team %d(%s) permissions on repo %s to %s: %v", gt.ID, name, repo, permission, err))
+			updateErrors = append(updateErrors, fmt.Errorf("failed to update team %d(%s) permissions on repo %s to %s: %w", gt.ID, name, repo, permission, err))
 		}
 	}
 
 	for childName, childTeam := range team.Children {
 		if err := configureTeamRepos(client, githubTeams, childName, orgName, childTeam); err != nil {
-			updateErrors = append(updateErrors, fmt.Errorf("failed to configure %s child team %s repos: %v", orgName, childName, err))
+			updateErrors = append(updateErrors, fmt.Errorf("failed to configure %s child team %s repos: %w", orgName, childName, err))
 		}
 	}
 
@@ -1258,7 +1258,7 @@ func configureTeamMembers(client teamMembersClient, orgName string, gt github.Te
 
 	members, err := client.ListTeamMembers(orgName, gt.ID, github.RoleMember)
 	if err != nil {
-		return fmt.Errorf("failed to list %d(%s) members: %v", gt.ID, gt.Name, err)
+		return fmt.Errorf("failed to list %d(%s) members: %w", gt.ID, gt.Name, err)
 	}
 	for _, m := range members {
 		haveMembers.Insert(m.Login)
@@ -1266,7 +1266,7 @@ func configureTeamMembers(client teamMembersClient, orgName string, gt github.Te
 
 	maintainers, err := client.ListTeamMembers(orgName, gt.ID, github.RoleMaintainer)
 	if err != nil {
-		return fmt.Errorf("failed to list %d(%s) maintainers: %v", gt.ID, gt.Name, err)
+		return fmt.Errorf("failed to list %d(%s) maintainers: %w", gt.ID, gt.Name, err)
 	}
 	for _, m := range maintainers {
 		haveMaintainers.Insert(m.Login)
@@ -1274,7 +1274,7 @@ func configureTeamMembers(client teamMembersClient, orgName string, gt github.Te
 
 	invitees, err := teamInvitations(client, orgName, gt.ID)
 	if err != nil {
-		return fmt.Errorf("failed to list %d(%s) invitees: %v", gt.ID, gt.Name, err)
+		return fmt.Errorf("failed to list %d(%s) invitees: %w", gt.ID, gt.Name, err)
 	}
 
 	adder := func(user string, super bool) error {
@@ -1289,7 +1289,7 @@ func configureTeamMembers(client teamMembersClient, orgName string, gt github.Te
 		tm, err := client.UpdateTeamMembership(orgName, gt.ID, user, super)
 		if err != nil {
 			// Augment the error with the operation we attempted so that the error makes sense after return
-			err = fmt.Errorf("UpdateTeamMembership(%d(%s), %s, %t) failed: %v", gt.ID, gt.Name, user, super, err)
+			err = fmt.Errorf("UpdateTeamMembership(%d(%s), %s, %t) failed: %w", gt.ID, gt.Name, user, super, err)
 			logrus.Warnf(err.Error())
 		} else if tm.State == github.StatePending {
 			logrus.Infof("Invited %s to %d(%s) as a %s", user, gt.ID, gt.Name, role)
@@ -1303,7 +1303,7 @@ func configureTeamMembers(client teamMembersClient, orgName string, gt github.Te
 		err := client.RemoveTeamMembership(orgName, gt.ID, user)
 		if err != nil {
 			// Augment the error with the operation we attempted so that the error makes sense after return
-			err = fmt.Errorf("RemoveTeamMembership(%d(%s), %s) failed: %v", gt.ID, gt.Name, user, err)
+			err = fmt.Errorf("RemoveTeamMembership(%d(%s), %s) failed: %w", gt.ID, gt.Name, user, err)
 			logrus.Warnf(err.Error())
 		} else {
 			logrus.Infof("Removed %s from team %d(%s)", user, gt.ID, gt.Name)

--- a/prow/cmd/peribolos/main_test.go
+++ b/prow/cmd/peribolos/main_test.go
@@ -293,7 +293,7 @@ func (c *fakeClient) ListTeamMembers(org string, id int, role string) ([]github.
 	case github.RoleMaintainer:
 		return c.makeMembers(c.admins), nil
 	default:
-		return nil, fmt.Errorf("fake does not support: %v", role)
+		return nil, fmt.Errorf("fake does not support: %s", role)
 	}
 }
 

--- a/prow/cmd/phaino/local.go
+++ b/prow/cmd/phaino/local.go
@@ -84,7 +84,7 @@ func readMount(ctx context.Context, mount coreapi.VolumeMount) (string, error) {
 	fmt.Fprintf(os.Stderr, "local %s path (%q mount): ", mount.MountPath, mount.Name)
 	out, err := scanln(ctx)
 	if err != nil {
-		return "", fmt.Errorf("scan: %v", err)
+		return "", fmt.Errorf("scan: %w", err)
 	}
 	return realPath(out)
 }
@@ -112,7 +112,7 @@ func pathAlias(r prowapi.Refs) string {
 func readRepo(path string, readUserInput func(string, string) (string, error)) (string, error) {
 	wd, err := workingDir()
 	if err != nil {
-		return "", fmt.Errorf("workingDir: %v", err)
+		return "", fmt.Errorf("workingDir: %w", err)
 	}
 	// First finding repo from under GOPATH, then fall back from local path.
 	// Prefers GOPATH as it's more accurate, as finding from local path performs
@@ -131,7 +131,7 @@ func readRepo(path string, readUserInput func(string, string) (string, error)) (
 
 	out, err := readUserInput(path, def)
 	if err != nil {
-		return "", fmt.Errorf("scan: %v", err)
+		return "", fmt.Errorf("scan: %w", err)
 	}
 	return realPath(out)
 }
@@ -162,7 +162,7 @@ func workingDir() (string, error) {
 func findRepoFromLocal(wd, path string) (string, error) {
 	opwd, err := realPath(wd)
 	if err != nil {
-		return "", fmt.Errorf("wd not found: %v", err)
+		return "", fmt.Errorf("wd not found: %w", err)
 	}
 
 	var old string
@@ -320,7 +320,7 @@ func (opts *options) resolveVolumeMounts(ctx context.Context, pj prowapi.ProwJob
 		} else {
 			local, err := getMount(ctx, mount)
 			if err != nil {
-				return nil, fmt.Errorf("bad mount %q: %v", mount.Name, err)
+				return nil, fmt.Errorf("bad mount %q: %w", mount.Name, err)
 			}
 			mountPath := mount.MountPath
 			if mount.ReadOnly {
@@ -435,7 +435,7 @@ func (opts *options) resolveRefs(ctx context.Context, volumeMounts map[string]st
 		if _, ok := opts.extraVolumesMounts[dest]; !ok {
 			repo, err := readRepo(repoPath, readUserInput)
 			if err != nil {
-				return "", fmt.Errorf("bad repo(%s) when resolving the refs: %v", repoPath, err)
+				return "", fmt.Errorf("bad repo(%s) when resolving the refs: %w", repoPath, err)
 			}
 			volumeMounts[dest] = repo
 		}
@@ -492,7 +492,7 @@ func (opts *options) convertJob(ctx context.Context, log *logrus.Entry, pj prowa
 	cid := containerID()
 	args, err := opts.convertToLocal(ctx, log, pj, cid)
 	if err != nil {
-		return fmt.Errorf("convert: %v", err)
+		return fmt.Errorf("convert: %w", err)
 	}
 	printArgs(args)
 	if opts.printCmd {
@@ -507,7 +507,7 @@ func (opts *options) convertJob(ctx context.Context, log *logrus.Entry, pj prowa
 	}
 	cmd, err := start(args)
 	if err != nil {
-		return fmt.Errorf("start: %v", err)
+		return fmt.Errorf("start: %w", err)
 	}
 	log = log.WithField("container", cid)
 	ch := make(chan error)
@@ -542,9 +542,9 @@ func (opts *options) convertJob(ctx context.Context, log *logrus.Entry, pj prowa
 	case <-abort.Done():
 	}
 	if err := kill(cid, "SIGKILL"); err != nil {
-		return fmt.Errorf("kill: %v", err)
+		return fmt.Errorf("kill: %w", err)
 	}
-	return fmt.Errorf("grace period expired, aborted: %v", ctx.Err())
+	return fmt.Errorf("grace period expired, aborted: %w", ctx.Err())
 }
 
 func getTimeout(optionsTimeout time.Duration, prowJobTimeout time.Duration) time.Duration {

--- a/prow/cmd/phaino/main.go
+++ b/prow/cmd/phaino/main.go
@@ -116,13 +116,13 @@ func readPJ(reader io.ReadCloser) (*prowapi.ProwJob, error) {
 	var pj prowapi.ProwJob
 	buf, err := ioutil.ReadAll(reader)
 	if err != nil {
-		return nil, fmt.Errorf("read: %v", err)
+		return nil, fmt.Errorf("read: %w", err)
 	}
 	if err := yaml.Unmarshal(buf, &pj); err != nil {
-		return nil, fmt.Errorf("unmarshal: %v", err)
+		return nil, fmt.Errorf("unmarshal: %w", err)
 	}
 	if err := validate(pj); err != nil {
-		return nil, fmt.Errorf("validate: %v", err)
+		return nil, fmt.Errorf("validate: %w", err)
 	}
 	return &pj, nil
 }
@@ -130,7 +130,7 @@ func readPJ(reader io.ReadCloser) (*prowapi.ProwJob, error) {
 func readFile(path string) (*prowapi.ProwJob, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("open: %v", err)
+		return nil, fmt.Errorf("open: %w", err)
 	}
 	defer f.Close()
 	return readPJ(f)
@@ -139,7 +139,7 @@ func readFile(path string) (*prowapi.ProwJob, error) {
 func readHTTP(url string) (*prowapi.ProwJob, error) {
 	resp, err := http.Get(url)
 	if err != nil {
-		return nil, fmt.Errorf("get: %v", err)
+		return nil, fmt.Errorf("get: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
@@ -176,7 +176,7 @@ func readPJs(jobs []string) (<-chan prowapi.ProwJob, <-chan error) {
 				pj, err = readFile(j)
 			}
 			if err != nil {
-				errch <- fmt.Errorf("%q: %v", j, err)
+				errch <- fmt.Errorf("%q: %w", j, err)
 				return
 			}
 			ch <- *pj
@@ -238,7 +238,7 @@ func processJobs(ctx context.Context, opt options, pjs <-chan prowapi.ProwJob, e
 		case err := <-errs:
 			return err
 		case <-ctx.Done():
-			return fmt.Errorf("cancel: %v", ctx.Err())
+			return fmt.Errorf("cancel: %w", ctx.Err())
 		}
 	}
 }

--- a/prow/cmd/pipeline/main.go
+++ b/prow/cmd/pipeline/main.go
@@ -68,7 +68,7 @@ func (o *options) parse(flags *flag.FlagSet, args []string) error {
 	o.instrumentationOptions.AddFlags(flags)
 	o.config.AddFlags(flags)
 	if err := flags.Parse(args); err != nil {
-		return fmt.Errorf("Parse flags: %v", err)
+		return fmt.Errorf("Parse flags: %w", err)
 	}
 	if err := o.config.Validate(false); err != nil {
 		return err

--- a/prow/cmd/tackle/main.go
+++ b/prow/cmd/tackle/main.go
@@ -182,7 +182,7 @@ func selectProject(choice string) (string, error) {
 			fmt.Println("  *", proj)
 		}
 		if err != nil {
-			return "", fmt.Errorf("list projects: %v", err)
+			return "", fmt.Errorf("list projects: %w", err)
 		}
 		if len(projs) == 0 {
 			fmt.Println("Create a project at https://console.cloud.google.com/")
@@ -195,7 +195,7 @@ func selectProject(choice string) (string, error) {
 
 		def, err := currentProject()
 		if err != nil {
-			return "", fmt.Errorf("get current project: %v", err)
+			return "", fmt.Errorf("get current project: %w", err)
 		}
 
 		choice = prompt("Select project", def)
@@ -218,7 +218,7 @@ func selectProject(choice string) (string, error) {
 
 	// no, make sure user has access to it
 	if err = exec.Command("gcloud", "projects", "describe", choice).Run(); err != nil {
-		return "", fmt.Errorf("%s cannot describe project: %v", who, err)
+		return "", fmt.Errorf("%s cannot describe project: %w", who, err)
 	}
 
 	return choice, nil
@@ -230,14 +230,14 @@ func selectZone() (string, error) {
 
 	def, err := currentZone()
 	if err != nil {
-		return "", fmt.Errorf("get current zone: %v", err)
+		return "", fmt.Errorf("get current zone: %w", err)
 	}
 
 	fmt.Printf("Available zones:\n")
 
 	zoneList, err := zones()
 	if err != nil {
-		return "", fmt.Errorf("list zones: %v", err)
+		return "", fmt.Errorf("list zones: %w", err)
 	}
 
 	isNonEmpty := validateNotEmpty(zoneList)
@@ -260,7 +260,7 @@ func selectZone() (string, error) {
 
 	isContained := validateContainment(zoneList, choice)
 	if !isContained {
-		return "", fmt.Errorf("invalid zone selection: %v", choice)
+		return "", fmt.Errorf("invalid zone selection: %s", choice)
 	}
 
 	return choice, nil
@@ -281,7 +281,7 @@ func (c cluster) context() string {
 func currentClusters(proj string) (map[string]cluster, error) {
 	clusters, err := output("gcloud", "container", "clusters", "list", "--project="+proj, "--format=value(name,zone)")
 	if err != nil {
-		return nil, fmt.Errorf("list clusters: %v", err)
+		return nil, fmt.Errorf("list clusters: %w", err)
 	}
 	options := map[string]cluster{}
 	for _, line := range strings.Split(clusters, "\n") {
@@ -307,7 +307,7 @@ func createCluster(proj, choice string) (*cluster, error) {
 
 	zone, err := selectZone()
 	if err != nil {
-		return nil, fmt.Errorf("select current zone for cluster: %v", err)
+		return nil, fmt.Errorf("select current zone for cluster: %w", err)
 	}
 
 	cmd := exec.Command("gcloud", "container", "clusters", "create", choice, "--zone="+zone, "--enable-legacy-authorization", "--issue-client-certificate")
@@ -315,12 +315,12 @@ func createCluster(proj, choice string) (*cluster, error) {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("create cluster: %v", err)
+		return nil, fmt.Errorf("create cluster: %w", err)
 	}
 
 	out, err := output("gcloud", "container", "clusters", "describe", choice, "--zone="+zone, "--format=value(name,zone)")
 	if err != nil {
-		return nil, fmt.Errorf("describe cluster: %v", err)
+		return nil, fmt.Errorf("describe cluster: %w", err)
 	}
 	parts := strings.Split(out, "\t")
 	if len(parts) != 2 {
@@ -335,14 +335,14 @@ func createContext(co contextOptions) (string, error) {
 	proj, err := selectProject(co.project)
 	if err != nil {
 		logrus.Info("Run gcloud auth login to initialize gcloud")
-		return "", fmt.Errorf("get current project: %v", err)
+		return "", fmt.Errorf("get current project: %w", err)
 	}
 
 	fmt.Printf("Existing GKE clusters in %s:", proj)
 	fmt.Println()
 	clusters, err := currentClusters(proj)
 	if err != nil {
-		return "", fmt.Errorf("list %s clusters: %v", proj, err)
+		return "", fmt.Errorf("list %s clusters: %w", proj, err)
 	}
 	for name := range clusters {
 		fmt.Println("  *", name)
@@ -369,7 +369,7 @@ func createContext(co contextOptions) (string, error) {
 	if choice == "" || choice == "new" || choice == "create new" {
 		cluster, err := createCluster(proj, create)
 		if err != nil {
-			return "", fmt.Errorf("create cluster in %s: %v", proj, err)
+			return "", fmt.Errorf("create cluster in %s: %w", proj, err)
 		}
 		return cluster.context(), nil
 	}
@@ -383,7 +383,7 @@ func createContext(co contextOptions) (string, error) {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("get credentials: %v", err)
+		return "", fmt.Errorf("get credentials: %w", err)
 	}
 	return cluster.context(), nil
 }
@@ -445,7 +445,7 @@ func selectContext(co contextOptions) (string, error) {
 	if choice == "create" || choice == "" || choice == "create new" || choice == "new" {
 		ctx, err := createContext(co)
 		if err != nil {
-			return "", fmt.Errorf("create context: %v", err)
+			return "", fmt.Errorf("create context: %w", err)
 		}
 		return ctx, nil
 	}
@@ -475,17 +475,17 @@ func applyCreate(ctx string, args ...string) error {
 	create.Stderr = os.Stderr
 	obj, err := create.StdoutPipe()
 	if err != nil {
-		return fmt.Errorf("rolebinding pipe: %v", err)
+		return fmt.Errorf("rolebinding pipe: %w", err)
 	}
 
 	if err := create.Start(); err != nil {
-		return fmt.Errorf("start create: %v", err)
+		return fmt.Errorf("start create: %w", err)
 	}
 	if err := apply(ctx, obj); err != nil {
-		return fmt.Errorf("apply: %v", err)
+		return fmt.Errorf("apply: %w", err)
 	}
 	if err := create.Wait(); err != nil {
-		return fmt.Errorf("create: %v", err)
+		return fmt.Errorf("create: %w", err)
 	}
 	return nil
 }
@@ -496,7 +496,7 @@ func apply(ctx string, in io.Reader) error {
 	apply.Stdout = os.Stdout
 	apply.Stdin = in
 	if err := apply.Start(); err != nil {
-		return fmt.Errorf("start: %v", err)
+		return fmt.Errorf("start: %w", err)
 	}
 	return apply.Wait()
 }
@@ -504,7 +504,7 @@ func apply(ctx string, in io.Reader) error {
 func applyRoleBinding(context string) error {
 	who, err := currentAccount()
 	if err != nil {
-		return fmt.Errorf("current account: %v", err)
+		return fmt.Errorf("current account: %w", err)
 	}
 	return applyCreate(context, "clusterrolebinding", "prow-admin", "--clusterrole=cluster-admin", "--user="+who)
 }
@@ -544,14 +544,14 @@ func githubToken(choice string) (string, error) {
 	}
 	path := os.ExpandEnv(choice)
 	if _, err := os.Stat(path); err != nil {
-		return "", fmt.Errorf("open %s: %v", path, err)
+		return "", fmt.Errorf("open %s: %w", path, err)
 	}
 	return path, nil
 }
 
 func githubClient(tokenPath string, dry bool) (github.Client, error) {
 	if err := secret.Add(tokenPath); err != nil {
-		return nil, fmt.Errorf("start agent: %v", err)
+		return nil, fmt.Errorf("start agent: %w", err)
 	}
 
 	gen := secret.GetTokenGenerator(tokenPath)
@@ -581,7 +581,7 @@ func applyStarter(kc *kubernetes.Clientset, ns, choice, ctx string, overwrite bo
 	case err != nil && apierrors.IsNotFound(err):
 		// Great, new clean namespace to deploy!
 	case err != nil: // unexpected error
-		return fmt.Errorf("get plank: %v", err)
+		return fmt.Errorf("get plank: %w", err)
 	case !overwrite: // already a plank, confirm overwrite
 		overwriteChoice := prompt(fmt.Sprintf("Prow is already deployed to %s in %s, overwrite?", ns, ctx), "no")
 		switch overwriteChoice {
@@ -600,7 +600,7 @@ func applyStarter(kc *kubernetes.Clientset, ns, choice, ctx string, overwrite bo
 func clientConfigNamespace(context string) (string, bool, error) {
 	loader, cfg, err := contextConfig()
 	if err != nil {
-		return "", false, fmt.Errorf("load contexts: %v", err)
+		return "", false, fmt.Errorf("load contexts: %w", err)
 	}
 
 	return clientcmd.NewNonInteractiveClientConfig(*cfg, context, &clientcmd.ConfigOverrides{}, loader).Namespace()
@@ -609,7 +609,7 @@ func clientConfigNamespace(context string) (string, bool, error) {
 func clientConfig(context string) (*rest.Config, error) {
 	loader, cfg, err := contextConfig()
 	if err != nil {
-		return nil, fmt.Errorf("load contexts: %v", err)
+		return nil, fmt.Errorf("load contexts: %w", err)
 	}
 
 	return clientcmd.NewNonInteractiveClientConfig(*cfg, context, &clientcmd.ConfigOverrides{}, loader).ClientConfig()
@@ -717,7 +717,7 @@ func findHook(client github.Client, org, repo string, loc url.URL) (*github.Hook
 		hooks, err = client.ListRepoHooks(org, repo)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("list hooks: %v", err)
+		return nil, fmt.Errorf("list hooks: %w", err)
 	}
 
 	for _, h := range hooks {
@@ -747,7 +747,7 @@ func orgRepo(in string) (string, string) {
 func ensureHmac(kc *kubernetes.Clientset, ns string) (string, error) {
 	secret, err := kc.CoreV1().Secrets(ns).Get(context2.TODO(), "hmac-token", metav1.GetOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
-		return "", fmt.Errorf("get: %v", err)
+		return "", fmt.Errorf("get: %w", err)
 	}
 	if err == nil {
 		buf, ok := secret.Data["hmac"]
@@ -765,11 +765,11 @@ func ensureHmac(kc *kubernetes.Clientset, ns string) (string, error) {
 	secret.StringData = map[string]string{"hmac": hmac}
 	if err == nil {
 		if _, err = kc.CoreV1().Secrets(ns).Update(context2.TODO(), secret, metav1.UpdateOptions{}); err != nil {
-			return "", fmt.Errorf("update: %v", err)
+			return "", fmt.Errorf("update: %w", err)
 		}
 	} else {
 		if _, err = kc.CoreV1().Secrets(ns).Create(context2.TODO(), secret, metav1.CreateOptions{}); err != nil {
-			return "", fmt.Errorf("create: %v", err)
+			return "", fmt.Errorf("create: %w", err)
 		}
 	}
 	return hmac, nil
@@ -799,7 +799,7 @@ func enableHooks(client github.Client, loc url.URL, secret string, repos ...stri
 		org, repo := orgRepo(choice)
 		hook, err := findHook(client, org, repo, loc)
 		if err != nil {
-			return enabled, fmt.Errorf("find %s hook in %s: %v", locStr, choice, err)
+			return enabled, fmt.Errorf("find %s hook in %s: %w", locStr, choice, err)
 		}
 		yes := true
 		j := "json"
@@ -821,7 +821,7 @@ func enableHooks(client github.Client, loc url.URL, secret string, repos ...stri
 				id, err = client.CreateRepoHook(org, repo, req)
 			}
 			if err != nil {
-				return enabled, fmt.Errorf("create %s hook in %s: %v", locStr, choice, err)
+				return enabled, fmt.Errorf("create %s hook in %s: %w", locStr, choice, err)
 			}
 			fmt.Printf("Created hook %d to %s in %s", id, locStr, choice)
 			fmt.Println()
@@ -832,7 +832,7 @@ func enableHooks(client github.Client, loc url.URL, secret string, repos ...stri
 				err = client.EditRepoHook(org, repo, hook.ID, req)
 			}
 			if err != nil {
-				return enabled, fmt.Errorf("edit %s hook %d in %s: %v", locStr, hook.ID, choice, err)
+				return enabled, fmt.Errorf("edit %s hook %d in %s: %w", locStr, hook.ID, choice, err)
 			}
 		}
 		enabled = append(enabled, choice)
@@ -843,7 +843,7 @@ func ensureConfigMap(kc *kubernetes.Clientset, ns, name, key string) error {
 	cm, err := kc.CoreV1().ConfigMaps(ns).Get(context2.TODO(), name, metav1.GetOptions{})
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("get: %v", err)
+			return fmt.Errorf("get: %w", err)
 		}
 		cm = &corev1.ConfigMap{
 			Data: map[string]string{key: ""},
@@ -852,7 +852,7 @@ func ensureConfigMap(kc *kubernetes.Clientset, ns, name, key string) error {
 		cm.Namespace = ns
 		_, err := kc.CoreV1().ConfigMaps(ns).Create(context2.TODO(), cm, metav1.CreateOptions{})
 		if err != nil {
-			return fmt.Errorf("create: %v", err)
+			return fmt.Errorf("create: %w", err)
 		}
 	}
 
@@ -865,7 +865,7 @@ func ensureConfigMap(kc *kubernetes.Clientset, ns, name, key string) error {
 	}
 	cm.Data[key] = ""
 	if _, err := kc.CoreV1().ConfigMaps(ns).Update(context2.TODO(), cm, metav1.UpdateOptions{}); err != nil {
-		return fmt.Errorf("update: %v", err)
+		return fmt.Errorf("update: %w", err)
 	}
 	return nil
 }

--- a/prow/config/agent.go
+++ b/prow/config/agent.go
@@ -51,7 +51,7 @@ type Agent struct {
 func IsConfigMapMount(path string) (bool, error) {
 	files, err := ioutil.ReadDir(path)
 	if err != nil {
-		return false, fmt.Errorf("Could not read provided directory %s: %v", path, err)
+		return false, fmt.Errorf("Could not read provided directory %s: %w", path, err)
 	}
 	for _, file := range files {
 		if file.Name() == "..data" {
@@ -180,7 +180,7 @@ func ListCMsAndDirs(path string) (cms sets.String, dirs sets.String, err error) 
 		// for files in a directory trigger events for the directory
 		if info != nil && info.IsDir() {
 			if isCM, err := IsConfigMapMount(path); err != nil {
-				return fmt.Errorf("Failed to check is path %s is configmap mounted: %v", path, err)
+				return fmt.Errorf("Failed to check is path %s is configmap mounted: %w", path, err)
 			} else if isCM {
 				cms.Insert(path)
 				// configmaps can't have nested directories

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -344,13 +344,13 @@ func (c *Config) getProwYAML(gc git.ClientFactory, identifier string, baseSHAGet
 
 	baseSHA, err := baseSHAGetter()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get baseSHA: %v", err)
+		return nil, fmt.Errorf("failed to get baseSHA: %w", err)
 	}
 	var headSHAs []string
 	for _, headSHAGetter := range headSHAGetters {
 		headSHA, err := headSHAGetter()
 		if err != nil {
-			return nil, fmt.Errorf("failed to get headRef: %v", err)
+			return nil, fmt.Errorf("failed to get headRef: %w", err)
 		}
 		headSHAs = append(headSHAs, headSHA)
 	}
@@ -951,7 +951,7 @@ func (d *Deck) Validate() error {
 	if d.RerunAuthConfigs != nil {
 		for k, config := range d.RerunAuthConfigs {
 			if err := config.Validate(); err != nil {
-				return fmt.Errorf("rerun_auth_configs[%s]: %v", k, err)
+				return fmt.Errorf("rerun_auth_configs[%s]: %w", k, err)
 			}
 		}
 	}
@@ -1182,10 +1182,10 @@ func (cfg *SlackReporter) DefaultAndValidate() error {
 	// Validate ReportTemplate
 	tmpl, err := template.New("").Parse(cfg.ReportTemplate)
 	if err != nil {
-		return fmt.Errorf("failed to parse template: %v", err)
+		return fmt.Errorf("failed to parse template: %w", err)
 	}
 	if err := tmpl.Execute(&bytes.Buffer{}, &prowapi.ProwJob{}); err != nil {
-		return fmt.Errorf("failed to execute report_template: %v", err)
+		return fmt.Errorf("failed to execute report_template: %w", err)
 	}
 
 	return nil
@@ -1436,10 +1436,10 @@ func loadConfig(prowConfig, jobConfig string, additionalProwConfigDirs []string,
 func yamlToConfig(path string, nc interface{}) error {
 	b, err := ReadFileMaybeGZIP(path)
 	if err != nil {
-		return fmt.Errorf("error reading %s: %v", path, err)
+		return fmt.Errorf("error reading %s: %w", path, err)
 	}
 	if err := yaml.Unmarshal(b, nc); err != nil {
-		return fmt.Errorf("error unmarshaling %s: %v", path, err)
+		return fmt.Errorf("error unmarshaling %s: %w", path, err)
 	}
 	var jc *JobConfig
 	switch v := nc.(type) {
@@ -1623,7 +1623,7 @@ func defaultPresubmits(presubmits []Presubmit, additionalPresets []Preset, c *Co
 		}
 	}
 	if err := SetPresubmitRegexes(presubmits); err != nil {
-		errs = append(errs, fmt.Errorf("could not set regex: %v", err))
+		errs = append(errs, fmt.Errorf("could not set regex: %w", err))
 	}
 
 	return utilerrors.NewAggregate(errs)
@@ -1641,7 +1641,7 @@ func defaultPostsubmits(postsubmits []Postsubmit, additionalPresets []Preset, c 
 		}
 	}
 	if err := SetPostsubmitRegexes(postsubmits); err != nil {
-		errs = append(errs, fmt.Errorf("could not set regex: %v", err))
+		errs = append(errs, fmt.Errorf("could not set regex: %w", err))
 	}
 	return utilerrors.NewAggregate(errs)
 }
@@ -1715,7 +1715,7 @@ func (c *Config) validateComponentConfig() error {
 	if c.SlackReporterConfigs != nil {
 		for k, config := range c.SlackReporterConfigs {
 			if err := config.DefaultAndValidate(); err != nil {
-				return fmt.Errorf("failed to validate slackreporter config: %v", err)
+				return fmt.Errorf("failed to validate slackreporter config: %w", err)
 			}
 			c.SlackReporterConfigs[k] = config
 		}
@@ -1790,13 +1790,13 @@ func validatePresubmits(presubmits []Presubmit, podNamespace string) error {
 			}
 		}
 		if err := validateJobBase(ps.JobBase, prowapi.PresubmitJob, podNamespace); err != nil {
-			errs = append(errs, fmt.Errorf("invalid presubmit job %s: %v", ps.Name, err))
+			errs = append(errs, fmt.Errorf("invalid presubmit job %s: %w", ps.Name, err))
 		}
 		if err := validateTriggering(ps); err != nil {
 			errs = append(errs, err)
 		}
 		if err := validateReporting(ps.JobBase, ps.Reporter); err != nil {
-			errs = append(errs, fmt.Errorf("invalid presubmit job %s: %v", ps.Name, err))
+			errs = append(errs, fmt.Errorf("invalid presubmit job %s: %w", ps.Name, err))
 		}
 		validPresubmits[ps.Name] = append(validPresubmits[ps.Name], ps)
 	}
@@ -1849,13 +1849,13 @@ func validatePostsubmits(postsubmits []Postsubmit, podNamespace string) error {
 		}
 
 		if err := validateJobBase(ps.JobBase, prowapi.PostsubmitJob, podNamespace); err != nil {
-			errs = append(errs, fmt.Errorf("invalid postsubmit job %s: %v", ps.Name, err))
+			errs = append(errs, fmt.Errorf("invalid postsubmit job %s: %w", ps.Name, err))
 		}
 		if err := validateAlwaysRun(ps); err != nil {
 			errs = append(errs, err)
 		}
 		if err := validateReporting(ps.JobBase, ps.Reporter); err != nil {
-			errs = append(errs, fmt.Errorf("invalid postsubmit job %s: %v", ps.Name, err))
+			errs = append(errs, fmt.Errorf("invalid postsubmit job %s: %w", ps.Name, err))
 		}
 		validPostsubmits[ps.Name] = append(validPostsubmits[ps.Name], ps)
 	}
@@ -1875,7 +1875,7 @@ func validatePeriodics(periodics []Periodic, podNamespace string) error {
 		}
 		validPeriodics.Insert(p.Name)
 		if err := validateJobBase(p.JobBase, prowapi.PeriodicJob, podNamespace); err != nil {
-			return fmt.Errorf("invalid periodic job %s: %v", p.Name, err)
+			return fmt.Errorf("invalid periodic job %s: %w", p.Name, err)
 		}
 	}
 
@@ -1915,12 +1915,12 @@ func (c *Config) ValidateJobConfig() error {
 			errs = append(errs, fmt.Errorf("cron and interval cannot be both empty in periodic %s", p.Name))
 		} else if p.Cron != "" {
 			if _, err := cron.Parse(p.Cron); err != nil {
-				errs = append(errs, fmt.Errorf("invalid cron string %s in periodic %s: %v", p.Cron, p.Name, err))
+				errs = append(errs, fmt.Errorf("invalid cron string %s in periodic %s: %w", p.Cron, p.Name, err))
 			}
 		} else {
 			d, err := time.ParseDuration(c.Periodics[j].Interval)
 			if err != nil {
-				errs = append(errs, fmt.Errorf("cannot parse duration for %s: %v", c.Periodics[j].Name, err))
+				errs = append(errs, fmt.Errorf("cannot parse duration for %s: %w", c.Periodics[j].Name, err))
 			}
 			c.Periodics[j].interval = d
 		}
@@ -1933,7 +1933,7 @@ func (c *Config) ValidateJobConfig() error {
 
 func parseProwConfig(c *Config) error {
 	if err := ValidateController(&c.Plank.Controller); err != nil {
-		return fmt.Errorf("validating plank config: %v", err)
+		return fmt.Errorf("validating plank config: %w", err)
 	}
 
 	if c.Plank.PodPendingTimeout == nil {
@@ -1970,11 +1970,11 @@ func parseProwConfig(c *Config) error {
 
 	for i := range c.JenkinsOperators {
 		if err := ValidateController(&c.JenkinsOperators[i].Controller); err != nil {
-			return fmt.Errorf("validating jenkins_operators config: %v", err)
+			return fmt.Errorf("validating jenkins_operators config: %w", err)
 		}
 		sel, err := labels.Parse(c.JenkinsOperators[i].LabelSelectorString)
 		if err != nil {
-			return fmt.Errorf("invalid jenkins_operators.label_selector option: %v", err)
+			return fmt.Errorf("invalid jenkins_operators.label_selector option: %w", err)
 		}
 		c.JenkinsOperators[i].LabelSelector = sel
 		// TODO: Invalidate overlapping selectors more
@@ -1989,14 +1989,14 @@ func parseProwConfig(c *Config) error {
 	for i, agentToTmpl := range c.Deck.ExternalAgentLogs {
 		urlTemplate, err := template.New(agentToTmpl.Agent).Parse(agentToTmpl.URLTemplateString)
 		if err != nil {
-			return fmt.Errorf("parsing template for agent %q: %v", agentToTmpl.Agent, err)
+			return fmt.Errorf("parsing template for agent %q: %w", agentToTmpl.Agent, err)
 		}
 		c.Deck.ExternalAgentLogs[i].URLTemplate = urlTemplate
 		// we need to validate selectors used by deck since these are not
 		// sent to the api server.
 		s, err := labels.Parse(c.Deck.ExternalAgentLogs[i].SelectorString)
 		if err != nil {
-			return fmt.Errorf("error parsing selector %q: %v", c.Deck.ExternalAgentLogs[i].SelectorString, err)
+			return fmt.Errorf("error parsing selector %q: %w", c.Deck.ExternalAgentLogs[i].SelectorString, err)
 		}
 		c.Deck.ExternalAgentLogs[i].Selector = s
 	}
@@ -2038,7 +2038,7 @@ func parseProwConfig(c *Config) error {
 			}
 			r, err := regexp.Compile(v)
 			if err != nil {
-				return fmt.Errorf("cannot compile regexp %q, err: %v", v, err)
+				return fmt.Errorf("cannot compile regexp %q, err: %w", v, err)
 			}
 			c.Deck.Spyglass.RegexCache[v] = r
 		}
@@ -2151,7 +2151,7 @@ func parseProwConfig(c *Config) error {
 			titleTemplate, err := template.New("CommitTitle").Parse(templates.TitleTemplate)
 
 			if err != nil {
-				return fmt.Errorf("parsing template for commit title: %v", err)
+				return fmt.Errorf("parsing template for commit title: %w", err)
 			}
 
 			templates.Title = titleTemplate
@@ -2161,7 +2161,7 @@ func parseProwConfig(c *Config) error {
 			bodyTemplate, err := template.New("CommitBody").Parse(templates.BodyTemplate)
 
 			if err != nil {
-				return fmt.Errorf("parsing template for commit body: %v", err)
+				return fmt.Errorf("parsing template for commit body: %w", err)
 			}
 
 			templates.Body = bodyTemplate
@@ -2172,7 +2172,7 @@ func parseProwConfig(c *Config) error {
 
 	for i, tq := range c.Tide.Queries {
 		if err := tq.Validate(); err != nil {
-			return fmt.Errorf("tide query (index %d) is invalid: %v", i, err)
+			return fmt.Errorf("tide query (index %d) is invalid: %w", i, err)
 		}
 	}
 
@@ -2192,7 +2192,7 @@ func parseProwConfig(c *Config) error {
 	}
 	linkURL, err := url.Parse(c.GitHubOptions.LinkURLFromConfig)
 	if err != nil {
-		return fmt.Errorf("unable to parse github.link_url, might not be a valid url: %v", err)
+		return fmt.Errorf("unable to parse github.link_url, might not be a valid url: %w", err)
 	}
 	c.GitHubOptions.LinkURL = linkURL
 
@@ -2286,7 +2286,7 @@ func validateDecoration(container v1.Container, config *prowapi.DecorationConfig
 	}
 
 	if err := config.Validate(); err != nil {
-		return fmt.Errorf("invalid decoration config: %v", err)
+		return fmt.Errorf("invalid decoration config: %w", err)
 	}
 	var args []string
 	args = append(append(args, container.Command...), container.Args...)
@@ -2300,7 +2300,7 @@ func resolvePresets(name string, labels map[string]string, spec *v1.PodSpec, pre
 	for _, preset := range presets {
 		if spec != nil {
 			if err := mergePreset(preset, labels, spec.Containers, &spec.Volumes); err != nil {
-				return fmt.Errorf("job %s failed to merge presets for podspec: %v", name, err)
+				return fmt.Errorf("job %s failed to merge presets for podspec: %w", name, err)
 			}
 		}
 	}
@@ -2493,7 +2493,7 @@ func validateReporting(j JobBase, r Reporter) error {
 func ValidateController(c *Controller) error {
 	urlTmpl, err := template.New("JobURL").Parse(c.JobURLTemplateString)
 	if err != nil {
-		return fmt.Errorf("parsing template: %v", err)
+		return fmt.Errorf("parsing template: %w", err)
 	}
 	c.JobURLTemplate = urlTmpl
 
@@ -2531,7 +2531,7 @@ func defaultAndValidateReportTemplate(c *Controller) error {
 	for orgRepo, value := range c.ReportTemplateStrings {
 		reportTmpl, err := template.New("Report").Parse(value)
 		if err != nil {
-			return fmt.Errorf("error while parsing template for %s: %v", orgRepo, err)
+			return fmt.Errorf("error while parsing template for %s: %w", orgRepo, err)
 		}
 		c.ReportTemplates[orgRepo] = reportTmpl
 	}
@@ -2603,20 +2603,20 @@ func SetPresubmitRegexes(js []Presubmit) error {
 		if re, err := regexp.Compile(j.Trigger); err == nil {
 			js[i].re = re
 		} else {
-			return fmt.Errorf("could not compile trigger regex for %s: %v", j.Name, err)
+			return fmt.Errorf("could not compile trigger regex for %s: %w", j.Name, err)
 		}
 		if !js[i].re.MatchString(j.RerunCommand) {
 			return fmt.Errorf("for job %s, rerun command \"%s\" does not match trigger \"%s\"", j.Name, j.RerunCommand, j.Trigger)
 		}
 		b, err := setBrancherRegexes(j.Brancher)
 		if err != nil {
-			return fmt.Errorf("could not set branch regexes for %s: %v", j.Name, err)
+			return fmt.Errorf("could not set branch regexes for %s: %w", j.Name, err)
 		}
 		js[i].Brancher = b
 
 		c, err := setChangeRegexes(j.RegexpChangeMatcher)
 		if err != nil {
-			return fmt.Errorf("could not set change regexes for %s: %v", j.Name, err)
+			return fmt.Errorf("could not set change regexes for %s: %w", j.Name, err)
 		}
 		js[i].RegexpChangeMatcher = c
 	}
@@ -2630,14 +2630,14 @@ func setBrancherRegexes(br Brancher) (Brancher, error) {
 		if re, err := regexp.Compile(strings.Join(br.Branches, `|`)); err == nil {
 			br.re = re
 		} else {
-			return br, fmt.Errorf("could not compile positive branch regex: %v", err)
+			return br, fmt.Errorf("could not compile positive branch regex: %w", err)
 		}
 	}
 	if len(br.SkipBranches) > 0 {
 		if re, err := regexp.Compile(strings.Join(br.SkipBranches, `|`)); err == nil {
 			br.reSkip = re
 		} else {
-			return br, fmt.Errorf("could not compile negative branch regex: %v", err)
+			return br, fmt.Errorf("could not compile negative branch regex: %w", err)
 		}
 	}
 	return br, nil
@@ -2653,7 +2653,7 @@ func setChangeRegexes(cm RegexpChangeMatcher) (RegexpChangeMatcher, error) {
 	if reString != "" {
 		re, err := regexp.Compile(reString)
 		if err != nil {
-			return cm, fmt.Errorf("could not compile %s regex: %v", propName, err)
+			return cm, fmt.Errorf("could not compile %s regex: %w", propName, err)
 		}
 		cm.reChanges = re
 	}
@@ -2666,12 +2666,12 @@ func SetPostsubmitRegexes(ps []Postsubmit) error {
 	for i, j := range ps {
 		b, err := setBrancherRegexes(j.Brancher)
 		if err != nil {
-			return fmt.Errorf("could not set branch regexes for %s: %v", j.Name, err)
+			return fmt.Errorf("could not set branch regexes for %s: %w", j.Name, err)
 		}
 		ps[i].Brancher = b
 		c, err := setChangeRegexes(j.RegexpChangeMatcher)
 		if err != nil {
-			return fmt.Errorf("could not set change regexes for %s: %v", j.Name, err)
+			return fmt.Errorf("could not set change regexes for %s: %w", j.Name, err)
 		}
 		ps[i].RegexpChangeMatcher = c
 	}

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -1802,7 +1802,7 @@ func TestValidateReportingWithGerritLabel(t *testing.T) {
 			}
 			var expected error
 			if tc.expected != nil {
-				expected = fmt.Errorf("invalid presubmit job %s: %v", "test-job", tc.expected)
+				expected = fmt.Errorf("invalid presubmit job %s: %w", "test-job", tc.expected)
 			}
 			if err := validatePresubmits(presubmits, "default-namespace"); !reflect.DeepEqual(err, utilerrors.NewAggregate([]error{expected})) {
 				t.Errorf("did not get expected validation result:\n%v", cmp.Diff(expected, err))
@@ -1815,7 +1815,7 @@ func TestValidateReportingWithGerritLabel(t *testing.T) {
 				},
 			}
 			if tc.expected != nil {
-				expected = fmt.Errorf("invalid postsubmit job %s: %v", "test-job", tc.expected)
+				expected = fmt.Errorf("invalid postsubmit job %s: %w", "test-job", tc.expected)
 			}
 			if err := validatePostsubmits(postsubmits, "default-namespace"); !reflect.DeepEqual(err, utilerrors.NewAggregate([]error{expected})) {
 				t.Errorf("did not get expected validation result:\n%v", cmp.Diff(expected, err))
@@ -3875,7 +3875,7 @@ func TestRefGetterForGitHubPullRequest(t *testing.T) {
 			verify: func(rg *RefGetterForGitHubPullRequest) error {
 				pr, err := rg.PullRequest()
 				if err != nil {
-					return fmt.Errorf("failed to fetch PullRequest: %v", err)
+					return fmt.Errorf("failed to fetch PullRequest: %w", err)
 				}
 				if rg.pr == nil || rg.pr.ID != 123456 {
 					return fmt.Errorf("expected agent to contain pr with id 123456, pr was %v", rg.pr)
@@ -3892,7 +3892,7 @@ func TestRefGetterForGitHubPullRequest(t *testing.T) {
 			verify: func(rg *RefGetterForGitHubPullRequest) error {
 				baseSHA, err := rg.BaseSHA()
 				if err != nil {
-					return fmt.Errorf("error calling baseSHA: %v", err)
+					return fmt.Errorf("error calling baseSHA: %w", err)
 				}
 				if rg.baseSHA != "12345" {
 					return fmt.Errorf("expected agent baseSHA to be 12345, was %q", rg.baseSHA)
@@ -3913,7 +3913,7 @@ func TestRefGetterForGitHubPullRequest(t *testing.T) {
 			verify: func(rg *RefGetterForGitHubPullRequest) error {
 				baseSHA, err := rg.BaseSHA()
 				if err != nil {
-					return fmt.Errorf("expected err to be nil, was %v", err)
+					return fmt.Errorf("expected err to be nil, was %w", err)
 				}
 				if rg.baseSHA != fakegithub.TestRef {
 					return fmt.Errorf("expected baseSHA on agent to be %q, was %q", fakegithub.TestRef, rg.baseSHA)

--- a/prow/config/inrepoconfig.go
+++ b/prow/config/inrepoconfig.go
@@ -72,7 +72,7 @@ func defaultProwYAMLGetter(
 	}
 	repo, err := gc.ClientFor(orgRepo.Org, orgRepo.Repo)
 	if err != nil {
-		return nil, fmt.Errorf("failed to clone repo for %q: %v", identifier, err)
+		return nil, fmt.Errorf("failed to clone repo for %q: %w", identifier, err)
 	}
 	defer func() {
 		if err := repo.Clean(); err != nil {
@@ -93,7 +93,7 @@ func defaultProwYAMLGetter(
 	mergeMethod := c.Tide.MergeMethod(orgRepo)
 	log.Debugf("Using merge strategy %q.", mergeMethod)
 	if err := repo.MergeAndCheckout(baseSHA, string(mergeMethod), headSHAs...); err != nil {
-		return nil, fmt.Errorf("failed to merge: %v", err)
+		return nil, fmt.Errorf("failed to merge: %w", err)
 	}
 
 	prowYAML := &ProwYAML{}
@@ -143,11 +143,11 @@ func defaultProwYAMLGetter(
 				return nil, fmt.Errorf("failed to read %q: %w", prowYAMLDirPath, err)
 			}
 			if err := yaml.Unmarshal(bytes, prowYAML); err != nil {
-				return nil, fmt.Errorf("failed to unmarshal %q: %v", prowYAMLDirPath, err)
+				return nil, fmt.Errorf("failed to unmarshal %q: %w", prowYAMLDirPath, err)
 			}
 		} else {
 			if !os.IsNotExist(err) {
-				return nil, fmt.Errorf("failed to check if file %q exists: %v", prowYAMLDirPath, err)
+				return nil, fmt.Errorf("failed to check if file %q exists: %w", prowYAMLDirPath, err)
 			}
 		}
 	}

--- a/prow/config/inrepoconfig_test.go
+++ b/prow/config/inrepoconfig_test.go
@@ -54,7 +54,7 @@ func testDefaultProwYAMLGetter(clients localgit.Clients, t *testing.T) {
 			},
 			validate: func(p *ProwYAML, err error) error {
 				if err != nil {
-					return fmt.Errorf("unexpected error: %v", err)
+					return fmt.Errorf("unexpected error: %w", err)
 				}
 				if n := len(p.Presubmits); n != 1 || p.Presubmits[0].Name != "hans" {
 					return fmt.Errorf(`expected exactly one presubmit with name "hans", got %v`, p.Presubmits)
@@ -69,7 +69,7 @@ func testDefaultProwYAMLGetter(clients localgit.Clients, t *testing.T) {
 			},
 			validate: func(p *ProwYAML, err error) error {
 				if err != nil {
-					return fmt.Errorf("unexpected error: %v", err)
+					return fmt.Errorf("unexpected error: %w", err)
 				}
 				if n := len(p.Presubmits); n != 1 || p.Presubmits[0].Name != "hans" {
 					return fmt.Errorf(`expected exactly one presubmit with name "hans", got %v`, p.Presubmits)
@@ -84,7 +84,7 @@ func testDefaultProwYAMLGetter(clients localgit.Clients, t *testing.T) {
 			},
 			validate: func(p *ProwYAML, err error) error {
 				if err != nil {
-					return fmt.Errorf("unexpected error: %v", err)
+					return fmt.Errorf("unexpected error: %w", err)
 				}
 				if n := len(p.Presubmits); n != 1 || p.Presubmits[0].Name != "hans" {
 					return fmt.Errorf(`expected exactly one presubmit with name "hans", got %v`, p.Presubmits)
@@ -139,7 +139,7 @@ func testDefaultProwYAMLGetter(clients localgit.Clients, t *testing.T) {
 			},
 			validate: func(p *ProwYAML, err error) error {
 				if err != nil {
-					return fmt.Errorf("unexpected error: %v", err)
+					return fmt.Errorf("unexpected error: %w", err)
 				}
 				if n := len(p.Presubmits); n != 1 || p.Presubmits[0].Name != "hans" {
 					return fmt.Errorf(`expected exactly one postsubmit with name "hans", got %v`, p.Presubmits)
@@ -174,7 +174,7 @@ func testDefaultProwYAMLGetter(clients localgit.Clients, t *testing.T) {
 			},
 			validate: func(p *ProwYAML, err error) error {
 				if err != nil {
-					return fmt.Errorf("unexpected error: %v", err)
+					return fmt.Errorf("unexpected error: %w", err)
 				}
 				if n := len(p.Postsubmits); n != 1 || p.Postsubmits[0].Name != "hans" {
 					return fmt.Errorf(`expected exactly one postsubmit with name "hans", got %v`, p.Postsubmits)
@@ -189,7 +189,7 @@ func testDefaultProwYAMLGetter(clients localgit.Clients, t *testing.T) {
 			},
 			validate: func(p *ProwYAML, err error) error {
 				if err != nil {
-					return fmt.Errorf("unexpected error: %v", err)
+					return fmt.Errorf("unexpected error: %w", err)
 				}
 				if n := len(p.Postsubmits); n != 1 || p.Postsubmits[0].Name != "hans" {
 					return fmt.Errorf(`expected exactly one postsubmit with name "hans", got %v`, p.Postsubmits)
@@ -244,7 +244,7 @@ func testDefaultProwYAMLGetter(clients localgit.Clients, t *testing.T) {
 			},
 			validate: func(p *ProwYAML, err error) error {
 				if err != nil {
-					return fmt.Errorf("unexpected error: %v", err)
+					return fmt.Errorf("unexpected error: %w", err)
 				}
 				if n := len(p.Postsubmits); n != 1 || p.Postsubmits[0].Name != "hans" {
 					return fmt.Errorf(`expected exactly one postsubmit with name "hans", got %v`, p.Postsubmits)
@@ -276,7 +276,7 @@ func testDefaultProwYAMLGetter(clients localgit.Clients, t *testing.T) {
 			name: "No prow.yaml, no error, no nullpointer",
 			validate: func(p *ProwYAML, err error) error {
 				if err != nil {
-					return fmt.Errorf("unexpected error: %v", err)
+					return fmt.Errorf("unexpected error: %w", err)
 				}
 				if p == nil {
 					return errors.New("prowYAML is nil")
@@ -294,7 +294,7 @@ func testDefaultProwYAMLGetter(clients localgit.Clients, t *testing.T) {
 			},
 			validate: func(p *ProwYAML, err error) error {
 				if err != nil {
-					return fmt.Errorf("unexpected error: %v", err)
+					return fmt.Errorf("unexpected error: %w", err)
 				}
 				if n := len(p.Postsubmits); n != 1 || p.Postsubmits[0].Name != "hans" {
 					return fmt.Errorf(`expected exactly one postsubmit with name "hans", got %v`, p.Postsubmits)
@@ -321,7 +321,7 @@ func testDefaultProwYAMLGetter(clients localgit.Clients, t *testing.T) {
 			},
 			validate: func(p *ProwYAML, err error) error {
 				if err != nil {
-					return fmt.Errorf("unexpected error: %v", err)
+					return fmt.Errorf("unexpected error: %w", err)
 				}
 				if n := len(p.Presubmits); n != 1 || p.Presubmits[0].Name != "hans" {
 					return fmt.Errorf(`expected exactly one presubmit with name "hans", got %v`, p.Presubmits)
@@ -337,7 +337,7 @@ func testDefaultProwYAMLGetter(clients localgit.Clients, t *testing.T) {
 			},
 			validate: func(p *ProwYAML, err error) error {
 				if err != nil {
-					return fmt.Errorf("unexpected error: %v", err)
+					return fmt.Errorf("unexpected error: %w", err)
 				}
 				if n := len(p.Presubmits); n != 1 || p.Presubmits[0].Name != "kurt" {
 					return fmt.Errorf(`expected exactly one presubmit with name "kurt", got %v`, p.Presubmits)
@@ -353,7 +353,7 @@ func testDefaultProwYAMLGetter(clients localgit.Clients, t *testing.T) {
 			},
 			validate: func(p *ProwYAML, err error) error {
 				if err != nil {
-					return fmt.Errorf("unexpected error: %v", err)
+					return fmt.Errorf("unexpected error: %w", err)
 				}
 				if n := len(p.Presubmits); n != 2 ||
 					p.Presubmits[0].Name != "hans" ||
@@ -371,7 +371,7 @@ func testDefaultProwYAMLGetter(clients localgit.Clients, t *testing.T) {
 			},
 			validate: func(p *ProwYAML, err error) error {
 				if err != nil {
-					return fmt.Errorf("unexpected error: %v", err)
+					return fmt.Errorf("unexpected error: %w", err)
 				}
 				if n := len(p.Presubmits); n != 2 ||
 					p.Presubmits[0].Name != "hans" ||
@@ -389,7 +389,7 @@ func testDefaultProwYAMLGetter(clients localgit.Clients, t *testing.T) {
 			},
 			validate: func(p *ProwYAML, err error) error {
 				if err != nil {
-					return fmt.Errorf("unexpected error: %v", err)
+					return fmt.Errorf("unexpected error: %w", err)
 				}
 				if n := len(p.Postsubmits); n != 2 ||
 					p.Postsubmits[0].Name != "hans" ||
@@ -407,7 +407,7 @@ func testDefaultProwYAMLGetter(clients localgit.Clients, t *testing.T) {
 			},
 			validate: func(p *ProwYAML, err error) error {
 				if err != nil {
-					return fmt.Errorf("unexpected error: %v", err)
+					return fmt.Errorf("unexpected error: %w", err)
 				}
 				if n := len(p.Postsubmits); n != 2 ||
 					p.Postsubmits[0].Name != "hans" ||
@@ -425,7 +425,7 @@ func testDefaultProwYAMLGetter(clients localgit.Clients, t *testing.T) {
 			},
 			validate: func(p *ProwYAML, err error) error {
 				if err != nil {
-					return fmt.Errorf("unexpected error: %v", err)
+					return fmt.Errorf("unexpected error: %w", err)
 				}
 				if n := len(p.Presets); n != 2 ||
 					p.Presets[0].Labels["hans"] != "hansValue" ||
@@ -443,7 +443,7 @@ func testDefaultProwYAMLGetter(clients localgit.Clients, t *testing.T) {
 			},
 			validate: func(p *ProwYAML, err error) error {
 				if err != nil {
-					return fmt.Errorf("unexpected error: %v", err)
+					return fmt.Errorf("unexpected error: %w", err)
 				}
 				if n := len(p.Presets); n != 2 ||
 					p.Presets[0].Labels["hans"] != "hansValue" ||
@@ -466,7 +466,7 @@ postsubmits: [{"name": "oli", "spec": {"containers": [{}]}}]`),
 			},
 			validate: func(p *ProwYAML, err error) error {
 				if err != nil {
-					return fmt.Errorf("unexpected error: %v", err)
+					return fmt.Errorf("unexpected error: %w", err)
 				}
 				if n := len(p.Presubmits); n != 2 ||
 					p.Presubmits[0].Name != "hans" ||
@@ -496,7 +496,7 @@ postsubmits: [{"name": "oli", "spec": {"containers": [{}]}}]`),
 			},
 			validate: func(p *ProwYAML, err error) error {
 				if err != nil {
-					return fmt.Errorf("unexpected error: %v", err)
+					return fmt.Errorf("unexpected error: %w", err)
 				}
 				if n := len(p.Presubmits); n != 2 ||
 					p.Presubmits[0].Name != "hans" ||
@@ -514,7 +514,7 @@ postsubmits: [{"name": "oli", "spec": {"containers": [{}]}}]`),
 			},
 			validate: func(p *ProwYAML, err error) error {
 				if err != nil {
-					return fmt.Errorf("unexpected error: %v", err)
+					return fmt.Errorf("unexpected error: %w", err)
 				}
 				if n := len(p.Presubmits); n != 2 ||
 					p.Presubmits[0].Name != "hans" ||

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -430,7 +430,7 @@ func NewGitHubDeferredChangedFilesProvider(client githubClient, org, repo string
 		if changedFiles == nil {
 			changes, err := client.GetPullRequestChanges(org, repo, num)
 			if err != nil {
-				return nil, fmt.Errorf("error getting pull request changes: %v", err)
+				return nil, fmt.Errorf("error getting pull request changes: %w", err)
 			}
 			for _, change := range changes {
 				changedFiles = append(changedFiles, change.Filename)
@@ -482,7 +482,7 @@ func (u *UtilityConfig) Validate() error {
 		if len(u.CloneURI) != 0 {
 			uri, err := url.Parse(cloneURI)
 			if err != nil {
-				return fmt.Errorf("couldn't parse uri from clone_uri: %v", err)
+				return fmt.Errorf("couldn't parse uri from clone_uri: %w", err)
 			}
 
 			if u.DecorationConfig != nil && u.DecorationConfig.OauthTokenSecret != nil {
@@ -501,7 +501,7 @@ func (u *UtilityConfig) Validate() error {
 
 	for i, ref := range u.ExtraRefs {
 		if err := cloneURIValidate(ref.CloneURI); err != nil {
-			return fmt.Errorf("extra_ref[%d]: %v", i, err)
+			return fmt.Errorf("extra_ref[%d]: %w", i, err)
 		}
 	}
 

--- a/prow/config/secret/secret.go
+++ b/prow/config/secret/secret.go
@@ -40,7 +40,7 @@ func loadSecrets(paths []string) (map[string][]byte, error) {
 func loadSingleSecret(path string) ([]byte, error) {
 	b, err := ioutil.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("error reading %s: %v", path, err)
+		return nil, fmt.Errorf("error reading %s: %w", path, err)
 	}
 	return bytes.TrimSpace(b), nil
 }

--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -665,7 +665,7 @@ func (c Config) GetTideContextPolicy(gitClient git.ClientFactory, org, repo, bra
 	}
 	presubmits, err := c.GetPresubmits(gitClient, org+"/"+repo, baseSHAGetter, headSHAGetter)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get presubmits: %v", err)
+		return nil, fmt.Errorf("failed to get presubmits: %w", err)
 	}
 
 	// automatically generate required and optional entries for Prow Jobs

--- a/prow/crier/reporters/gcs/kubernetes/reporter.go
+++ b/prow/crier/reporters/gcs/kubernetes/reporter.go
@@ -202,7 +202,7 @@ func (gr *gcsK8sReporter) reportPodInfo(ctx context.Context, log *logrus.Entry, 
 
 	bucketName, dir, err := util.GetJobDestination(gr.cfg, pj)
 	if err != nil {
-		return fmt.Errorf("couldn't get job destination: %v", err)
+		return fmt.Errorf("couldn't get job destination: %w", err)
 	}
 
 	if gr.dryRun {

--- a/prow/crier/reporters/gcs/reporter.go
+++ b/prow/crier/reporters/gcs/reporter.go
@@ -77,12 +77,12 @@ func (gr *gcsReporter) reportStartedJob(ctx context.Context, log *logrus.Entry, 
 	}
 	output, err := json.MarshalIndent(s, "", "\t")
 	if err != nil {
-		return fmt.Errorf("failed to marshal started metadata: %v", err)
+		return fmt.Errorf("failed to marshal started metadata: %w", err)
 	}
 
 	bucketName, dir, err := util.GetJobDestination(gr.cfg, pj)
 	if err != nil {
-		return fmt.Errorf("failed to get job destination: %v", err)
+		return fmt.Errorf("failed to get job destination: %w", err)
 	}
 
 	if gr.dryRun {
@@ -107,12 +107,12 @@ func (gr *gcsReporter) reportFinishedJob(ctx context.Context, log *logrus.Entry,
 	}
 	output, err := json.MarshalIndent(f, "", "\t")
 	if err != nil {
-		return fmt.Errorf("failed to marshal finished metadata: %v", err)
+		return fmt.Errorf("failed to marshal finished metadata: %w", err)
 	}
 
 	bucketName, dir, err := util.GetJobDestination(gr.cfg, pj)
 	if err != nil {
-		return fmt.Errorf("failed to get job destination: %v", err)
+		return fmt.Errorf("failed to get job destination: %w", err)
 	}
 
 	if gr.dryRun {
@@ -126,12 +126,12 @@ func (gr *gcsReporter) reportProwjob(ctx context.Context, log *logrus.Entry, pj 
 	// Unconditionally dump the prowjob to GCS, on all job updates.
 	output, err := json.MarshalIndent(pj, "", "\t")
 	if err != nil {
-		return fmt.Errorf("failed to marshal prowjob: %v", err)
+		return fmt.Errorf("failed to marshal prowjob: %w", err)
 	}
 
 	bucketName, dir, err := util.GetJobDestination(gr.cfg, pj)
 	if err != nil {
-		return fmt.Errorf("failed to get job destination: %v", err)
+		return fmt.Errorf("failed to get job destination: %w", err)
 	}
 
 	if gr.dryRun {

--- a/prow/crier/reporters/github/reporter.go
+++ b/prow/crier/reporters/github/reporter.go
@@ -150,7 +150,7 @@ func (c *Client) Report(ctx context.Context, log *logrus.Entry, pj *v1.ProwJob) 
 	if pj.Spec.Type == v1.PresubmitJob {
 		key, err := lockKeyForPJ(pj)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to get lockkey for job: %v", err)
+			return nil, nil, fmt.Errorf("failed to get lockkey for job: %w", err)
 		}
 		lock, err := c.prLocks.getLock(ctx, *key)
 		if err != nil {

--- a/prow/crier/reporters/pubsub/reporter.go
+++ b/prow/crier/reporters/pubsub/reporter.go
@@ -103,7 +103,7 @@ func (c *Client) Report(ctx context.Context, _ *logrus.Entry, pj *prowapi.ProwJo
 	// TODO: Consider caching the pubsub client.
 	client, err := pubsub.NewClient(ctx, message.Project)
 	if err != nil {
-		return nil, nil, fmt.Errorf("could not create pubsub Client: %v", err)
+		return nil, nil, fmt.Errorf("could not create pubsub Client: %w", err)
 	}
 	defer func() {
 		logrus.WithError(client.Close()).Debug("Closed pubsub client.")
@@ -114,7 +114,7 @@ func (c *Client) Report(ctx context.Context, _ *logrus.Entry, pj *prowapi.ProwJo
 
 	d, err := json.Marshal(message)
 	if err != nil {
-		return nil, nil, fmt.Errorf("could not marshal pubsub report: %v", err)
+		return nil, nil, fmt.Errorf("could not marshal pubsub report: %w", err)
 	}
 
 	res := topic.Publish(ctx, &pubsub.Message{

--- a/prow/crier/reporters/slack/reporter.go
+++ b/prow/crier/reporters/slack/reporter.go
@@ -90,11 +90,11 @@ func (sr *slackReporter) report(log *logrus.Entry, pj *v1.ProwJob) error {
 	tmpl, err := template.New("").Parse(jobSlackConfig.ReportTemplate)
 	if err != nil {
 		log.WithError(err).Error("failed to parse template")
-		return fmt.Errorf("failed to parse template: %v", err)
+		return fmt.Errorf("failed to parse template: %w", err)
 	}
 	if err := tmpl.Execute(b, pj); err != nil {
 		log.WithError(err).Error("failed to execute report template")
-		return fmt.Errorf("failed to execute report template: %v", err)
+		return fmt.Errorf("failed to execute report template: %w", err)
 	}
 	if sr.dryRun {
 		log.WithField("messagetext", b.String()).Debug("Skipping reporting because dry-run is enabled")
@@ -102,7 +102,7 @@ func (sr *slackReporter) report(log *logrus.Entry, pj *v1.ProwJob) error {
 	}
 	if err := client.WriteMessage(b.String(), channel); err != nil {
 		log.WithError(err).Error("failed to write Slack message")
-		return fmt.Errorf("failed to write Slack message: %v", err)
+		return fmt.Errorf("failed to write Slack message: %w", err)
 	}
 	return nil
 }

--- a/prow/cron/cron.go
+++ b/prow/cron/cron.go
@@ -158,7 +158,7 @@ func (c *Cron) addJob(name, cron string) error {
 	})
 
 	if err != nil {
-		return fmt.Errorf("cronAgent fails to add job %s with cron %s: %v", name, cron, err)
+		return fmt.Errorf("cronAgent fails to add job %s with cron %s: %w", name, cron, err)
 	}
 
 	c.jobs[name] = &jobStatus{

--- a/prow/deck/jobs/jobs.go
+++ b/prow/deck/jobs/jobs.go
@@ -133,7 +133,7 @@ func (c *filteringProwJobLister) ListProwJobs(selector string) ([]prowapi.ProwJo
 	prowJobList := &prowapi.ProwJobList{}
 	parsedSelector, err := labels.Parse(selector)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse selector: %v", err)
+		return nil, fmt.Errorf("failed to parse selector: %w", err)
 	}
 	listOpts := &ctrlruntimeclient.ListOptions{LabelSelector: parsedSelector, Namespace: c.cfg().ProwJobNamespace}
 	if err := c.client.List(c.ctx, prowJobList, listOpts); err != nil {
@@ -240,7 +240,7 @@ func (ja *JobAgent) GetProwJob(job, id string) (prowapi.ProwJob, error) {
 func (ja *JobAgent) GetJobLog(job, id string, container string) ([]byte, error) {
 	j, err := ja.GetProwJob(job, id)
 	if err != nil {
-		return nil, fmt.Errorf("error getting prowjob: %v", err)
+		return nil, fmt.Errorf("error getting prowjob: %w", err)
 	}
 	if j.Spec.Agent == prowapi.KubernetesAgent {
 		client, ok := ja.pkcs[j.ClusterAlias()]
@@ -258,7 +258,7 @@ func (ja *JobAgent) GetJobLog(job, id string, container string) ([]byte, error) 
 		}
 		var b bytes.Buffer
 		if err := agentToTmpl.URLTemplate.Execute(&b, &j); err != nil {
-			return nil, fmt.Errorf("cannot execute URL template for prowjob %q with agent %q: %v", j.ObjectMeta.Name, j.Spec.Agent, err)
+			return nil, fmt.Errorf("cannot execute URL template for prowjob %q with agent %q: %w", j.ObjectMeta.Name, j.Spec.Agent, err)
 		}
 		resp, err := http.Get(b.String())
 		if err != nil {

--- a/prow/external-plugins/refresh/server.go
+++ b/prow/external-plugins/refresh/server.go
@@ -137,7 +137,7 @@ func (s *server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent
 		PJs []prowapi.ProwJob `json:"items"`
 	}
 	if err := json.Unmarshal(data, &list); err != nil {
-		return fmt.Errorf("cannot unmarshal data from deck: %v", err)
+		return fmt.Errorf("cannot unmarshal data from deck: %w", err)
 	}
 
 	pr, err := s.ghc.GetPullRequest(org, repo, num)

--- a/prow/flagutil/github.go
+++ b/prow/flagutil/github.go
@@ -360,7 +360,7 @@ func (o *GitHubOptions) getGitAuthentication(dryRun bool) (string, git.GitTokenG
 	// the client must have been created at least once for us to have generators
 	if o.userGenerator == nil {
 		if _, err := o.GitHubClient(dryRun); err != nil {
-			return "", nil, fmt.Errorf("error getting GitHub client: %v", err)
+			return "", nil, fmt.Errorf("error getting GitHub client: %w", err)
 		}
 	}
 

--- a/prow/flagutil/kubernetes_cluster_clients.go
+++ b/prow/flagutil/kubernetes_cluster_clients.go
@@ -182,13 +182,13 @@ func (o *KubernetesOptions) AddFlags(fs *flag.FlagSet) {
 func (o *KubernetesOptions) Validate(_ bool) error {
 	if o.kubeconfig != "" {
 		if _, err := os.Stat(o.kubeconfig); err != nil {
-			return fmt.Errorf("error accessing --kubeconfig: %v", err)
+			return fmt.Errorf("error accessing --kubeconfig: %w", err)
 		}
 	}
 
 	if o.kubeconfigDir != "" {
 		if fileInfo, err := os.Stat(o.kubeconfigDir); err != nil {
-			return fmt.Errorf("error accessing --kubeconfig-dir: %v", err)
+			return fmt.Errorf("error accessing --kubeconfig-dir: %w", err)
 		} else if !fileInfo.IsDir() {
 			return fmt.Errorf("--kubeconfig-dir must be a directory")
 		}
@@ -209,7 +209,7 @@ func (o *KubernetesOptions) resolve(dryRun bool) error {
 		kube.ConfigDir(o.kubeconfigDir), kube.ConfigProjectedTokenFile(o.projectedTokenFile),
 		kube.NoInClusterConfig(o.noInClusterConfig)))
 	if err != nil {
-		return fmt.Errorf("load --kubeconfig=%q configs: %v", o.kubeconfig, err)
+		return fmt.Errorf("load --kubeconfig=%q configs: %w", o.kubeconfig, err)
 	}
 	o.clusterConfigs = clusterConfigs
 
@@ -217,7 +217,7 @@ func (o *KubernetesOptions) resolve(dryRun bool) error {
 	for context, config := range clusterConfigs {
 		client, err := kubernetes.NewForConfig(&config)
 		if err != nil {
-			return fmt.Errorf("create %s kubernetes client: %v", context, err)
+			return fmt.Errorf("create %s kubernetes client: %w", context, err)
 		}
 		clients[context] = client
 	}

--- a/prow/flagutil/storage.go
+++ b/prow/flagutil/storage.go
@@ -68,7 +68,7 @@ func (o *StorageClientOptions) StorageClient(ctx context.Context) (io.Opener, er
 		if o.S3CredentialsFile != "" {
 			message = fmt.Sprintf("%s s3-credentials-file: %s", message, o.S3CredentialsFile)
 		}
-		return opener, fmt.Errorf("error creating opener%s: %v", message, err)
+		return opener, fmt.Errorf("error creating opener%s: %w", message, err)
 	}
 	return opener, nil
 }

--- a/prow/genfiles/genfiles.go
+++ b/prow/genfiles/genfiles.go
@@ -82,7 +82,7 @@ func NewGroup(gc ghFileClient, owner, repo, sha string) (*Group, error) {
 		case *github.FileNotFound:
 			return g, nil
 		default:
-			return nil, fmt.Errorf("could not get .generated_files: %v", err)
+			return nil, fmt.Errorf("could not get .generated_files: %w", err)
 		}
 	}
 
@@ -163,7 +163,7 @@ func (g *Group) loadPaths(r io.Reader) error {
 	}
 
 	if err := s.Err(); err != nil {
-		return fmt.Errorf("scan error: %v", err)
+		return fmt.Errorf("scan error: %w", err)
 	}
 
 	return nil

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -114,7 +114,7 @@ func (c *Controller) Sync() error {
 func makeCloneURI(instance, project string) (*url.URL, error) {
 	u, err := url.Parse(instance)
 	if err != nil {
-		return nil, fmt.Errorf("instance %s is not a url: %v", instance, err)
+		return nil, fmt.Errorf("instance %s is not a url: %w", instance, err)
 	}
 	if u.Host == "" {
 		return nil, errors.New("instance does not set host")
@@ -249,7 +249,7 @@ func (c *Controller) processChange(logger logrus.FieldLogger, instance string, c
 		postsubmits = append(postsubmits, c.config().PostsubmitsStatic[cloneURI.Host+"/"+cloneURI.Path]...)
 		for _, postsubmit := range postsubmits {
 			if shouldRun, err := postsubmit.ShouldRun(change.Branch, changedFiles); err != nil {
-				return fmt.Errorf("failed to determine if postsubmit %q should run: %v", postsubmit.Name, err)
+				return fmt.Errorf("failed to determine if postsubmit %q should run: %w", postsubmit.Name, err)
 			} else if shouldRun {
 				jobSpecs = append(jobSpecs, jobSpec{
 					spec:   pjutil.PostsubmitSpec(postsubmit, refs),
@@ -265,7 +265,7 @@ func (c *Controller) processChange(logger logrus.FieldLogger, instance string, c
 		account, err := c.gc.Account(instance)
 		if err != nil {
 			// This would happen if authenticateOnce hasn't done register this instance yet
-			return fmt.Errorf("account not found for %q: %v", instance, err)
+			return fmt.Errorf("account not found for %q: %w", instance, err)
 		}
 
 		lastUpdate, ok := c.tracker.Current()[instance][change.Project]
@@ -397,7 +397,7 @@ func deckLinkForPR(deckURL string, refs prowapi.Refs, changeStatus string) (stri
 
 	parsed, err := url.Parse(deckURL)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse gerrit.deck_url (impossible: this should have been caught at load time): %v", err)
+		return "", fmt.Errorf("failed to parse gerrit.deck_url (impossible: this should have been caught at load time): %w", err)
 	}
 	query := parsed.Query()
 	query.Set("repo", fmt.Sprintf("%s/%s", refs.Org, refs.Repo))

--- a/prow/gerrit/client/client.go
+++ b/prow/gerrit/client/client.go
@@ -293,7 +293,7 @@ func (c *Client) SetReview(instance, id, revision, message string, labels map[st
 		Message: message,
 		Labels:  labels,
 	}); err != nil {
-		return fmt.Errorf("cannot comment to gerrit: %v", err)
+		return fmt.Errorf("cannot comment to gerrit: %w", err)
 	}
 
 	return nil
@@ -329,7 +329,7 @@ func (c *Client) Account(instance string) (*gerrit.AccountInfo, error) {
 
 	self, _, err := handler.accountService.GetAccount("self")
 	if err != nil {
-		return nil, fmt.Errorf("GetAccount() failed with new authentication: %v", err)
+		return nil, fmt.Errorf("GetAccount() failed with new authentication: %w", err)
 
 	}
 	c.accounts[instance] = self

--- a/prow/ghhook/ghhook.go
+++ b/prow/ghhook/ghhook.go
@@ -86,7 +86,7 @@ func GetOptions(fs *flag.FlagSet, args []string) (*Options, error) {
 
 	o.GitHubHookClient, err = o.GitHubOptions.GitHubClient(!o.Confirm)
 	if err != nil {
-		return nil, fmt.Errorf("error creating github client: %v", err)
+		return nil, fmt.Errorf("error creating github client: %w", err)
 	}
 
 	return &o, nil
@@ -95,7 +95,7 @@ func GetOptions(fs *flag.FlagSet, args []string) (*Options, error) {
 func (o *Options) hmacValueFromFile() (string, error) {
 	b, err := ioutil.ReadFile(o.HMACPath)
 	if err != nil {
-		return "", fmt.Errorf("read %s: %v", o.HMACPath, err)
+		return "", fmt.Errorf("read %s: %w", o.HMACPath, err)
 	}
 	return string(bytes.TrimSpace(b)), nil
 }
@@ -107,7 +107,7 @@ func (o *Options) HandleWebhookConfigChange() error {
 	if !o.ShouldDelete {
 		hmac, err = o.hmacValue()
 		if err != nil {
-			return fmt.Errorf("could not load hmac secret: %v", err)
+			return fmt.Errorf("could not load hmac secret: %w", err)
 		}
 	}
 
@@ -135,7 +135,7 @@ func (o *Options) HandleWebhookConfigChange() error {
 
 		org := parts[0]
 		if err := reconcileHook(ch, org, req, o); err != nil {
-			return fmt.Errorf("could not apply hook to %s: %v", orgRepo, err)
+			return fmt.Errorf("could not apply hook to %s: %w", orgRepo, err)
 		}
 	}
 	return nil
@@ -144,7 +144,7 @@ func (o *Options) HandleWebhookConfigChange() error {
 func reconcileHook(ch changer, org string, req github.HookRequest, o *Options) error {
 	hooks, err := ch.lister(org)
 	if err != nil {
-		return fmt.Errorf("list: %v", err)
+		return fmt.Errorf("list: %w", err)
 	}
 	id := findHook(hooks, req.Config.URL)
 	if id == nil {

--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -437,7 +437,7 @@ func (r *Repo) PushToNamedFork(forkName, branch string, force bool) error {
 	out, err := co.CombinedOutput()
 	if err != nil {
 		r.logger.WithField("out", string(out)).WithError(err).Error("Pushing failed.")
-		return fmt.Errorf("pushing failed, output: %q, error: %v", string(out), err)
+		return fmt.Errorf("pushing failed, output: %q, error: %w", string(out), err)
 	}
 	return nil
 }
@@ -518,7 +518,7 @@ func (r *Repo) ShowRef(commitlike string) (string, error) {
 	r.logger.WithField("commitlike", commitlike).Info("Getting the commit sha.")
 	out, err := r.gitCommand("show-ref", "-s", commitlike).CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("failed to get commit sha for commitlike %s: %v", commitlike, err)
+		return "", fmt.Errorf("failed to get commit sha for commitlike %s: %w", commitlike, err)
 	}
 	return strings.TrimSpace(string(out)), nil
 }

--- a/prow/git/v2/interactor.go
+++ b/prow/git/v2/interactor.go
@@ -109,7 +109,7 @@ func (i *interactor) Clean() error {
 func (i *interactor) Clone(from string) error {
 	i.logger.Infof("Creating a clone of the repo at %s from %s", i.dir, from)
 	if out, err := i.executor.Run("clone", from, i.dir); err != nil {
-		return fmt.Errorf("error creating a clone: %v %v", err, string(out))
+		return fmt.Errorf("error creating a clone: %w %v", err, string(out))
 	}
 	return nil
 }
@@ -120,10 +120,10 @@ func (i *interactor) MirrorClone() error {
 	i.logger.Infof("Creating a mirror of the repo at %s", i.dir)
 	remote, err := i.remote()
 	if err != nil {
-		return fmt.Errorf("could not resolve remote for cloning: %v", err)
+		return fmt.Errorf("could not resolve remote for cloning: %w", err)
 	}
 	if out, err := i.executor.Run("clone", "--mirror", remote, i.dir); err != nil {
-		return fmt.Errorf("error creating a mirror clone: %v %v", err, string(out))
+		return fmt.Errorf("error creating a mirror clone: %w %v", err, string(out))
 	}
 	return nil
 }
@@ -132,7 +132,7 @@ func (i *interactor) MirrorClone() error {
 func (i *interactor) Checkout(commitlike string) error {
 	i.logger.Infof("Checking out %q", commitlike)
 	if out, err := i.executor.Run("checkout", commitlike); err != nil {
-		return fmt.Errorf("error checking out %q: %v %v", commitlike, err, string(out))
+		return fmt.Errorf("error checking out %q: %w %v", commitlike, err, string(out))
 	}
 	return nil
 }
@@ -142,7 +142,7 @@ func (i *interactor) RevParse(commitlike string) (string, error) {
 	i.logger.Infof("Parsing revision %q", commitlike)
 	out, err := i.executor.Run("rev-parse", commitlike)
 	if err != nil {
-		return "", fmt.Errorf("error parsing %q: %v %v", commitlike, err, string(out))
+		return "", fmt.Errorf("error parsing %q: %w %v", commitlike, err, string(out))
 	}
 	return string(out), nil
 }
@@ -158,7 +158,7 @@ func (i *interactor) BranchExists(branch string) bool {
 func (i *interactor) CheckoutNewBranch(branch string) error {
 	i.logger.Infof("Checking out new branch %q", branch)
 	if out, err := i.executor.Run("checkout", "-b", branch); err != nil {
-		return fmt.Errorf("error checking out new branch %q: %v %v", branch, err, string(out))
+		return fmt.Errorf("error checking out new branch %q: %w %v", branch, err, string(out))
 	}
 	return nil
 }
@@ -203,7 +203,7 @@ func (i *interactor) mergeMerge(commitlike string, opts ...MergeOpt) (bool, erro
 	}
 	i.logger.WithError(err).Warnf("Error merging %q: %s", commitlike, string(out))
 	if out, err := i.executor.Run("merge", "--abort"); err != nil {
-		return false, fmt.Errorf("error aborting merge of %q: %v %v", commitlike, err, string(out))
+		return false, fmt.Errorf("error aborting merge of %q: %w %v", commitlike, err, string(out))
 	}
 	return false, nil
 }
@@ -213,7 +213,7 @@ func (i *interactor) squashMerge(commitlike string) (bool, error) {
 	if err != nil {
 		i.logger.WithError(err).Warnf("Error staging merge for %q: %s", commitlike, string(out))
 		if out, err := i.executor.Run("reset", "--hard", "HEAD"); err != nil {
-			return false, fmt.Errorf("error aborting merge of %q: %v %v", commitlike, err, string(out))
+			return false, fmt.Errorf("error aborting merge of %q: %w %v", commitlike, err, string(out))
 		}
 		return false, nil
 	}
@@ -221,7 +221,7 @@ func (i *interactor) squashMerge(commitlike string) (bool, error) {
 	if err != nil {
 		i.logger.WithError(err).Warnf("Error committing merge for %q: %s", commitlike, string(out))
 		if out, err := i.executor.Run("reset", "--hard", "HEAD"); err != nil {
-			return false, fmt.Errorf("error aborting merge of %q: %v %v", commitlike, err, string(out))
+			return false, fmt.Errorf("error aborting merge of %q: %w %v", commitlike, err, string(out))
 		}
 		return false, nil
 	}
@@ -267,7 +267,7 @@ func (i *interactor) Am(path string) error {
 func (i *interactor) RemoteUpdate() error {
 	i.logger.Info("Updating from remote")
 	if out, err := i.executor.Run("remote", "update", "--prune"); err != nil {
-		return fmt.Errorf("error updating: %v %v", err, string(out))
+		return fmt.Errorf("error updating: %w %v", err, string(out))
 	}
 	return nil
 }
@@ -276,11 +276,11 @@ func (i *interactor) RemoteUpdate() error {
 func (i *interactor) Fetch() error {
 	remote, err := i.remote()
 	if err != nil {
-		return fmt.Errorf("could not resolve remote for fetching: %v", err)
+		return fmt.Errorf("could not resolve remote for fetching: %w", err)
 	}
 	i.logger.Infof("Fetching from %s", remote)
 	if out, err := i.executor.Run("fetch", remote); err != nil {
-		return fmt.Errorf("error fetching: %v %v", err, string(out))
+		return fmt.Errorf("error fetching: %w %v", err, string(out))
 	}
 	return nil
 }
@@ -289,11 +289,11 @@ func (i *interactor) Fetch() error {
 func (i *interactor) FetchRef(refspec string) error {
 	remote, err := i.remote()
 	if err != nil {
-		return fmt.Errorf("could not resolve remote for fetching: %v", err)
+		return fmt.Errorf("could not resolve remote for fetching: %w", err)
 	}
 	i.logger.Infof("Fetching %q from %s", refspec, remote)
 	if out, err := i.executor.Run("fetch", remote, refspec); err != nil {
-		return fmt.Errorf("error fetching %q: %v %v", refspec, err, string(out))
+		return fmt.Errorf("error fetching %q: %w %v", refspec, err, string(out))
 	}
 	return nil
 }
@@ -302,12 +302,12 @@ func (i *interactor) FetchRef(refspec string) error {
 func (i *interactor) FetchFromRemote(remote RemoteResolver, branch string) error {
 	r, err := remote()
 	if err != nil {
-		return fmt.Errorf("couldn't get remote: %v", err)
+		return fmt.Errorf("couldn't get remote: %w", err)
 	}
 
 	i.logger.Infof("Fetching %s from %s", branch, r)
 	if out, err := i.executor.Run("fetch", r, branch); err != nil {
-		return fmt.Errorf("error fetching %s from %s: %v %v", branch, r, err, string(out))
+		return fmt.Errorf("error fetching %s from %s: %w %v", branch, r, err, string(out))
 	}
 	return nil
 }
@@ -332,7 +332,7 @@ func (i *interactor) CheckoutPullRequest(number int) error {
 func (i *interactor) Config(args ...string) error {
 	i.logger.WithField("args", args).Info("Configuring.")
 	if out, err := i.executor.Run(append([]string{"config"}, args...)...); err != nil {
-		return fmt.Errorf("error configuring %v: %v %v", args, err, string(out))
+		return fmt.Errorf("error configuring %v: %w %v", args, err, string(out))
 	}
 	return nil
 }
@@ -369,7 +369,7 @@ func (i *interactor) ShowRef(commitlike string) (string, error) {
 	i.logger.Infof("Getting the commit sha for commitlike %s", commitlike)
 	out, err := i.executor.Run("show-ref", "-s", commitlike)
 	if err != nil {
-		return "", fmt.Errorf("failed to get commit sha for commitlike %s: %v", commitlike, err)
+		return "", fmt.Errorf("failed to get commit sha for commitlike %s: %w", commitlike, err)
 	}
 	return strings.TrimSpace(string(out)), nil
 }

--- a/prow/git/v2/publisher.go
+++ b/prow/git/v2/publisher.go
@@ -63,7 +63,7 @@ func (p *publisher) Commit(title, body string) error {
 	}
 	for _, command := range commands {
 		if out, err := p.executor.Run(command...); err != nil {
-			return fmt.Errorf("error committing %q: %v %v", title, err, string(out))
+			return fmt.Errorf("error committing %q: %w %v", title, err, string(out))
 		}
 	}
 	return nil
@@ -88,7 +88,7 @@ func (p *publisher) PushToFork(branch string, force bool) error {
 
 	p.logger.Infof("Pushing branch %q to %q", branch, remote)
 	if out, err := p.executor.Run(args...); err != nil {
-		return fmt.Errorf("error pushing %q: %v %v", branch, err, string(out))
+		return fmt.Errorf("error pushing %q: %w %v", branch, err, string(out))
 	}
 	return nil
 }
@@ -108,7 +108,7 @@ func (p *publisher) PushToCentral(branch string, force bool) error {
 
 	p.logger.Infof("Pushing branch %q to %q", branch, remote)
 	if out, err := p.executor.Run(args...); err != nil {
-		return fmt.Errorf("error pushing %q: %v %v", branch, err, string(out))
+		return fmt.Errorf("error pushing %q: %w %v", branch, err, string(out))
 	}
 	return nil
 }

--- a/prow/git/v2/remote.go
+++ b/prow/git/v2/remote.go
@@ -108,13 +108,13 @@ func HttpResolver(remote func() (*url.URL, error), username LoginGetter, token T
 	return func() (string, error) {
 		remote, err := remote()
 		if err != nil {
-			return "", fmt.Errorf("could not resolve remote: %v", err)
+			return "", fmt.Errorf("could not resolve remote: %w", err)
 		}
 
 		if username != nil {
 			name, err := username()
 			if err != nil {
-				return "", fmt.Errorf("could not resolve username: %v", err)
+				return "", fmt.Errorf("could not resolve username: %w", err)
 			}
 			remote.User = url.UserPassword(name, string(token()))
 		}

--- a/prow/git/v2/remote_test.go
+++ b/prow/git/v2/remote_test.go
@@ -18,6 +18,7 @@ package git
 
 import (
 	"errors"
+	"fmt"
 	"net/url"
 	"reflect"
 	"testing"
@@ -196,7 +197,7 @@ func TestHTTPResolverFactory(t *testing.T) {
 	central := factory.CentralRemote("org", "repo")
 	for i, expected := range []stringWithError{
 		{str: "https://first:one@host.com/org/repo", err: nil},
-		{str: "", err: errors.New("could not resolve username: oops")},
+		{str: "", err: fmt.Errorf("could not resolve username: %w", errors.New("oops"))},
 		{str: "https://third:three@host.com/org/repo", err: nil},
 	} {
 		actualRemote, actualErr := central()
@@ -211,9 +212,9 @@ func TestHTTPResolverFactory(t *testing.T) {
 	publish := factory.PublishRemote("org", "repo")
 	for i, expected := range []stringWithError{
 		{str: "https://first:one@host.com/first/repo", err: nil},
-		{str: "", err: errors.New("could not resolve remote: oops")},
+		{str: "", err: fmt.Errorf("could not resolve remote: %w", errors.New("oops"))},
 		{str: "https://third:three@host.com/third/repo", err: nil},
-		{str: "", err: errors.New("could not resolve username: oops")},
+		{str: "", err: fmt.Errorf("could not resolve username: %w", errors.New("oops"))},
 	} {
 		actualRemote, actualErr := publish()
 		if actualRemote != expected.str {

--- a/prow/gitattributes/gitattributes.go
+++ b/prow/gitattributes/gitattributes.go
@@ -52,7 +52,7 @@ func NewGroup(gitAttributesContent func() ([]byte, error)) (*Group, error) {
 		case *github.FileNotFound:
 			return g, nil
 		default:
-			return nil, fmt.Errorf("could not get .gitattributes: %v", err)
+			return nil, fmt.Errorf("could not get .gitattributes: %w", err)
 		}
 	}
 
@@ -87,14 +87,14 @@ func (g *Group) load(r io.Reader) error {
 		if attributes.Has("linguist-generated=true") {
 			p, err := parsePattern(fs[0])
 			if err != nil {
-				return fmt.Errorf("error parsing pattern: %v", err)
+				return fmt.Errorf("error parsing pattern: %w", err)
 			}
 			g.LinguistGeneratedPatterns = append(g.LinguistGeneratedPatterns, p)
 		}
 	}
 
 	if err := s.Err(); err != nil {
-		return fmt.Errorf("scan error: %v", err)
+		return fmt.Errorf("scan error: %w", err)
 	}
 
 	return nil

--- a/prow/github/app_auth_roundtripper_test.go
+++ b/prow/github/app_auth_roundtripper_test.go
@@ -98,7 +98,7 @@ func TestAppsAuth(t *testing.T) {
 			doRequest: func(c Client) error {
 				_, err := c.GetApp()
 				if expectedMsg := "status code 401 not one of [200], body: "; err == nil || err.Error() != expectedMsg {
-					return fmt.Errorf("expected error to have message %s, was %v", expectedMsg, err)
+					return fmt.Errorf("expected error to have message %s, was %w", expectedMsg, err)
 				}
 				return nil
 			},
@@ -291,7 +291,7 @@ func TestAppsAuth(t *testing.T) {
 				_, err := c.GetOrg("other-org")
 				expectedErrMsgSubstr := "failed to get installation id for org other-org: the github app is not installed in organization other-org"
 				if err == nil || !strings.Contains(err.Error(), expectedErrMsgSubstr) {
-					return fmt.Errorf("expected error to contain string %s, was %v", expectedErrMsgSubstr, err)
+					return fmt.Errorf("expected error to contain string %s, was %w", expectedErrMsgSubstr, err)
 				}
 				return nil
 			},

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -1055,7 +1055,7 @@ func (c *client) requestRetryWithContext(ctx context.Context, method, path, acce
 							break
 						}
 					} else {
-						err = fmt.Errorf("failed to parse rate limit reset unix time %q: %v", resp.Header.Get("X-RateLimit-Reset"), err)
+						err = fmt.Errorf("failed to parse rate limit reset unix time %q: %w", resp.Header.Get("X-RateLimit-Reset"), err)
 						resp.Body.Close()
 						break
 					}
@@ -1076,7 +1076,7 @@ func (c *client) requestRetryWithContext(ctx context.Context, method, path, acce
 							break
 						}
 					} else {
-						err = fmt.Errorf("failed to parse abuse rate limit wait time %q: %v", rawTime, err)
+						err = fmt.Errorf("failed to parse abuse rate limit wait time %q: %w", rawTime, err)
 						resp.Body.Close()
 						break
 					}
@@ -1280,7 +1280,7 @@ func (c *client) BotUser() (*UserData, error) {
 	defer c.mut.Unlock()
 	if c.userData == nil {
 		if err := c.getUserData(context.Background()); err != nil {
-			return nil, fmt.Errorf("fetching bot name from GitHub: %v", err)
+			return nil, fmt.Errorf("fetching bot name from GitHub: %w", err)
 		}
 	}
 	return c.userData, nil
@@ -1316,7 +1316,7 @@ func (c *client) Email() (string, error) {
 	defer c.mut.Unlock()
 	if c.userData == nil {
 		if err := c.getUserData(context.Background()); err != nil {
-			return "", fmt.Errorf("fetching e-mail from GitHub: %v", err)
+			return "", fmt.Errorf("fetching e-mail from GitHub: %w", err)
 		}
 	}
 	return c.userData.Email, nil
@@ -1997,7 +1997,7 @@ func (c *client) readPaginatedResultsWithValuesWithContext(ctx context.Context, 
 
 		u, err := url.Parse(link)
 		if err != nil {
-			return fmt.Errorf("failed to parse 'next' link: %v", err)
+			return fmt.Errorf("failed to parse 'next' link: %w", err)
 		}
 		pagedPath = strings.TrimPrefix(u.RequestURI(), prefix)
 	}
@@ -2260,7 +2260,7 @@ func (c *client) CreatePullRequest(org, repo, title, body, head, base string, ca
 		exitCodes:   []int{201},
 	}, &resp)
 	if err != nil {
-		return 0, fmt.Errorf("failed to create pull request against %s/%s#%s from head %s: %v", org, repo, base, head, err)
+		return 0, fmt.Errorf("failed to create pull request against %s/%s#%s from head %s: %w", org, repo, base, head, err)
 	}
 	return resp.Num, nil
 }
@@ -2629,7 +2629,7 @@ func (c *client) GetBranchProtection(org, repo, branch string) (*BranchProtectio
 	case code == 404:
 		// continue
 	default:
-		return nil, fmt.Errorf("unexpected status code: %v", code)
+		return nil, fmt.Errorf("unexpected status code: %d", code)
 	}
 
 	var ge githubError
@@ -2868,7 +2868,7 @@ func (c *client) RemoveLabelWithContext(ctx context.Context, org, repo string, n
 	case err != nil:
 		return err
 	default:
-		return fmt.Errorf("unexpected status code: %v", code)
+		return fmt.Errorf("unexpected status code: %d", code)
 	}
 
 	ge := &githubError{}
@@ -3091,7 +3091,7 @@ func (c *client) RequestReview(org, repo string, number int, logins []string) er
 				// User is not a contributor, or team not in org.
 				missing.Users = append(missing.Users, user)
 			} else if err != nil {
-				return fmt.Errorf("failed to add reviewer to PR. Status code: %d, errmsg: %v", statusCode, err)
+				return fmt.Errorf("failed to add reviewer to PR. Status code: %d, errmsg: %w", statusCode, err)
 			}
 		}
 		if len(missing.Users) > 0 {
@@ -3464,7 +3464,7 @@ func (c *client) GetFile(org, repo, filepath, commit string) ([]byte, error) {
 
 	decoded, err := base64.StdEncoding.DecodeString(res.Content)
 	if err != nil {
-		return nil, fmt.Errorf("error decoding %s : %v", res.Content, err)
+		return nil, fmt.Errorf("error decoding %s : %w", res.Content, err)
 	}
 
 	return decoded, nil
@@ -4003,18 +4003,18 @@ func (c *client) EnsureFork(forkingUser, org, repo string) (string, error) {
 	fork := forkingUser + "/" + repo
 	repos, err := c.GetRepos(forkingUser, true)
 	if err != nil {
-		return repo, fmt.Errorf("could not fetch all existing repos: %v", err)
+		return repo, fmt.Errorf("could not fetch all existing repos: %w", err)
 	}
 	// if the repo does not exist, or it does, but is not a fork of the repo we want
 	if forkedRepo := getFork(fork, repos); forkedRepo == nil || forkedRepo.Parent.FullName != fmt.Sprintf("%s/%s", org, repo) {
 		if name, err := c.CreateFork(org, repo); err != nil {
-			return repo, fmt.Errorf("cannot fork %s/%s: %v", org, repo, err)
+			return repo, fmt.Errorf("cannot fork %s/%s: %w", org, repo, err)
 		} else {
 			// we got a fork but it may be named differently
 			repo = name
 		}
 		if err := c.waitForRepo(forkingUser, repo); err != nil {
-			return repo, fmt.Errorf("fork of %s/%s cannot show up on GitHub: %v", org, repo, err)
+			return repo, fmt.Errorf("fork of %s/%s cannot show up on GitHub: %w", org, repo, err)
 		}
 	}
 	return repo, nil

--- a/prow/github/helpers.go
+++ b/prow/github/helpers.go
@@ -56,7 +56,7 @@ func ImageTooBig(url string) (bool, error) {
 	// try to get the image size from Content-Length header
 	resp, err := http.Head(url)
 	if err != nil {
-		return true, fmt.Errorf("HEAD error: %v", err)
+		return true, fmt.Errorf("HEAD error: %w", err)
 	}
 	defer resp.Body.Close()
 	if sc := resp.StatusCode; sc != http.StatusOK {

--- a/prow/github/report/report.go
+++ b/prow/github/report/report.go
@@ -64,7 +64,7 @@ func prowjobStateToGitHubStatus(pjState prowapi.ProwJobState) (string, error) {
 	case prowapi.AbortedState:
 		return github.StatusFailure, nil
 	}
-	return "", fmt.Errorf("Unknown prowjob state: %v", pjState)
+	return "", fmt.Errorf("Unknown prowjob state: %s", pjState)
 }
 
 // reportStatus should be called on any prowjob status changes
@@ -153,7 +153,7 @@ func Report(ctx context.Context, ghc GitHubClient, reportTemplate *template.Temp
 
 	ics, err := ghc.ListIssueCommentsWithContext(ctx, refs.Org, refs.Repo, refs.Pulls[0].Number)
 	if err != nil {
-		return fmt.Errorf("error listing comments: %v", err)
+		return fmt.Errorf("error listing comments: %w", err)
 	}
 	botNameChecker, err := ghc.BotUserCheckerWithContext(ctx)
 	if err != nil {
@@ -162,21 +162,21 @@ func Report(ctx context.Context, ghc GitHubClient, reportTemplate *template.Temp
 	deletes, entries, updateID := parseIssueComments(pj, botNameChecker, ics)
 	for _, delete := range deletes {
 		if err := ghc.DeleteCommentWithContext(ctx, refs.Org, refs.Repo, delete); err != nil {
-			return fmt.Errorf("error deleting comment: %v", err)
+			return fmt.Errorf("error deleting comment: %w", err)
 		}
 	}
 	if len(entries) > 0 {
 		comment, err := createComment(reportTemplate, pj, entries)
 		if err != nil {
-			return fmt.Errorf("generating comment: %v", err)
+			return fmt.Errorf("generating comment: %w", err)
 		}
 		if updateID == 0 {
 			if err := ghc.CreateCommentWithContext(ctx, refs.Org, refs.Repo, refs.Pulls[0].Number, comment); err != nil {
-				return fmt.Errorf("error creating comment: %v", err)
+				return fmt.Errorf("error creating comment: %w", err)
 			}
 		} else {
 			if err := ghc.EditCommentWithContext(ctx, refs.Org, refs.Repo, updateID, comment); err != nil {
-				return fmt.Errorf("error updating comment: %v", err)
+				return fmt.Errorf("error updating comment: %w", err)
 			}
 		}
 	}

--- a/prow/initupload/run.go
+++ b/prow/initupload/run.go
@@ -85,7 +85,7 @@ func shaForRefs(refs prowv1.Refs, cloneRecords []clone.Record) string {
 func (o Options) Run() error {
 	spec, err := downwardapi.ResolveSpecFromEnv()
 	if err != nil {
-		return fmt.Errorf("could not resolve job spec: %v", err)
+		return fmt.Errorf("could not resolve job spec: %w", err)
 	}
 
 	uploadTargets := map[string]gcs.UploadFunc{}
@@ -102,14 +102,14 @@ func (o Options) Run() error {
 
 	startedData, err := json.Marshal(&started)
 	if err != nil {
-		return fmt.Errorf("could not marshal starting data: %v", err)
+		return fmt.Errorf("could not marshal starting data: %w", err)
 	}
 
 	uploadTargets[prowv1.StartedStatusFile] = gcs.DataUpload(bytes.NewReader(startedData))
 
 	ctx := context.Background()
 	if err := o.Options.Run(ctx, spec, uploadTargets); err != nil {
-		return fmt.Errorf("failed to upload to blob storage: %v", err)
+		return fmt.Errorf("failed to upload to blob storage: %w", err)
 	}
 
 	if failed {
@@ -128,10 +128,10 @@ func processCloneLog(logfile string, uploadTargets map[string]gcs.UploadFunc) (b
 	var cloneRecords []clone.Record
 	data, err := ioutil.ReadFile(logfile)
 	if err != nil {
-		return true, cloneRecords, fmt.Errorf("could not read clone log: %v", err)
+		return true, cloneRecords, fmt.Errorf("could not read clone log: %w", err)
 	}
 	if err = json.Unmarshal(data, &cloneRecords); err != nil {
-		return true, cloneRecords, fmt.Errorf("could not unmarshal clone records: %v", err)
+		return true, cloneRecords, fmt.Errorf("could not unmarshal clone records: %w", err)
 	}
 	// Do not read from cloneLog directly. Instead create multiple readers from cloneLog so it can
 	// be uploaded to both clone-log.txt and build-log.txt on failure.
@@ -157,7 +157,7 @@ func processCloneLog(logfile string, uploadTargets map[string]gcs.UploadFunc) (b
 		}
 		finishedData, err := json.Marshal(&finished)
 		if err != nil {
-			return true, cloneRecords, fmt.Errorf("could not marshal finishing data: %v", err)
+			return true, cloneRecords, fmt.Errorf("could not marshal finishing data: %w", err)
 		}
 		uploadTargets[prowv1.FinishedStatusFile] = gcs.DataUpload(bytes.NewReader(finishedData))
 	}

--- a/prow/interrupts/interrupts_test.go
+++ b/prow/interrupts/interrupts_test.go
@@ -229,7 +229,7 @@ func TestInterrupts(t *testing.T) {
 func generateCerts(url string) (string, string, error) {
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to generate private key: %v", err)
+		return "", "", fmt.Errorf("failed to generate private key: %w", err)
 	}
 
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
@@ -271,11 +271,11 @@ func generateCerts(url string) (string, string, error) {
 
 	keyOut, err := ioutil.TempFile("", "key.pem")
 	if err != nil {
-		return "", "", fmt.Errorf("failed to open key.pem for writing: %v", err)
+		return "", "", fmt.Errorf("failed to open key.pem for writing: %w", err)
 	}
 	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
 	if err != nil {
-		return "", "", fmt.Errorf("unable to marshal private key: %v", err)
+		return "", "", fmt.Errorf("unable to marshal private key: %w", err)
 	}
 	if err := pem.Encode(keyOut, &pem.Block{Type: "PRIVATE KEY", Bytes: privBytes}); err != nil {
 		return "", "", fmt.Errorf("failed to write data to key.pem: %s", err)
@@ -284,7 +284,7 @@ func generateCerts(url string) (string, string, error) {
 		return "", "", fmt.Errorf("error closing key.pem: %s", err)
 	}
 	if err := os.Chmod(keyOut.Name(), 0600); err != nil {
-		return "", "", fmt.Errorf("could not change permissions on key.pem: %v", err)
+		return "", "", fmt.Errorf("could not change permissions on key.pem: %w", err)
 	}
 	return certOut.Name(), keyOut.Name(), nil
 }

--- a/prow/io/opener.go
+++ b/prow/io/opener.go
@@ -204,7 +204,7 @@ func (o *opener) Reader(ctx context.Context, path string) (io.ReadCloser, error)
 	if strings.HasPrefix(path, providers.GS+"://") {
 		g, err := o.openGCS(path)
 		if err != nil {
-			return nil, fmt.Errorf("bad gcs path: %v", err)
+			return nil, fmt.Errorf("bad gcs path: %w", err)
 		}
 		return g.NewReader(ctx)
 	}
@@ -227,7 +227,7 @@ func (o *opener) RangeReader(ctx context.Context, path string, offset, length in
 	if strings.HasPrefix(path, providers.GS+"://") {
 		g, err := o.openGCS(path)
 		if err != nil {
-			return nil, fmt.Errorf("bad gcs path: %v", err)
+			return nil, fmt.Errorf("bad gcs path: %w", err)
 		}
 		return g.NewRangeReader(ctx, offset, length)
 	}
@@ -254,7 +254,7 @@ func (o *opener) Writer(ctx context.Context, p string, opts ...WriterOptions) (i
 	if strings.HasPrefix(p, providers.GS+"://") {
 		g, err := o.openGCS(p)
 		if err != nil {
-			return nil, fmt.Errorf("bad gcs path: %v", err)
+			return nil, fmt.Errorf("bad gcs path: %w", err)
 		}
 		if options.PreconditionDoesNotExist != nil && *options.PreconditionDoesNotExist {
 			g = g.If(storage.Conditions{DoesNotExist: true})
@@ -307,7 +307,7 @@ func (o *opener) Attributes(ctx context.Context, path string) (Attributes, error
 	if strings.HasPrefix(path, providers.GS+"://") {
 		g, err := o.openGCS(path)
 		if err != nil {
-			return Attributes{}, fmt.Errorf("bad gcs path: %v", err)
+			return Attributes{}, fmt.Errorf("bad gcs path: %w", err)
 		}
 		attr, err := g.Attrs(ctx)
 		if err != nil {

--- a/prow/io/providers/providers.go
+++ b/prow/io/providers/providers.go
@@ -93,7 +93,7 @@ type s3Credentials struct {
 func getS3Bucket(ctx context.Context, creds []byte, bucketName string) (*blob.Bucket, error) {
 	s3Creds := &s3Credentials{}
 	if err := json.Unmarshal(creds, s3Creds); err != nil {
-		return nil, fmt.Errorf("error getting S3 credentials from JSON: %v", err)
+		return nil, fmt.Errorf("error getting S3 credentials from JSON: %w", err)
 	}
 
 	cfg := &aws.Config{}
@@ -117,12 +117,12 @@ func getS3Bucket(ctx context.Context, creds []byte, bucketName string) (*blob.Bu
 
 	sess, err := session.NewSession(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("error creating S3 Session: %v", err)
+		return nil, fmt.Errorf("error creating S3 Session: %w", err)
 	}
 
 	bkt, err := s3blob.OpenBucket(ctx, sess, bucketName, nil)
 	if err != nil {
-		return nil, fmt.Errorf("error opening S3 bucket: %v", err)
+		return nil, fmt.Errorf("error opening S3 bucket: %w", err)
 	}
 	return bkt, nil
 }
@@ -147,7 +147,7 @@ func HasStorageProviderPrefix(path string) bool {
 func ParseStoragePath(storagePath string) (storageProvider, bucket, relativePath string, err error) {
 	parsedPath, err := url.Parse(storagePath)
 	if err != nil {
-		return "", "", "", fmt.Errorf("unable to parse path %q: %v", storagePath, err)
+		return "", "", "", fmt.Errorf("unable to parse path %q: %w", storagePath, err)
 	}
 
 	storageProvider = parsedPath.Scheme

--- a/prow/jenkins/controller.go
+++ b/prow/jenkins/controller.go
@@ -169,7 +169,7 @@ func (c *Controller) incrementNumPendingJobs(job string) {
 func (c *Controller) Sync() error {
 	pjs, err := c.prowJobClient.List(context.TODO(), metav1.ListOptions{LabelSelector: c.selector})
 	if err != nil {
-		return fmt.Errorf("error listing prow jobs: %v", err)
+		return fmt.Errorf("error listing prow jobs: %w", err)
 	}
 	// Share what we have for gathering metrics.
 	c.pjLock.Lock()
@@ -186,7 +186,7 @@ func (c *Controller) Sync() error {
 	}
 	jbs, err := c.jc.ListBuilds(getJenkinsJobs(jenkinsJobs))
 	if err != nil {
-		return fmt.Errorf("error listing jenkins builds: %v", err)
+		return fmt.Errorf("error listing jenkins builds: %w", err)
 	}
 
 	var syncErrs []error
@@ -414,7 +414,7 @@ func (c *Controller) syncAbortedJob(pj prowapi.ProwJob, _ chan<- prowapi.ProwJob
 
 	if build, exists := jbs[pj.Name]; exists {
 		if err := c.jc.Abort(getJobName(&pj.Spec), &build); err != nil {
-			return fmt.Errorf("failed to abort Jenkins build: %v", err)
+			return fmt.Errorf("failed to abort Jenkins build: %w", err)
 		}
 	}
 
@@ -435,7 +435,7 @@ func (c *Controller) syncTriggeredJob(pj prowapi.ProwJob, reports chan<- prowapi
 		}
 		buildID, err := c.getBuildID(pj.Spec.Job)
 		if err != nil {
-			return fmt.Errorf("error getting build ID: %v", err)
+			return fmt.Errorf("error getting build ID: %w", err)
 		}
 		// Start the Jenkins job.
 		if err := c.jc.Build(&pj, buildID); err != nil {

--- a/prow/jenkins/jenkins.go
+++ b/prow/jenkins/jenkins.go
@@ -283,7 +283,7 @@ func NewClient(
 	}
 	if c.authConfig.CSRFProtect {
 		if err := c.CrumbRequest(); err != nil {
-			return nil, fmt.Errorf("cannot get Jenkins crumb: %v", err)
+			return nil, fmt.Errorf("cannot get Jenkins crumb: %w", err)
 		}
 	}
 	return c, nil
@@ -306,7 +306,7 @@ func (c *Client) CrumbRequest() error {
 		CrumbRequestField string `json:"crumbRequestField"`
 	}{}
 	if err := json.Unmarshal(data, &crumbResp); err != nil {
-		return fmt.Errorf("cannot unmarshal crumb response: %v", err)
+		return fmt.Errorf("cannot unmarshal crumb response: %w", err)
 	}
 	c.authConfig.csrfToken = crumbResp.Crumb
 	c.authConfig.csrfRequestField = crumbResp.CrumbRequestField
@@ -471,7 +471,7 @@ func (c *Client) GetJobInfo(spec *prowapi.ProwJobSpec) (*JobInfo, error) {
 	var jobInfo JobInfo
 
 	if err := json.Unmarshal(data, &jobInfo); err != nil {
-		return nil, fmt.Errorf("Cannot unmarshal job info from API: %v", err)
+		return nil, fmt.Errorf("Cannot unmarshal job info from API: %w", err)
 	}
 
 	c.logger.Tracef("JobInfo: %+v", jobInfo)
@@ -616,7 +616,7 @@ func (c *Client) BuildFromSpec(spec *prowapi.ProwJobSpec, buildID, prowJobID str
 	}
 
 	if err := c.EnsureBuildableJob(spec); err != nil {
-		return fmt.Errorf("Job %v cannot be build: %v", spec.Job, err)
+		return fmt.Errorf("Job %v cannot be build: %w", spec.Job, err)
 	}
 
 	return c.LaunchBuild(spec, params)
@@ -676,13 +676,13 @@ func (c *Client) GetEnqueuedBuilds(jobs []BuildQueryParams) (map[string]Build, e
 
 	data, err := c.Get("/queue/api/json?tree=items[task[name],actions[parameters[name,value]]]")
 	if err != nil {
-		return nil, fmt.Errorf("cannot list builds from the queue: %v", err)
+		return nil, fmt.Errorf("cannot list builds from the queue: %w", err)
 	}
 	page := struct {
 		QueuedBuilds []Build `json:"items"`
 	}{}
 	if err := json.Unmarshal(data, &page); err != nil {
-		return nil, fmt.Errorf("cannot unmarshal builds from the queue: %v", err)
+		return nil, fmt.Errorf("cannot unmarshal builds from the queue: %w", err)
 	}
 	jenkinsBuilds := make(map[string]Build)
 	for _, jb := range page.QueuedBuilds {
@@ -721,13 +721,13 @@ func (c *Client) GetBuilds(job string) (map[string]Build, error) {
 			c.logger.WithError(err).Warnf("Cannot list builds for job %q", job)
 			return nil, nil
 		}
-		return nil, fmt.Errorf("cannot list builds for job %q: %v", job, err)
+		return nil, fmt.Errorf("cannot list builds for job %q: %w", job, err)
 	}
 	page := struct {
 		Builds []Build `json:"builds"`
 	}{}
 	if err := json.Unmarshal(data, &page); err != nil {
-		return nil, fmt.Errorf("cannot unmarshal builds for job %q: %v", job, err)
+		return nil, fmt.Errorf("cannot unmarshal builds for job %q: %w", job, err)
 	}
 	jenkinsBuilds := make(map[string]Build)
 	for _, jb := range page.Builds {

--- a/prow/jenkins/jenkins_test.go
+++ b/prow/jenkins/jenkins_test.go
@@ -176,7 +176,7 @@ func TestListBuilds(t *testing.T) {
 			requestedJobs: []BuildQueryParams{{JobName: "unit", ProwJobID: "prowjobidhere"}},
 			status:        intP(502),
 
-			expectedErr: fmt.Errorf("cannot list builds for job \"unit\": response not 2XX: 502 Bad Gateway"),
+			expectedErr: fmt.Errorf("cannot list builds for job \"unit\": %w", fmt.Errorf("response not 2XX: %s", "502 Bad Gateway")),
 		},
 	}
 

--- a/prow/jira/jira.go
+++ b/prow/jira/jira.go
@@ -233,7 +233,7 @@ func JiraError(response *jira.Response, err error) error {
 			if readError != nil && readError.Error() != "http: read on closed response body" {
 				logrus.WithError(readError).Warn("Failed to read Jira response body.")
 			}
-			return fmt.Errorf("%w: %v", err, string(body))
+			return fmt.Errorf("%w: %s", err, string(body))
 		}
 	}
 	return err

--- a/prow/kube/cluster.go
+++ b/prow/kube/cluster.go
@@ -42,12 +42,12 @@ func loadClusterConfig(masterURL, kubeConfig string) (*rest.Config, error) {
 
 	credentials, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
 	if err != nil {
-		return nil, fmt.Errorf("could not load credentials from config: %v", err)
+		return nil, fmt.Errorf("could not load credentials from config: %w", err)
 	}
 
 	clusterConfig, err = clientcmd.NewDefaultClientConfig(*credentials, &clientcmd.ConfigOverrides{}).ClientConfig()
 	if err != nil {
-		return nil, fmt.Errorf("could not load client configuration: %v", err)
+		return nil, fmt.Errorf("could not load client configuration: %w", err)
 	}
 	return clusterConfig, nil
 }

--- a/prow/kube/config.go
+++ b/prow/kube/config.go
@@ -33,13 +33,13 @@ import (
 func kubeConfigs(loader clientcmd.ClientConfigLoader) (map[string]rest.Config, string, error) {
 	cfg, err := loader.Load()
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to load: %v", err)
+		return nil, "", fmt.Errorf("failed to load: %w", err)
 	}
 	configs := map[string]rest.Config{}
 	for context := range cfg.Contexts {
 		contextCfg, err := clientcmd.NewNonInteractiveClientConfig(*cfg, context, &clientcmd.ConfigOverrides{}, loader).ClientConfig()
 		if err != nil {
-			return nil, "", fmt.Errorf("create %s client: %v", context, err)
+			return nil, "", fmt.Errorf("create %s client: %w", context, err)
 		}
 		contextCfg.UserAgent = version.UserAgent()
 		configs[context] = *contextCfg
@@ -94,7 +94,7 @@ func LoadClusterConfigs(opts *Options) (map[string]rest.Config, error) {
 	if opts.dir != "" {
 		files, err := ioutil.ReadDir(opts.dir)
 		if err != nil {
-			return nil, fmt.Errorf("kubecfg dir: %v", err)
+			return nil, fmt.Errorf("kubecfg dir: %w", err)
 		}
 		for _, file := range files {
 			filename := file.Name()
@@ -122,7 +122,7 @@ func LoadClusterConfigs(opts *Options) (map[string]rest.Config, error) {
 			logrus.Infof("Loading kubeconfig from: %q", candidate)
 			kubeCfgs, tempCurrentContext, err := kubeConfigs(&clientcmd.ClientConfigLoadingRules{ExplicitPath: candidate})
 			if err != nil {
-				return nil, fmt.Errorf("fail to load kubecfg from %q: %v", candidate, err)
+				return nil, fmt.Errorf("fail to load kubecfg from %q: %w", candidate, err)
 			}
 			currentContext = tempCurrentContext
 			for c, k := range kubeCfgs {

--- a/prow/pjutil/abort.go
+++ b/prow/pjutil/abort.go
@@ -124,17 +124,17 @@ func TerminateOlderJobs(pjc patchClient, log *logrus.Entry, pjs []prowapi.ProwJo
 func PatchProwjob(ctx context.Context, pjc prowClient, log *logrus.Entry, srcPJ prowapi.ProwJob, destPJ prowapi.ProwJob) (*prowapi.ProwJob, error) {
 	srcPJData, err := json.Marshal(srcPJ)
 	if err != nil {
-		return nil, fmt.Errorf("marshal source prow job: %v", err)
+		return nil, fmt.Errorf("marshal source prow job: %w", err)
 	}
 
 	destPJData, err := json.Marshal(destPJ)
 	if err != nil {
-		return nil, fmt.Errorf("marshal dest prow job: %v", err)
+		return nil, fmt.Errorf("marshal dest prow job: %w", err)
 	}
 
 	patch, err := jsonpatch.CreateMergePatch(srcPJData, destPJData)
 	if err != nil {
-		return nil, fmt.Errorf("cannot create JSON patch: %v", err)
+		return nil, fmt.Errorf("cannot create JSON patch: %w", err)
 	}
 
 	newPJ, err := pjc.Patch(ctx, srcPJ.Name, ktypes.MergePatchType, patch, metav1.PatchOptions{})

--- a/prow/pjutil/tot.go
+++ b/prow/pjutil/tot.go
@@ -84,7 +84,7 @@ func GetBuildID(name, totURL string) (string, error) {
 	var err error
 	url, err := url.Parse(totURL)
 	if err != nil {
-		return "", fmt.Errorf("invalid tot url: %v", err)
+		return "", fmt.Errorf("invalid tot url: %w", err)
 	}
 	url.Path = path.Join(url.Path, "vend", name)
 	sleepDuration := 100 * time.Millisecond
@@ -100,7 +100,7 @@ func GetBuildID(name, totURL string) (string, error) {
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode != 200 {
-			err = fmt.Errorf("got unexpected response from tot: %v", resp.Status)
+			err = fmt.Errorf("got unexpected response from tot: %s", resp.Status)
 			continue
 		}
 		var buf []byte

--- a/prow/plank/reconciler.go
+++ b/prow/plank/reconciler.go
@@ -247,7 +247,7 @@ func (r *reconciler) defaultReconcile(ctx context.Context, request reconcile.Req
 	pj := &prowv1.ProwJob{}
 	if err := r.pjClient.Get(ctx, request.NamespacedName, pj); err != nil {
 		if !kerrors.IsNotFound(err) {
-			return reconcile.Result{}, fmt.Errorf("failed to get prowjob %s: %v", request.Name, err)
+			return reconcile.Result{}, fmt.Errorf("failed to get prowjob %s: %w", request.Name, err)
 		}
 
 		// Objects can be deleted from the API while being in our workqueue
@@ -306,7 +306,7 @@ func (r *reconciler) reconcile(ctx context.Context, pj *prowv1.ProwJob) (*reconc
 func (r *reconciler) terminateDupes(ctx context.Context, pj *prowv1.ProwJob) error {
 	pjs := &prowv1.ProwJobList{}
 	if err := r.pjClient.List(ctx, pjs, optPendingTriggeredJobsNamed(pj.Spec.Job)); err != nil {
-		return fmt.Errorf("failed to list prowjobs: %v", err)
+		return fmt.Errorf("failed to list prowjobs: %w", err)
 	}
 
 	return pjutil.TerminateOlderJobs(r.pjClient, r.log, pjs.Items)
@@ -327,7 +327,7 @@ func (r *reconciler) syncPendingJob(ctx context.Context, pj *prowv1.ProwJob) (*r
 		id, pn, err := r.startPod(ctx, pj)
 		if err != nil {
 			if !isRequestError(err) {
-				return nil, fmt.Errorf("error starting pod %s: %v", pod.Name, err)
+				return nil, fmt.Errorf("error starting pod %s: %w", pod.Name, err)
 			}
 			pj.Status.State = prowv1.ErrorState
 			pj.SetComplete()
@@ -562,7 +562,7 @@ func (r *reconciler) syncTriggeredJob(ctx context.Context, pj *prowv1.ProwJob) (
 		// Do not start more jobs than specified and check again later.
 		canExecuteConcurrently, err := r.canExecuteConcurrently(ctx, pj)
 		if err != nil {
-			return nil, fmt.Errorf("canExecuteConcurrently: %v", err)
+			return nil, fmt.Errorf("canExecuteConcurrently: %w", err)
 		}
 		if !canExecuteConcurrently {
 			return &reconcile.Result{RequeueAfter: 10 * time.Second}, nil
@@ -571,7 +571,7 @@ func (r *reconciler) syncTriggeredJob(ctx context.Context, pj *prowv1.ProwJob) (
 		id, pn, err = r.startPod(ctx, pj)
 		if err != nil {
 			if !isRequestError(err) {
-				return nil, fmt.Errorf("error starting pod: %v", err)
+				return nil, fmt.Errorf("error starting pod: %w", err)
 			}
 			pj.Status.State = prowv1.ErrorState
 			pj.SetComplete()
@@ -663,7 +663,7 @@ func (r *reconciler) pod(ctx context.Context, pj *prowv1.ProwJob) (*corev1.Pod, 
 		if kerrors.IsNotFound(err) {
 			return nil, false, nil
 		}
-		return nil, false, fmt.Errorf("failed to get pod: %v", err)
+		return nil, false, fmt.Errorf("failed to get pod: %w", err)
 	}
 
 	return pod, true, nil
@@ -693,7 +693,7 @@ func (r *reconciler) deletePod(ctx context.Context, pj *prowv1.ProwJob) error {
 func (r *reconciler) startPod(ctx context.Context, pj *prowv1.ProwJob) (string, string, error) {
 	buildID, err := r.getBuildID(pj.Spec.Job)
 	if err != nil {
-		return "", "", fmt.Errorf("error getting build ID: %v", err)
+		return "", "", fmt.Errorf("error getting build ID: %w", err)
 	}
 
 	pj.Status.BuildID = buildID

--- a/prow/pluginhelp/hook/hook.go
+++ b/prow/pluginhelp/hook/hook.go
@@ -202,12 +202,12 @@ func externalHelpProvider(endpoint string) externalplugins.ExternalPluginHelpPro
 	return func(enabledRepos []prowconfig.OrgRepo) (*pluginhelp.PluginHelp, error) {
 		u, err := url.Parse(endpoint)
 		if err != nil {
-			return nil, fmt.Errorf("error parsing url: %s err: %v", endpoint, err)
+			return nil, fmt.Errorf("error parsing url: %s err: %w", endpoint, err)
 		}
 		u.Path = path.Join(u.Path, "/help")
 		b, err := json.Marshal(enabledRepos)
 		if err != nil {
-			return nil, fmt.Errorf("error marshalling enabled repos: %q, err: %v", enabledRepos, err)
+			return nil, fmt.Errorf("error marshalling enabled repos: %q, err: %w", enabledRepos, err)
 		}
 
 		// Don't retry because user is waiting for response to their browser.
@@ -215,7 +215,7 @@ func externalHelpProvider(endpoint string) externalplugins.ExternalPluginHelpPro
 		urlString := u.String()
 		resp, err := http.Post(urlString, "application/json", bytes.NewReader(b))
 		if err != nil {
-			return nil, fmt.Errorf("error posting to %s err: %v", urlString, err)
+			return nil, fmt.Errorf("error posting to %s err: %w", urlString, err)
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode < 200 || resp.StatusCode > 299 {
@@ -223,7 +223,7 @@ func externalHelpProvider(endpoint string) externalplugins.ExternalPluginHelpPro
 		}
 		var help pluginhelp.PluginHelp
 		if err := json.NewDecoder(resp.Body).Decode(&help); err != nil {
-			return nil, fmt.Errorf("failed to decode json response from %s err: %v", urlString, err)
+			return nil, fmt.Errorf("failed to decode json response from %s err: %w", urlString, err)
 		}
 		return &help, nil
 	}

--- a/prow/plugins/approve/approve.go
+++ b/prow/plugins/approve/approve.go
@@ -378,7 +378,7 @@ func handle(log *logrus.Entry, ghc githubClient, repo approvers.Repo, githubConf
 		log.WithField("duration", time.Since(funcStart).String()).Debug("Completed handle")
 	}()
 	fetchErr := func(context string, err error) error {
-		return fmt.Errorf("failed to get %s for %s/%s#%d: %v", context, pr.org, pr.repo, pr.number, err)
+		return fmt.Errorf("failed to get %s for %s/%s#%d: %w", context, pr.org, pr.repo, pr.number, err)
 	}
 
 	start := time.Now()

--- a/prow/plugins/approve/approvers/owners.go
+++ b/prow/plugins/approve/approvers/owners.go
@@ -616,9 +616,9 @@ func (ua UnapprovedFile) String() string {
 func GenerateTemplate(templ, name string, data interface{}) (string, error) {
 	buf := bytes.NewBufferString("")
 	if messageTempl, err := template.New(name).Parse(templ); err != nil {
-		return "", fmt.Errorf("failed to parse template for %s: %v", name, err)
+		return "", fmt.Errorf("failed to parse template for %s: %w", name, err)
 	} else if err := messageTempl.Execute(buf, data); err != nil {
-		return "", fmt.Errorf("failed to execute template for %s: %v", name, err)
+		return "", fmt.Errorf("failed to execute template for %s: %w", name, err)
 	}
 	return buf.String(), nil
 }

--- a/prow/plugins/assign/assign.go
+++ b/prow/plugins/assign/assign.go
@@ -98,7 +98,7 @@ func parseLogins(text string) []string {
 
 func combineErrors(err1, err2 error) error {
 	if err1 != nil && err2 != nil {
-		return fmt.Errorf("two errors: 1) %v 2) %v", err1, err2)
+		return fmt.Errorf("two errors: 1) %v 2) %w", err1, err2)
 	} else if err1 != nil {
 		return err1
 	} else {
@@ -153,7 +153,7 @@ func handle(h *handler) error {
 					return nil
 				}
 				if err := h.gc.CreateComment(org, repo, e.Number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, e.User.Login, msg)); err != nil {
-					return fmt.Errorf("comment err: %v", err)
+					return fmt.Errorf("comment err: %w", err)
 				}
 				return nil
 			}

--- a/prow/plugins/blunderbuss/blunderbuss.go
+++ b/prow/plugins/blunderbuss/blunderbuss.go
@@ -187,7 +187,7 @@ func handleGenericComment(ghc githubClient, roc repoownersClient, log *logrus.En
 
 	pr, err := ghc.GetPullRequest(repo.Owner.Login, repo.Name, prNumber)
 	if err != nil {
-		return fmt.Errorf("error loading PullRequest: %v", err)
+		return fmt.Errorf("error loading PullRequest: %w", err)
 	}
 
 	return handle(
@@ -206,12 +206,12 @@ func handleGenericComment(ghc githubClient, roc repoownersClient, log *logrus.En
 func handle(ghc githubClient, roc repoownersClient, log *logrus.Entry, reviewerCount *int, maxReviewers int, excludeApprovers bool, useStatusAvailability bool, repo *github.Repo, pr *github.PullRequest) error {
 	oc, err := roc.LoadRepoOwners(repo.Owner.Login, repo.Name, pr.Base.Ref)
 	if err != nil {
-		return fmt.Errorf("error loading RepoOwners: %v", err)
+		return fmt.Errorf("error loading RepoOwners: %w", err)
 	}
 
 	changes, err := ghc.GetPullRequestChanges(repo.Owner.Login, repo.Name, pr.Number)
 	if err != nil {
-		return fmt.Errorf("error getting PR changes: %v", err)
+		return fmt.Errorf("error getting PR changes: %w", err)
 	}
 
 	var reviewers []string

--- a/prow/plugins/branchcleaner/branchcleaner.go
+++ b/prow/plugins/branchcleaner/branchcleaner.go
@@ -62,7 +62,7 @@ func handle(gc githubClient, log *logrus.Entry, pre github.PullRequestEvent) err
 	}
 
 	if err := gc.DeleteRef(pr.Base.Repo.Owner.Login, pr.Base.Repo.Name, fmt.Sprintf("heads/%s", pr.Head.Ref)); err != nil {
-		return fmt.Errorf("failed to delete branch %s on repo %s/%s after Pull Request #%d got merged: %v",
+		return fmt.Errorf("failed to delete branch %s on repo %s/%s after Pull Request #%d got merged: %w",
 			pr.Head.Ref, pr.Base.Repo.Owner.Login, pr.Base.Repo.Name, pre.PullRequest.Number, err)
 	}
 

--- a/prow/plugins/bugzilla/bugzilla.go
+++ b/prow/plugins/bugzilla/bugzilla.go
@@ -366,7 +366,7 @@ func getCherryPickMatch(pre github.PullRequestEvent) (bool, int, string, error) 
 		cherrypickOf, err := strconv.Atoi(cherrypickMatch[1])
 		if err != nil {
 			// should be impossible based on the regex
-			return false, 0, "", fmt.Errorf("Failed to parse cherrypick bugID as int - is the regex correct? Err: %v", err)
+			return false, 0, "", fmt.Errorf("Failed to parse cherrypick bugID as int - is the regex correct? Err: %w", err)
 		}
 		return true, cherrypickOf, pre.PullRequest.Base.Ref, nil
 	}

--- a/prow/plugins/buildifier/buildifier.go
+++ b/prow/plugins/buildifier/buildifier.go
@@ -121,7 +121,7 @@ func problemsInFiles(r git.RepoClient, files map[string]string) (map[string]bool
 		// https://github.com/bazelbuild/buildtools/blob/8818289/buildifier/buildifier.go#L261
 		content, err := build.Parse(f, src)
 		if err != nil {
-			return nil, fmt.Errorf("parsing as Bazel file %v", err)
+			return nil, fmt.Errorf("parsing as Bazel file %w", err)
 		}
 		beforeRewrite := build.FormatWithoutRewriting(content)
 		ndata := build.Format(content)

--- a/prow/plugins/cat/cat.go
+++ b/prow/plugins/cat/cat.go
@@ -127,7 +127,7 @@ func (cr catResult) Format() (string, error) {
 	}
 	img, err := url.Parse(cr.Image)
 	if err != nil {
-		return "", fmt.Errorf("invalid image url %s: %v", cr.Image, err)
+		return "", fmt.Errorf("invalid image url %s: %w", cr.Image, err)
 	}
 
 	return fmt.Sprintf("![cat image](%s)", img), nil
@@ -157,7 +157,7 @@ func (c *realClowder) readCat(category string, movieCat bool, grumpyRoot string)
 	} else {
 		resp, err := http.Get(uri)
 		if err != nil {
-			return "", fmt.Errorf("could not read cat from %s: %v", uri, err)
+			return "", fmt.Errorf("could not read cat from %s: %w", uri, err)
 		}
 		defer resp.Body.Close()
 		if sc := resp.StatusCode; sc > 299 || sc < 200 {
@@ -177,7 +177,7 @@ func (c *realClowder) readCat(category string, movieCat bool, grumpyRoot string)
 	// checking size, GitHub doesn't support big images
 	toobig, err := github.ImageTooBig(a.Image)
 	if err != nil {
-		return "", fmt.Errorf("could not validate image size %s: %v", a.Image, err)
+		return "", fmt.Errorf("could not validate image size %s: %w", a.Image, err)
 	} else if toobig {
 		return "", fmt.Errorf("longcat is too long: %s", a.Image)
 	}

--- a/prow/plugins/cla/cla.go
+++ b/prow/plugins/cla/cla.go
@@ -125,7 +125,7 @@ func handle(gc gitHubClient, log *logrus.Entry, se github.StatusEvent) error {
 	for i := 0; i < maxRetries; i++ {
 		issues, err = gc.FindIssues(fmt.Sprintf("%s repo:%s/%s type:pr state:open", se.SHA, org, repo), "", false)
 		if err != nil {
-			return fmt.Errorf("error searching for issues matching commit: %v", err)
+			return fmt.Errorf("error searching for issues matching commit: %w", err)
 		}
 		if len(issues) > 0 {
 			break

--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -1144,7 +1144,7 @@ func validateConfigUpdater(updater *ConfigUpdater) error {
 func validateRequireMatchingLabel(rs []RequireMatchingLabel) error {
 	for i, r := range rs {
 		if err := r.validate(); err != nil {
-			return fmt.Errorf("error validating require_matching_label config #%d: %v", i, err)
+			return fmt.Errorf("error validating require_matching_label config #%d: %w", i, err)
 		}
 	}
 	return nil
@@ -1220,7 +1220,7 @@ func compileRegexpsAndDurations(pc *Configuration) error {
 		}
 		branchRe, err := regexp.Compile(*pc.Blockades[i].BranchRegexp)
 		if err != nil {
-			return fmt.Errorf("failed to compile blockade branchregexp: %q, error: %v", *pc.Blockades[i].BranchRegexp, err)
+			return fmt.Errorf("failed to compile blockade branchregexp: %q, error: %w", *pc.Blockades[i].BranchRegexp, err)
 		}
 		pc.Blockades[i].BranchRe = branchRe
 	}
@@ -1235,14 +1235,14 @@ func compileRegexpsAndDurations(pc *Configuration) error {
 	for i := range rs {
 		re, err := regexp.Compile(rs[i].Regexp)
 		if err != nil {
-			return fmt.Errorf("failed to compile label regexp: %q, error: %v", rs[i].Regexp, err)
+			return fmt.Errorf("failed to compile label regexp: %q, error: %w", rs[i].Regexp, err)
 		}
 		rs[i].Re = re
 
 		var dur time.Duration
 		dur, err = time.ParseDuration(rs[i].GracePeriod)
 		if err != nil {
-			return fmt.Errorf("failed to compile grace period duration: %q, error: %v", rs[i].GracePeriod, err)
+			return fmt.Errorf("failed to compile grace period duration: %q, error: %w", rs[i].GracePeriod, err)
 		}
 		rs[i].GracePeriodDuration = dur
 	}

--- a/prow/plugins/dco/dco.go
+++ b/prow/plugins/dco/dco.go
@@ -127,7 +127,7 @@ func filterTrustedUsers(gc gitHubClient, l *logrus.Entry, skipDCOCheckForCollabo
 	for _, commit := range allCommits {
 		trustedResponse, err := trigger.TrustedUser(gc, !skipDCOCheckForCollaborators, trustedOrg, commit.Author.Login, org, repo)
 		if err != nil {
-			return nil, fmt.Errorf("Error checking is member trusted: %v", err)
+			return nil, fmt.Errorf("Error checking is member trusted: %w", err)
 		}
 		if !trustedResponse.IsTrusted {
 			l.Debugf("Member %s is not trusted", commit.Author.Login)
@@ -145,7 +145,7 @@ func filterTrustedUsers(gc gitHubClient, l *logrus.Entry, skipDCOCheckForCollabo
 func checkCommitMessages(gc gitHubClient, l *logrus.Entry, org, repo string, number int) ([]github.RepositoryCommit, error) {
 	allCommits, err := gc.ListPRCommits(org, repo, number)
 	if err != nil {
-		return nil, fmt.Errorf("error listing commits for pull request: %v", err)
+		return nil, fmt.Errorf("error listing commits for pull request: %w", err)
 	}
 	l.Debugf("Found %d commits in PR", len(allCommits))
 
@@ -165,7 +165,7 @@ func checkCommitMessages(gc gitHubClient, l *logrus.Entry, org, repo string, num
 func checkExistingStatus(gc gitHubClient, l *logrus.Entry, org, repo, sha string) (string, error) {
 	combinedStatus, err := gc.GetCombinedStatus(org, repo, sha)
 	if err != nil {
-		return "", fmt.Errorf("error listing pull request combined statuses: %v", err)
+		return "", fmt.Errorf("error listing pull request combined statuses: %w", err)
 	}
 
 	existingStatus := ""
@@ -185,7 +185,7 @@ func checkExistingStatus(gc gitHubClient, l *logrus.Entry, org, repo, sha string
 func checkExistingLabels(gc gitHubClient, l *logrus.Entry, org, repo string, number int) (hasYesLabel, hasNoLabel bool, err error) {
 	labels, err := gc.GetIssueLabels(org, repo, number)
 	if err != nil {
-		return false, false, fmt.Errorf("error getting pull request labels: %v", err)
+		return false, false, fmt.Errorf("error getting pull request labels: %w", err)
 	}
 
 	for _, l := range labels {
@@ -214,14 +214,14 @@ func takeAction(gc gitHubClient, cp commentPruner, l *logrus.Entry, org, repo st
 			l.Debugf("Removing %q label", dcoNoLabel)
 			// remove 'dco-signoff: no' label
 			if err := gc.RemoveLabel(org, repo, pr.Number, dcoNoLabel); err != nil {
-				return fmt.Errorf("error removing label: %v", err)
+				return fmt.Errorf("error removing label: %w", err)
 			}
 		}
 		if !hasYesLabel {
 			l.Debugf("Adding %q label", dcoYesLabel)
 			// add 'dco-signoff: yes' label
 			if err := gc.AddLabel(org, repo, pr.Number, dcoYesLabel); err != nil {
-				return fmt.Errorf("error adding label: %v", err)
+				return fmt.Errorf("error adding label: %w", err)
 			}
 		}
 		if existingStatus != github.StatusSuccess {
@@ -232,7 +232,7 @@ func takeAction(gc gitHubClient, cp commentPruner, l *logrus.Entry, org, repo st
 				TargetURL:   targetURL,
 				Description: dcoContextMessageSuccess,
 			}); err != nil {
-				return fmt.Errorf("error setting pull request status: %v", err)
+				return fmt.Errorf("error setting pull request status: %w", err)
 			}
 		}
 
@@ -245,14 +245,14 @@ func takeAction(gc gitHubClient, cp commentPruner, l *logrus.Entry, org, repo st
 		l.Debugf("Adding %q label", dcoNoLabel)
 		// add 'dco-signoff: no' label
 		if err := gc.AddLabel(org, repo, pr.Number, dcoNoLabel); err != nil {
-			return fmt.Errorf("error adding label: %v", err)
+			return fmt.Errorf("error adding label: %w", err)
 		}
 	}
 	if hasYesLabel {
 		l.Debugf("Removing %q label", dcoYesLabel)
 		// remove 'dco-signoff: yes' label
 		if err := gc.RemoveLabel(org, repo, pr.Number, dcoYesLabel); err != nil {
-			return fmt.Errorf("error removing label: %v", err)
+			return fmt.Errorf("error removing label: %w", err)
 		}
 	}
 	if existingStatus != github.StatusFailure {
@@ -263,7 +263,7 @@ func takeAction(gc gitHubClient, cp commentPruner, l *logrus.Entry, org, repo st
 			TargetURL:   targetURL,
 			Description: dcoContextMessageFailed,
 		}); err != nil {
-			return fmt.Errorf("error setting pull request status: %v", err)
+			return fmt.Errorf("error setting pull request status: %w", err)
 		}
 	}
 
@@ -405,7 +405,7 @@ func handleComment(config plugins.Dco, gc gitHubClient, cp commentPruner, log *l
 
 	pr, err := gc.GetPullRequest(org, repo, ce.Number)
 	if err != nil {
-		return fmt.Errorf("error getting pull request for comment: %v", err)
+		return fmt.Errorf("error getting pull request for comment: %w", err)
 	}
 
 	return handle(config, gc, cp, log, org, repo, *pr, true)

--- a/prow/plugins/dog/dog.go
+++ b/prow/plugins/dog/dog.go
@@ -92,7 +92,7 @@ func FormatURL(dogURL string) (string, error) {
 	}
 	src, err := url.ParseRequestURI(dogURL)
 	if err != nil {
-		return "", fmt.Errorf("invalid url %s: %v", dogURL, err)
+		return "", fmt.Errorf("invalid url %s: %w", dogURL, err)
 	}
 	return fmt.Sprintf("[![dog image](%s)](%s)", src, src), nil
 }
@@ -102,12 +102,12 @@ func (u realPack) readDog(dogURL string) (string, error) {
 		uri := string(u)
 		req, err := http.NewRequest("GET", uri, nil)
 		if err != nil {
-			return "", fmt.Errorf("could not create request %s: %v", uri, err)
+			return "", fmt.Errorf("could not create request %s: %w", uri, err)
 		}
 		req.Header.Add("Accept", "application/json")
 		resp, err := client.Do(req)
 		if err != nil {
-			return "", fmt.Errorf("could not read dog from %s: %v", uri, err)
+			return "", fmt.Errorf("could not read dog from %s: %w", uri, err)
 		}
 		defer resp.Body.Close()
 		var a dogResult

--- a/prow/plugins/golint/golint.go
+++ b/prow/plugins/golint/golint.go
@@ -350,7 +350,7 @@ func AddedLines(patch string) (map[int]int, error) {
 		}
 		_, oldLen, newLine, newLen, err := parseHunkLine(lines[i])
 		if err != nil {
-			return nil, fmt.Errorf("couldn't parse hunk on line %d in patch %s: %v", i, patch, err)
+			return nil, fmt.Errorf("couldn't parse hunk on line %d in patch %s: %w", i, patch, err)
 		}
 		oldAdd := 0
 		newAdd := 0

--- a/prow/plugins/goose/goose.go
+++ b/prow/plugins/goose/goose.go
@@ -133,7 +133,7 @@ func (gr gooseResult) Format() (string, error) {
 	}
 	img, err := url.Parse(gr.Images.Small)
 	if err != nil {
-		return "", fmt.Errorf("invalid image url %s: %v", gr.Images.Small, err)
+		return "", fmt.Errorf("invalid image url %s: %w", gr.Images.Small, err)
 	}
 
 	return fmt.Sprintf("\n![goose image](%s)", img), nil
@@ -154,7 +154,7 @@ func (g *realGaggle) readGoose() (string, error) {
 	uri := g.URL()
 	resp, err := http.Get(uri)
 	if err != nil {
-		return "", fmt.Errorf("could not read goose from %s: %v", uri, err)
+		return "", fmt.Errorf("could not read goose from %s: %w", uri, err)
 	}
 	defer resp.Body.Close()
 	if sc := resp.StatusCode; sc > 299 || sc < 200 {
@@ -173,7 +173,7 @@ func (g *realGaggle) readGoose() (string, error) {
 	// checking size, GitHub doesn't support big images
 	toobig, err := github.ImageTooBig(a.Images.Small)
 	if err != nil {
-		return "", fmt.Errorf("could not validate image size %s: %v", a.Images.Small, err)
+		return "", fmt.Errorf("could not validate image size %s: %w", a.Images.Small, err)
 	} else if toobig {
 		return "", fmt.Errorf("long goose is too long: %s", a.Images.Small)
 	}

--- a/prow/plugins/hold/hold.go
+++ b/prow/plugins/hold/hold.go
@@ -100,7 +100,7 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, f
 	repo := e.Repo.Name
 	issueLabels, err := gc.GetIssueLabels(org, repo, e.Number)
 	if err != nil {
-		return fmt.Errorf("failed to get the labels on %s/%s#%d: %v", org, repo, e.Number, err)
+		return fmt.Errorf("failed to get the labels on %s/%s#%d: %w", org, repo, e.Number, err)
 	}
 
 	hasLabel := f(labels.Hold, issueLabels)

--- a/prow/plugins/invalidcommitmsg/invalidcommitmsg.go
+++ b/prow/plugins/invalidcommitmsg/invalidcommitmsg.go
@@ -119,7 +119,7 @@ func handle(gc githubClient, log *logrus.Entry, pr github.PullRequestEvent, cp c
 
 	allCommits, err := gc.ListPRCommits(org, repo, number)
 	if err != nil {
-		return fmt.Errorf("error listing commits for pull request: %v", err)
+		return fmt.Errorf("error listing commits for pull request: %w", err)
 	}
 	log.Debugf("Found %d commits in PR", len(allCommits))
 

--- a/prow/plugins/lgtm/lgtm.go
+++ b/prow/plugins/lgtm/lgtm.go
@@ -462,7 +462,7 @@ func handlePullRequest(log *logrus.Entry, gc githubClient, config *plugins.Confi
 	}
 
 	if err := gc.RemoveLabel(org, repo, number, LGTMLabel); err != nil {
-		return fmt.Errorf("failed removing lgtm label: %v", err)
+		return fmt.Errorf("failed removing lgtm label: %w", err)
 	}
 
 	// Create a comment to inform participants that LGTM label is removed due to new

--- a/prow/plugins/lifecycle/close.go
+++ b/prow/plugins/lifecycle/close.go
@@ -39,7 +39,7 @@ type closeClient interface {
 func isActive(gc closeClient, org, repo string, number int) (bool, error) {
 	labels, err := gc.GetIssueLabels(org, repo, number)
 	if err != nil {
-		return true, fmt.Errorf("list issue labels error: %v", err)
+		return true, fmt.Errorf("list issue labels error: %w", err)
 	}
 	for _, label := range []string{"lifecycle/stale", "lifecycle/rotten"} {
 		if github.HasLabel(label, labels) {
@@ -94,7 +94,7 @@ func handleClose(gc closeClient, log *logrus.Entry, e *github.GenericCommentEven
 	if e.IsPR {
 		log.Info("Closing PR.")
 		if err := gc.ClosePR(org, repo, number); err != nil {
-			return fmt.Errorf("Error closing PR: %v", err)
+			return fmt.Errorf("Error closing PR: %w", err)
 		}
 		response := plugins.FormatResponseRaw(e.Body, e.HTMLURL, commentAuthor, "Closed this PR.")
 		return gc.CreateComment(org, repo, number, response)
@@ -102,7 +102,7 @@ func handleClose(gc closeClient, log *logrus.Entry, e *github.GenericCommentEven
 
 	log.Info("Closing issue.")
 	if err := gc.CloseIssue(org, repo, number); err != nil {
-		return fmt.Errorf("Error closing issue: %v", err)
+		return fmt.Errorf("Error closing issue: %w", err)
 	}
 	response := plugins.FormatResponseRaw(e.Body, e.HTMLURL, commentAuthor, "Closing this issue.")
 	return gc.CreateComment(org, repo, number, response)

--- a/prow/plugins/merge-method-comment/merge-method-comment.go
+++ b/prow/plugins/merge-method-comment/merge-method-comment.go
@@ -115,7 +115,7 @@ func issueHasComment(gc githubClient, org, repo string, number int, comment stri
 
 	comments, err := gc.ListIssueComments(org, repo, number)
 	if err != nil {
-		return false, fmt.Errorf("error listing issue comments: %v", err)
+		return false, fmt.Errorf("error listing issue comments: %w", err)
 	}
 
 	for _, c := range comments {

--- a/prow/plugins/override/override.go
+++ b/prow/plugins/override/override.go
@@ -119,7 +119,7 @@ func (c client) presubmits(org, repo string, baseSHAGetter config.RefGetter, hea
 	}
 	presubmits, err := c.config.GetPresubmits(c.gc, org+"/"+repo, baseSHAGetter, headSHAGetter)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get presubmits: %v", err)
+		return nil, fmt.Errorf("failed to get presubmits: %w", err)
 	}
 	return presubmits, nil
 }

--- a/prow/plugins/owners-label/owners-label.go
+++ b/prow/plugins/owners-label/owners-label.go
@@ -62,7 +62,7 @@ func handlePullRequest(pc plugins.Agent, pre github.PullRequestEvent) error {
 
 	oc, err := pc.OwnersClient.LoadRepoOwners(pre.Repo.Owner.Login, pre.Repo.Name, pre.PullRequest.Base.Ref)
 	if err != nil {
-		return fmt.Errorf("error loading RepoOwners: %v", err)
+		return fmt.Errorf("error loading RepoOwners: %w", err)
 	}
 
 	return handle(pc.GitHubClient, oc, pc.Logger, &pre)
@@ -76,7 +76,7 @@ func handle(ghc githubClient, oc ownersClient, log *logrus.Entry, pre *github.Pu
 	// First see if there are any labels requested based on the files changed.
 	changes, err := ghc.GetPullRequestChanges(org, repo, number)
 	if err != nil {
-		return fmt.Errorf("error getting PR changes: %v", err)
+		return fmt.Errorf("error getting PR changes: %w", err)
 	}
 	neededLabels := sets.NewString()
 	for _, change := range changes {

--- a/prow/plugins/pony/pony.go
+++ b/prow/plugins/pony/pony.go
@@ -96,7 +96,7 @@ func (h realHerd) readPony(tags string) (string, error) {
 	uri := string(h) + "?q=" + url.QueryEscape(tags)
 	resp, err := client.Get(uri)
 	if err != nil {
-		return "", fmt.Errorf("failed to make request: %v", err)
+		return "", fmt.Errorf("failed to make request: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
@@ -104,13 +104,13 @@ func (h realHerd) readPony(tags string) (string, error) {
 	}
 	var a ponyResult
 	if err = json.NewDecoder(resp.Body).Decode(&a); err != nil {
-		return "", fmt.Errorf("failed to decode response: %v", err)
+		return "", fmt.Errorf("failed to decode response: %w", err)
 	}
 
 	embedded := a.Pony.Representations.Small
 	tooBig, err := github.ImageTooBig(embedded)
 	if err != nil {
-		return "", fmt.Errorf("couldn't fetch pony for size check: %v", err)
+		return "", fmt.Errorf("couldn't fetch pony for size check: %w", err)
 	}
 	if tooBig {
 		return "", fmt.Errorf("the pony is too big")

--- a/prow/plugins/releasenote/releasenote.go
+++ b/prow/plugins/releasenote/releasenote.go
@@ -18,10 +18,11 @@ package releasenote
 
 import (
 	"fmt"
-	"k8s.io/test-infra/prow/labels"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"k8s.io/test-infra/prow/labels"
 
 	"github.com/sirupsen/logrus"
 
@@ -247,7 +248,7 @@ func handlePR(gc githubClient, log *logrus.Entry, pr *github.PullRequestEvent) e
 
 	prInitLabels, err := gc.GetIssueLabels(org, repo, pr.Number)
 	if err != nil {
-		return fmt.Errorf("failed to list labels on PR #%d. err: %v", pr.Number, err)
+		return fmt.Errorf("failed to list labels on PR #%d. err: %w", pr.Number, err)
 	}
 	prLabels := labelsSet(prInitLabels)
 
@@ -270,7 +271,7 @@ func handlePR(gc githubClient, log *logrus.Entry, pr *github.PullRequestEvent) e
 		} else {
 			comments, err = gc.ListIssueComments(org, repo, pr.Number)
 			if err != nil {
-				return fmt.Errorf("failed to list comments on %s/%s#%d. err: %v", org, repo, pr.Number, err)
+				return fmt.Errorf("failed to list comments on %s/%s#%d. err: %w", org, repo, pr.Number, err)
 			}
 			if containsNoneCommand(comments) {
 				labelToAdd = labels.ReleaseNoteNone
@@ -474,7 +475,7 @@ func editReleaseNote(gc githubClient, log *logrus.Entry, ic github.IssueCommentE
 
 	isMember, err := gc.IsMember(org, user)
 	if err != nil {
-		return fmt.Errorf("unable to fetch if %s is an org member of %s: %v", user, org, err)
+		return fmt.Errorf("unable to fetch if %s is an org member of %s: %w", user, org, err)
 	}
 	if !isMember {
 		return gc.CreateComment(
@@ -510,7 +511,7 @@ func editReleaseNote(gc githubClient, log *logrus.Entry, ic github.IssueCommentE
 
 	_, err = gc.EditIssue(ic.Repo.Owner.Login, ic.Repo.Name, ic.Issue.Number, &ic.Issue)
 	if err != nil {
-		return fmt.Errorf("unable to edit issue: %v", err)
+		return fmt.Errorf("unable to edit issue: %w", err)
 	}
 	log.WithFields(logrus.Fields{
 		"user":        user,

--- a/prow/plugins/require-matching-label/require-matching-label.go
+++ b/prow/plugins/require-matching-label/require-matching-label.go
@@ -207,7 +207,7 @@ func handle(log *logrus.Entry, ghc githubClient, cp commentPruner, configs []plu
 		var err error
 		e.currentLabels, err = ghc.GetIssueLabels(e.org, e.repo, e.number)
 		if err != nil {
-			return fmt.Errorf("error getting the issue or pr's labels: %v", err)
+			return fmt.Errorf("error getting the issue or pr's labels: %w", err)
 		}
 	}
 

--- a/prow/plugins/shrug/shrug.go
+++ b/prow/plugins/shrug/shrug.go
@@ -100,7 +100,7 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent) e
 		resp := "¯\\\\\\_(ツ)\\_/¯"
 		log.Infof("Commenting with \"%s\".", resp)
 		if err := gc.CreateComment(org, repo, e.Number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, e.User.Login, resp)); err != nil {
-			return fmt.Errorf("failed to comment on %s/%s#%d: %v", org, repo, e.Number, err)
+			return fmt.Errorf("failed to comment on %s/%s#%d: %w", org, repo, e.Number, err)
 		}
 		return gc.RemoveLabel(org, repo, e.Number, labels.Shrug)
 	} else if !hasShrug && wantShrug {

--- a/prow/plugins/size/size.go
+++ b/prow/plugins/size/size.go
@@ -123,7 +123,7 @@ func handlePR(gc githubClient, sizes plugins.Size, le *logrus.Entry, pe github.P
 
 	changes, err := gc.GetPullRequestChanges(owner, repo, num)
 	if err != nil {
-		return fmt.Errorf("can not get PR changes for size plugin: %v", err)
+		return fmt.Errorf("can not get PR changes for size plugin: %w", err)
 	}
 
 	var count int
@@ -162,7 +162,7 @@ func handlePR(gc githubClient, sizes plugins.Size, le *logrus.Entry, pe github.P
 	}
 
 	if err := gc.AddLabel(owner, repo, num, newLabel); err != nil {
-		return fmt.Errorf("error adding label to %s/%s PR #%d: %v", owner, repo, num, err)
+		return fmt.Errorf("error adding label to %s/%s PR #%d: %w", owner, repo, num, err)
 	}
 
 	return nil

--- a/prow/plugins/skip/skip.go
+++ b/prow/plugins/skip/skip.go
@@ -91,7 +91,7 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, c
 	baseSHAGetter := func() (string, error) {
 		baseSHA, err := gc.GetRef(org, repo, "heads/"+pr.Base.Ref)
 		if err != nil {
-			return "", fmt.Errorf("failed to get baseSHA: %v", err)
+			return "", fmt.Errorf("failed to get baseSHA: %w", err)
 		}
 		return baseSHA, nil
 	}
@@ -100,7 +100,7 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, c
 	}
 	presubmits, err := c.GetPresubmits(gitClient, org+"/"+repo, baseSHAGetter, headSHAGetter)
 	if err != nil {
-		return fmt.Errorf("failed to get presubmits: %v", err)
+		return fmt.Errorf("failed to get presubmits: %w", err)
 	}
 
 	combinedStatus, err := gc.GetCombinedStatus(org, repo, pr.Head.SHA)

--- a/prow/plugins/slackevents/slackevents.go
+++ b/prow/plugins/slackevents/slackevents.go
@@ -219,7 +219,7 @@ func echoToSlack(pc client, e github.GenericCommentEvent) error {
 
 		msg := fmt.Sprintf("%s was mentioned by %s (<@%s>) on GitHub. (%s)\n>>>%s", sig, e.User.Login, e.User.Login, e.HTMLURL, e.Body)
 		if err := pc.SlackClient.WriteMessage(msg, sig); err != nil {
-			return fmt.Errorf("Failed to send message on slack channel: %q with message %q. Err: %v", sig, msg, err)
+			return fmt.Errorf("Failed to send message on slack channel: %q with message %q. Err: %w", sig, msg, err)
 		}
 	}
 	return nil

--- a/prow/plugins/transfer-issue/transfer-issue.go
+++ b/prow/plugins/transfer-issue/transfer-issue.go
@@ -102,7 +102,7 @@ func handleTransfer(gc githubClient, log *logrus.Entry, e github.GenericCommentE
 
 	isMember, err := gc.IsMember(org, user)
 	if err != nil {
-		return fmt.Errorf("unable to fetch if %s is an org member of %s: %v", user, org, err)
+		return fmt.Errorf("unable to fetch if %s is an org member of %s: %w", user, org, err)
 	}
 	if !isMember {
 		return gc.CreateComment(

--- a/prow/plugins/trigger/generic-comment.go
+++ b/prow/plugins/trigger/generic-comment.go
@@ -78,7 +78,7 @@ func handleGenericComment(c Client, trigger plugins.Trigger, gc github.GenericCo
 	// Skip untrusted users comments.
 	trustedResponse, err := TrustedUser(c.GitHubClient, trigger.OnlyOrgMembers, trigger.TrustedOrg, commentAuthor, org, repo)
 	if err != nil {
-		return fmt.Errorf("error checking trust of %s: %v", commentAuthor, err)
+		return fmt.Errorf("error checking trust of %s: %w", commentAuthor, err)
 	}
 
 	trusted := trustedResponse.IsTrusted

--- a/prow/plugins/trigger/pull-request.go
+++ b/prow/plugins/trigger/pull-request.go
@@ -48,7 +48,7 @@ func handlePR(c Client, trigger plugins.Trigger, pr github.PullRequestEvent) err
 		var err error
 		baseSHA, err = c.GitHubClient.GetRef(org, repo, "heads/"+pr.PullRequest.Base.Ref)
 		if err != nil {
-			return "", fmt.Errorf("failed to get baseSHA: %v", err)
+			return "", fmt.Errorf("failed to get baseSHA: %w", err)
 		}
 		return baseSHA, nil
 	}
@@ -88,7 +88,7 @@ func handlePR(c Client, trigger plugins.Trigger, pr github.PullRequestEvent) err
 		}
 		c.Logger.Infof("Welcome message to PR author %q.", author)
 		if err := welcomeMsg(c.GitHubClient, trigger, pr.PullRequest); err != nil {
-			return fmt.Errorf("could not welcome non-org member %q: %v", author, err)
+			return fmt.Errorf("could not welcome non-org member %q: %w", author, err)
 		}
 	case github.PullRequestActionReopened:
 		return buildAllIfTrusted(c, trigger, pr, baseSHA, presubmits)
@@ -314,7 +314,7 @@ func draftMsg(ghc githubClient, pr github.PullRequest) error {
 func TrustedPullRequest(tprc trustedPullRequestClient, trigger plugins.Trigger, author, org, repo string, num int, l []github.Label) ([]github.Label, bool, error) {
 	// First check if the author is a member of the org.
 	if trustedResponse, err := TrustedUser(tprc, trigger.OnlyOrgMembers, trigger.TrustedOrg, author, org, repo); err != nil {
-		return l, false, fmt.Errorf("error checking %s for trust: %v", author, err)
+		return l, false, fmt.Errorf("error checking %s for trust: %w", author, err)
 	} else if trustedResponse.IsTrusted {
 		return l, true, nil
 	}

--- a/prow/plugins/trigger/trigger.go
+++ b/prow/plugins/trigger/trigger.go
@@ -237,7 +237,7 @@ func TrustedUser(ghc trustedUserClient, onlyOrgMembers bool, trustedOrg, user, o
 
 	// First check if the user is an org member. This caches across all repos.
 	if member, err := ghc.IsMember(org, user); err != nil {
-		return errorResponse, fmt.Errorf("error in IsMember(%s): %v", org, err)
+		return errorResponse, fmt.Errorf("error in IsMember(%s): %w", org, err)
 	} else if member {
 		return okResponse, nil
 	}
@@ -246,7 +246,7 @@ func TrustedUser(ghc trustedUserClient, onlyOrgMembers bool, trustedOrg, user, o
 	// expensive as it only caches per repo.
 	if !onlyOrgMembers {
 		if ok, err := ghc.IsCollaborator(org, repo, user); err != nil {
-			return errorResponse, fmt.Errorf("error in IsCollaborator: %v", err)
+			return errorResponse, fmt.Errorf("error in IsCollaborator: %w", err)
 		} else if ok {
 			return okResponse, nil
 		}
@@ -265,7 +265,7 @@ func TrustedUser(ghc trustedUserClient, onlyOrgMembers bool, trustedOrg, user, o
 	// Check the second trusted org.
 	member, err := ghc.IsMember(trustedOrg, user)
 	if err != nil {
-		return errorResponse, fmt.Errorf("error in IsMember(%s): %v", trustedOrg, err)
+		return errorResponse, fmt.Errorf("error in IsMember(%s): %w", trustedOrg, err)
 	} else if member {
 		return okResponse, nil
 	}

--- a/prow/plugins/updateconfig/updateconfig.go
+++ b/prow/plugins/updateconfig/updateconfig.go
@@ -103,7 +103,7 @@ func Update(fg FileGetter, kc corev1.ConfigMapInterface, name, namespace string,
 	cm, getErr := kc.Get(context.TODO(), name, metav1.GetOptions{})
 	isNotFound := errors.IsNotFound(getErr)
 	if getErr != nil && !isNotFound {
-		return fmt.Errorf("failed to fetch current state of configmap: %v", getErr)
+		return fmt.Errorf("failed to fetch current state of configmap: %w", getErr)
 	}
 
 	if cm == nil || isNotFound {
@@ -134,7 +134,7 @@ func Update(fg FileGetter, kc corev1.ConfigMapInterface, name, namespace string,
 
 		content, err := fg.GetFile(upd.Filename)
 		if err != nil {
-			return fmt.Errorf("get file err: %v", err)
+			return fmt.Errorf("get file err: %w", err)
 		}
 		logger.WithFields(logrus.Fields{"key": upd.Key, "filename": upd.Filename}).Debug("Populating key.")
 		value := content
@@ -173,7 +173,7 @@ func Update(fg FileGetter, kc corev1.ConfigMapInterface, name, namespace string,
 		_, updateErr = kc.Update(context.TODO(), cm, metav1.UpdateOptions{})
 	}
 	if updateErr != nil {
-		return fmt.Errorf("%s config map err: %v", verb, updateErr)
+		return fmt.Errorf("%s config map err: %w", verb, updateErr)
 	}
 	if metrics != nil {
 		var size float64
@@ -369,7 +369,7 @@ func handle(gc githubClient, gitClient git.ClientFactory, kc corev1.ConfigMapsGe
 	}
 
 	if err := gc.CreateComment(org, repo, pr.Number, plugins.FormatResponseRaw(pr.Body, pr.HTMLURL, pr.User.Login, msg)); err != nil {
-		errs = append(errs, fmt.Errorf("comment err: %v", err))
+		errs = append(errs, fmt.Errorf("comment err: %w", err))
 	}
 	return utilerrors.NewAggregate(errs)
 }

--- a/prow/plugins/verify-owners/verify-owners.go
+++ b/prow/plugins/verify-owners/verify-owners.go
@@ -215,7 +215,7 @@ func handle(ghc githubClient, gc git.ClientFactory, roc repoownersClient, log *l
 	// Get changes.
 	changes, err := ghc.GetPullRequestChanges(org, repo, number)
 	if err != nil {
-		return fmt.Errorf("error getting PR changes: %v", err)
+		return fmt.Errorf("error getting PR changes: %w", err)
 	}
 
 	// List modified OWNERS files.
@@ -280,7 +280,7 @@ func handle(ghc githubClient, gc git.ClientFactory, roc repoownersClient, log *l
 	// check if all newly added owners are trusted users.
 	oc, err := roc.LoadRepoOwners(org, repo, pr.Base.Ref)
 	if err != nil {
-		return fmt.Errorf("error loading RepoOwners: %v", err)
+		return fmt.Errorf("error loading RepoOwners: %w", err)
 	}
 
 	for _, c := range modifiedOwnersFiles {
@@ -330,7 +330,7 @@ func handle(ghc githubClient, gc git.ClientFactory, roc repoownersClient, log *l
 		}
 		err := ghc.CreateReview(org, repo, number, draftReview)
 		if err != nil {
-			return fmt.Errorf("error creating a review for invalid %s file%s: %v", filenames.Owners, s, err)
+			return fmt.Errorf("error creating a review for invalid %s file%s: %w", filenames.Owners, s, err)
 		}
 	}
 
@@ -354,7 +354,7 @@ func handle(ghc githubClient, gc git.ClientFactory, roc repoownersClient, log *l
 		// Don't bother checking if it has the label...it's a race, and we'll have
 		// to handle failure due to not being labeled anyway.
 		if err := ghc.RemoveLabel(org, repo, number, labels.InvalidOwners); err != nil {
-			return fmt.Errorf("failed removing %s label: %v", labels.InvalidOwners, err)
+			return fmt.Errorf("failed removing %s label: %w", labels.InvalidOwners, err)
 		}
 		cp.PruneComments(func(comment github.IssueComment) bool {
 			return strings.Contains(comment.Body, fmt.Sprintf(untrustedResponseFormat, filenames.Owners, triggerConfig.JoinOrgURL, org))
@@ -456,11 +456,11 @@ func nonTrustedUsersInOwnersAliases(ghc githubClient, log *logrus.Entry, trigger
 	if _, err := os.Stat(path); err == nil {
 		b, err := ioutil.ReadFile(path)
 		if err != nil {
-			return nonTrustedUsers, trustedUsers, repoAliases, fmt.Errorf("Failed to read %s: %v", path, err)
+			return nonTrustedUsers, trustedUsers, repoAliases, fmt.Errorf("Failed to read %s: %w", path, err)
 		}
 		repoAliases, err = repoowners.ParseAliasesConfig(b)
 		if err != nil {
-			return nonTrustedUsers, trustedUsers, repoAliases, fmt.Errorf("error parsing aliases config for %s file: %v", filenames.OwnersAliases, err)
+			return nonTrustedUsers, trustedUsers, repoAliases, fmt.Errorf("error parsing aliases config for %s file: %w", filenames.OwnersAliases, err)
 		}
 	}
 

--- a/prow/plugins/welcome/welcome.go
+++ b/prow/plugins/welcome/welcome.go
@@ -121,7 +121,7 @@ func handlePR(c client, t plugins.Trigger, pre github.PullRequestEvent, welcomeT
 
 	trustedResponse, err := trigger.TrustedUser(c.GitHubClient, t.OnlyOrgMembers, t.TrustedOrg, user, org, repo)
 	if err != nil {
-		return fmt.Errorf("check if user %s is trusted: %v", user, err)
+		return fmt.Errorf("check if user %s is trusted: %w", user, err)
 	}
 	if trustedResponse.IsTrusted {
 		return nil

--- a/prow/plugins/wip/wip-label.go
+++ b/prow/plugins/wip/wip-label.go
@@ -91,7 +91,7 @@ func handlePullRequest(pc plugins.Agent, pe github.PullRequestEvent) error {
 
 	currentLabels, err := pc.GitHubClient.GetIssueLabels(org, repo, number)
 	if err != nil {
-		return fmt.Errorf("could not get labels for PR %s/%s:%d in WIP plugin: %v", org, repo, number, err)
+		return fmt.Errorf("could not get labels for PR %s/%s:%d in WIP plugin: %w", org, repo, number, err)
 	}
 	hasLabel := false
 	for _, l := range currentLabels {

--- a/prow/plugins/yuks/yuks.go
+++ b/prow/plugins/yuks/yuks.go
@@ -80,12 +80,12 @@ type jokeResult struct {
 func (url realJoke) readJoke() (string, error) {
 	req, err := http.NewRequest("GET", string(url), nil)
 	if err != nil {
-		return "", fmt.Errorf("could not create request %s: %v", url, err)
+		return "", fmt.Errorf("could not create request %s: %w", url, err)
 	}
 	req.Header.Add("Accept", "application/json")
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("could not read joke from %s: %v", url, err)
+		return "", fmt.Errorf("could not read joke from %s: %w", url, err)
 	}
 	defer resp.Body.Close()
 	var a jokeResult

--- a/prow/pod-utils/decorate/podspec_test.go
+++ b/prow/pod-utils/decorate/podspec_test.go
@@ -983,10 +983,10 @@ func TestProwJobToPod(t *testing.T) {
 			return fmt.Errorf("missing %s env var", env)
 		}
 		if err := opt.LoadConfig(*val); err != nil {
-			return fmt.Errorf("load: %v", err)
+			return fmt.Errorf("load: %w", err)
 		}
 		if err := opt.Validate(); err != nil {
-			return fmt.Errorf("validate: %v", err)
+			return fmt.Errorf("validate: %w", err)
 		}
 		return nil
 	}

--- a/prow/pod-utils/downwardapi/jobspec.go
+++ b/prow/pod-utils/downwardapi/jobspec.go
@@ -72,7 +72,7 @@ func ResolveSpecFromEnv() (*JobSpec, error) {
 
 	spec := &JobSpec{}
 	if err := json.Unmarshal([]byte(specEnv), spec); err != nil {
-		return nil, fmt.Errorf("malformed $%s: %v", JobSpecEnv, err)
+		return nil, fmt.Errorf("malformed $%s: %w", JobSpecEnv, err)
 	}
 
 	return spec, nil
@@ -121,7 +121,7 @@ func EnvForSpec(spec JobSpec) (map[string]string, error) {
 
 	raw, err := json.Marshal(spec)
 	if err != nil {
-		return env, fmt.Errorf("failed to marshal job spec: %v", err)
+		return env, fmt.Errorf("failed to marshal job spec: %w", err)
 	}
 	env[JobSpecEnv] = string(raw)
 

--- a/prow/pod-utils/gcs/upload.go
+++ b/prow/pod-utils/gcs/upload.go
@@ -151,11 +151,11 @@ func FileUploadWithOptions(file string, opts pkgio.WriterOptions) UploadFunc {
 
 		uploadErr := DataUploadWithOptions(reader, opts)(writer)
 		if uploadErr != nil {
-			uploadErr = fmt.Errorf("upload error: %v", uploadErr)
+			uploadErr = fmt.Errorf("upload error: %w", uploadErr)
 		}
 		closeErr := reader.Close()
 		if closeErr != nil {
-			closeErr = fmt.Errorf("reader close error: %v", closeErr)
+			closeErr = fmt.Errorf("reader close error: %w", closeErr)
 		}
 
 		return utilerrors.NewAggregate([]error{uploadErr, closeErr})
@@ -183,11 +183,11 @@ func DataUploadWithOptions(src io.Reader, attrs pkgio.WriterOptions) UploadFunc 
 		writer.ApplyWriterOptions(attrs)
 		_, copyErr := io.Copy(writer, src)
 		if copyErr != nil {
-			copyErr = fmt.Errorf("copy error: %v", copyErr)
+			copyErr = fmt.Errorf("copy error: %w", copyErr)
 		}
 		closeErr := writer.Close()
 		if closeErr != nil {
-			closeErr = fmt.Errorf("writer close error: %v", closeErr)
+			closeErr = fmt.Errorf("writer close error: %w", closeErr)
 		}
 		return utilerrors.NewAggregate([]error{copyErr, closeErr})
 	}

--- a/prow/pod-utils/options/load.go
+++ b/prow/pod-utils/options/load.go
@@ -36,7 +36,7 @@ type OptionLoader interface {
 func Load(loader OptionLoader) error {
 	if jsonConfig, provided := os.LookupEnv(loader.ConfigVar()); provided {
 		if err := loader.LoadConfig(jsonConfig); err != nil {
-			return fmt.Errorf("could not load config from JSON var %s: %v", loader.ConfigVar(), err)
+			return fmt.Errorf("could not load config from JSON var %s: %w", loader.ConfigVar(), err)
 		}
 		return nil
 	}

--- a/prow/pod-utils/wrapper/options.go
+++ b/prow/pod-utils/wrapper/options.go
@@ -102,7 +102,7 @@ func WaitForMarkers(ctx context.Context, paths ...string) map[string]MarkerResul
 	}
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		populateMapWithError(results, fmt.Errorf("new fsnotify watch: %v", err), paths...)
+		populateMapWithError(results, fmt.Errorf("new fsnotify watch: %w", err), paths...)
 		return results
 	}
 	defer watcher.Close()
@@ -118,7 +118,7 @@ func WaitForMarkers(ctx context.Context, paths ...string) map[string]MarkerResul
 	}
 
 	if err := watcher.Add(dir); err != nil {
-		populateMapWithError(results, fmt.Errorf("add %s to fsnotify watch: %v", dir, err), paths...)
+		populateMapWithError(results, fmt.Errorf("add %s to fsnotify watch: %w", dir, err), paths...)
 		return results
 	}
 
@@ -128,7 +128,7 @@ func WaitForMarkers(ctx context.Context, paths ...string) map[string]MarkerResul
 	for len(results) < len(paths) {
 		select {
 		case <-ctx.Done():
-			populateMapWithError(results, fmt.Errorf("cancelled: %v", ctx.Err()), paths...)
+			populateMapWithError(results, fmt.Errorf("cancelled: %w", ctx.Err()), paths...)
 			return results
 		case event := <-watcher.Events:
 			for _, path := range paths {
@@ -161,11 +161,11 @@ func populateMapWithError(markerMap map[string]MarkerResult, err error, paths ..
 func readMarkerFile(path string) MarkerResult {
 	returnCodeData, err := ioutil.ReadFile(path)
 	if err != nil {
-		return MarkerResult{-1, fmt.Errorf("bad read: %v", err)}
+		return MarkerResult{-1, fmt.Errorf("bad read: %w", err)}
 	}
 	returnCode, err := strconv.Atoi(strings.TrimSpace(string(returnCodeData)))
 	if err != nil {
-		return MarkerResult{-1, fmt.Errorf("invalid return code: %v", err)}
+		return MarkerResult{-1, fmt.Errorf("invalid return code: %w", err)}
 	}
 	return MarkerResult{returnCode, nil}
 }

--- a/prow/prstatus/prstatus.go
+++ b/prow/prstatus/prstatus.go
@@ -344,11 +344,11 @@ func (da *DashboardAgent) getHeadContexts(ghc githubStatusFetcher, pr PullReques
 	repo := string(pr.Repository.Name)
 	combined, err := ghc.GetCombinedStatus(org, repo, string(pr.HeadRefOID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to get the combined status: %v", err)
+		return nil, fmt.Errorf("failed to get the combined status: %w", err)
 	}
 	checkruns, err := ghc.ListCheckRuns(org, repo, string(pr.HeadRefOID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch checkruns: %v", err)
+		return nil, fmt.Errorf("failed to fetch checkruns: %w", err)
 	}
 	contexts := make([]Context, 0, len(combined.Statuses)+len(checkruns.CheckRuns))
 	for _, status := range combined.Statuses {

--- a/prow/repoowners/repoowners.go
+++ b/prow/repoowners/repoowners.go
@@ -268,7 +268,7 @@ func (c *Client) LoadRepoOwners(org, repo, base string) (RepoOwner, error) {
 	start := time.Now()
 	sha, err := c.ghc.GetRef(org, repo, fmt.Sprintf("heads/%s", base))
 	if err != nil {
-		return nil, fmt.Errorf("failed to get current SHA for %s: %v", fullName, err)
+		return nil, fmt.Errorf("failed to get current SHA for %s: %w", fullName, err)
 	}
 	if sha == "" {
 		return nil, fmt.Errorf("got an empty SHA for %s@heads/%s", fullName, base)
@@ -318,7 +318,7 @@ func (c *Client) cacheEntryFor(org, repo, base, cloneRef, fullName, sha string, 
 		start := time.Now()
 		gitRepo, err := c.git.ClientFor(org, repo)
 		if err != nil {
-			return cacheEntry{}, fmt.Errorf("failed to clone %s: %v", cloneRef, err)
+			return cacheEntry{}, fmt.Errorf("failed to clone %s: %w", cloneRef, err)
 		}
 		log.WithField("duration", time.Since(start).String()).Debugf("Completed git.ClientFor(%s, %s)", org, repo)
 		defer gitRepo.Clean()
@@ -377,7 +377,7 @@ func (c *Client) cacheEntryFor(org, repo, base, cloneRef, fullName, sha string, 
 			start = time.Now()
 			entry.owners, err = loadOwnersFrom(gitRepo.Directory(), mdYaml, entry.aliases, dirIgnorelist, filenames, log)
 			if err != nil {
-				return cacheEntry{}, fmt.Errorf("failed to load RepoOwners for %s: %v", fullName, err)
+				return cacheEntry{}, fmt.Errorf("failed to load RepoOwners for %s: %w", fullName, err)
 			}
 			log.WithField("duration", time.Since(start).String()).Debugf("Completed loadOwnersFrom(%s, %t, entry.aliases, dirIgnorelist, log)", gitRepo.Directory(), mdYaml)
 			entry.sha = sha

--- a/prow/repoowners/repoowners_test.go
+++ b/prow/repoowners/repoowners_test.go
@@ -169,15 +169,15 @@ func getTestClient(
 	}
 
 	if err := localGit.MakeFakeRepo("org", "repo"); err != nil {
-		return nil, nil, fmt.Errorf("cannot make fake repo: %v", err)
+		return nil, nil, fmt.Errorf("cannot make fake repo: %w", err)
 	}
 
 	if err := localGit.AddCommit("org", "repo", files); err != nil {
-		return nil, nil, fmt.Errorf("cannot add initial commit: %v", err)
+		return nil, nil, fmt.Errorf("cannot add initial commit: %w", err)
 	}
 	if includeAliases {
 		if err := localGit.AddCommit("org", "repo", testAliasesFile); err != nil {
-			return nil, nil, fmt.Errorf("cannot add OWNERS_ALIASES commit: %v", err)
+			return nil, nil, fmt.Errorf("cannot add OWNERS_ALIASES commit: %w", err)
 		}
 	}
 	if len(extraBranchesAndFiles) > 0 {
@@ -187,7 +187,7 @@ func getTestClient(
 			}
 			if len(extraFiles) > 0 {
 				if err := localGit.AddCommit("org", "repo", extraFiles); err != nil {
-					return nil, nil, fmt.Errorf("cannot add commit: %v", err)
+					return nil, nil, fmt.Errorf("cannot add commit: %w", err)
 				}
 			}
 		}
@@ -200,7 +200,7 @@ func getTestClient(
 		var entry cacheEntry
 		entry.sha, err = localGit.RevParse("org", "repo", "HEAD")
 		if err != nil {
-			return nil, nil, fmt.Errorf("cannot get commit SHA: %v", err)
+			return nil, nil, fmt.Errorf("cannot get commit SHA: %w", err)
 		}
 		if cacheOptions.hasAliases {
 			entry.aliases = make(map[string]sets.String)
@@ -213,7 +213,7 @@ func getTestClient(
 This file could be anything
 ---`)}
 			if err := localGit.AddCommit("org", "repo", md); err != nil {
-				return nil, nil, fmt.Errorf("cannot add commit: %v", err)
+				return nil, nil, fmt.Errorf("cannot add commit: %w", err)
 			}
 		}
 		if cacheOptions.mdFileChanged {
@@ -226,7 +226,7 @@ labels:
 - docs
 ---`)}
 			if err := localGit.AddCommit("org", "repo", md); err != nil {
-				return nil, nil, fmt.Errorf("cannot add commit: %v", err)
+				return nil, nil, fmt.Errorf("cannot add commit: %w", err)
 			}
 		}
 		if cacheOptions.ownersAliasesFileChanged {
@@ -234,7 +234,7 @@ labels:
 				"OWNERS_ALIASES": []byte("aliases:\n  Best-approvers:\n\n  - carl\n  - cjwagner\n  best-reviewers:\n  - Carl\n  - BOB"),
 			}
 			if err := localGit.AddCommit("org", "repo", testAliasesFile); err != nil {
-				return nil, nil, fmt.Errorf("cannot add commit: %v", err)
+				return nil, nil, fmt.Errorf("cannot add commit: %w", err)
 			}
 		}
 		if cacheOptions.ownersFileChanged {
@@ -251,7 +251,7 @@ labels:
 - EVERYTHING`),
 			}
 			if err := localGit.AddCommit("org", "repo", owners); err != nil {
-				return nil, nil, fmt.Errorf("cannot add commit: %v", err)
+				return nil, nil, fmt.Errorf("cannot add commit: %w", err)
 			}
 		}
 		cache.data["org"+"/"+"repo:master"] = entry
@@ -261,7 +261,7 @@ labels:
 	ghc := &fakeGitHubClient{Collaborators: []string{"cjwagner", "k8s-ci-robot", "alice", "bob", "carl", "mml", "maggie"}}
 	ghc.ref, err = localGit.RevParse("org", "repo", "HEAD")
 	if err != nil {
-		return nil, nil, fmt.Errorf("cannot get commit SHA: %v", err)
+		return nil, nil, fmt.Errorf("cannot get commit SHA: %w", err)
 	}
 	return &Client{
 			logger: logrus.WithField("client", "repoowners"),

--- a/prow/sidecar/censor.go
+++ b/prow/sidecar/censor.go
@@ -178,7 +178,7 @@ func fileCensorer(sem *semaphore.Weighted, errors chan<- error, censorer secretu
 func determineContentType(path string) (string, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		return "", fmt.Errorf("could not open file to check content type: %v", err)
+		return "", fmt.Errorf("could not open file to check content type: %w", err)
 	}
 	defer func() {
 		if err := file.Close(); err != nil {
@@ -188,7 +188,7 @@ func determineContentType(path string) (string, error) {
 
 	header := make([]byte, 512)
 	if _, err := file.Read(header); err != nil {
-		return "", fmt.Errorf("could not read file to check content type: %v", err)
+		return "", fmt.Errorf("could not read file to check content type: %w", err)
 	}
 	return http.DetectContentType(header), nil
 }
@@ -276,10 +276,10 @@ func unarchive(archivePath, destPath string) error {
 			}
 			n, err := io.Copy(file, tarReader)
 			if closeErr := file.Close(); closeErr != nil && err == nil {
-				return fmt.Errorf("error closing %s: %v", abs, closeErr)
+				return fmt.Errorf("error closing %s: %w", abs, closeErr)
 			}
 			if err != nil {
-				return fmt.Errorf("error writing to %s: %v", abs, err)
+				return fmt.Errorf("error writing to %s: %w", abs, err)
 			}
 			if n != entry.Size {
 				return fmt.Errorf("only wrote %d bytes to %s; expected %d", n, abs, entry.Size)
@@ -502,7 +502,7 @@ func loadSecrets(paths []string) ([][]byte, error) {
 			}
 			extra, parseErr := parser(raw)
 			if parseErr != nil {
-				return fmt.Errorf("could not read %s as a docker secret: %v", path, parseErr)
+				return fmt.Errorf("could not read %s as a docker secret: %w", path, parseErr)
 			}
 			// It is important that these are added to the list of secrets *after* their parent data
 			// as we will censor in order and this will give a reasonable guarantee that the parent

--- a/prow/sidecar/options.go
+++ b/prow/sidecar/options.go
@@ -153,7 +153,7 @@ func (o *Options) Validate() error {
 	}
 	for i, e := range ents {
 		if err := e.Validate(); err != nil {
-			return fmt.Errorf("entry %d: %v", i, err)
+			return fmt.Errorf("entry %d: %w", i, err)
 		}
 	}
 

--- a/prow/sidecar/run.go
+++ b/prow/sidecar/run.go
@@ -79,7 +79,7 @@ func (o Options) Run(ctx context.Context) (int, error) {
 	}
 	spec, err := downwardapi.ResolveSpecFromEnv()
 	if err != nil {
-		return 0, fmt.Errorf("could not resolve job spec: %v", err)
+		return 0, fmt.Errorf("could not resolve job spec: %w", err)
 	}
 
 	entries := o.entries()
@@ -245,7 +245,7 @@ func (o Options) doUpload(ctx context.Context, spec *downwardapi.JobSpec, passed
 	}
 
 	if err := o.GcsOptions.Run(ctx, spec, uploadTargets); err != nil {
-		return fmt.Errorf("failed to upload to GCS: %v", err)
+		return fmt.Errorf("failed to upload to GCS: %w", err)
 	}
 
 	return nil

--- a/prow/sidecar/run_test.go
+++ b/prow/sidecar/run_test.go
@@ -264,7 +264,7 @@ func TestWaitParallelContainers(t *testing.T) {
 				}
 				marker, err := strconv.Atoi(m)
 				if err != nil {
-					errCh <- fmt.Errorf("invalid exit code: %v", err)
+					errCh <- fmt.Errorf("invalid exit code: %w", err)
 				}
 				go func() {
 					errCh <- entrypointOptions.Mark(marker)

--- a/prow/slack/client.go
+++ b/prow/slack/client.go
@@ -125,11 +125,11 @@ func (sl *Client) postMessage(url string, uv *url.Values) error {
 	}{}
 
 	if err := json.Unmarshal(body, &apiResponse); err != nil {
-		return fmt.Errorf("API returned invalid JSON (%q): %v", string(body), err)
+		return fmt.Errorf("API returned invalid JSON (%q): %w", string(body), err)
 	}
 
 	if resp.StatusCode != 200 || !apiResponse.Ok {
-		return fmt.Errorf("request failed: %v", apiResponse.Error)
+		return fmt.Errorf("request failed: %s", apiResponse.Error)
 	}
 
 	return nil

--- a/prow/spyglass/lenses/buildlog/lens.go
+++ b/prow/spyglass/lenses/buildlog/lens.go
@@ -229,7 +229,7 @@ func artifactByName(artifacts []api.Artifact, name string) (api.Artifact, bool) 
 func logLinesAll(artifact api.Artifact) ([]string, error) {
 	read, err := artifact.ReadAll()
 	if err != nil {
-		return nil, fmt.Errorf("failed to read log %q: %v", artifact.JobPath(), err)
+		return nil, fmt.Errorf("failed to read log %q: %w", artifact.JobPath(), err)
 	}
 	logLines := strings.Split(string(read), "\n")
 
@@ -241,11 +241,11 @@ func logLines(artifact api.Artifact, offset, length int64) ([]string, error) {
 	_, err := artifact.ReadAt(b, offset)
 	if err != nil && err != io.EOF {
 		if err != lenses.ErrGzipOffsetRead {
-			return nil, fmt.Errorf("couldn't read requested bytes: %v", err)
+			return nil, fmt.Errorf("couldn't read requested bytes: %w", err)
 		}
 		moreBytes, err := artifact.ReadAtMost(offset + length)
 		if err != nil && err != io.EOF {
-			return nil, fmt.Errorf("couldn't handle reading gzipped file: %v", err)
+			return nil, fmt.Errorf("couldn't handle reading gzipped file: %w", err)
 		}
 		b = moreBytes[offset:]
 	}

--- a/prow/spyglass/lenses/common/bindata.go
+++ b/prow/spyglass/lenses/common/bindata.go
@@ -122,7 +122,7 @@ func AssetInfo(name string) (os.FileInfo, error) {
 	if f, ok := _bindata[cannonicalName]; ok {
 		a, err := f()
 		if err != nil {
-			return nil, fmt.Errorf("AssetInfo %s can't read by error: %v", name, err)
+			return nil, fmt.Errorf("AssetInfo %s can't read by error: %w", name, err)
 		}
 		return a.info, nil
 	}

--- a/prow/spyglass/lenses/common/common.go
+++ b/prow/spyglass/lenses/common/common.go
@@ -184,7 +184,7 @@ func FetchArtifacts(
 	arts := []api.Artifact{}
 	keyType, key, err := splitSrc(src)
 	if err != nil {
-		return arts, fmt.Errorf("error parsing src: %v", err)
+		return arts, fmt.Errorf("error parsing src: %w", err)
 	}
 	gcsKey := ""
 	switch keyType {
@@ -246,12 +246,12 @@ type ProwJobFetcher interface {
 func ProwToGCS(fetcher ProwJobFetcher, config config.Getter, prowKey string) (string, string, error) {
 	jobName, buildID, err := KeyToJob(prowKey)
 	if err != nil {
-		return "", "", fmt.Errorf("could not get GCS src: %v", err)
+		return "", "", fmt.Errorf("could not get GCS src: %w", err)
 	}
 
 	job, err := fetcher.GetProwJob(jobName, buildID)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to get prow job from src %q: %v", prowKey, err)
+		return "", "", fmt.Errorf("failed to get prow job from src %q: %w", prowKey, err)
 	}
 
 	url := job.Status.URL

--- a/prow/spyglass/lenses/lenses.go
+++ b/prow/spyglass/lenses/lenses.go
@@ -128,7 +128,7 @@ func LastNLinesChunked(a api.Artifact, n, chunkSize int64) ([]string, error) {
 	var linesInContents int64
 	artifactSize, err := a.Size()
 	if err != nil {
-		return nil, fmt.Errorf("error getting artifact size: %v", err)
+		return nil, fmt.Errorf("error getting artifact size: %w", err)
 	}
 	offset := artifactSize - chunks*chunkSize
 	lastOffset := offset
@@ -142,7 +142,7 @@ func LastNLinesChunked(a api.Artifact, n, chunkSize int64) ([]string, error) {
 		bytesRead := make([]byte, toRead)
 		numBytesRead, err := a.ReadAt(bytesRead, offset)
 		if err != nil && err != io.EOF {
-			return nil, fmt.Errorf("error reading artifact: %v", err)
+			return nil, fmt.Errorf("error reading artifact: %w", err)
 		}
 		lastRead = int64(numBytesRead)
 		lastOffset = offset

--- a/prow/spyglass/lenses/links/links.go
+++ b/prow/spyglass/lenses/links/links.go
@@ -70,12 +70,12 @@ func (lens Lens) Header(artifacts []api.Artifact, resourceDir string, config jso
 func renderTemplate(resourceDir, block string, params interface{}) (string, error) {
 	t, err := template.ParseFiles(filepath.Join(resourceDir, "template.html"))
 	if err != nil {
-		return "", fmt.Errorf("Failed to parse template: %v", err)
+		return "", fmt.Errorf("Failed to parse template: %w", err)
 	}
 
 	var buf bytes.Buffer
 	if err := t.ExecuteTemplate(&buf, block, params); err != nil {
-		return "", fmt.Errorf("Failed to execute template: %v", err)
+		return "", fmt.Errorf("Failed to execute template: %w", err)
 	}
 	return buf.String(), nil
 }

--- a/prow/spyglass/podlogartifact.go
+++ b/prow/spyglass/podlogartifact.go
@@ -100,7 +100,7 @@ func (a *PodLogArtifact) ReadAt(p []byte, off int64) (n int, err error) {
 	}
 	logs, err := a.jobAgent.GetJobLog(a.name, a.buildID, a.container)
 	if err != nil {
-		return 0, fmt.Errorf("error getting pod log: %v", err)
+		return 0, fmt.Errorf("error getting pod log: %w", err)
 	}
 	r := bytes.NewReader(logs)
 	readBytes, err := r.ReadAt(p, off)
@@ -108,7 +108,7 @@ func (a *PodLogArtifact) ReadAt(p []byte, off int64) (n int, err error) {
 		return readBytes, io.EOF
 	}
 	if err != nil {
-		return 0, fmt.Errorf("error reading pod logs: %v", err)
+		return 0, fmt.Errorf("error reading pod logs: %w", err)
 	}
 	return readBytes, nil
 }
@@ -117,14 +117,14 @@ func (a *PodLogArtifact) ReadAt(p []byte, off int64) (n int, err error) {
 func (a *PodLogArtifact) ReadAll() ([]byte, error) {
 	size, err := a.Size()
 	if err != nil {
-		return nil, fmt.Errorf("error getting pod log size: %v", err)
+		return nil, fmt.Errorf("error getting pod log size: %w", err)
 	}
 	if size > a.sizeLimit {
 		return nil, lenses.ErrFileTooLarge
 	}
 	logs, err := a.jobAgent.GetJobLog(a.name, a.buildID, a.container)
 	if err != nil {
-		return nil, fmt.Errorf("error getting pod log: %v", err)
+		return nil, fmt.Errorf("error getting pod log: %w", err)
 	}
 	return logs, nil
 }
@@ -136,7 +136,7 @@ func (a *PodLogArtifact) ReadAtMost(n int64) ([]byte, error) {
 	}
 	logs, err := a.jobAgent.GetJobLog(a.name, a.buildID, a.container)
 	if err != nil {
-		return nil, fmt.Errorf("error getting pod log: %v", err)
+		return nil, fmt.Errorf("error getting pod log: %w", err)
 	}
 	reader := bytes.NewReader(logs)
 	var byteCount int64
@@ -147,7 +147,7 @@ func (a *PodLogArtifact) ReadAtMost(n int64) ([]byte, error) {
 			return p, io.EOF
 		}
 		if err != nil {
-			return nil, fmt.Errorf("error reading pod log: %v", err)
+			return nil, fmt.Errorf("error reading pod log: %w", err)
 		}
 		p = append(p, b)
 		byteCount++
@@ -162,7 +162,7 @@ func (a *PodLogArtifact) ReadTail(n int64) ([]byte, error) {
 	}
 	logs, err := a.jobAgent.GetJobLog(a.name, a.buildID, a.container)
 	if err != nil {
-		return nil, fmt.Errorf("error getting pod log tail: %v", err)
+		return nil, fmt.Errorf("error getting pod log tail: %w", err)
 	}
 	size := int64(len(logs))
 	var off int64
@@ -174,7 +174,7 @@ func (a *PodLogArtifact) ReadTail(n int64) ([]byte, error) {
 	p := make([]byte, n)
 	readBytes, err := bytes.NewReader(logs).ReadAt(p, off)
 	if err != nil && err != io.EOF {
-		return nil, fmt.Errorf("error reading pod log tail: %v", err)
+		return nil, fmt.Errorf("error reading pod log tail: %w", err)
 	}
 	return p[:readBytes], nil
 }
@@ -183,7 +183,7 @@ func (a *PodLogArtifact) ReadTail(n int64) ([]byte, error) {
 func (a *PodLogArtifact) Size() (int64, error) {
 	logs, err := a.jobAgent.GetJobLog(a.name, a.buildID, a.container)
 	if err != nil {
-		return 0, fmt.Errorf("error getting size of pod log: %v", err)
+		return 0, fmt.Errorf("error getting size of pod log: %w", err)
 	}
 	return int64(len(logs)), nil
 

--- a/prow/spyglass/podlogartifact_fetcher.go
+++ b/prow/spyglass/podlogartifact_fetcher.go
@@ -42,7 +42,7 @@ func NewPodLogArtifactFetcher(ja jobAgent) *PodLogArtifactFetcher {
 func (af *PodLogArtifactFetcher) Artifact(_ context.Context, key, artifactName string, sizeLimit int64) (api.Artifact, error) {
 	jobName, buildID, err := common.KeyToJob(key)
 	if err != nil {
-		return nil, fmt.Errorf("could not derive job: %v", err)
+		return nil, fmt.Errorf("could not derive job: %w", err)
 	}
 	containerName := containerName(artifactName)
 	podLog, err := NewPodLogArtifact(jobName, buildID, artifactName, containerName, sizeLimit, af.jobAgent)

--- a/prow/spyglass/storageartifact_fetcher.go
+++ b/prow/spyglass/storageartifact_fetcher.go
@@ -154,7 +154,7 @@ func (af *StorageArtifactFetcher) artifacts(ctx context.Context, key string) ([]
 			}
 			logrus.WithFields(fieldsForJob(src)).WithError(err).Error("Error accessing GCS artifact.")
 			if i >= len(wait) {
-				return artifacts, fmt.Errorf("timed out: error accessing GCS artifact: %v", err)
+				return artifacts, fmt.Errorf("timed out: error accessing GCS artifact: %w", err)
 			}
 			time.Sleep((wait[i] + time.Duration(rand.Intn(10))) * time.Millisecond)
 			i++

--- a/prow/spyglass/storageartifact_test.go
+++ b/prow/spyglass/storageartifact_test.go
@@ -92,10 +92,10 @@ func (h *fakeArtifactHandle) NewReader(ctx context.Context) (io.ReadCloser, erro
 	zw := gzip.NewWriter(&buf)
 	_, err := zw.Write([]byte("unreadable contents"))
 	if err != nil {
-		return nil, fmt.Errorf("Failed to gzip log text, err: %v", err)
+		return nil, fmt.Errorf("Failed to gzip log text, err: %w", err)
 	}
 	if err := zw.Close(); err != nil {
-		return nil, fmt.Errorf("Failed to close gzip writer, err: %v", err)
+		return nil, fmt.Errorf("Failed to close gzip writer, err: %w", err)
 	}
 	if bytes.Equal(h.contents, buf.Bytes()) {
 		return nil, fmt.Errorf("cannot read unreadable contents, even if they're gzipped")

--- a/prow/statusreconciler/controller.go
+++ b/prow/statusreconciler/controller.go
@@ -108,7 +108,7 @@ func (t *kubeProwJobTriggerer) runAndSkip(pr *github.PullRequest, requestedJobs 
 	org, repo := pr.Base.Repo.Owner.Login, pr.Base.Repo.Name
 	baseSHA, err := t.githubClient.GetRef(org, repo, "heads/"+pr.Base.Ref)
 	if err != nil {
-		return fmt.Errorf("failed to get baseSHA: %v", err)
+		return fmt.Errorf("failed to get baseSHA: %w", err)
 	}
 	return trigger.RunRequested(
 		trigger.Client{
@@ -227,7 +227,7 @@ func (c *Controller) triggerNewPresubmits(addedPresubmits map[string][]config.Pr
 		}
 		prs, err := c.githubClient.GetPullRequests(org, repo)
 		if err != nil {
-			triggerErrors = append(triggerErrors, fmt.Errorf("failed to list pull requests for %s: %v", orgrepo, err))
+			triggerErrors = append(triggerErrors, fmt.Errorf("failed to list pull requests for %s: %w", orgrepo, err))
 			if !c.continueOnError {
 				return utilerrors.NewAggregate(triggerErrors)
 			}
@@ -255,7 +255,7 @@ func (c *Controller) triggerNewPresubmits(addedPresubmits map[string][]config.Pr
 				return err
 			}
 			if err := c.triggerIfTrusted(org, repo, pr, toTrigger); err != nil {
-				triggerErrors = append(triggerErrors, fmt.Errorf("failed to trigger jobs for %s#%d: %v", orgrepo, pr.Number, err))
+				triggerErrors = append(triggerErrors, fmt.Errorf("failed to trigger jobs for %s#%d: %w", orgrepo, pr.Number, err))
 				if !c.continueOnError {
 					return utilerrors.NewAggregate(triggerErrors)
 				}
@@ -269,7 +269,7 @@ func (c *Controller) triggerNewPresubmits(addedPresubmits map[string][]config.Pr
 func (c *Controller) triggerIfTrusted(org, repo string, pr github.PullRequest, toTrigger []config.Presubmit) error {
 	trusted, err := c.trustedChecker.trustedPullRequest(pr.User.Login, org, repo, pr.Number)
 	if err != nil {
-		return fmt.Errorf("failed to determine if %s/%s#%d is trusted: %v", org, repo, pr.Number, err)
+		return fmt.Errorf("failed to determine if %s/%s#%d is trusted: %w", org, repo, pr.Number, err)
 	}
 	if !trusted {
 		return nil

--- a/prow/test/integration/test/hook_test.go
+++ b/prow/test/integration/test/hook_test.go
@@ -80,7 +80,7 @@ func TestHook(t *testing.T) {
 	if err := wait.Poll(500*time.Millisecond, 1*time.Minute, func() (bool, error) {
 		gotLabels, err := githubClient.GetIssueLabels(org, repo, issueID)
 		if err != nil {
-			return false, fmt.Errorf("failed listing issue labels: %v", err)
+			return false, fmt.Errorf("failed listing issue labels: %w", err)
 		}
 		for _, l := range gotLabels {
 			if l.Name == label {

--- a/prow/test/integration/test/setup.go
+++ b/prow/test/integration/test/setup.go
@@ -57,7 +57,7 @@ func NewClients(configPath, clusterName string) (ctrlruntimeclient.Client, error
 	cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		loader, &overrides).ClientConfig()
 	if err != nil {
-		return nil, fmt.Errorf("failed create rest config: %v", err)
+		return nil, fmt.Errorf("failed create rest config: %w", err)
 	}
 	return ctrlruntimeclient.New(cfg, ctrlruntimeclient.Options{})
 }

--- a/prow/tide/blockers/blockers.go
+++ b/prow/tide/blockers/blockers.go
@@ -120,7 +120,7 @@ func FindAll(ghc githubClient, log *logrus.Entry, label string, orgRepoTokensByO
 	wg.Wait()
 
 	if err := utilerrors.NewAggregate(errs); err != nil {
-		return Blockers{}, fmt.Errorf("error searching for blocker issues: %v", err)
+		return Blockers{}, fmt.Errorf("error searching for blocker issues: %w", err)
 	}
 
 	return fromIssues(issues, log), nil

--- a/prow/tide/history/history.go
+++ b/prow/tide/history/history.go
@@ -61,16 +61,16 @@ func readHistory(maxRecordsPerKey int, opener opener, path string) (map[string]*
 		return map[string]*recordLog{}, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("open: %v", err)
+		return nil, fmt.Errorf("open: %w", err)
 	}
 	defer io.LogClose(reader)
 	raw, err := ioutil.ReadAll(reader)
 	if err != nil {
-		return nil, fmt.Errorf("read: %v", err)
+		return nil, fmt.Errorf("read: %w", err)
 	}
 	var recordsByPool map[string][]*Record
 	if err := json.Unmarshal(raw, &recordsByPool); err != nil {
-		return nil, fmt.Errorf("unmarshal: %v", err)
+		return nil, fmt.Errorf("unmarshal: %w", err)
 	}
 
 	// Load records into a new recordLog map.
@@ -96,18 +96,18 @@ func writeHistory(opener opener, path string, hist map[string][]*Record) error {
 	defer cancel()
 	writer, err := opener.Writer(ctx, path)
 	if err != nil {
-		return fmt.Errorf("open: %v", err)
+		return fmt.Errorf("open: %w", err)
 	}
 	b, err := json.Marshal(hist)
 	if err != nil {
-		return fmt.Errorf("marshal: %v", err)
+		return fmt.Errorf("marshal: %w", err)
 	}
 	if _, err := fmt.Fprint(writer, string(b)); err != nil {
 		io.LogClose(writer)
-		return fmt.Errorf("write: %v", err)
+		return fmt.Errorf("write: %w", err)
 	}
 	if err := writer.Close(); err != nil {
-		return fmt.Errorf("close: %v", err)
+		return fmt.Errorf("close: %w", err)
 	}
 	return nil
 }

--- a/prow/tide/search.go
+++ b/prow/tide/search.go
@@ -64,7 +64,7 @@ func search(query querier, log *logrus.Entry, q string, start, end time.Time, or
 		log.Debug("Sending query")
 		if err := query(ctx, &sq, vars, org); err != nil {
 			if cursor != nil {
-				err = fmt.Errorf("cursor: %q, err: %v", *cursor, err)
+				err = fmt.Errorf("cursor: %q, err: %w", *cursor, err)
 			}
 			return ret, err
 		}

--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -262,14 +262,14 @@ func (sc *statusController) expectedStatus(log *logrus.Entry, queryMap *config.Q
 	repo := config.OrgRepo{Org: string(pr.Repository.Owner.Login), Repo: string(pr.Repository.Name)}
 
 	if reason, err := sc.mergeChecker.isAllowed(pr); err != nil {
-		return "", "", fmt.Errorf("error checking if merge is allowed: %v", err)
+		return "", "", fmt.Errorf("error checking if merge is allowed: %w", err)
 	} else if reason != "" {
 		return github.StatusError, fmt.Sprintf(statusNotInPool, " "+reason), nil
 	}
 
 	cc, err := ccg()
 	if err != nil {
-		return "", "", fmt.Errorf("failed to set up context register: %v", err)
+		return "", "", fmt.Errorf("failed to set up context register: %w", err)
 	}
 
 	if _, ok := pool[prKey(pr)]; !ok {

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -239,7 +239,7 @@ func NewController(ghcSync, ghcStatus github.Client, mgr manager, cfg config.Get
 	}
 	hist, err := history.New(maxRecordsPerPool, opener, historyURI)
 	if err != nil {
-		return nil, fmt.Errorf("error initializing history client from %q: %v", historyURI, err)
+		return nil, fmt.Errorf("error initializing history client from %q: %w", historyURI, err)
 	}
 	mergeChecker := newMergeChecker(cfg, ghcSync)
 
@@ -255,7 +255,7 @@ func NewController(ghcSync, ghcStatus github.Client, mgr manager, cfg config.Get
 
 func newStatusController(ctx context.Context, logger *logrus.Entry, ghc githubClient, mgr manager, gc git.ClientFactory, cfg config.Getter, opener io.Opener, statusURI string, mergeChecker *mergeChecker, usesGitHubAppsAuth bool) (*statusController, error) {
 	if err := mgr.GetFieldIndexer().IndexField(ctx, &prowapi.ProwJob{}, indexNamePassingJobs, indexFuncPassingJobs); err != nil {
-		return nil, fmt.Errorf("failed to add index for passing jobs to cache: %v", err)
+		return nil, fmt.Errorf("failed to add index for passing jobs to cache: %w", err)
 	}
 	return &statusController{
 		pjClient:           mgr.GetClient(),
@@ -290,7 +290,7 @@ func newSyncController(
 		cacheIndexName,
 		cacheIndexFunc,
 	); err != nil {
-		return nil, fmt.Errorf("failed to add baseSHA index to cache: %v", err)
+		return nil, fmt.Errorf("failed to add baseSHA index to cache: %w", err)
 	}
 	if err := mgr.GetFieldIndexer().IndexField(
 		ctx,
@@ -462,7 +462,7 @@ func (c *Controller) query() (map[string]PullRequest, error) {
 
 				if err != nil && len(results) == 0 {
 					c.logger.WithField("query", q).WithError(err).Warn("Failed to execute query.")
-					errs = append(errs, fmt.Errorf("query %d, err: %v", i, err))
+					errs = append(errs, fmt.Errorf("query %d, err: %w", i, err))
 					return
 				}
 				if err != nil {
@@ -551,13 +551,13 @@ func (c *Controller) initSubpoolData(sp *subpool) error {
 	var err error
 	sp.presubmits, err = c.presubmitsByPull(sp)
 	if err != nil {
-		return fmt.Errorf("error determining required presubmit prowjobs: %v", err)
+		return fmt.Errorf("error determining required presubmit prowjobs: %w", err)
 	}
 	sp.cc = make(map[int]contextChecker, len(sp.prs))
 	for _, pr := range sp.prs {
 		sp.cc[int(pr.Number)], err = c.config().GetTideContextPolicy(c.gc, sp.org, sp.repo, sp.branch, refGetterFactory(string(sp.sha)), string(pr.HeadRefOID))
 		if err != nil {
-			return fmt.Errorf("error setting up context checker for pr %d: %v", int(pr.Number), err)
+			return fmt.Errorf("error setting up context checker for pr %d: %w", int(pr.Number), err)
 		}
 	}
 	return nil
@@ -694,12 +694,12 @@ func (m *mergeChecker) isAllowed(pr *PullRequest) (string, error) {
 	mergeMethod, err := prMergeMethod(m.config().Tide, pr)
 	if err != nil {
 		// This should be impossible.
-		return "", fmt.Errorf("Programmer error! Failed to determine a merge method: %v", err)
+		return "", fmt.Errorf("Programmer error! Failed to determine a merge method: %w", err)
 	}
 	orgRepo := config.OrgRepo{Org: string(pr.Repository.Owner.Login), Repo: string(pr.Repository.Name)}
 	repoMethods, err := m.repoMethods(orgRepo)
 	if err != nil {
-		return "", fmt.Errorf("error getting repo data: %v", err)
+		return "", fmt.Errorf("error getting repo data: %w", err)
 	}
 	if allowed, exists := repoMethods[mergeMethod]; !exists {
 		// Should be impossible as well.
@@ -1254,7 +1254,7 @@ func (c *Controller) mergePRs(sp subpool, prs []PullRequest) error {
 			batch = fmt.Sprintf("%s, partial merge %v", batch, merged)
 		}
 	}
-	return fmt.Errorf("failed merging %v%s: %v", failed, batch, utilerrors.NewAggregate(errs))
+	return fmt.Errorf("failed merging %v%s: %w", failed, batch, utilerrors.NewAggregate(errs))
 }
 
 // setTideStatusSuccess ensures the tide context is set to success
@@ -1314,7 +1314,7 @@ func tryMerge(mergeFunc func() error) (bool, error) {
 			// modifies their PR as we try to merge it in a batch then we
 			// end up in an untested state. This is unlikely to cause any
 			// real problems.
-			return true, fmt.Errorf("PR was modified: %v", err)
+			return true, fmt.Errorf("PR was modified: %w", err)
 		} else if _, ok = err.(github.UnmergablePRBaseChangedError); ok {
 			//  complained that the base branch was modified. This is a
 			// strange error because the API doesn't even allow the request to
@@ -1324,7 +1324,7 @@ func tryMerge(mergeFunc func() error) (bool, error) {
 			// in time. https://github.com/kubernetes/test-infra/issues/5171
 			// We handle this by sleeping for a few seconds before trying to
 			// merge again.
-			err = fmt.Errorf("base branch was modified: %v", err)
+			err = fmt.Errorf("base branch was modified: %w", err)
 			if retry+1 < maxRetries {
 				sleep(backoff)
 				backoff *= 2
@@ -1335,15 +1335,15 @@ func tryMerge(mergeFunc func() error) (bool, error) {
 			// overzealous branch protection setting will not allow the robot to
 			// push to a specific branch.
 			// We won't be able to merge the other PRs.
-			return false, fmt.Errorf("branch needs to be configured to allow this robot to push: %v", err)
+			return false, fmt.Errorf("branch needs to be configured to allow this robot to push: %w", err)
 		} else if _, ok = err.(github.MergeCommitsForbiddenError); ok {
 			// GitHub let us know that the merge method configured for this repo
 			// is not allowed by other repo settings, so we should let the admins
 			// know that the configuration needs to be updated.
 			// We won't be able to merge the other PRs.
-			return false, fmt.Errorf("Tide needs to be configured to use the 'rebase' merge method for this repo or the repo needs to allow merge commits: %v", err)
+			return false, fmt.Errorf("Tide needs to be configured to use the 'rebase' merge method for this repo or the repo needs to allow merge commits: %w", err)
 		} else if _, ok = err.(github.UnmergablePRError); ok {
-			return true, fmt.Errorf("PR is unmergable. Do the Tide merge requirements match the GitHub settings for the repo? %v", err)
+			return true, fmt.Errorf("PR is unmergable. Do the Tide merge requirements match the GitHub settings for the repo? %w", err)
 		} else {
 			return true, err
 		}
@@ -1395,7 +1395,7 @@ func (c *Controller) trigger(sp subpool, presubmits []config.Presubmit, prs []Pu
 		start := time.Now()
 		if err := c.prowJobClient.Create(c.ctx, &pj); err != nil {
 			log.WithField("duration", time.Since(start).String()).Debug("Failed to create ProwJob on the cluster.")
-			return fmt.Errorf("failed to create a ProwJob for job: %q, PRs: %v: %v", spec.Job, prNumbers(prs), err)
+			return fmt.Errorf("failed to create a ProwJob for job: %q, PRs: %v: %w", spec.Job, prNumbers(prs), err)
 		}
 		log.WithField("duration", time.Since(start).String()).Debug("Created ProwJob on the cluster.")
 	}
@@ -1501,7 +1501,7 @@ func (c *changedFilesAgent) prChanges(pr *PullRequest) config.ChangedFilesProvid
 			int(pr.Number),
 		)
 		if err != nil {
-			return nil, fmt.Errorf("error getting PR changes for #%d: %v", int(pr.Number), err)
+			return nil, fmt.Errorf("error getting PR changes for #%d: %w", int(pr.Number), err)
 		}
 		changedFiles = make([]string, 0, len(changes))
 		for _, change := range changes {
@@ -1600,7 +1600,7 @@ func (c *Controller) presubmitsForBatch(prs []PullRequest, org, repo, baseSHA, b
 
 	presubmits, err := c.config().GetPresubmits(c.gc, org+"/"+repo, refGetterFactory(baseSHA), headRefGetters...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get presubmits for batch: %v", err)
+		return nil, fmt.Errorf("failed to get presubmits for batch: %w", err)
 	}
 	log.Debugf("Found %d possible presubmits for batch", len(presubmits))
 
@@ -1798,7 +1798,7 @@ func (c *Controller) dividePool(pool map[string]PullRequest) (map[string]*subpoo
 			ctrlruntimeclient.MatchingFields{cacheIndexName: cacheIndexKey(sp.org, sp.repo, sp.branch, sp.sha)},
 			ctrlruntimeclient.InNamespace(c.config().ProwJobNamespace))
 		if err != nil {
-			return nil, fmt.Errorf("failed to list jobs for subpool %s: %v", subpoolkey, err)
+			return nil, fmt.Errorf("failed to list jobs for subpool %s: %w", subpoolkey, err)
 		}
 		c.logger.WithField("subpool", subpoolkey).Debugf("Found %d prowjobs.", len(pjs.Items))
 		sps[subpoolkey].pjs = pjs.Items
@@ -1944,7 +1944,7 @@ func headContexts(log *logrus.Entry, ghc githubClient, pr *PullRequest) ([]Conte
 	log.Warnf("'last' %d commits didn't contain logical last commit. Querying GitHub...", len(pr.Commits.Nodes))
 	combined, err := ghc.GetCombinedStatus(org, repo, string(pr.HeadRefOID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to get the combined status: %v", err)
+		return nil, fmt.Errorf("failed to get the combined status: %w", err)
 	}
 	checkRunList, err := ghc.ListCheckRuns(org, repo, string(pr.HeadRefOID))
 	if err != nil {

--- a/releng/config-forker/main.go
+++ b/releng/config-forker/main.go
@@ -64,7 +64,7 @@ func generatePostsubmits(c config.JobConfig, version string) (map[string][]confi
 					var err error
 					c.Args, err = performReplacement(c.Args, version, p.Annotations[replacementAnnotation])
 					if err != nil {
-						return nil, fmt.Errorf("%s: %v", postsubmit.Name, err)
+						return nil, fmt.Errorf("%s: %w", postsubmit.Name, err)
 					}
 				}
 			}
@@ -95,7 +95,7 @@ func generatePresubmits(c config.JobConfig, version string) (map[string][]config
 					var err error
 					c.Args, err = performReplacement(c.Args, version, p.Annotations[replacementAnnotation])
 					if err != nil {
-						return nil, fmt.Errorf("%s: %v", presubmit.Name, err)
+						return nil, fmt.Errorf("%s: %w", presubmit.Name, err)
 					}
 				}
 			}
@@ -133,7 +133,7 @@ func generatePeriodics(conf config.JobConfig, version string) ([]config.Periodic
 				var err error
 				c.Args, err = performReplacement(c.Args, version, p.Annotations[replacementAnnotation])
 				if err != nil {
-					return nil, fmt.Errorf("%s: %v", periodic.Name, err)
+					return nil, fmt.Errorf("%s: %w", periodic.Name, err)
 				}
 			}
 		}
@@ -162,7 +162,7 @@ func generatePeriodics(conf config.JobConfig, version string) ([]config.Periodic
 		var err error
 		p.Tags, err = performReplacement(p.Tags, version, p.Annotations[replacementAnnotation])
 		if err != nil {
-			return nil, fmt.Errorf("%s: %v", periodic.Name, err)
+			return nil, fmt.Errorf("%s: %w", periodic.Name, err)
 		}
 		p.Labels = performDeletion(p.Labels, p.Annotations[deletionAnnotation])
 		p.Annotations = cleanAnnotations(fixTestgridAnnotations(p.Annotations, version, false))
@@ -191,12 +191,12 @@ func cleanAnnotations(annotations map[string]string) map[string]string {
 func evaluateTemplate(s string, c interface{}) (string, error) {
 	t, err := template.New("t").Parse(s)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse template %q: %v", s, err)
+		return "", fmt.Errorf("failed to parse template %q: %w", s, err)
 	}
 	wr := bytes.Buffer{}
 	err = t.Execute(&wr, c)
 	if err != nil {
-		return "", fmt.Errorf("failed to execute template: %v", err)
+		return "", fmt.Errorf("failed to execute template: %w", err)
 	}
 	return wr.String(), nil
 }

--- a/releng/config-rotator/main.go
+++ b/releng/config-rotator/main.go
@@ -39,7 +39,7 @@ type options struct {
 func cdToRootDir() error {
 	if bazelWorkspace := os.Getenv("BUILD_WORKSPACE_DIRECTORY"); bazelWorkspace != "" {
 		if err := os.Chdir(bazelWorkspace); err != nil {
-			return fmt.Errorf("failed to chdir to bazel workspace (%s): %v", bazelWorkspace, err)
+			return fmt.Errorf("failed to chdir to bazel workspace (%s): %w", bazelWorkspace, err)
 		}
 		return nil
 	}

--- a/robots/commenter/main.go
+++ b/robots/commenter/main.go
@@ -224,7 +224,7 @@ func run(c client, query, sort string, asc, random bool, commenter func(meta) (s
 	log.Printf("Searching: %s", query)
 	issues, err := c.FindIssues(query, sort, asc)
 	if err != nil {
-		return fmt.Errorf("search failed: %v", err)
+		return fmt.Errorf("search failed: %w", err)
 	}
 	problems := []string{}
 	log.Printf("Found %d matches", len(issues))

--- a/robots/coverage/downloader/downloader.go
+++ b/robots/coverage/downloader/downloader.go
@@ -50,7 +50,7 @@ func listGcsObjects(ctx context.Context, client *storage.Client, bucketName, pre
 			break
 		}
 		if err != nil {
-			return objects, fmt.Errorf("error iterating: %v", err)
+			return objects, fmt.Errorf("error iterating: %w", err)
 		}
 
 		if attrs.Prefix != "" {
@@ -66,7 +66,7 @@ func readGcsObject(ctx context.Context, client *storage.Client, bucket, object s
 	o := client.Bucket(bucket).Object(object)
 	reader, err := o.NewReader(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("cannot read object '%s': %v", object, err)
+		return nil, fmt.Errorf("cannot read object '%s': %w", object, err)
 	}
 	return ioutil.ReadAll(reader)
 }
@@ -80,7 +80,7 @@ func FindBaseProfile(ctx context.Context, client *storage.Client, bucket, prowJo
 
 	strBuilds, err := listGcsObjects(ctx, client, bucket, dirOfJob+"/", "/")
 	if err != nil {
-		return nil, fmt.Errorf("error listing gcs objects: %v", err)
+		return nil, fmt.Errorf("error listing gcs objects: %w", err)
 	}
 
 	builds := sortBuilds(strBuilds)

--- a/robots/issue-creator/creator/creator.go
+++ b/robots/issue-creator/creator/creator.go
@@ -159,7 +159,7 @@ func (c *IssueCreator) initialize() error {
 	}
 	b, err := ioutil.ReadFile(c.tokenFile)
 	if err != nil {
-		return fmt.Errorf("failed to read token file '%s': %v", c.tokenFile, err)
+		return fmt.Errorf("failed to read token file '%s': %w", c.tokenFile, err)
 	}
 	token := strings.TrimSpace(string(b))
 
@@ -218,7 +218,7 @@ func (c *IssueCreator) CreateAndSync() {
 func (c *IssueCreator) loadCache() error {
 	user, err := c.client.GetUser("")
 	if err != nil {
-		return fmt.Errorf("failed to fetch the User struct for the current authenticated user. errmsg: %v", err)
+		return fmt.Errorf("failed to fetch the User struct for the current authenticated user. errmsg: %w", err)
 	}
 	if user == nil {
 		return fmt.Errorf("received a nil User struct pointer when trying to look up the currently authenticated user")
@@ -263,7 +263,7 @@ func (c *IssueCreator) loadCache() error {
 		},
 	)
 	if err != nil {
-		return fmt.Errorf("failed to refresh the list of all issues created by %s in repo '%s/%s'. errmsg: %v", c.authorName, c.org, c.project, err)
+		return fmt.Errorf("failed to refresh the list of all issues created by %s in repo '%s/%s'. errmsg: %w", c.authorName, c.org, c.project, err)
 	}
 	if len(issues) == 0 {
 		glog.Warningf("IssueCreator found no issues in the repo '%s/%s' authored by '%s'.\n", c.org, c.project, c.authorName)

--- a/robots/issue-creator/sources/flakyjob-reporter.go
+++ b/robots/issue-creator/sources/flakyjob-reporter.go
@@ -103,7 +103,7 @@ func (fjr *FlakyJobReporter) parseFlakyJobs(jsonIn []byte) ([]*FlakyJob, error) 
 	var flakeMap map[string]*FlakyJob
 	err := json.Unmarshal(jsonIn, &flakeMap)
 	if err != nil || flakeMap == nil {
-		return nil, fmt.Errorf("error unmarshaling flaky jobs json: %v", err)
+		return nil, fmt.Errorf("error unmarshaling flaky jobs json: %w", err)
 	}
 	flakyJobs := make([]*FlakyJob, 0, len(flakeMap))
 
@@ -278,5 +278,5 @@ func ReadHTTP(url string) ([]byte, error) {
 		}
 		return body, nil
 	}
-	return nil, fmt.Errorf("ran out of retries reading from '%s'. Last error was %v", url, err)
+	return nil, fmt.Errorf("ran out of retries reading from '%s'. Last error was %w", url, err)
 }

--- a/robots/pr-creator/updater/updater.go
+++ b/robots/pr-creator/updater/updater.go
@@ -54,12 +54,12 @@ func EnsurePR(org, repo, title, body, source, branch, headBranch string, allowMo
 func EnsurePRWithQueryTokens(org, repo, title, body, source, baseBranch, queryTokensString string, allowMods bool, gc ensureClient) (*int, error) {
 	n, err := updatePRWithQueryTokens(org, repo, title, body, queryTokensString, gc)
 	if err != nil {
-		return nil, fmt.Errorf("update error: %v", err)
+		return nil, fmt.Errorf("update error: %w", err)
 	}
 	if n == nil {
 		pr, err := gc.CreatePullRequest(org, repo, title, body, source, baseBranch, allowMods)
 		if err != nil {
-			return nil, fmt.Errorf("create error: %v", err)
+			return nil, fmt.Errorf("create error: %w", err)
 		}
 		n = &pr
 	}
@@ -71,12 +71,12 @@ func updatePRWithQueryTokens(org, repo, title, body, queryTokensString string, g
 	logrus.Info("Looking for a PR to reuse...")
 	me, err := gc.BotUser()
 	if err != nil {
-		return nil, fmt.Errorf("bot name: %v", err)
+		return nil, fmt.Errorf("bot name: %w", err)
 	}
 
 	issues, err := gc.FindIssues(fmt.Sprintf("is:open is:pr archived:false repo:%s/%s author:%s %s", org, repo, me.Login, queryTokensString), "updated", false)
 	if err != nil {
-		return nil, fmt.Errorf("find issues: %v", err)
+		return nil, fmt.Errorf("find issues: %w", err)
 	} else if len(issues) == 0 {
 		logrus.Info("No reusable issues found")
 		return nil, nil
@@ -87,7 +87,7 @@ func updatePRWithQueryTokens(org, repo, title, body, queryTokensString string, g
 	var ignoreBranch *string
 	var ignoreModify *bool
 	if err := gc.UpdatePullRequest(org, repo, n, &title, &body, ignoreOpen, ignoreBranch, ignoreModify); err != nil {
-		return nil, fmt.Errorf("update %d: %v", n, err)
+		return nil, fmt.Errorf("update %d: %w", n, err)
 	}
 
 	return &n, nil
@@ -109,7 +109,7 @@ func EnsurePRWithQueryTokensAndLabels(org, repo, title, body, source, baseBranch
 
 	issue, err := gc.GetIssue(org, repo, *n)
 	if err != nil {
-		return n, fmt.Errorf("failed to get PR: %v", err)
+		return n, fmt.Errorf("failed to get PR: %w", err)
 	}
 
 	for _, label := range labels {
@@ -118,7 +118,7 @@ func EnsurePRWithQueryTokensAndLabels(org, repo, title, body, source, baseBranch
 		}
 
 		if err := gc.AddLabel(org, repo, *n, label); err != nil {
-			return n, fmt.Errorf("failed to add label %q: %v", label, err)
+			return n, fmt.Errorf("failed to add label %q: %w", label, err)
 		}
 		logrus.WithField("label", label).Info("Added label")
 	}

--- a/testgrid/cmd/configurator/main.go
+++ b/testgrid/cmd/configurator/main.go
@@ -182,7 +182,7 @@ func write(ctx context.Context, client *storage.Client, path string, bytes []byt
 
 	u, err := url.Parse(path)
 	if err != nil {
-		return fmt.Errorf("invalid url %s: %v", path, err)
+		return fmt.Errorf("invalid url %s: %w", path, err)
 	}
 	if u.Scheme != "gs" {
 		return ioutil.WriteFile(path, bytes, 0644)
@@ -200,7 +200,7 @@ func doOneshot(ctx context.Context, client *storage.Client, opt options, prowCon
 	// Read Data Sources: Default, YAML configs, Prow Annotations
 	c, err := yamlcfg.ReadConfig(opt.inputs, opt.defaultYAML, opt.strictUnmarshal)
 	if err != nil {
-		return fmt.Errorf("could not read testgrid config: %v", err)
+		return fmt.Errorf("could not read testgrid config: %w", err)
 	}
 
 	// Remains nil if no default YAML
@@ -228,7 +228,7 @@ func doOneshot(ctx context.Context, client *storage.Client, opt options, prowCon
 	if prowConfigAgent != nil {
 		pac.prowConfig = prowConfigAgent.Config()
 		if err := pac.applyProwjobAnnotations(&c); err != nil {
-			return fmt.Errorf("could not apply prowjob annotations: %v", err)
+			return fmt.Errorf("could not apply prowjob annotations: %w", err)
 		}
 	}
 
@@ -241,11 +241,11 @@ func doOneshot(ctx context.Context, client *storage.Client, opt options, prowCon
 		if opt.writeYAML {
 			b, err := yaml.Marshal(&c)
 			if err != nil {
-				return fmt.Errorf("could not print yaml config: %v", err)
+				return fmt.Errorf("could not print yaml config: %w", err)
 			}
 			os.Stdout.Write(b)
 		} else if err := tgCfgUtil.MarshalText(&c, os.Stdout); err != nil {
-			return fmt.Errorf("could not print config: %v", err)
+			return fmt.Errorf("could not print config: %w", err)
 		}
 	}
 
@@ -262,7 +262,7 @@ func doOneshot(ctx context.Context, client *storage.Client, opt options, prowCon
 			err = write(ctx, client, opt.output, b, opt.worldReadable, "")
 		}
 		if err != nil {
-			return fmt.Errorf("could not write config: %v", err)
+			return fmt.Errorf("could not write config: %w", err)
 		}
 	}
 	return nil


### PR DESCRIPTION

Genereated through find  -name '*.go'  -type f -print0 | xargs -0 sed -i -E 's#(fmt.Errorf\(".*)%v"#\1%w"#g followed by a couple of manual fixups where that incorrectly matched.
