### PR TITLE
Revert "config/jobs: mv some canary jobs to local ssd nodepool"

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -165,14 +165,6 @@ presubmits:
       preset-pull-kubernetes-e2e: "true"
       preset-pull-kubernetes-e2e-gce: "true"
     spec:
-      # TODO(https://github.com/kubernetes/k8s.io/issues/1187): remove nodeSelector/tolerations once new nodepool confirmed healthy
-      nodeSelector:
-        cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
-      tolerations:
-      - key: "ephemeral-ssd-experiment"
-        operator: "Equal"
-        value: "true"
-        effect: "NoSchedule"
       containers:
       - args:
         - --root=/go/src

--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -50,14 +50,6 @@ presubmits:
       preset-service-account: "true"
       preset-dind-enabled: "true"
     spec:
-      # TODO(https://github.com/kubernetes/k8s.io/issues/1187): remove nodeSelector/tolerations once new nodepool confirmed healthy
-      nodeSelector:
-        cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
-      tolerations:
-      - key: "ephemeral-ssd-experiment"
-        operator: "Equal"
-        value: "true"
-        effect: "NoSchedule"
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210928-2a55334641-go-canary
         command:

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -62,14 +62,6 @@ presubmits:
       grace_period: 15m
     path_alias: k8s.io/kubernetes
     spec:
-      # TODO(https://github.com/kubernetes/k8s.io/issues/1187): remove nodeSelector/tolerations once new nodepool confirmed healthy
-      nodeSelector:
-        cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
-      tolerations:
-      - key: "ephemeral-ssd-experiment"
-        operator: "Equal"
-        value: "true"
-        effect: "NoSchedule"
       containers:
       - image: gcr.io/k8s-staging-test-infra/krte:latest-master
         imagePullPolicy: Always # pull latest image for canary testing

--- a/config/jobs/kubernetes/sig-testing/make-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/make-test.yaml
@@ -87,14 +87,6 @@ presubmits:
     skip_report: false
     path_alias: k8s.io/kubernetes
     spec:
-      # TODO(https://github.com/kubernetes/k8s.io/issues/1187): remove nodeSelector/tolerations once new nodepool confirmed healthy
-      nodeSelector:
-        cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
-      tolerations:
-      - key: "ephemeral-ssd-experiment"
-        operator: "Equal"
-        value: "true"
-        effect: "NoSchedule"
       # unit tests have no business requiring root or doing privileged operations
       securityContext:
         runAsUser: 2000

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -64,14 +64,6 @@ presubmits:
       preset-service-account: "true"
       preset-dind-enabled: "true"
     spec:
-      # TODO(https://github.com/kubernetes/k8s.io/issues/1187): remove nodeSelector/tolerations once new nodepool confirmed healthy
-      nodeSelector:
-        cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
-      tolerations:
-      - key: "ephemeral-ssd-experiment"
-        operator: "Equal"
-        value: "true"
-        effect: "NoSchedule"
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210928-2a55334641-go-canary
         imagePullPolicy: Always


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1187
- Followup to: https://github.com/kubernetes/test-infra/pull/23783

This reverts commit 4d4660c966e25f82283c85aed22c6e813d7a0e4d.

Experiment has concluded and we've migrated to using a local-ssd-backed
nodepool exclusively.  These can be reverted to their original config