### PR TITLE
provider-gcp-presubmits: fix folded script

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -20,7 +20,8 @@ presubmits:
         - /bin/bash
         args:
         - -c
-        - if [ -f Makefile ]; then
+        - |
+          if [ -f Makefile ]; then
             make test
           else
             ../test-infra/hack/bazel.sh test --test_output=errors -- //... -//vendor/...


### PR DESCRIPTION
The script in the command line was collapsed into one single line. This PR fix it by marking it as multi-line string.