### PR TITLE
Ignore EasyCLA context in any repo

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -625,12 +625,11 @@ tide:
   context_options:
     orgs:
       kubernetes:
+        optional-contexts:
+        - "EasyCLA" # NOTE(cblecker): This is temporary until we fully roll out EasyCLA
         repos:
           dashboard:
             from-branch-protection: true
-          org:
-            optional-contexts:
-            - "EasyCLA"
   batch_size_limit:
     "kubernetes/kubernetes": 15
   priority:


### PR DESCRIPTION
This expands on https://github.com/kubernetes/test-infra/pull/23634 to ignore the EasyCLA context in any repo in the @kubernetes org until we roll this out everywhere.

/assign @mrbobbytables 