### PR TITLE
config/prow: allow k8s-infra-ci-robot to skip-review

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -598,6 +598,23 @@ tide:
     - needs-rebase
     repos:
     - kubernetes/test-infra
+  - author: k8s-infra-ci-robot
+    labels: # k8s-infra-ci-robot should only create autobump PR with this label
+    - skip-review
+    - "cncf-cla: yes"
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/blocked-paths
+    - do-not-merge/contains-merge-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-commit-message
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/release-note-label-needed
+    - do-not-merge/work-in-progress
+    - needs-rebase
+    repos:
+    - kubernetes/k8s.io
+    - kubernetes/test-infra
 
   merge_method:
     kubernetes-client/csharp: squash


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/test-infra/issues/21137
- Related to: https://github.com/kubernetes/enhancements/issues/2539
- Followup to: https://github.com/kubernetes/org/pull/2979

Now that the bot can apply the `skip-review` label, I realize that tide isn't setup to listen to it from anyone other than k8s-ci-robot.

So setup a pool for k8s-infra-ci-robot, for kubernetes/test-infra and kubernetes/k8s.io