### PR TITLE
prow/repoowners: Track filtered (non-collaborator) owners

### DIFF
--- a/prow/plugins/approve/approve.go
+++ b/prow/plugins/approve/approve.go
@@ -462,7 +462,7 @@ func handle(log *logrus.Entry, ghc githubClient, repo approvers.Repo, githubConf
 	start = time.Now()
 	notifications := filterComments(commentsFromIssueComments, notificationMatcher(botUserChecker))
 	latestNotification := getLast(notifications)
-	newMessage := updateNotification(githubConfig.LinkURL, opts.CommandHelpLink, opts.PrProcessLink, pr.org, pr.repo, pr.branch, latestNotification, approversHandler)
+	newMessage := updateNotification(githubConfig.LinkURL, opts.CommandHelpLink, opts.PrProcessLink, pr.org, pr.repo, pr.branch, repo.StaleRepositoryState(), latestNotification, approversHandler)
 	log.WithField("duration", time.Since(start).String()).Debug("Completed getting notifications in handle")
 	start = time.Now()
 	if newMessage != nil {
@@ -570,8 +570,8 @@ func notificationMatcher(isBot func(string) bool) func(*comment) bool {
 	}
 }
 
-func updateNotification(linkURL *url.URL, commandHelpLink, prProcessLink, org, repo, branch string, latestNotification *comment, approversHandler approvers.Approvers) *string {
-	message := approvers.GetMessage(approversHandler, linkURL, commandHelpLink, prProcessLink, org, repo, branch)
+func updateNotification(linkURL *url.URL, commandHelpLink, prProcessLink, org, repo, branch, staleRepositoryState string, latestNotification *comment, approversHandler approvers.Approvers) *string {
+	message := approvers.GetMessage(approversHandler, linkURL, commandHelpLink, prProcessLink, org, repo, branch, staleRepositoryState)
 	if message == nil || (latestNotification != nil && strings.Contains(latestNotification.Body, *message)) {
 		return nil
 	}

--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -151,6 +151,10 @@ func (fr fakeRepo) TopLevelApprovers() sets.String {
 	return nil
 }
 
+func (fr fakeRepo) StaleRepositoryState() string {
+	return ""
+}
+
 func (fr fakeRepo) ParseSimpleConfig(path string) (repoowners.SimpleConfig, error) {
 	dir := filepath.Dir(path)
 	for _, re := range fr.dirDenylist {

--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -1405,6 +1405,10 @@ func (fro fakeRepoOwners) RequiredReviewers(path string) sets.String {
 	return sets.NewString()
 }
 
+func (fro fakeRepoOwners) StaleRepositoryState() string {
+	return ""
+}
+
 func TestHandleGenericComment(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/prow/plugins/approve/approvers/approvers_test.go
+++ b/prow/plugins/approve/approvers/approvers_test.go
@@ -814,7 +814,7 @@ Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comme
 Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":["alice"]} -->`
-	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "https://go.k8s.io/bot-commands", "https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process", "org", "repo", "dev"); got == nil {
+	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "https://go.k8s.io/bot-commands", "https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process", "org", "repo", "dev", ""); got == nil {
 		t.Error("GetMessage() failed")
 	} else if *got != want {
 		t.Errorf("GetMessage() = %+v, want = %+v", *got, want)
@@ -856,7 +856,7 @@ Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comme
 Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":[]} -->`
-	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "https://go.k8s.io/bot-commands", "https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process", "org", "repo", "master"); got == nil {
+	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "https://go.k8s.io/bot-commands", "https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process", "org", "repo", "master", ""); got == nil {
 		t.Error("GetMessage() failed")
 	} else if *got != want {
 		t.Errorf("GetMessage() = %+v, want = %+v", *got, want)
@@ -896,7 +896,7 @@ Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comme
 Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":["alice","bill"]} -->`
-	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "https://go.k8s.io/bot-commands", "https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process", "org", "repo", "master"); got == nil {
+	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "https://go.k8s.io/bot-commands", "https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process", "org", "repo", "master", ""); got == nil {
 		t.Error("GetMessage() failed")
 	} else if *got != want {
 		t.Errorf("GetMessage() = %+v, want = %+v", *got, want)
@@ -940,7 +940,7 @@ Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comme
 Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":[]} -->`
-	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "https://go.k8s.io/bot-commands", "https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process", "org", "repo", "master"); got == nil {
+	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "https://go.k8s.io/bot-commands", "https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process", "org", "repo", "master", ""); got == nil {
 		t.Error("GetMessage() failed")
 	} else if *got != want {
 		t.Errorf("GetMessage() = %+v, want = %+v", *got, want)
@@ -983,7 +983,7 @@ Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comme
 Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":[]} -->`
-	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "https://go.k8s.io/bot-commands", "https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process", "org", "repo", "master"); got == nil {
+	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "https://go.k8s.io/bot-commands", "https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process", "org", "repo", "master", ""); got == nil {
 		t.Error("GetMessage() failed")
 	} else if *got != want {
 		t.Errorf("GetMessage() = %+v, want = %+v", *got, want)
@@ -1024,7 +1024,7 @@ Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comme
 Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":["alice","doctor"]} -->`
-	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "https://go.k8s.io/bot-commands", "https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process", "org", "repo", "master"); got == nil {
+	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "https://go.k8s.io/bot-commands", "https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process", "org", "repo", "master", ""); got == nil {
 		t.Error("GetMessage() failed")
 	} else if *got != want {
 		t.Errorf("GetMessage() = %+v, want = %+v", *got, want)
@@ -1065,7 +1065,7 @@ Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comme
 Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":["alice","doctor"]} -->`
-	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.mycorp.com"}, "https://go.k8s.io/bot-commands", "https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process", "org", "repo", "master"); got == nil {
+	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.mycorp.com"}, "https://go.k8s.io/bot-commands", "https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process", "org", "repo", "master", ""); got == nil {
 		t.Error("GetMessage() failed")
 	} else if *got != want {
 		t.Errorf("GetMessage() = %+v, want = %+v", *got, want)

--- a/prow/plugins/approve/approvers/owners_test.go
+++ b/prow/plugins/approve/approvers/owners_test.go
@@ -70,6 +70,10 @@ func (f FakeRepo) IsAutoApproveUnownedSubfolders(ownerFilePath string) bool {
 	return f.autoApproveUnownedSubfolders[ownerFilePath]
 }
 
+func (f FakeRepo) StaleRepositoryState() string {
+	return ""
+}
+
 func canonicalize(path string) string {
 	if path == "." {
 		return ""

--- a/prow/plugins/blunderbuss/blunderbuss_test.go
+++ b/prow/plugins/blunderbuss/blunderbuss_test.go
@@ -139,6 +139,10 @@ func (foc *fakeOwnersClient) RequiredReviewers(path string) sets.String {
 	return foc.requiredReviewers[path]
 }
 
+func (foc *fakeOwnersClient) StaleRepositoryState() string {
+	return ""
+}
+
 func (foc *fakeOwnersClient) LeafReviewers(path string) sets.String {
 	return foc.leafReviewers[path]
 }

--- a/prow/plugins/lgtm/lgtm_test.go
+++ b/prow/plugins/lgtm/lgtm_test.go
@@ -94,6 +94,7 @@ func (f *fakeRepoOwners) Approvers(path string) layeredsets.String        { retu
 func (f *fakeRepoOwners) LeafReviewers(path string) sets.String           { return nil }
 func (f *fakeRepoOwners) Reviewers(path string) layeredsets.String        { return f.reviewers[path] }
 func (f *fakeRepoOwners) RequiredReviewers(path string) sets.String       { return nil }
+func (f *fakeRepoOwners) StaleRepositoryState() string                    { return "" }
 func (f *fakeRepoOwners) TopLevelApprovers() sets.String                  { return nil }
 
 func (f *fakeRepoOwners) ParseSimpleConfig(path string) (repoowners.SimpleConfig, error) {

--- a/prow/plugins/override/override_test.go
+++ b/prow/plugins/override/override_test.go
@@ -87,6 +87,10 @@ func (foc *fakeOwnersClient) RequiredReviewers(path string) sets.String {
 	return sets.String{}
 }
 
+func (foc *fakeOwnersClient) StaleRepositoryState() string {
+	return ""
+}
+
 func (foc *fakeOwnersClient) LeafReviewers(path string) sets.String {
 	return sets.String{}
 }

--- a/prow/plugins/verify-owners/verify-owners_test.go
+++ b/prow/plugins/verify-owners/verify-owners_test.go
@@ -242,6 +242,10 @@ func (foc *fakeOwnersClient) RequiredReviewers(path string) sets.String {
 	return foc.requiredReviewers[path]
 }
 
+func (foc *fakeOwnersClient) StaleRepositoryState() string {
+	return ""
+}
+
 func (foc *fakeOwnersClient) LeafReviewers(path string) sets.String {
 	return foc.leafReviewers[path]
 }


### PR DESCRIPTION
GitHub-side docs for "collaborators" semantics are linked from:

```console
$ grep -hB5 'func .*ListCollaborators' prow/github/client.go
// ListCollaborators gets a list of all users who have access to a repo (and
// can become assignees or requested reviewers).
//
// See 'IsCollaborator' for more details.
// See https://developer.github.com/v3/repos/collaborators/
func (c *client) ListCollaborators(org, repo string) ([]User, error) {
```

Filtering non-collaborators out is good, and we do that already, but exposing an interface for stale entries will make it easier for consumers (like the `approve` plugin) to inform folks about stale content.