### PR TITLE
Switch to cos-beta for cgroupv2 image config

### DIFF
--- a/jobs/e2e_node/containerd/containerd-master/cgroupv2/image-config-cgroupv2.yaml
+++ b/jobs/e2e_node/containerd/containerd-master/cgroupv2/image-config-cgroupv2.yaml
@@ -1,5 +1,7 @@
 images:
   cos-stable:
-    image_family: cos-89-lts
+    # Using cos-beta to pick up COS-M93 which uses 5.10 kernel which includes cgroupv2 stat metrics.
+    # See https://github.com/kubernetes/kubernetes/issues/103759
+    image_family: cos-beta
     project: cos-cloud
     metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-master/cgroupv2/env-cgroupv2,gci-update-strategy=update_disabled"


### PR DESCRIPTION
Pick up newer COS image under 5.10 kernel which includes cgroupv2 cpu stat fixes

See https://github.com/kubernetes/kubernetes/issues/103759#issuecomment-926024150 for background

```
$ gcloud compute images list --project="cos-cloud" --no-standard-images
NAME                       PROJECT    FAMILY      DEPRECATED  STATUS
cos-81-12871-1317-1        cos-cloud  cos-81-lts              READY
cos-85-13310-1308-19       cos-cloud  cos-85-lts              READY
cos-89-16108-534-2         cos-cloud  cos-89-lts              READY
cos-beta-93-16623-0-15     cos-cloud  cos-beta                READY
cos-dev-97-16687-0-0       cos-cloud  cos-dev                 READY
cos-stable-89-16108-534-2  cos-cloud  cos-stable              READY
```

cos-beta will use `cos-93` which is running under 5.10 kernel (https://cloud.google.com/container-optimized-os/docs/release-notes/m93) 

Fixes https://github.com/kubernetes/kubernetes/issues/103759