### PR TITLE
Add ClosingIssuesReferences field to pull request object for tide

### DIFF
--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -1842,6 +1842,11 @@ type PullRequest struct {
 			Name githubql.String
 		}
 	} `graphql:"labels(first: 100)"`
+	ClosingIssuesReferences struct {
+		Nodes []struct {
+			Number githubql.Int
+		}
+	} `graphql:"closingIssuesReferences(last: 4)"`
 	Milestone *struct {
 		Title githubql.String
 	}


### PR DESCRIPTION
close #23701

Refer: https://docs.github.com/en/graphql/reference/objects#:~:text=closingIssuesReferences