### PR TITLE
Update CAPI jobs to use main branch after rename 

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
@@ -8,6 +8,7 @@ postsubmits:
         testgrid-dashboards: sig-cluster-lifecycle-image-pushes, sig-k8s-infra-gcb
       decorate: true
       branches:
+        - ^main$
         - ^master$
         - ^release-0.2$
         # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
@@ -232,7 +233,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api
-        base_ref: master
+        base_ref: main
         path_alias: sigs.k8s.io/cluster-api
     spec:
       serviceAccountName: gcb-builder
@@ -251,7 +252,7 @@ periodics:
         # We need to emulate a pull job for the cloud build to work the same
         # way as it usually does.
             - name: PULL_BASE_REF
-              value: master
+              value: main
     annotations:
     # this is the name of some testgrid dashboard to report to.
       testgrid-dashboards: sig-cluster-lifecycle-image-pushes, sig-k8s-infra-gcb

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
@@ -9,7 +9,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api
-    base_ref: master
+    base_ref: main
     path_alias: sigs.k8s.io/cluster-api
   - org: kubernetes
     repo: kubernetes
@@ -53,7 +53,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api
-    base_ref: master
+    base_ref: main
     path_alias: sigs.k8s.io/cluster-api
   - org: kubernetes
     repo: kubernetes
@@ -97,7 +97,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api
-    base_ref: master
+    base_ref: main
     path_alias: sigs.k8s.io/cluster-api
   - org: kubernetes
     repo: kubernetes
@@ -141,7 +141,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api
-    base_ref: master
+    base_ref: main
     path_alias: sigs.k8s.io/cluster-api
   - org: kubernetes
     repo: kubernetes
@@ -185,7 +185,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api
-    base_ref: master
+    base_ref: main
     path_alias: sigs.k8s.io/cluster-api
   - org: kubernetes
     repo: kubernetes

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -7,7 +7,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api
-    base_ref: master
+    base_ref: main
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
@@ -31,7 +31,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api
-    base_ref: master
+    base_ref: main
     path_alias: sigs.k8s.io/cluster-api
   - org: kubernetes
     repo: kubernetes
@@ -73,7 +73,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api
-    base_ref: master
+    base_ref: main
     path_alias: sigs.k8s.io/cluster-api
   - org: kubernetes
     repo: kubernetes
@@ -108,7 +108,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api
-    base_ref: master
+    base_ref: main
     path_alias: sigs.k8s.io/cluster-api
   - org: kubernetes
     repo: kubernetes
@@ -144,7 +144,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api
-    base_ref: master
+    base_ref: main
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:


### PR DESCRIPTION
/hold until default branch has been renamed

https://github.com/kubernetes-sigs/cluster-api/issues/3280#issuecomment-923313590

/assign @vincepri @fabriziopandini @sbueringer