### PR TITLE
cloud-provider-gcp-presubmits: fix missing '-c' in args.

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -19,6 +19,7 @@ presubmits:
         command:
         - /bin/bash
         args:
+        - -c
         - if [ -f Makefile ]; then
             make test
           else


### PR DESCRIPTION
This PR fixes a missing `-c` in `cloud-provider-gcp-presubmits.yaml`. The actual script was tested locally.