### PR TITLE
cloud-provider-gcp: non-Bazel testing support

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -15,15 +15,15 @@ presubmits:
       path_alias: k8s.io/test-infra
     spec:
       containers:
-      - image: gcr.io/cloud-builders/bazel
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210917-ee1e7c845b-master
         command:
-        - ../test-infra/hack/bazel.sh
+        - /bin/bash
         args:
-        - test
-        - --test_output=errors
-        - --
-        - //...
-        - -//vendor/...
+        - if [ -f Makefile ]; then
+            make test
+          else
+            ../test-infra/hack/bazel.sh test --test_output=errors -- //... -//vendor/...
+          fi
   - name: cloud-provider-gcp-verify-all
     always_run: true
     decorate: true


### PR DESCRIPTION
This PR enables job `cloud-provider-gcp-tests` to run tests without Bazel while retaining the ability to do so with Bazel to be compatible with existing release branches.

ref: https://github.com/kubernetes/cloud-provider-gcp/pull/259