### PR TITLE
sig-k8s-infra: migrate ci-kubernetes-kubemark-100-gce

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -123,8 +123,7 @@ periodics:
   - "perfDashPrefix: kubemark-100Nodes"
   - "perfDashJobType: performance"
   interval: 3h
-  # TODO(oxddr): renable this once we have a project pool in scalability build cluster
-  # cluster: scalability
+  cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"


### PR DESCRIPTION
Migrate `ci-kubernetes-kubemark-100-gce` to community-owned
infrastructure.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>