### PR TITLE
Update config for graceful node shutdown job

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -420,7 +420,8 @@ periodics:
           - --gcp-project-type=node-e2e-project
           - --gcp-zone=us-west1-b
           - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial.yaml
-          - --node-test-args=--feature-gates=GracefulNodeShutdown=true --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
+          # Remove DynamicKubeletConfig feature gate once https://github.com/kubernetes/kubernetes/issues/105047 is completed
+          - --node-test-args=--feature-gates=DynamicKubeletConfig=true --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
           - --node-tests=true
           - --provider=gce
           - --test_args=--nodes=1 --focus="\[NodeAlphaFeature:GracefulNodeShutdown\]"


### PR DESCRIPTION
* Remove explicitly setting `GracefulNodeShutdown` feature gate, since
  it's now enabled by defaulted as a beta feature as of 1.21
* Enable `DynamicKubeletConfig` feature gate, since the test needs to
  update kubelet config at runtime