### PR TITLE
Switch kettle/triage service account keys to Workload Identity.

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -30,6 +30,8 @@ periodics:
 - name: metrics-kettle
   interval: 1h
   spec:
+    # TODO(cjwagner): Uncomment the following and delete secret mount + env once SA exists and is bound.
+    # serviceAccountName: triage
     containers:
     - image: gcr.io/k8s-staging-test-infra/bigquery:v20210913-fc7c4e84f6
       args:

--- a/config/prow/cluster/build_serviceaccounts.yaml
+++ b/config/prow/cluster/build_serviceaccounts.yaml
@@ -53,4 +53,11 @@ metadata:
   name: secrets-store-csi-driver-gcp
   namespace: test-pods
 ---
-# TODO(fejta): any other service accounts
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    # Used by the metrics-kettle job. (Note that for some reason this job uses the triage SA not the kettle SA.)
+    iam.gke.io/gcp-service-account: triage@k8s-gubernator.iam.gserviceaccount.com
+  name: triage
+  namespace: test-pods

--- a/kettle/deployment-staging.yaml
+++ b/kettle/deployment-staging.yaml
@@ -1,3 +1,11 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: kettle@k8s-gubernator.iam.gserviceaccount.com
+  name: kettle
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -12,13 +20,12 @@ spec:
       labels:
         app: kettle-staging
     spec:
+      serviceAccountName: kettle
       containers:
       - name: kettle-staging
         image: gcr.io/k8s-testimages/kettle:latest
         imagePullPolicy: Always
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: BUILD_LIMIT
           value: "1000"
         - name: DEPLOYMENT
@@ -26,15 +33,9 @@ spec:
         - name: SUBSCRIPTION_PATH
           value: kubernetes-jenkins/gcs-changes/kettle-staging
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: data
           mountPath: /data
       volumes:
-      - name: service
-        secret:
-          secretName: kettle-service-account
       - name: data
         persistentVolumeClaim:
           claimName: kettle-data-staging

--- a/kettle/deployment.yaml
+++ b/kettle/deployment.yaml
@@ -1,3 +1,11 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: kettle@k8s-gubernator.iam.gserviceaccount.com
+  name: kettle
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -12,27 +20,20 @@ spec:
       labels:
         app: kettle
     spec:
+      serviceAccountName: kettle
       containers:
       - name: kettle
         image: gcr.io/k8s-testimages/kettle:latest
         imagePullPolicy: Always
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         - name: DEPLOYMENT
           value: prod
         - name: SUBSCRIPTION_PATH
           value: kubernetes-jenkins/gcs-changes/kettle-filtered
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: data
           mountPath: /data
       volumes:
-      - name: service
-        secret:
-          secretName: kettle-service-account
       - name: data
         persistentVolumeClaim:
           claimName: kettle-data


### PR DESCRIPTION
Once this merge I'll do the following:
- For the `metrics-kettle` job I'll
    - bind the new KSA to the GSA
    - Switch the job to use the KSA rather than a GSA key.
- For the Kettle deployments I'll
    - Create the KSA
    - Bind the KSA to the GSA
    - Manually deploy staging
    - Manually deploy prod

/hold
/assign @MushuEE @fejta 