### PR TITLE
upgrade pause image to 3.6

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -310,7 +310,7 @@ presets:
     preset-e2e-scalability-periodics: "true"
   env:
   - name: NODE_PRELOAD_IMAGES
-    value: k8s.gcr.io/pause:3.1
+    value: k8s.gcr.io/pause:3.6
 
 - labels:
     preset-e2e-scalability-periodics-master: "true"

--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -534,7 +534,7 @@ periodics:
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210917-ee1e7c845b-master
       env:
       - name: CL2_CONTAINER_IMAGE
-        value: "k8s.gcr.io/pause:3.4.1"
+        value: "k8s.gcr.io/pause:3.6"
       - name: CL2_WMI_EXPORTER_URL
         value: "https://github.com/prometheus-community/windows_exporter/releases/download/v0.16.0/windows_exporter-0.16.0-amd64.exe"
       - name: CL2_WMI_EXPORTER_ENABLED_COLLECTORS


### PR DESCRIPTION
Signed-off-by: kerthcet <kerthcet@gmail.com>
upgradation of pause image to tag 3.6,  support for Windows Server 2022 was added to the k8s.gcr.io/pause:3.6 image.
refer to :https://github.com/kubernetes/kubernetes/issues/104890