### PR TITLE
update go.mod to go1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -108,4 +108,4 @@ require (
 	sigs.k8s.io/yaml v1.2.0
 )
 
-go 1.13
+go 1.16


### PR DESCRIPTION
Fell out of date with the version of go defined in WORKSPACE