### PR TITLE
config/jobs: autobump prowjobs always

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
@@ -159,7 +159,6 @@ periodics:
       args:
       - --config=config/prow/autobump-config/prow-job-autobump-config.yaml
       - --labels-override=skip-review # This label is used by tide for identifying trusted PR
-      - --skip-if-no-oncall # Only apply `skip-review` label when oncall is active
       volumeMounts:
       - name: github
         mountPath: /etc/github-token


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/test-infra/issues/21137
- Followup to: https://github.com/kubernetes/test-infra/pull/23644

The morning autobump isn't getting skip-review applied