### PR TITLE
increase job timeout to 1h for secrets-store-csi-driver aws tests

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -370,7 +370,7 @@ presubmits:
   - name: pull-secrets-store-csi-driver-e2e-aws
     decorate: true
     decoration_config:
-      timeout: 45m
+      timeout: 1h
     always_run: true
     optional: true
     path_alias: sigs.k8s.io/secrets-store-csi-driver
@@ -595,7 +595,7 @@ presubmits:
   - name: release-secrets-store-csi-driver-e2e-aws
     decorate: true
     decoration_config:
-      timeout: 45m
+      timeout: 1h
     always_run: false
     run_if_changed: "^charts/.*"
     optional: true
@@ -885,7 +885,7 @@ postsubmits:
   - name: secrets-store-csi-driver-e2e-aws-postsubmit
     decorate: true
     decoration_config:
-      timeout: 45m
+      timeout: 1h
     always_run: true
     optional: true
     path_alias: sigs.k8s.io/secrets-store-csi-driver


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

The aws provider tests include cluster creation and deletion as part of the test suite which can take time. Increasing the timeout to 1h to accommodate delays in these steps. 