### PR TITLE
Increase deletion throughput in 5k test

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -103,7 +103,7 @@ periodics:
       - --provider=gce
       - --metadata-sources=cl2-metadata.json
       - --env=CL2_LOAD_TEST_THROUGHPUT=50
-      - --env=CL2_DELETE_TEST_THROUGHPUT=30
+      - --env=CL2_DELETE_TEST_THROUGHPUT=50
       - --env=CL2_ENABLE_HUGE_SERVICES=true
       # Overrides CONTROLLER_MANAGER_TEST_ARGS from preset-e2e-scalability-periodics.
       - --env=CONTROLLER_MANAGER_TEST_ARGS=--profiling --kube-api-qps=100 --kube-api-burst=100 --endpointslice-updates-batch-period=500ms --endpoint-updates-batch-period=500ms


### PR DESCRIPTION
With https://github.com/kubernetes/kubernetes/pull/104966 we should be able to achieve ~60 pods/s deletion throughput.
The expected test duration saving is ~40m (out of ~5h).

I have started a manual run using this value and it looks good (metrics are OK, there is a lot of spare CPU during the object deletion phase).

We should consider increasing pod creation throughput to match this (there is a lot of spare CPU in that part as well).

/assign @wojtek-t 