### PR TITLE
config/jobs: fix trigger regex for benchmarkjunit-canary image push job

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-test-infra.yaml
+++ b/config/jobs/image-pushing/k8s-staging-test-infra.yaml
@@ -29,7 +29,7 @@ postsubmits:
           - images/bazelbuild/
     - name: post-test-infra-push-benchmarkjunit-canary
       cluster: k8s-infra-prow-build-trusted
-      run_if_changed: '^images/benchmarkjunit/'
+      run_if_changed: '^pkg/benchmarkjunit/'
       annotations:
         testgrid-dashboards: sig-testing-canaries, sig-k8s-infra-canaries, sig-k8s-infra-gcb
         testgrid-tab-name: benchmarkjunit-canary


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1523
- Followup to: https://github.com/kubernetes/test-infra/pull/23616
- Addresses issue discovered in: https://github.com/kubernetes/test-infra/pull/23737#discussion_r715647329

Images haven't been getting pushed to gcr.io/k8s-staging-test-infra/benchmarkjunit because the canary image push job was never triggering because of an incorrect `run_if_changed` regex leftover from copy-pasting