### PR TITLE
config/jobs: use k8s-staging-test-infra images for some jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-ci.yaml
+++ b/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-ci.yaml
@@ -51,7 +51,7 @@ periodics:
     path_alias: sigs.k8s.io/structured-merge-diff
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/benchmarkjunit:latest
+    - image: gcr.io/k8s-staging-test-infra/benchmarkjunit:latest
       command:
       - /benchmarkjunit
       args:

--- a/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
     path_alias: sigs.k8s.io/structured-merge-diff
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/benchmarkjunit:latest
+      - image: gcr.io/k8s-staging-test-infra/benchmarkjunit:latest
         command:
         - /benchmarkjunit
         args:

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -904,7 +904,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/benchmarkjunit:latest
+    - image: gcr.io/k8s-staging-test-infra/benchmarkjunit:latest
       command:
       - /benchmarkjunit
       args:

--- a/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
@@ -21,7 +21,7 @@ periodics:
     path_alias: k8s.io/test-infra
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/benchmarkjunit:latest
+    - image: gcr.io/k8s-staging-test-infra/benchmarkjunit:latest
       command:
       - /benchmarkjunit
       args:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -179,7 +179,7 @@ postsubmits:
     spec:
       serviceAccountName: pusher
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20210917-12df099-test-infra
+      - image: gcr.io/k8s-staging-test-infra/bazelbuild:v20210917-12df099d55-test-infra
         command:
         - prow/push.sh
       tolerations:
@@ -433,7 +433,7 @@ postsubmits:
     spec:
       serviceAccountName: testgrid-config-updater
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20210917-12df099-test-infra
+      - image: gcr.io/k8s-staging-test-infra/bazelbuild:v20210917-12df099d55-test-infra
         command:
         - ./testgrid/config-upload.sh
         resources:
@@ -455,7 +455,7 @@ postsubmits:
     spec:
       serviceAccountName: deployer # TODO(fejta): should be pusher
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20210917-12df099-test-infra
+      - image: gcr.io/k8s-staging-test-infra/bazelbuild:v20210917-12df099d55-test-infra
         command:
         - ./boskos/update_prow_config.sh
     annotations:
@@ -571,7 +571,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20210917-12df099-test-infra
+    - image: gcr.io/k8s-staging-test-infra/bazelbuild:v20210917-12df099d55-test-infra
       command:
       - hack/autodeps.sh
       args:
@@ -608,7 +608,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20210917-12df099-test-infra
+    - image: gcr.io/k8s-staging-test-infra/bazelbuild:v20210917-12df099d55-test-infra
       command:
       - hack/autodeps.sh
       args:

--- a/pkg/benchmarkjunit/prowjob_example.yaml
+++ b/pkg/benchmarkjunit/prowjob_example.yaml
@@ -9,7 +9,7 @@ periodics:
     path_alias: k8s.io/test-infra
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/benchmarkjunit:latest
+    - image: gcr.io/k8s-staging-test-infra/benchmarkjunit:latest
       command:
       - /benchmarkjunit
       args:

--- a/prow/life_of_a_prow_job.md
+++ b/prow/life_of_a_prow_job.md
@@ -63,7 +63,7 @@ spec:
   decorate: true
   pod_spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:0.11
+    - image: gcr.io/k8s-staging-test-infra/bazelbuild:latest-test-infra
   refs:
     base_ref: master
     base_sha: 064678510782db5b382df478bb374aaa32e577ea


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1523
- Followup to: https://github.com/kubernetes/test-infra/pull/23656