### PR TITLE
spyglass: add nil-pointer check

### DIFF
--- a/prow/spyglass/artifacts.go
+++ b/prow/spyglass/artifacts.go
@@ -77,14 +77,16 @@ func (s *Spyglass) ListArtifacts(ctx context.Context, src string) ([]string, err
 		return artifactNamesSet.List(), nil
 	}
 
-	jobContainers := job.Spec.PodSpec.Containers
+	if job.Spec.PodSpec != nil {
+		jobContainers := job.Spec.PodSpec.Containers
 
-	for _, container := range jobContainers {
-		logName := singleLogName
-		if len(jobContainers) > 1 {
-			logName = fmt.Sprintf("%s-%s", container.Name, singleLogName)
+		for _, container := range jobContainers {
+			logName := singleLogName
+			if len(jobContainers) > 1 {
+				logName = fmt.Sprintf("%s-%s", container.Name, singleLogName)
+			}
+			artifactNamesSet.Insert(logName)
 		}
-		artifactNamesSet.Insert(logName)
 	}
 
 	return artifactNamesSet.List(), nil


### PR DESCRIPTION
Sometimes the job may not have a PodSpec (it will be nil) because it
will not be using a Kubernetes agent.

/assign @cjwagner 