### PR TITLE
Deflake TestDiskCachePruning by using a fake clock

### DIFF
--- a/ghproxy/BUILD.bazel
+++ b/ghproxy/BUILD.bazel
@@ -73,6 +73,7 @@ go_test(
     srcs = ["ghproxy_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//ghproxy/ghcache:go_default_library",
         "//prow/github:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],

--- a/ghproxy/ghcache/ghcache.go
+++ b/ghproxy/ghcache/ghcache.go
@@ -247,7 +247,7 @@ func NewDiskCache(delegate http.RoundTripper, cacheDir string, cacheSizeGB, maxC
 
 	go func() {
 		for range time.NewTicker(cachePruneInterval).C {
-			prune(cacheDir)
+			Prune(cacheDir, time.Now)
 		}
 	}()
 	return NewFromCache(delegate,
@@ -268,7 +268,7 @@ func NewDiskCache(delegate http.RoundTripper, cacheDir string, cacheSizeGB, maxC
 	)
 }
 
-func prune(baseDir string) {
+func Prune(baseDir string, now func() time.Time) {
 	// All of this would be easier if the structure was base/partition/{data,temp}
 	// but because of compatibility we can not change it.
 	for _, dir := range []string{"data", "temp"} {
@@ -294,7 +294,7 @@ func prune(baseDir string) {
 				logrus.WithError(err).WithField("filepath", metadataPath).Error("failed to deserialize metadata file")
 				continue
 			}
-			if metadata.ExpiresAt.After(time.Now()) {
+			if metadata.ExpiresAt.After(now()) {
 				continue
 			}
 			paritionPath := filepath.Dir(metadataPath)


### PR DESCRIPTION
TestDiskCachePruning relied on a specific sequence of events by waiting
for the github client to request a token, then returning a very
shortlived one, then waiting twice the token ttl for the cache pruning
to take effect. If for whatever reason the request from the client to
the testserver fails, the client will retry but construct a new token
along the way, causing the expected number of caches partitions to be
off.

Fix this scenario by using a fakeclock in Prune() and calling Prune()
explicitly.

/cc @stevekuznetsov @spiffxp 