### PR TITLE
added pull-kubernetes-node-e2e-kubetest2 job

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -87,7 +87,7 @@ presubmits:
             cpu: 4
             memory: 6Gi
   - name: pull-kubernetes-node-e2e-kubetest2
-    # explicitly needs /test pull-kubernetes-node-e2e to run
+    # explicitly needs /test pull-kubernetes-node-e2e-kubetest2 to run
     always_run: false
     # if it is run and fails, don't block the PR
     optional: true
@@ -112,6 +112,8 @@ presubmits:
       testgrid-num-failures-to-alert: "10"
     spec:
       containers:
+        # experimental have the kubetest2 binaries 
+        # https://github.com/kubernetes/test-infra/blob/3c3d64f398a5e4f324200d25183c98a4bfa842ac/images/kubekins-e2e/variants.yaml#L8
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210915-5dbaf53458-experimental
         resources:
           limits:
@@ -132,7 +134,7 @@ presubmits:
         - --focus-regex='\[NodeConformance\]'
         - --skip-regex='\[Flaky\]|\[Slow\]|\[Serial\]'
         - --test-args='--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"'
-        - --image-config-file='/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/image-config.yaml'
+        - --image-config-file='../test-infra/jobs/e2e_node/image-config.yaml'
   - name: pull-kubernetes-e2e-containerd-gce
     always_run: false
     optional: true

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -112,8 +112,8 @@ presubmits:
       testgrid-num-failures-to-alert: "10"
     spec:
       containers:
-        # experimental have the kubetest2 binaries 
-        # https://github.com/kubernetes/test-infra/blob/3c3d64f398a5e4f324200d25183c98a4bfa842ac/images/kubekins-e2e/variants.yaml#L8
+      # experimental have the kubetest2 binaries
+      # https://github.com/kubernetes/test-infra/blob/3c3d64f398a5e4f324200d25183c98a4bfa842ac/images/kubekins-e2e/variants.yaml#L8
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210915-5dbaf53458-experimental
         resources:
           limits:

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -104,8 +104,6 @@ presubmits:
       timeout: 65m
     labels:
       preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
       preset-k8s-ssh: "true"
     annotations:
       fork-per-release: "true"
@@ -114,7 +112,7 @@ presubmits:
       testgrid-num-failures-to-alert: "10"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210915-5dbaf53458-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210915-5dbaf53458-experimental
         resources:
           limits:
             cpu: 4
@@ -124,13 +122,9 @@ presubmits:
             memory: 6Gi
         command:
         - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
         args:
         - kubetest2
         - noop
-        - --build
-        - --up
-        - --down
         - --test=node
         - --
         - --zone=us-west1-b

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -86,6 +86,59 @@ presubmits:
           requests:
             cpu: 4
             memory: 6Gi
+  - name: pull-kubernetes-node-e2e-kubetest2
+    # explicitly needs /test pull-kubernetes-node-e2e to run
+    always_run: false
+    # if it is run and fails, don't block the PR
+    optional: true
+    branches:
+    - master
+    decorate: true
+    path_alias: k8s.io/kubernetes
+    extra_refs:
+    - org: kubernetes
+      repo: test-infra
+      base_ref: master
+      path_alias: k8s.io/test-infra
+    decoration_config:
+      timeout: 65m
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-k8s-ssh: "true"
+    annotations:
+      fork-per-release: "true"
+      testgrid-alert-stale-results-hours: "24"
+      testgrid-create-test-group: "true"
+      testgrid-num-failures-to-alert: "10"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210915-5dbaf53458-master
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        args:
+        - kubetest2
+        - noop
+        - --build
+        - --up
+        - --down
+        - --test=node
+        - --
+        - --zone=us-west1-b
+        - --parallelism=8
+        - --focus-regex='\[NodeConformance\]'
+        - --skip-regex='\[Flaky\]|\[Slow\]|\[Serial\]'
+        - --test-args='--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"'
+        - --image-config-file='/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/image-config.yaml'
   - name: pull-kubernetes-e2e-containerd-gce
     always_run: false
     optional: true

--- a/config/testgrids/kubernetes/presubmits/config.yaml
+++ b/config/testgrids/kubernetes/presubmits/config.yaml
@@ -149,6 +149,7 @@ dashboards:
     test_group_name: pull-kubernetes-node-e2e
   - name: pull-kubernetes-node-e2e-kubetest2
     test_group_name: pull-kubernetes-node-e2e-kubetest2
+    base_options: width=10
 - name: presubmits-kubernetes-scalability
   dashboard_tab:
   - name: pull-kubernetes-e2e-gce-100-performance

--- a/config/testgrids/kubernetes/presubmits/config.yaml
+++ b/config/testgrids/kubernetes/presubmits/config.yaml
@@ -147,6 +147,8 @@ dashboards:
     base_options: width=10
   - name: pull-kubernetes-node-e2e
     test_group_name: pull-kubernetes-node-e2e
+  - name: pull-kubernetes-node-e2e-kubetest2
+    test_group_name: pull-kubernetes-node-e2e-kubetest2
 - name: presubmits-kubernetes-scalability
   dashboard_tab:
   - name: pull-kubernetes-e2e-gce-100-performance


### PR DESCRIPTION
Signed-off-by: Namanl2001 <namanlakhwani@gmail.com>

This PR is part of the CI migration from kubetest to kubetest2
https://github.com/kubernetes/enhancements/tree/master/keps/sig-testing/2464-kubetest2-ci-migration

Added new `pull-kubernetes-node-e2e-kubetest2` job

Required flags for this job in kubetest2 node tester(which were not present) are added via https://github.com/kubernetes-sigs/kubetest2/pull/166

xref: https://github.com/kubernetes-sigs/kubetest2/issues/164