### PR TITLE
added `--repo-root` arg in kubetest2 canary jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -128,6 +128,7 @@ presubmits:
         - noop
         - --test=node
         - --
+        - --repo-root=k8s.io/$(REPO_NAME)=$(PULL_REFS)
         - --gcp-zone=us-west1-b
         - --parallelism=8
         - --focus-regex='\[NodeConformance\]'
@@ -259,6 +260,7 @@ presubmits:
         - noop
         - --test=node
         - --
+        - --repo-root=k8s.io/$(REPO_NAME)=$(PULL_REFS)
         - --gcp-zone=us-west1-b
         - --parallelism=8
         - --focus-regex='\[NodeConformance\]'


### PR DESCRIPTION
Signed-off-by: Namanl2001 <namanlakhwani@gmail.com>

Added `--repo-root=k8s.io/$(REPO_NAME)=$(PULL_REFS)` in `pull-kubernetes-node-e2e-kubetest2` and `pull-kubernetes-node-e2e-containerd-kubetest2`

ref: https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/92316/pull-kubernetes-node-e2e-kubetest2/1442916543041114112/build-log.txt