### PR TITLE
config/jobs: Update OWNERS for sig-k8s-infra

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/OWNERS
+++ b/config/jobs/kubernetes/sig-k8s-infra/OWNERS
@@ -1,13 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- cblecker
-- dims
-- spiffxp
+- sig-k8s-infra-leads
 approvers:
-- cblecker
-- dims
-- spiffxp
+- sig-k8s-infra-leads
 
 labels:
 - sig/k8s-infra


### PR DESCRIPTION
Related:
  - Part of : https://github.com/kubernetes/community/issues/6036
  - https://github.com/kubernetes/test-infra/pull/23694

Switch to OWNERS_ALIASES instead of individual accounts.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>