### PR TITLE
fix cluster API mink8s job names

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -57,7 +57,7 @@ periodics:
     testgrid-tab-name: capi-e2e-main
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
-- name: periodic-cluster-api-e2e-main-mink8s
+- name: periodic-cluster-api-e2e-mink8s-main
   interval: 1h
   decorate: true
   labels:
@@ -93,7 +93,7 @@ periodics:
           cpu: 7300m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-    testgrid-tab-name: capi-e2e-main-mink8s
+    testgrid-tab-name: capi-e2e-mink8s-main
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-verify-book-links-main

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-4.yaml
@@ -57,7 +57,7 @@ periodics:
     testgrid-tab-name: capi-e2e-release-0-4
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
-- name: periodic-cluster-api-e2e-release-0-4-mink8s
+- name: periodic-cluster-api-e2e-mink8s-release-0-4
   interval: 1h
   decorate: true
   labels:
@@ -93,7 +93,7 @@ periodics:
           cpu: 7300m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.4
-    testgrid-tab-name: capi-e2e-release-0-4-mink8s
+    testgrid-tab-name: capi-e2e-mink8s-release-0-4
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-verify-book-links-release-0-4

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -110,7 +110,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-test-main
-  - name: pull-cluster-api-test-main-mink8s
+  - name: pull-cluster-api-test-mink8s-main
     decorate: true
     path_alias: sigs.k8s.io/cluster-api
     always_run: true
@@ -139,7 +139,7 @@ presubmits:
             cpu: 7300m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-      testgrid-tab-name: capi-pr-test-main-mink8s
+      testgrid-tab-name: capi-pr-test-mink8s-main
   - name: pull-cluster-api-e2e-main
     labels:
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-0-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-0-4.yaml
@@ -110,7 +110,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.4
       testgrid-tab-name: capi-pr-test-release-0-4
-  - name: pull-cluster-api-test-release-0-4-mink8s
+  - name: pull-cluster-api-test-mink8s-release-0-4
     decorate: true
     path_alias: sigs.k8s.io/cluster-api
     always_run: true
@@ -139,7 +139,7 @@ presubmits:
             cpu: 7300m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.4
-      testgrid-tab-name: capi-pr-test-release-0-4-mink8s
+      testgrid-tab-name: capi-pr-test-mink8s-release-0-4
   - name: pull-cluster-api-e2e-release-0-4
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
This PR fixes Cluster API minK8s job names to our convention that requires job names to end with the branch