### PR TITLE
config: shrink and begin migrating away from node-e2e boskos pool

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -25,7 +25,6 @@ presubmits:
         - --scenario=kubernetes_e2e
         - -- # end bootstrap args, scenario args below
         - --deployment=node
-        - --gcp-project-type=node-e2e-project
         - --gcp-zone=us-west1-b
         - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
         - --node-tests=true
@@ -320,7 +319,6 @@ presubmits:
         - --scenario=kubernetes_e2e
         - --
         - --deployment=node
-        - --gcp-project-type=node-e2e-project
         - --gcp-zone=us-west1-b
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial.yaml
         - --node-test-args=--feature-gates=DynamicKubeletConfig=true,LocalStorageCapacityIsolation=true --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
@@ -363,7 +361,6 @@ presubmits:
           - --scenario=kubernetes_e2e
           - --
           - --deployment=node
-          - --gcp-project-type=node-e2e-project
           - --gcp-zone=us-west1-b
           - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/image-config-serial.yaml
           - '--node-test-args=--feature-gates=DynamicKubeletConfig=true,LocalStorageCapacityIsolation=true --container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
@@ -404,7 +401,6 @@ presubmits:
         - --scenario=kubernetes_e2e
         - --
         - --deployment=node
-        - --gcp-project-type=node-e2e-project
         - --gcp-zone=us-west1-b
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial.yaml
         - --node-test-args=--feature-gates=DynamicKubeletConfig=true,LocalStorageCapacityIsolation=true --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"

--- a/config/prow/cluster/boskos-resources.yaml
+++ b/config/prow/cluster/boskos-resources.yaml
@@ -531,21 +531,6 @@ resources:
   state: dirty
   type: scalability-presubmit-project
 - names:
-  - k8s-jkns-gci-gke-1-3
-  - k8s-jkns-gci-gke-1-4
-  - k8s-jkns-gci-gke-1-6
-  - k8s-jkns-gci-gke-alpha-1-4
-  - k8s-jkns-gci-gke-ingress-1-4
-  - k8s-jkns-gci-gke-ingress-1-6
-  - k8s-jkns-gci-gke-reboot-1-3
-  - k8s-jkns-gci-gke-reboot-1-6
-  - k8s-jkns-gci-gke-serial-1-2
-  - k8s-jkns-gci-gke-serial-1-3
-  - k8s-jkns-gci-gke-serial-1-4
-  - k8s-jkns-gci-gke-serial-1-6
-  - k8s-jkns-gci-gke-slow-1-3
-  - k8s-jkns-gci-gke-slow-1-4
-  - k8s-jkns-gci-gke-slow-1-6
   - k8s-jkns-gke-ubuntu
   - k8s-jkns-gke-ubuntu-1-6
   - k8s-jkns-gke-ubuntu-1-6-alpha
@@ -564,14 +549,5 @@ resources:
   - k8s-jkns-gke-ubuntu-serial
   - k8s-jkns-gke-ubuntu-slow
   - k8s-jkns-gke-ubuntu-updown
-  - k8s-test-139569f31c
-  - k8s-test-3e74ad8150
-  - k8s-test-4b6146a96f
-  - k8s-test-73afed9487
-  - k8s-test-761f0eadc1
-  - k8s-test-7b1edb0409
-  - k8s-test-7f37c1d417
-  - k8s-test-aac0a04ffb
-  - k8s-test-f08378c6bb
   state: dirty
   type: node-e2e-project


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/test-infra/issues/23291
- Followup to: https://github.com/kubernetes/test-infra/pull/23292
- Followup to: https://github.com/kubernetes/test-infra/pull/17284

Apparently doing the project addition and removal in a single PR wasn't enough to cause boskos to grow the node-e2e pool, so undoing that change to reflect reality

Also, there is nothing special about the projects in the node-e2e pool, so let's stop using it, and begin to migrate jobs over to the main gce-project pool

I chose an arbitrary group of presubmits first, since I suspect presubmits are the main reason the pool gets exhausted occasionally