### PR TITLE
Revert "Run the serial job(s) if e2e node tests are updated"

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -346,7 +346,6 @@ presubmits:
       testgrid-create-test-group: 'true'
   - name: pull-kubernetes-node-kubelet-serial
     always_run: false
-    run_if_changed: '^test/.*(e2e_node|node)'
     optional: true
     skip_report: false
     skip_branches:
@@ -388,7 +387,6 @@ presubmits:
 
   - name: pull-kubernetes-node-kubelet-serial-containerd
     always_run: false
-    run_if_changed: '^test/.*(e2e_node|node)'
     optional: true
     skip_report: false
     skip_branches:


### PR DESCRIPTION
This reverts commit 7f177cd8c6680a2000616055a558061955e8dd41 / #23124.

These jobs aren't passing and are relatively resource-intensive. We shouldn't be running them on PRs until we get consistent signal.

This change was made without discussion in Node CI Subproject -- per the 09/29 meeting we are reverting until the test jobs are green and will consistently pass.

/assign @SergeyKanzhelev 
/sig node