### PR TITLE
config/jobs: fix kubernetes/org postsubmits

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -14,10 +14,10 @@ postsubmits:
         args:
         - deploy
         - --
-        - --github-endpoint=http://ghproxy.default.svc.cluster.local
-        - --github-endpoint=https://api.github.com
-        - --github-token-path=/etc/github-token/oauth
-        - --tokens=1200
+        - --github-endpoint http://ghproxy.default.svc.cluster.local
+        - --github-endpoint https://api.github.com
+        - --github-token-path /etc/github-token/oauth
+        - --tokens 1200
         - --confirm
         volumeMounts:
         - name: github
@@ -544,10 +544,10 @@ periodics:
       args:
       - deploy
       - --
-      - --github-endpoint=http://ghproxy.default.svc.cluster.local
-      - --github-endpoint=https://api.github.com
-      - --github-token-path=/etc/github-token/oauth
-      - --tokens=1200
+      - --github-endpoint http://ghproxy.default.svc.cluster.local
+      - --github-endpoint https://api.github.com
+      - --github-token-path /etc/github-token/oauth
+      - --tokens 1200
       - --confirm
       volumeMounts:
       - name: github


### PR DESCRIPTION
Related:
- Followup to: https://github.com/kubernetes/org/pull/3007
- Followup to: https://github.com/kubernetes/test-infra/pull/23745
- Followup to: https://github.com/kubernetes/org/pull/3010

Until I have time to put together a better entrypoint, replace `--flag=value` with `--flag value` for kubernetes/org postsubmits.  This will ensure both values of the `--github-endpoint` flag are passed through to peribolos.  See https://github.com/kubernetes/org/pull/3010#issuecomment-926977295 for a longer explanation