### PR TITLE
Migrated node throughput tests

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: ci-kubernetes-e2e-gce-node-throughput
+  cluster: k8s-infra-prow-build
   tags:
   - "perfDashPrefix: docker-node-throughput"
   - "perfDashJobType: throughput"
@@ -59,6 +60,7 @@ periodics:
           memory: "6Gi"
 
 - name: ci-kubernetes-e2e-gce-node-containerd-throughput
+  cluster: k8s-infra-prow-build
   tags:
   - "perfDashPrefix: containerd-node-throughput"
   - "perfDashJobType: throughput"


### PR DESCRIPTION
Ref: https://github.com/kubernetes/perf-tests/issues/1898

Migrate node throughput tests to community-owned infrastructure

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>