### PR TITLE
Remove redundant delete throughput setting from master-scalability-100

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -192,7 +192,6 @@ periodics:
       - --metadata-sources=cl2-metadata.json
       - --env=CL2_ENABLE_DNS_PROGRAMMING=true
       - --env=CL2_SCHEDULER_THROUGHPUT_THRESHOLD=0
-      - --env=CL2_DELETE_TEST_THROUGHPUT=14
       - --env=CL2_ENABLE_HUGE_SERVICES=true
       - --env=CL2_ENABLE_API_AVAILABILITY_MEASUREMENT=true
       - --env=CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD=99.5


### PR DESCRIPTION
Since delete throughput is now set to 14 in load_throughput.yaml override (https://github.com/kubernetes/perf-tests/pull/1902) setting delete throughput in test is redundant.