### PR TITLE
chore: up to 4 CPU request for secrets-store-csi-driver

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -100,7 +100,7 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: "2"
+              cpu: "4"
               memory: "4Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
@@ -168,7 +168,7 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: "2"
+            cpu: "4"
             memory: "4Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
@@ -200,7 +200,7 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: "2"
+            cpu: "4"
             memory: "4Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
@@ -237,7 +237,7 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: "2"
+            cpu: "4"
             memory: "4Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
@@ -298,7 +298,7 @@ presubmits:
             value: "true"
         resources:
           requests:
-            cpu: "2"
+            cpu: "4"
             memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
@@ -334,7 +334,7 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: "2"
+            cpu: "4"
             memory: "4Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
@@ -372,7 +372,7 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: "2"
+            cpu: "4"
             memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
@@ -431,7 +431,7 @@ presubmits:
           value: "1.19.11"
         resources:
           requests:
-            cpu: "2"
+            cpu: "4"
             memory: "4Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
@@ -465,7 +465,7 @@ presubmits:
           value: "1.20.7"
         resources:
           requests:
-            cpu: "2"
+            cpu: "4"
             memory: "4Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
@@ -499,7 +499,7 @@ presubmits:
           value: "1.21.2"
         resources:
           requests:
-            cpu: "2"
+            cpu: "4"
             memory: "4Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
@@ -533,7 +533,7 @@ presubmits:
           value: "1.22.1"
         resources:
           requests:
-            cpu: "2"
+            cpu: "4"
             memory: "4Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
@@ -577,7 +577,7 @@ presubmits:
             value: "true"
         resources:
           requests:
-            cpu: "2"
+            cpu: "4"
             memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-release-signal
@@ -617,7 +617,7 @@ presubmits:
             value: "true"
         resources:
           requests:
-            cpu: "2"
+            cpu: "4"
             memory: "4Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-release-signal
@@ -658,7 +658,7 @@ presubmits:
             value: "true"
         resources:
           requests:
-            cpu: "2"
+            cpu: "4"
             memory: "4Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-release-signal
@@ -698,7 +698,7 @@ presubmits:
             value: "true"
         resources:
           requests:
-            cpu: "2"
+            cpu: "4"
             memory: "4Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-release-signal
@@ -735,7 +735,7 @@ postsubmits:
           privileged: true
         resources:
           requests:
-            cpu: "2"
+            cpu: "4"
             memory: "4Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-postsubmit
@@ -775,7 +775,7 @@ postsubmits:
           privileged: true
         resources:
           requests:
-            cpu: "2"
+            cpu: "4"
             memory: "4Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-postsubmit
@@ -814,7 +814,7 @@ postsubmits:
           privileged: true
         resources:
           requests:
-            cpu: "2"
+            cpu: "4"
             memory: "4Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-postsubmit
@@ -855,7 +855,7 @@ postsubmits:
           privileged: true
         resources:
           requests:
-            cpu: "2"
+            cpu: "4"
             memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-postsubmit


### PR DESCRIPTION
We are still observing docker errors on builds: https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/744

Slack thread with additional context: https://kubernetes.slack.com/archives/C09QZ4DQB/p1632414457031600