### PR TITLE
kops-grid: use k8s-kops-test serviceAccount for periodics

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -33849,6 +33849,7 @@ periodics:
     workdir: true
     path_alias: k8s.io/kops
   spec:
+    serviceAccountName: k8s-kops-test
     containers:
     - command:
       - runner.sh
@@ -33910,6 +33911,7 @@ periodics:
     workdir: true
     path_alias: k8s.io/kops
   spec:
+    serviceAccountName: k8s-kops-test
     containers:
     - command:
       - runner.sh
@@ -33971,6 +33973,7 @@ periodics:
     workdir: true
     path_alias: k8s.io/kops
   spec:
+    serviceAccountName: k8s-kops-test
     containers:
     - command:
       - runner.sh
@@ -34032,6 +34035,7 @@ periodics:
     workdir: true
     path_alias: k8s.io/kops
   spec:
+    serviceAccountName: k8s-kops-test
     containers:
     - command:
       - runner.sh
@@ -34093,6 +34097,7 @@ periodics:
     workdir: true
     path_alias: k8s.io/kops
   spec:
+    serviceAccountName: k8s-kops-test
     containers:
     - command:
       - runner.sh
@@ -34154,6 +34159,7 @@ periodics:
     workdir: true
     path_alias: k8s.io/kops
   spec:
+    serviceAccountName: k8s-kops-test
     containers:
     - command:
       - runner.sh

--- a/config/jobs/kubernetes/kops/templates/periodic.yaml.jinja
+++ b/config/jobs/kubernetes/kops/templates/periodic.yaml.jinja
@@ -19,6 +19,9 @@
     workdir: true
     path_alias: k8s.io/kops
   spec:
+    {%- if cloud == "gce" %}
+    serviceAccountName: k8s-kops-test
+    {%- endif %}
     containers:
     - command:
       - runner.sh


### PR DESCRIPTION
This is what we use in the presubmit tests on GCE.