### PR TITLE
Remove helm e2e test from prow

### DIFF
--- a/config/jobs/kubernetes/sig-network/ingress-nginx/ingress-nginx-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-nginx/ingress-nginx-presubmit.yaml
@@ -272,34 +272,3 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-network-ingress-nginx
       testgrid-tab-name: e2e-1-19
-
-  - name: pull-ingress-nginx-e2e-helm-chart
-    always_run: false
-    decorate: true
-    decoration_config:
-      timeout: 1h
-    max_concurrency: 5
-    path_alias: k8s.io/ingress-nginx
-    run_if_changed: "^charts/"
-    labels:
-      preset-kind-volume-mounts: "true"
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/krte:v20210915-5dbaf53458-master
-        command:
-          - wrapper.sh
-          - bash
-          - -c
-          - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && make kind-e2e-chart-tests
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        env:
-        - name: REPO_INFO
-          value: https://github.com/kubernetes/ingress-nginx
-        - name: K8S_VERSION
-          value: v1.19.1@sha256:98cf5288864662e37115e362b23e4369c8c4a408f99cbc06e58ac30ddc721600
-    annotations:
-      testgrid-dashboards: sig-network-ingress-nginx
-      testgrid-tab-name: e2e-helm-chart


### PR DESCRIPTION
We already run this test via gh actions:

https://github.com/kubernetes/ingress-nginx/blob/main/.github/workflows/ci.yaml#L164

So probably we can remove this from prow

/cc @strongjz @tao12345666333 @cpanato 