### PR TITLE
Revert "Bumping Prow and Boskos"

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -82,7 +82,7 @@ presubmits:
     run_if_changed: '^(config/prow/(config|plugins).yaml$|config/jobs/.*.yaml$)'
     spec:
       containers:
-      - image: gcr.io/k8s-prow/checkconfig:v20210917-ee1e7c845b
+      - image: gcr.io/k8s-prow/checkconfig:v20210916-7657ce97bf
         command:
         - /checkconfig
         args:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -132,7 +132,7 @@ postsubmits:
     max_concurrency: 1
     spec:
       containers:
-      - image: gcr.io/k8s-prow/hmac:v20210917-ee1e7c845b
+      - image: gcr.io/k8s-prow/hmac:v20210916-7657ce97bf
         command:
         - /hmac
         args:
@@ -635,7 +635,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20210917-ee1e7c845b
+    - image: gcr.io/k8s-prow/generic-autobumper:v20210916-7657ce97bf
       command:
       - /app/prow/cmd/generic-autobumper/app.binary
       args:
@@ -672,7 +672,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20210917-ee1e7c845b
+    - image: gcr.io/k8s-prow/generic-autobumper:v20210916-7657ce97bf
       command:
       - /app/prow/cmd/generic-autobumper/app.binary
       args:
@@ -743,7 +743,7 @@ periodics:
   spec:
     containers:
     - name: branchprotector
-      image: gcr.io/k8s-prow/branchprotector:v20210917-ee1e7c845b
+      image: gcr.io/k8s-prow/branchprotector:v20210916-7657ce97bf
       command:
       - /app/prow/cmd/branchprotector/app.binary
       args:
@@ -777,7 +777,7 @@ periodics:
   spec:
     containers:
     - name: label-sync
-      image: gcr.io/k8s-prow/label_sync:v20210917-ee1e7c845b
+      image: gcr.io/k8s-prow/label_sync:v20210916-7657ce97bf
       command:
       - /app/label_sync/app.binary
       args:
@@ -823,7 +823,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-prow/checkconfig:v20210917-ee1e7c845b
+    - image: gcr.io/k8s-prow/checkconfig:v20210916-7657ce97bf
       command:
       - /checkconfig
       args:

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
@@ -10,7 +10,7 @@ periodics:
     testgrid-tab-name: api-review-help
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20210917-ee1e7c845b
+    - image: gcr.io/k8s-prow/commenter:v20210916-7657ce97bf
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -58,7 +58,7 @@ periodics:
     testgrid-tab-name: cla
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20210917-ee1e7c845b
+    - image: gcr.io/k8s-prow/commenter:v20210916-7657ce97bf
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -100,7 +100,7 @@ periodics:
     testgrid-tab-name: close
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20210917-ee1e7c845b
+    - image: gcr.io/k8s-prow/commenter:v20210916-7657ce97bf
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -154,7 +154,7 @@ periodics:
     description: Automatically /retest for approved PRs that are failing tests
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20210917-ee1e7c845b
+    - image: gcr.io/k8s-prow/commenter:v20210916-7657ce97bf
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -222,7 +222,7 @@ periodics:
     testgrid-tab-name: rotten
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20210917-ee1e7c845b
+    - image: gcr.io/k8s-prow/commenter:v20210916-7657ce97bf
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -277,7 +277,7 @@ periodics:
     testgrid-tab-name: stale
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20210917-ee1e7c845b
+    - image: gcr.io/k8s-prow/commenter:v20210916-7657ce97bf
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -333,7 +333,7 @@ periodics:
     testgrid-tab-name: thaw-prs
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20210917-ee1e7c845b
+    - image: gcr.io/k8s-prow/commenter:v20210916-7657ce97bf
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -382,7 +382,7 @@ periodics:
     description: Creates github issues based on data from various 'IssueSource's.
   spec:
     containers:
-    - image: gcr.io/k8s-prow/issue-creator:v20210917-ee1e7c845b
+    - image: gcr.io/k8s-prow/issue-creator:v20210916-7657ce97bf
       command:
       - /app/robots/issue-creator/app.binary
       args:

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-prow.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-prow.yaml
@@ -99,7 +99,7 @@ periodics:
       slug: test-infra-admins
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20210917-ee1e7c845b
+    - image: gcr.io/k8s-prow/generic-autobumper:v20210916-7657ce97bf
       command:
       - /app/prow/cmd/generic-autobumper/app.binary
       args:

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-test-infra.yaml
@@ -123,7 +123,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20210917-ee1e7c845b
+    - image: gcr.io/k8s-prow/generic-autobumper:v20210916-7657ce97bf
       command:
       - /app/prow/cmd/generic-autobumper/app.binary
       args:
@@ -153,7 +153,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20210917-ee1e7c845b
+    - image: gcr.io/k8s-prow/generic-autobumper:v20210916-7657ce97bf
       command:
       - /app/prow/cmd/generic-autobumper/app.binary
       args:

--- a/config/prow/cluster/cherrypicker_deployment.yaml
+++ b/config/prow/cluster/cherrypicker_deployment.yaml
@@ -39,7 +39,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: cherrypicker
-        image: gcr.io/k8s-prow/cherrypicker:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/cherrypicker:v20210916-7657ce97bf
         imagePullPolicy: Always
         args:
         - --github-token-path=/etc/github/token

--- a/config/prow/cluster/crier_deployment.yaml
+++ b/config/prow/cluster/crier_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/crier:v20210916-7657ce97bf
         args:
         - --blob-storage-workers=1
         - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/deck_deployment.yaml
+++ b/config/prow/cluster/deck_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/deck:v20210916-7657ce97bf
         imagePullPolicy: Always
         ports:
         - name: http

--- a/config/prow/cluster/ghproxy.yaml
+++ b/config/prow/cluster/ghproxy.yaml
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/ghproxy:v20210916-7657ce97bf
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99

--- a/config/prow/cluster/grandmatriarch.yaml
+++ b/config/prow/cluster/grandmatriarch.yaml
@@ -56,6 +56,6 @@ spec:
       serviceAccountName: grandmatriarch
       containers:
       - name: bakery
-        image: gcr.io/k8s-prow/grandmatriarch:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/grandmatriarch:v20210916-7657ce97bf
         args:
         - http-cookiefile

--- a/config/prow/cluster/hook_deployment.yaml
+++ b/config/prow/cluster/hook_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/hook:v20210916-7657ce97bf
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/config/prow/cluster/horologium_deployment.yaml
+++ b/config/prow/cluster/horologium_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/horologium:v20210916-7657ce97bf
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/config/prow/cluster/needs-rebase_deployment.yaml
+++ b/config/prow/cluster/needs-rebase_deployment.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/needs-rebase:v20210916-7657ce97bf
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/config/prow/cluster/pipeline_deployment.yaml
+++ b/config/prow/cluster/pipeline_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: prow-pipeline
       containers:
       - name: pipeline
-        image: gcr.io/k8s-prow/pipeline:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/pipeline:v20210916-7657ce97bf
         args:
         - --all-contexts
         - --config=/etc/prow-config/config.yaml

--- a/config/prow/cluster/prow_controller_manager_deployment.yaml
+++ b/config/prow/cluster/prow_controller_manager_deployment.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        image: gcr.io/k8s-prow/prow-controller-manager:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/prow-controller-manager:v20210916-7657ce97bf
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/config/prow/cluster/sinker_deployment.yaml
+++ b/config/prow/cluster/sinker_deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
-        image: gcr.io/k8s-prow/sinker:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/sinker:v20210916-7657ce97bf
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG

--- a/config/prow/cluster/starter-gcs.yaml
+++ b/config/prow/cluster/starter-gcs.yaml
@@ -100,10 +100,10 @@ data:
             path_strategy: explicit
           gcs_credentials_secret: gcs-credentials
           utility_images:
-            clonerefs: gcr.io/k8s-prow/clonerefs:v20210917-ee1e7c845b
-            entrypoint: gcr.io/k8s-prow/entrypoint:v20210917-ee1e7c845b
-            initupload: gcr.io/k8s-prow/initupload:v20210917-ee1e7c845b
-            sidecar: gcr.io/k8s-prow/sidecar:v20210917-ee1e7c845b
+            clonerefs: gcr.io/k8s-prow/clonerefs:v20210916-7657ce97bf
+            entrypoint: gcr.io/k8s-prow/entrypoint:v20210916-7657ce97bf
+            initupload: gcr.io/k8s-prow/initupload:v20210916-7657ce97bf
+            sidecar: gcr.io/k8s-prow/sidecar:v20210916-7657ce97bf
 
     tide:
       queries:
@@ -154,7 +154,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/hook:v20210916-7657ce97bf
         imagePullPolicy: Always
         args:
         - --dry-run=false
@@ -244,7 +244,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/sinker:v20210916-7657ce97bf
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false
@@ -283,7 +283,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/deck:v20210916-7657ce97bf
         args:
         - --config-path=/etc/config/config.yaml
         - --plugin-config=/etc/plugins/plugins.yaml
@@ -380,7 +380,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/horologium:v20210916-7657ce97bf
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml
@@ -415,7 +415,7 @@ spec:
       serviceAccountName: "tide"
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/tide:v20210916-7657ce97bf
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml
@@ -526,7 +526,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/status-reconciler:v20210916-7657ce97bf
         args:
         - --dry-run=false
         - --continue-on-error=true
@@ -918,7 +918,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/ghproxy:v20210916-7657ce97bf
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99
@@ -987,7 +987,7 @@ spec:
             secretKeyRef:
               name: github-token
               key: appid
-        image: gcr.io/k8s-prow/prow-controller-manager:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/prow-controller-manager:v20210916-7657ce97bf
         volumeMounts:
         - name: github-token
           mountPath: /etc/github
@@ -1122,7 +1122,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/crier:v20210916-7657ce97bf
         args:
         - --blob-storage-workers=10
         - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/starter-s3.yaml
+++ b/config/prow/cluster/starter-s3.yaml
@@ -100,10 +100,10 @@ data:
             path_strategy: explicit
           s3_credentials_secret: s3-credentials
           utility_images:
-            clonerefs: gcr.io/k8s-prow/clonerefs:v20210917-ee1e7c845b
-            entrypoint: gcr.io/k8s-prow/entrypoint:v20210917-ee1e7c845b
-            initupload: gcr.io/k8s-prow/initupload:v20210917-ee1e7c845b
-            sidecar: gcr.io/k8s-prow/sidecar:v20210917-ee1e7c845b
+            clonerefs: gcr.io/k8s-prow/clonerefs:v20210916-7657ce97bf
+            entrypoint: gcr.io/k8s-prow/entrypoint:v20210916-7657ce97bf
+            initupload: gcr.io/k8s-prow/initupload:v20210916-7657ce97bf
+            sidecar: gcr.io/k8s-prow/sidecar:v20210916-7657ce97bf
 
     tide:
       queries:
@@ -154,7 +154,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/hook:v20210916-7657ce97bf
         imagePullPolicy: Always
         args:
         - --dry-run=false
@@ -243,7 +243,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/sinker:v20210916-7657ce97bf
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false
@@ -282,7 +282,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/deck:v20210916-7657ce97bf
         args:
         - --config-path=/etc/config/config.yaml
         - --plugin-config=/etc/plugins/plugins.yaml
@@ -379,7 +379,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/horologium:v20210916-7657ce97bf
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml
@@ -414,7 +414,7 @@ spec:
       serviceAccountName: "tide"
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/tide:v20210916-7657ce97bf
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml
@@ -524,7 +524,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/status-reconciler:v20210916-7657ce97bf
         args:
         - --dry-run=false
         - --continue-on-error=true
@@ -916,7 +916,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/ghproxy:v20210916-7657ce97bf
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99
@@ -985,7 +985,7 @@ spec:
             secretKeyRef:
               name: github-token
               key: appid
-        image: gcr.io/k8s-prow/prow-controller-manager:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/prow-controller-manager:v20210916-7657ce97bf
         volumeMounts:
         - name: github-token
           mountPath: /etc/github
@@ -1120,7 +1120,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/crier:v20210916-7657ce97bf
         args:
         - --blob-storage-workers=10
         - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/statusreconciler_deployment.yaml
+++ b/config/prow/cluster/statusreconciler_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/status-reconciler:v20210916-7657ce97bf
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/config/prow/cluster/tide_deployment.yaml
+++ b/config/prow/cluster/tide_deployment.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: tide
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/tide:v20210916-7657ce97bf
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -11,10 +11,10 @@ plank:
       timeout: 2h
       grace_period: 15m
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20210917-ee1e7c845b"
-        initupload: "gcr.io/k8s-prow/initupload:v20210917-ee1e7c845b"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20210917-ee1e7c845b"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20210917-ee1e7c845b"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20210916-7657ce97bf"
+        initupload: "gcr.io/k8s-prow/initupload:v20210916-7657ce97bf"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20210916-7657ce97bf"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20210916-7657ce97bf"
       gcs_configuration:
         bucket: "kubernetes-jenkins"
         path_strategy: "legacy"

--- a/config/prow/experimental/controller_manager.yaml
+++ b/config/prow/experimental/controller_manager.yaml
@@ -22,7 +22,7 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
-        image: gcr.io/k8s-prow/prow-controller-manager:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/prow-controller-manager:v20210916-7657ce97bf
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/label_sync/cluster/label_sync_cron_job.yaml
+++ b/label_sync/cluster/label_sync_cron_job.yaml
@@ -28,7 +28,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20210917-ee1e7c845b
+              image: gcr.io/k8s-prow/label_sync:v20210916-7657ce97bf
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true

--- a/label_sync/cluster/label_sync_job.yaml
+++ b/label_sync/cluster/label_sync_job.yaml
@@ -26,7 +26,7 @@ spec:
       restartPolicy: Never  # https://github.com/kubernetes/kubernetes/issues/54870
       containers:
       - name: label-sync
-        image: gcr.io/k8s-prow/label_sync:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/label_sync:v20210916-7657ce97bf
         args:
         - --config=/etc/config/labels.yaml
         - --confirm=true

--- a/prow/test/integration/prow/cluster/deck_deployment.yaml
+++ b/prow/test/integration/prow/cluster/deck_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/deck:v20210916-7657ce97bf
         imagePullPolicy: Always
         ports:
           - name: http

--- a/prow/test/integration/prow/cluster/deck_tenant_deployment.yaml
+++ b/prow/test/integration/prow/cluster/deck_tenant_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck-tenanted
-        image: gcr.io/k8s-prow/deck:v20210917-ee1e7c845b
+        image: gcr.io/k8s-prow/deck:v20210916-7657ce97bf
         imagePullPolicy: Always
         ports:
           - name: http


### PR DESCRIPTION
This reverts commit 318f1cce0e328c8e75e5b63c7c1223c9f46e77fc.

Reverting due to Tide outage. Suspected culprit is https://github.com/kubernetes/test-infra/pull/23647
/assign @mpherman2 @chaodaiG 