### PR TITLE
Update descheduler 1.22-1.20 test to use available image

### DIFF
--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.22.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.22.yaml
@@ -133,7 +133,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBERNETES_VERSION
-          value: "v1.20.10"
+          value: "v1.20.7"
         - name: KIND_E2E
           value: "true"
         args:


### PR DESCRIPTION
Ref https://github.com/kubernetes-sigs/descheduler/pull/634#issuecomment-929738453

There is no `1.20.10` image available: `ERROR: failed to create cluster: failed to pull image "kindest/node:v1.20.10": command "docker pull kindest/node:v1.20.10" failed with error: exit status 1`