### PR TITLE
CAPA - Added needs-triage prow plugin config

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -689,6 +689,18 @@ require_matching_label:
   issues: true
   prs: true
   regexp: ^priority/
+- missing_label: needs-triage
+  org: kubernetes-sigs
+  repo: cluster-api-provider-aws
+  issues: true
+  prs: true
+  regexp: ^triage/accepted$
+  missing_comment: |
+    This issue is currently awaiting triage.
+
+    If CAPA/CAPI contributors determines this is a relevant issue, they will accept it by applying the `triage/accepted` label and provide further guidance.
+    
+    The `triage/accepted` label can be added by org members by writing `/triage accepted` in a comment.
 - missing_label: needs-sig
   org: kubernetes
   repo: test-infra


### PR DESCRIPTION
Added configuration for the required labels prow plugin for `needs-triage`.

/cc @randomvariable @sedefsavas 