### PR TITLE
sig-scalability: migrate scheduler benchmark tests

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -700,6 +700,7 @@ periodics:
           memory: "2Gi"
 
 - name: ci-benchmark-scheduler-master
+  cluster: k8s-infra-prow-build
   tags:
   - "perfDashPrefix: scheduler-benchmark"
   - "perfDashJobType: benchmark"
@@ -736,6 +737,7 @@ periodics:
           memory: "32Gi"
 
 - name: ci-benchmark-scheduler-perf-master
+  cluster: k8s-infra-prow-build
   tags:
   - "perfDashPrefix: scheduler-perf-benchmark"
   - "perfDashJobType: benchmark"


### PR DESCRIPTION
Ref: https://github.com/kubernetes/perf-tests/issues/1898

Migrate to community-owned infrastructure:
 - ci-benchmark-scheduler-master
 - ci-benchmark-scheduler-perf-master

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>