### PR TITLE
sig-k8s-infra: add auto-deploy jobs for kettle and elekto

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-apps.sh
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-apps.sh
@@ -24,7 +24,9 @@ SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 readonly OUTPUT="${SCRIPT_DIR}/sig-k8s-infra-apps.yaml"
 # list of subdirs in kubernetes/k8s.io/apps
 readonly APPS=(
+    elekto
     gcsweb
+    kettle
     k8s-io
     kubernetes-external-secrets
     perfdash

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-apps.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-apps.yaml
@@ -2,6 +2,47 @@
 
 postsubmits:
   kubernetes/k8s.io:
+    - name: post-k8sio-deploy-app-elekto
+      cluster: k8s-infra-prow-build-trusted
+      decorate: true
+      max_concurrency: 1
+      # intended for ignoring changes to README.md or OWNERS
+      run_if_changed: '^apps\/elekto\/(.*.yaml|deploy.sh)$'
+      branches:
+      - ^main$
+      reporter_config:
+        slack:
+          channel: "k8s-infra-alerts"
+          job_states_to_report:
+          - success
+          - failure
+          - aborted
+          - error
+          report_template: 'Deploying elekto: {{.Status.State}}. Commit: <{{.Spec.Refs.BaseLink}}|{{printf "%.7s" .Spec.Refs.BaseSHA}}> | <{{.Status.URL}}|Spyglass> | <https://testgrid.k8s.io/sig-k8s-infra-apps#deploy-elekto|Testgrid> | <https://prow.k8s.io/?job={{.Spec.Job}}|Deck>'
+      annotations:
+        testgrid-create-test-group: 'true'
+        testgrid-dashboards: sig-k8s-infra-apps
+        testgrid-tab-name: deploy-elekto
+        testgrid-description: 'runs https://git.k8s.io/k8s.io/apps/elekto/deploy.sh if files change in kubernetes/k8s.io/apps/elekto'
+        testgrid-alert-email: k8s-infra-rbac-elekto@kubernetes.io, k8s-infra-alerts@kubernetes.io
+        testgrid-num-failures-to-alert: '1'
+      rerun_auth_config:
+        github_team_slugs:
+        # proxy for sig-k8s-infra-oncall
+        - org: kubernetes
+          slug: sig-k8s-infra-leads
+        # proxy for test-infra-oncall
+        - org: kubernetes
+          slug: test-infra-admins
+        # TODO: sig-specific team in charge of this app
+        # - org: kubernetes
+        #   slug: sig-foo-bar
+      spec:
+        serviceAccountName: prow-deployer
+        containers:
+        - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
+          command:
+          - ./apps/elekto/deploy.sh
     - name: post-k8sio-deploy-app-gcsweb
       cluster: k8s-infra-prow-build-trusted
       decorate: true
@@ -43,6 +84,47 @@ postsubmits:
         - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
           command:
           - ./apps/gcsweb/deploy.sh
+    - name: post-k8sio-deploy-app-kettle
+      cluster: k8s-infra-prow-build-trusted
+      decorate: true
+      max_concurrency: 1
+      # intended for ignoring changes to README.md or OWNERS
+      run_if_changed: '^apps\/kettle\/(.*.yaml|deploy.sh)$'
+      branches:
+      - ^main$
+      reporter_config:
+        slack:
+          channel: "k8s-infra-alerts"
+          job_states_to_report:
+          - success
+          - failure
+          - aborted
+          - error
+          report_template: 'Deploying kettle: {{.Status.State}}. Commit: <{{.Spec.Refs.BaseLink}}|{{printf "%.7s" .Spec.Refs.BaseSHA}}> | <{{.Status.URL}}|Spyglass> | <https://testgrid.k8s.io/sig-k8s-infra-apps#deploy-kettle|Testgrid> | <https://prow.k8s.io/?job={{.Spec.Job}}|Deck>'
+      annotations:
+        testgrid-create-test-group: 'true'
+        testgrid-dashboards: sig-k8s-infra-apps
+        testgrid-tab-name: deploy-kettle
+        testgrid-description: 'runs https://git.k8s.io/k8s.io/apps/kettle/deploy.sh if files change in kubernetes/k8s.io/apps/kettle'
+        testgrid-alert-email: k8s-infra-rbac-kettle@kubernetes.io, k8s-infra-alerts@kubernetes.io
+        testgrid-num-failures-to-alert: '1'
+      rerun_auth_config:
+        github_team_slugs:
+        # proxy for sig-k8s-infra-oncall
+        - org: kubernetes
+          slug: sig-k8s-infra-leads
+        # proxy for test-infra-oncall
+        - org: kubernetes
+          slug: test-infra-admins
+        # TODO: sig-specific team in charge of this app
+        # - org: kubernetes
+        #   slug: sig-foo-bar
+      spec:
+        serviceAccountName: prow-deployer
+        containers:
+        - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
+          command:
+          - ./apps/kettle/deploy.sh
     - name: post-k8sio-deploy-app-k8s-io
       cluster: k8s-infra-prow-build-trusted
       decorate: true


### PR DESCRIPTION
Related:
  - https://github.com/kubernetes/k8s.io/issues/2575
  - https://github.com/kubernetes/k8s.io/issues/787

Auto-deploy jobs on GKE cluster aaa

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>