### PR TITLE
Fix link to overview on kettle's README

### DIFF
--- a/kettle/README.md
+++ b/kettle/README.md
@@ -2,7 +2,7 @@
 
 This collects test results scattered across a variety of GCS buckets,
 stores them in a local SQLite database, and outputs newline-delimited
-JSON files for import into BigQuery. *See [overview](./overview.md) for more details.*
+JSON files for import into BigQuery. *See [overview](./OVERVIEW.md) for more details.*
 
 Results are stored in the [k8s-gubernator:build BigQuery dataset][Big Query Tables],
 which is publicly accessible.


### PR DESCRIPTION
Hello team. This PR fixes the lint to OVERVIEW.md on kettle/.