### PR TITLE
OWNERS: follow wg-k8s-infra -> sig-k8s-infra rename

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -74,6 +74,11 @@ aliases:
     - brancz
     - ehashman
     - logicalhan
+  sig-k8s-infra-leads:
+    - ameukam
+    - dims
+    - spiffxp
+    - thockin
   sig-multicluster-leads:
     - pmorie
     - quinton-hoole
@@ -136,10 +141,6 @@ aliases:
     - cantbewong
     - cindyxing
     - dejanb
-  wg-k8s-infra-leads:
-    - ameukam
-    - dims
-    - spiffxp
   wg-lts-leads:
     - imkin
     - quinton-hoole

--- a/config/jobs/kubernetes/wg-k8s-infra/OWNERS
+++ b/config/jobs/kubernetes/wg-k8s-infra/OWNERS
@@ -10,4 +10,4 @@ approvers:
 - spiffxp
 
 labels:
-- wg/k8s-infra
+- sig/k8s-infra

--- a/config/jobs/kubernetes/wg-k8s-infra/releng/OWNERS
+++ b/config/jobs/kubernetes/wg-k8s-infra/releng/OWNERS
@@ -6,7 +6,7 @@ approvers:
 # TODO(releng): Distill down to SIG K8s Infra leads, once the proposal to
 #               convert to a SIG is approved.
 #               ref: https://github.com/kubernetes/community/pull/5928
-- wg-k8s-infra-leads
+- sig-k8s-infra-leads
 - thockin
 
 reviewers:

--- a/config/testgrids/kubernetes/wg-k8s-infa/OWNERS
+++ b/config/testgrids/kubernetes/wg-k8s-infa/OWNERS
@@ -1,8 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- wg-k8s-infra-leads
+- sig-k8s-infra-leads
 approvers:
-- wg-k8s-infra-leads
+- sig-k8s-infra-leads
 labels:
 - wg/k8s-infra

--- a/config/testgrids/kubernetes/wg-k8s-infa/OWNERS
+++ b/config/testgrids/kubernetes/wg-k8s-infa/OWNERS
@@ -5,4 +5,4 @@ reviewers:
 approvers:
 - sig-k8s-infra-leads
 labels:
-- wg/k8s-infra
+- sig/k8s-infra


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/community/issues/6036
- Followup to: https://github.com/kubernetes/test-infra/pull/23674

Saving other renames like jobs, paths, testgrids etc. for followup PRs