### PR TITLE
sig-scalability: migrate dns benchmark jobs

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -781,6 +781,7 @@ periodics:
           memory: "24Gi"
 
 - name: ci-benchmark-kube-dns-master
+  cluster: k8s-infra-prow-build
   interval: 2h
   tags:
   - "perfDashPrefix: kube-dns benchmark"
@@ -835,6 +836,7 @@ periodics:
           memory: "6Gi"
 
 - name: ci-benchmark-nodelocal-dns-master
+  cluster: k8s-infra-prow-build
   interval: 2h
   tags:
   - "perfDashPrefix: node-local-dns benchmark"


### PR DESCRIPTION
Ref: https://github.com/kubernetes/perf-tests/issues/1898

Migrate to community-owned infrastructure:
- ci-benchmark-kube-dns-master
- ci-benchmark-nodelocal-dns-master

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>