### PR TITLE
Change the test back to always run and remove check-leaked-resources flag

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-smb/csi-driver-smb-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-smb/csi-driver-smb-config.yaml
@@ -366,8 +366,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   - name: pull-csi-driver-smb-e2e-gce
     decorate: true
-    always_run: false
-    optional: true
+    always_run: true
     path_alias: sigs.k8s.io/csi-driver-smb
     branches:
     - master
@@ -385,7 +384,6 @@ presubmits:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
         args:
-        - --check-leaked-resources
         - --cluster=
         - --env=KUBE_MASTER_OS_DISTRIBUTION=cos
         - --env=KUBE_GCE_MASTER_IMAGE=cos-89-16108-470-11


### PR DESCRIPTION
This test shall be always run to add some test coverage for gce. I also remove check-leaked-resources flag for now because of https://github.com/kubernetes/kubernetes/issues/104131. I will add the check back once the issue is fixed. 