### PR TITLE
sub: remove obsolete comment

### DIFF
--- a/prow/cmd/sub/README.md
+++ b/prow/cmd/sub/README.md
@@ -1,7 +1,7 @@
 # Sub
 
 Sub is a Prow Cloud Pub/Sub adapter for handling CI Pub/Sub notification requests.
-It currently supports Periodic Prow Job. Note that the prow job need to be defined in the configuration.
+Note that the prow job need to be defined in the configuration.
 
 ## Deployment Usage
 


### PR DESCRIPTION
It has been obsolete since #22777.

/assign @chaodaiG 