### PR TITLE
sig-scalability: migrate ci-perf-tests-kubemark-100-benchmark

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -666,6 +666,7 @@ periodics:
           memory: "8Gi"
 
 - name: ci-perf-tests-kubemark-100-benchmark
+  cluster: k8s-infra-prow-build
   interval: 2h
   labels:
     preset-service-account: "true"


### PR DESCRIPTION
Ref: https://github.com/kubernetes/perf-tests/issues/1898

Migrate the job ot community-owned infrastructure

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>