### PR TITLE
config/jobs: mv some canary jobs to local ssd nodepool

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -165,6 +165,14 @@ presubmits:
       preset-pull-kubernetes-e2e: "true"
       preset-pull-kubernetes-e2e-gce: "true"
     spec:
+      # TODO(https://github.com/kubernetes/k8s.io/issues/1187): remove nodeSelector/tolerations once new nodepool confirmed healthy
+      nodeSelector:
+        cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
+      tolerations:
+      - key: "ephemeral-ssd-experiment"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
       containers:
       - args:
         - --root=/go/src

--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -50,6 +50,14 @@ presubmits:
       preset-service-account: "true"
       preset-dind-enabled: "true"
     spec:
+      # TODO(https://github.com/kubernetes/k8s.io/issues/1187): remove nodeSelector/tolerations once new nodepool confirmed healthy
+      nodeSelector:
+        cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
+      tolerations:
+      - key: "ephemeral-ssd-experiment"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210927-471c27b6e3-go-canary
         command:

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -62,6 +62,14 @@ presubmits:
       grace_period: 15m
     path_alias: k8s.io/kubernetes
     spec:
+      # TODO(https://github.com/kubernetes/k8s.io/issues/1187): remove nodeSelector/tolerations once new nodepool confirmed healthy
+      nodeSelector:
+        cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
+      tolerations:
+      - key: "ephemeral-ssd-experiment"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
       containers:
       - image: gcr.io/k8s-staging-test-infra/krte:latest-master
         imagePullPolicy: Always # pull latest image for canary testing

--- a/config/jobs/kubernetes/sig-testing/make-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/make-test.yaml
@@ -87,6 +87,14 @@ presubmits:
     skip_report: false
     path_alias: k8s.io/kubernetes
     spec:
+      # TODO(https://github.com/kubernetes/k8s.io/issues/1187): remove nodeSelector/tolerations once new nodepool confirmed healthy
+      nodeSelector:
+        cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
+      tolerations:
+      - key: "ephemeral-ssd-experiment"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
       # unit tests have no business requiring root or doing privileged operations
       securityContext:
         runAsUser: 2000

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -64,6 +64,14 @@ presubmits:
       preset-service-account: "true"
       preset-dind-enabled: "true"
     spec:
+      # TODO(https://github.com/kubernetes/k8s.io/issues/1187): remove nodeSelector/tolerations once new nodepool confirmed healthy
+      nodeSelector:
+        cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
+      tolerations:
+      - key: "ephemeral-ssd-experiment"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210927-471c27b6e3-go-canary
         imagePullPolicy: Always


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1187
- Followup to: https://github.com/kubernetes/k8s.io/pull/2835

Allow us to manually trigger some presubmits to see what the behaior of
local-ssd-backed ephemeral storage looks like

Specifically for jobs:

- pull-kubernetes-e2e-gce-canary
- pull-kubernetes-integration-go-canary
- pull-kubernetes-e2e-kind-canary
- pull-kubernetes-unit-go-canary
- pull-kubernetes-verify-go-canary