### PR TITLE
Kops - Use Kubernetes service for SA issuer URLs in gossip clusters

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
@@ -27,7 +27,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=gce \
-          --create-args="--channel=alpha" \
+          --create-args="--channel=alpha --override=cluster.spec.kubeAPIServer.serviceAccountIssuer=https://kubernetes.default" \
           --env=KOPS_FEATURE_FLAGS=GoogleCloudBucketACL \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/latest.txt \
@@ -92,7 +92,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=gce \
-          --create-args="--channel=alpha" \
+          --create-args="--channel=alpha --override=cluster.spec.kubeAPIServer.serviceAccountIssuer=https://kubernetes.default" \
           --env=KOPS_FEATURE_FLAGS=GoogleCloudBucketACL \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \

--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -59,7 +59,7 @@ periodics:
           --up --down \
           --cloud-provider=digitalocean \
           --env S3_ENDPOINT=sfo3.digitaloceanspaces.com \
-          --create-args "--networking=calico --api-loadbalancer-type=public --node-count=2 --master-count=3" \
+          --create-args "--networking=calico --api-loadbalancer-type=public --node-count=2 --master-count=3 --override=cluster.spec.kubeAPIServer.serviceAccountIssuer=https://kubernetes.default" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.21.txt \
           --test=kops \


### PR DESCRIPTION
The GCE and DO jobs started failing their OIDC tests due to https://github.com/kubernetes/kops/pull/12297 changing the default back to the k8s.local domain for gossip clusters which doesn't resolve. This overrides the issuer on those jobs back to the kubernetes service so that the e2e jobs that actually resolve the URL will pass.

ref: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-gce-latest/1439723215860535296

`2021/09/19 23:11:19 OK: got issuer https://api.internal.e2e-f2dae1cd6d-d3d02.k8s.local
2021/09/19 23:11:19 Full, not-validated claims: 
openidmetadata.claims{Claims:jwt.Claims{Issuer:"https://api.internal.e2e-f2dae1cd6d-d3d02.k8s.local", Subject:"system:serviceaccount:svcaccounts-3514:default", Audience:jwt.Audience{"oidc-discovery-test"}, Expiry:1632093674, NotBefore:1632093074, IssuedAt:1632093074, ID:""}, Kubernetes:openidmetadata.kubeClaims{Namespace:"svcaccounts-3514", ServiceAccount:openidmetadata.kubeName{Name:"default", UID:"db9542ca-0cae-478d-b1e2-01a3cf4eef23"}}}
2021/09/19 23:11:19 Get "https://api.internal.e2e-f2dae1cd6d-d3d02.k8s.local/.well-known/openid-configuration": dial tcp: lookup api.internal.e2e-f2dae1cd6d-d3d02.k8s.local on 100.64.0.10:53: no such host`