### PR TITLE
fix area label in cloud-provider-gcp jobs

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/OWNERS
+++ b/config/jobs/kubernetes/cloud-provider-gcp/OWNERS
@@ -10,4 +10,4 @@ approvers:
 - jpbetz
 labels:
 - sig/cloud-provider
-- area/provider/aws
+- area/provider/gcp


### PR DESCRIPTION
There is a copy-and-paste error in `config/jobs/kubernetes/cloud-provider-gcp/OWNERS` that marks the wrong cloud provider. This PR fixes it.