### PR TITLE
test: add k8s test matrix for secrets-store-csi-driver

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -167,6 +167,7 @@ presubmits:
       testgrid-tab-name: pr-secrets-store-csi-driver-e2e-azure
       description: "Run e2e test with azure provider for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
+  # TODO(aramase): remove this job after the e2e-provider tests with the kind k8s matrix is made required
   - name: pull-secrets-store-csi-driver-e2e-provider
     decorate: true
     decoration_config:
@@ -374,6 +375,126 @@ presubmits:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-build
       description: "Run make build build-windows for Secrets Store CSI driver."
+      testgrid-num-columns-recent: '30'
+  - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-19-11
+    decorate: true
+    decoration_config:
+      timeout: 25m
+    always_run: true
+    optional: true # change to false once the provider job is stable
+    path_alias: sigs.k8s.io/secrets-store-csi-driver
+    branches:
+    - ^main$
+    labels:
+      # this is required because we want to run kind in docker
+      preset-dind-enabled: "true"
+      # this is required to make CNI installation to succeed for kind
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210917-ee1e7c845b-master
+        command:
+        - runner.sh
+        - "./test/scripts/e2e_provider.sh"
+        securityContext:
+          privileged: true
+        env:
+        - name: KUBERNETES_VERSION
+          value: "1.19.11"
+    annotations:
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
+      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-19-11
+      description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.19.11"
+      testgrid-num-columns-recent: '30'
+  - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-20-7
+    decorate: true
+    decoration_config:
+      timeout: 25m
+    always_run: true
+    optional: true # change to false once the provider job is stable
+    path_alias: sigs.k8s.io/secrets-store-csi-driver
+    branches:
+    - ^main$
+    labels:
+      # this is required because we want to run kind in docker
+      preset-dind-enabled: "true"
+      # this is required to make CNI installation to succeed for kind
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210917-ee1e7c845b-master
+        command:
+        - runner.sh
+        - "./test/scripts/e2e_provider.sh"
+        securityContext:
+          privileged: true
+        env:
+        - name: KUBERNETES_VERSION
+          value: "1.20.7"
+    annotations:
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
+      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-20-7
+      description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.20.7"
+      testgrid-num-columns-recent: '30'
+  - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-21-2
+    decorate: true
+    decoration_config:
+      timeout: 25m
+    always_run: true
+    optional: true # change to false once the provider job is stable
+    path_alias: sigs.k8s.io/secrets-store-csi-driver
+    branches:
+    - ^main$
+    labels:
+      # this is required because we want to run kind in docker
+      preset-dind-enabled: "true"
+      # this is required to make CNI installation to succeed for kind
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210917-ee1e7c845b-master
+        command:
+        - runner.sh
+        - "./test/scripts/e2e_provider.sh"
+        securityContext:
+          privileged: true
+        env:
+        - name: KUBERNETES_VERSION
+          value: "1.21.2"
+    annotations:
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
+      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-21-2
+      description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.21.2"
+      testgrid-num-columns-recent: '30'
+  - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-22-1
+    decorate: true
+    decoration_config:
+      timeout: 25m
+    always_run: true
+    optional: true # change to false once the provider job is stable
+    path_alias: sigs.k8s.io/secrets-store-csi-driver
+    branches:
+    - ^main$
+    labels:
+      # this is required because we want to run kind in docker
+      preset-dind-enabled: "true"
+      # this is required to make CNI installation to succeed for kind
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210917-ee1e7c845b-master
+        command:
+        - runner.sh
+        - "./test/scripts/e2e_provider.sh"
+        securityContext:
+          privileged: true
+        env:
+        - name: KUBERNETES_VERSION
+          value: "1.22.1"
+    annotations:
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
+      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-22-1
+      description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.22.1"
       testgrid-num-columns-recent: '30'
 
   # release jobs


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

- Adds e2e test for secrets-store-csi-driver with e2e provider for kubernetes versions `1.19.11`, `1.20.7`, `1.21.2` and `1.22.1`. The matrix maintained as long as the Kubernetes releases are supported: https://github.com/kubernetes/website/blob/main/content/en/releases/patch-releases.md

The `make` target uses `KUBERNETES_VERSION` variable when creating the kind cluster: https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/main/Makefile#L369

fixes https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/740