### PR TITLE
Migrate metrics-kettle to pod utils.

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -29,15 +29,17 @@ periodics:
 
 - name: metrics-kettle
   interval: 1h
+  decorate: true
+  extra_refs:
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
   spec:
     serviceAccountName: triage
     containers:
     - image: gcr.io/k8s-staging-test-infra/bigquery:v20210913-fc7c4e84f6
       args:
-      - --scenario=execute
-      - --
-      - test-infra/kettle/monitor.py
-      - --
+      - ./kettle/monitor.py
       - --stale=6
       - --table
       - k8s-gubernator:build.all


### PR DESCRIPTION
`metrics-kettle` was secretly supplying extra args to bootstrap and was actually dependent on the service account environment variable: https://github.com/kubernetes/test-infra/blob/81584c84a3a3941abf657993ca0f9dd67aa784fa/images/bigquery/runner#L22-L25
so switching to WI broke the job: https://github.com/kubernetes/test-infra/pull/23698

Bootstrap has been deprecated for years to I took a stab at migrating it to pod utils.
/assign @MushuEE @chaodaiG @fejta 