### PR TITLE
Revert "Spyglass: Batch PR links"

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -1043,15 +1043,10 @@ lensesLoop:
 		return "", fmt.Errorf("error determining jobName / buildID: %w", err)
 	}
 
-	prLinks := map[int]string{}
+	prLink := ""
 	j, err := sg.JobAgent.GetProwJob(jobName, buildID)
 	if err == nil && j.Spec.Refs != nil && len(j.Spec.Refs.Pulls) > 0 {
-		for _, pull := range j.Spec.Refs.Pulls {
-			if len(pull.Link) > 0 {
-				prLinks[pull.Number] = pull.Link
-			}
-		}
-
+		prLink = j.Spec.Refs.Pulls[0].Link
 	}
 
 	announcement := ""
@@ -1101,7 +1096,7 @@ lensesLoop:
 		TestgridLink    string
 		JobName         string
 		BuildID         string
-		PRLinks         map[int]string
+		PRLink          string
 		ExtraLinks      []spyglass.ExtraLink
 		ReRunCreatesJob bool
 		ProwJobName     string
@@ -1119,7 +1114,7 @@ lensesLoop:
 		TestgridLink:    tgLink,
 		JobName:         jobName,
 		BuildID:         buildID,
-		PRLinks:         prLinks,
+		PRLink:          prLink,
 		ExtraLinks:      extraLinks,
 		ReRunCreatesJob: o.rerunCreatesJob,
 		ProwJobName:     prowJobName,

--- a/prow/cmd/deck/template/spyglass.html
+++ b/prow/cmd/deck/template/spyglass.html
@@ -20,14 +20,12 @@
 </div>
 {{end}}
 <div id="lens-container">
-  {{if or .JobHistLink .ProwJobLink .ArtifactsLink .PRHistLink .PRLinks .TestgridLink .ExtraLinks}}
+  {{if or .JobHistLink .ProwJobLink .ArtifactsLink .PRHistLink .PRLink .TestgridLink .ExtraLinks}}
   <div id="links-card" class="mdl-card mdl-shadow--2dp lens-card">
     {{if .JobHistLink}}<a href="{{.JobHistLink}}">Job History</a>{{end}}
     {{if .ProwJobLink}}<a href="{{.ProwJobLink}}" onclick="gtag('event', 'view_job_yaml', {event_category: 'engagement', transport_type: 'beacon'})">Prow Job YAML</a>{{end}}
     {{if .PRHistLink}}<a href="{{.PRHistLink}}">PR History</a>{{end}}
-    {{range $number, $link := .PRLinks}}
-    <a href="{{$link}}">PR #{{$number}}</a>
-    {{end}}
+    {{if .PRLink}}<a href="{{.PRLink}}">PR</a>{{end}}
     {{if .ArtifactsLink}}<a href="{{.ArtifactsLink}}">Artifacts</a>{{end}}
     {{if .TestgridLink}}<a href="{{.TestgridLink}}">Testgrid</a>{{end}}
     {{range .ExtraLinks}}

--- a/prow/tide/status_test.go
+++ b/prow/tide/status_test.go
@@ -789,9 +789,8 @@ func TestExpectedStatus(t *testing.T) {
 				},
 			)
 			pr.Author = struct {
-				Login   githubql.String
-				HTMLURL githubql.String
-			}{githubql.String(tc.author), githubql.String("html")}
+				Login githubql.String
+			}{githubql.String(tc.author)}
 			if tc.milestone != "" {
 				pr.Milestone = &struct {
 					Title githubql.String
@@ -1013,13 +1012,11 @@ func TestTargetUrl(t *testing.T) {
 			name: "PR dashboard config",
 			pr: &PullRequest{
 				Author: struct {
-					Login   githubql.String
-					HTMLURL githubql.String
+					Login githubql.String
 				}{Login: githubql.String("author")},
 				Repository: struct {
 					Name          githubql.String
 					NameWithOwner githubql.String
-					HTMLURL       githubql.String
 					Owner         struct {
 						Login githubql.String
 					}
@@ -1033,13 +1030,11 @@ func TestTargetUrl(t *testing.T) {
 			name: "generate link by default config",
 			pr: &PullRequest{
 				Author: struct {
-					Login   githubql.String
-					HTMLURL githubql.String
+					Login githubql.String
 				}{Login: githubql.String("author")},
 				Repository: struct {
 					Name          githubql.String
 					NameWithOwner githubql.String
-					HTMLURL       githubql.String
 					Owner         struct {
 						Login githubql.String
 					}
@@ -1057,13 +1052,11 @@ func TestTargetUrl(t *testing.T) {
 			name: "generate link by org config",
 			pr: &PullRequest{
 				Author: struct {
-					Login   githubql.String
-					HTMLURL githubql.String
+					Login githubql.String
 				}{Login: githubql.String("author")},
 				Repository: struct {
 					Name          githubql.String
 					NameWithOwner githubql.String
-					HTMLURL       githubql.String
 					Owner         struct {
 						Login githubql.String
 					}
@@ -1081,13 +1074,11 @@ func TestTargetUrl(t *testing.T) {
 			name: "generate link by repo config",
 			pr: &PullRequest{
 				Author: struct {
-					Login   githubql.String
-					HTMLURL githubql.String
+					Login githubql.String
 				}{Login: githubql.String("author")},
 				Repository: struct {
 					Name          githubql.String
 					NameWithOwner githubql.String
-					HTMLURL       githubql.String
 					Owner         struct {
 						Login githubql.String
 					}

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -1251,7 +1251,6 @@ func TestMergeMethodCheckerAndPRMergeMethod(t *testing.T) {
 				Repository: struct {
 					Name          githubql.String
 					NameWithOwner githubql.String
-					HTMLURL       githubql.String
 					Owner         struct {
 						Login githubql.String
 					}


### PR DESCRIPTION
reverting https://github.com/kubernetes/test-infra/pull/23647, it's caused tide down due to htmlUrl not recognized