### PR TITLE
config/jobs: remove *-sig-storage-local-static-provisioner-*-gke-*

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner.yaml
+++ b/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner.yaml
@@ -64,32 +64,6 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-  - name: pull-sig-storage-local-static-provisioner-e2e-gke
-    always_run: true
-    decorate: true
-    path_alias: sigs.k8s.io/sig-storage-local-static-provisioner
-    labels:
-      preset-dind-enabled: "true"
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210928-2a55334641-master
-        command:
-        - runner.sh
-        args:
-        - make
-        - e2e
-        env:
-        - name: PROVIDER
-          value: gke
-        - name: GKE_ENVIRONMENT
-          value: prod
-        - name: EXTRACT_STRATEGY
-          value: gke-default
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
 
 periodics:
 - name: ci-sig-storage-local-static-provisioner-master-gce-latest
@@ -117,38 +91,6 @@ periodics:
         value: gce
       - name: EXTRACT_STRATEGY
         value: ci/latest
-      - NAME: PROVISIONER_E2E_IMAGE
-        value: quay.io/external_storage/local-volume-provisioner:canary
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-- name: ci-sig-storage-local-static-provisioner-master-gke-default
-  interval: 4h
-  decorate: true
-  labels:
-    preset-dind-enabled: "true"
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: sig-storage-local-static-provisioner
-    base_ref: master
-    path_alias: sigs.k8s.io/sig-storage-local-static-provisioner
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210928-2a55334641-master
-      command:
-      - runner.sh
-      args:
-      - make
-      - e2e
-      env:
-      - name: PROVIDER
-        value: gke
-      - name: GKE_ENVIRONMENT
-        value: prod
-      - name: EXTRACT_STRATEGY
-        value: gke-default
       - NAME: PROVISIONER_E2E_IMAGE
         value: quay.io/external_storage/local-volume-provisioner:canary
       # docker-in-docker needs privileged mode

--- a/config/testgrids/kubernetes/sig-storage/config.yaml
+++ b/config/testgrids/kubernetes/sig-storage/config.yaml
@@ -97,10 +97,6 @@ dashboards:
       description: E2E tests against latest kubernetes on GCE
       alert_options:
         alert_mail_to_addresses: kubernetes-sig-storage-test-failures@googlegroups.com
-    - name: master-gke-default
-      test_group_name: ci-sig-storage-local-static-provisioner-master-gke-default
-      base_options: include-filter-by-regex=sig-storage
-      description: E2E tests against default kubernetes on GKE
 
 - name: sig-storage-csi-ci
 - name: sig-storage-csi-csi-driver-host-path


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/test-infra/issues/23778

These shouldn't be running on prow.k8s.io and there are gce alternatives
which already run on prow.k8s.io