### PR TITLE
config/jobs: follow wg-k8s-infra github team rename

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-apps.sh
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-apps.sh
@@ -72,7 +72,7 @@ for app in "${APPS[@]}"; do
         github_team_slugs:
         # proxy for wg-k8s-infra-oncall
         - org: kubernetes
-          slug: wg-k8s-infra-leads
+          slug: sig-k8s-infra-leads
         # proxy for test-infra-oncall
         - org: kubernetes
           slug: test-infra-admins

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-apps.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-apps.yaml
@@ -30,7 +30,7 @@ postsubmits:
         github_team_slugs:
         # proxy for wg-k8s-infra-oncall
         - org: kubernetes
-          slug: wg-k8s-infra-leads
+          slug: sig-k8s-infra-leads
         # proxy for test-infra-oncall
         - org: kubernetes
           slug: test-infra-admins
@@ -71,7 +71,7 @@ postsubmits:
         github_team_slugs:
         # proxy for wg-k8s-infra-oncall
         - org: kubernetes
-          slug: wg-k8s-infra-leads
+          slug: sig-k8s-infra-leads
         # proxy for test-infra-oncall
         - org: kubernetes
           slug: test-infra-admins
@@ -112,7 +112,7 @@ postsubmits:
         github_team_slugs:
         # proxy for wg-k8s-infra-oncall
         - org: kubernetes
-          slug: wg-k8s-infra-leads
+          slug: sig-k8s-infra-leads
         # proxy for test-infra-oncall
         - org: kubernetes
           slug: test-infra-admins
@@ -153,7 +153,7 @@ postsubmits:
         github_team_slugs:
         # proxy for wg-k8s-infra-oncall
         - org: kubernetes
-          slug: wg-k8s-infra-leads
+          slug: sig-k8s-infra-leads
         # proxy for test-infra-oncall
         - org: kubernetes
           slug: test-infra-admins
@@ -194,7 +194,7 @@ postsubmits:
         github_team_slugs:
         # proxy for wg-k8s-infra-oncall
         - org: kubernetes
-          slug: wg-k8s-infra-leads
+          slug: sig-k8s-infra-leads
         # proxy for test-infra-oncall
         - org: kubernetes
           slug: test-infra-admins
@@ -235,7 +235,7 @@ postsubmits:
         github_team_slugs:
         # proxy for wg-k8s-infra-oncall
         - org: kubernetes
-          slug: wg-k8s-infra-leads
+          slug: sig-k8s-infra-leads
         # proxy for test-infra-oncall
         - org: kubernetes
           slug: test-infra-admins
@@ -276,7 +276,7 @@ postsubmits:
         github_team_slugs:
         # proxy for wg-k8s-infra-oncall
         - org: kubernetes
-          slug: wg-k8s-infra-leads
+          slug: sig-k8s-infra-leads
         # proxy for test-infra-oncall
         - org: kubernetes
           slug: test-infra-admins
@@ -317,7 +317,7 @@ postsubmits:
         github_team_slugs:
         # proxy for wg-k8s-infra-oncall
         - org: kubernetes
-          slug: wg-k8s-infra-leads
+          slug: sig-k8s-infra-leads
         # proxy for test-infra-oncall
         - org: kubernetes
           slug: test-infra-admins
@@ -358,7 +358,7 @@ postsubmits:
         github_team_slugs:
         # proxy for wg-k8s-infra-oncall
         - org: kubernetes
-          slug: wg-k8s-infra-leads
+          slug: sig-k8s-infra-leads
         # proxy for test-infra-oncall
         - org: kubernetes
           slug: test-infra-admins

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-dns.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-dns.yaml
@@ -16,7 +16,7 @@ postsubmits:
       github_team_slugs:
       # proxy for wg-k8s-infra-oncall
       - org: kubernetes
-        slug: wg-k8s-infra-leads
+        slug: sig-k8s-infra-leads
       # TODO(spiffxp): team specifically for this service
       # - org: kubernetes
       #   slug: k8s-infra-dns-admins
@@ -49,7 +49,7 @@ periodics:
     github_team_slugs:
     # proxy for wg-k8s-infra-oncall
     - org: kubernetes
-      slug: wg-k8s-infra-leads
+      slug: sig-k8s-infra-leads
     # TODO(spiffxp): team specifically for this service
     # - org: kubernetes
     #   slug: k8s-infra-dns-admins

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-groups.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-groups.yaml
@@ -17,7 +17,7 @@ periodics:
     github_team_slugs:
     # proxy for wg-k8s-infra-oncall
     - org: kubernetes
-      slug: wg-k8s-infra-leads
+      slug: sig-k8s-infra-leads
     # team specifically for this service
     - org: kubernetes
       slug: k8s-infra-group-admins
@@ -52,7 +52,7 @@ postsubmits:
       github_team_slugs:
       # proxy for wg-k8s-infra-oncall
       - org: kubernetes
-        slug: wg-k8s-infra-leads
+        slug: sig-k8s-infra-leads
       # team specifically for this service
       - org: kubernetes
         slug: k8s-infra-group-admins

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-k8sio.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-k8sio.yaml
@@ -15,7 +15,7 @@ periodics:
   rerun_auth_config:
     github_team_slugs:
     - org: kubernetes
-      slug: wg-k8s-infra-leads
+      slug: sig-k8s-infra-leads
     - org: kubernetes
       slug: k8s-infra-gcp-auditors
   spec:

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-prow.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-prow.yaml
@@ -17,7 +17,7 @@ postsubmits:
       github_team_slugs:
       # proxy for wg-k8s-infra-oncall
       - org: kubernetes
-        slug: wg-k8s-infra-leads
+        slug: sig-k8s-infra-leads
       # proxy for test-infra-oncall
       - org: kubernetes
         slug: test-infra-admins
@@ -53,7 +53,7 @@ postsubmits:
       github_team_slugs:
       # proxy for wg-k8s-infra-oncall
       - org: kubernetes
-        slug: wg-k8s-infra-leads
+        slug: sig-k8s-infra-leads
       # proxy for test-infra-oncall
       - org: kubernetes
         slug: test-infra-admins
@@ -93,7 +93,7 @@ periodics:
     github_team_slugs:
     # proxy for wg-k8s-infra-oncall
     - org: kubernetes
-      slug: wg-k8s-infra-leads
+      slug: sig-k8s-infra-leads
     # proxy for test-infra-oncall
     - org: kubernetes
       slug: test-infra-admins

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-test-infra.yaml
@@ -46,7 +46,7 @@ periodics:
     github_team_slugs:
     # proxy for wg-k8s-infra-oncall
     - org: kubernetes
-      slug: wg-k8s-infra-leads
+      slug: sig-k8s-infra-leads
     # proxy for test-infra-oncall
     - org: kubernetes
       slug: test-infra-admins
@@ -77,7 +77,7 @@ periodics:
     github_team_slugs:
     # proxy for wg-k8s-infra-oncall
     - org: kubernetes
-      slug: wg-k8s-infra-leads
+      slug: sig-k8s-infra-leads
     # proxy for test-infra-oncall
     - org: kubernetes
       slug: test-infra-admins


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/community/issues/6036
- Followup to: https://github.com/kubernetes/org/pull/2991

Saving job, path and testgrid renames for followup PRs