### PR TITLE
metrics: make flakes-daily metrics match flakes metrics, run more frequently

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
@@ -29,7 +29,7 @@ postsubmits:
 
 periodics:
 - name: metrics-bigquery
-  cron: "03 0-23/6 * * *"  # like interval: 6h, but explicitly starting at 00:03 UTC
+  cron: "03 0-23/3 * * *"  # like interval: 6h, but explicitly starting at 00:03 UTC
   cluster: k8s-infra-prow-build-trusted
   decorate: true
   max_concurrency: 1

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -38,10 +38,10 @@ jqfilter: |
 * failures - find jobs that have been failing the longest
     - [Config](configs/failures-config.yaml)
     - [failures-latest.json](http://storage.googleapis.com/k8s-metrics/failures-latest.json)
-* flakes - find the flakiest jobs this week (and the flakiest tests in each job).
+* flakes - find the flakiest jobs this week (and the flakiest tests in each job)
     - [Config](configs/flakes-config.yaml)
     - [flakes-latest.json](http://storage.googleapis.com/k8s-metrics/flakes-latest.json)
-* flakes-daily - find flakes from the previous day. Similar to `flakes`, but creates more granular results.
+* flakes-daily - find the flakiest jobs in the last 24h (and the flakiest tests in each job)
     - [Config](configs/flakes-daily-config.yaml)
     - [flakes-daily-latest.json](http://storage.googleapis.com/k8s-metrics/flakes-daily-latest.json)
 * job-health - compute daily health metrics for jobs (runs, tests, failure rate for each, duration percentiles)

--- a/metrics/configs/flakes-daily-config.yaml
+++ b/metrics/configs/flakes-daily-config.yaml
@@ -1,5 +1,5 @@
-metric: flakes
-description: Calculates flakiness for each job for the past week and the flakiest tests for each job.
+metric: flakes-daily
+description: Calculates flakiness for each job for the past day and the flakiest tests for each job.
 query: |
   #standardSQL
   select

--- a/metrics/configs/flakes-daily-config.yaml
+++ b/metrics/configs/flakes-daily-config.yaml
@@ -1,26 +1,33 @@
-metric: flakes-daily
-description: Calculates flakiness for each job for each day.
+metric: flakes
+description: Calculates flakiness for each job for the past week and the flakiest tests for each job.
 query: |
   #standardSQL
   select
     job,
-    consistent_builds,
-    builds,
-    round(consistent_builds/builds, 3) build_consistency,
-    consistent_commits,
-    commits,
-    round(consistent_commits/commits, 3) commit_consistency,
+    build_consistency,
+    commit_consistency,
     flakes,
-    UNIX_SECONDS(TIMESTAMP(day)) day
+    runs,
+    commits,
+    array(
+      select as struct
+        i.n name,
+        count(i.failures) flakes
+      from tt.tests i
+      group by name
+      having name not in ('Test', 'DiffResources', 'DumpClusterLogs', 'DumpFederationLogs')  /* uninteresting tests */
+      order by flakes desc
+      limit 10 /* top ten flakiest tests in this job */
+    ) flakiest
   from (
-    select /* for each (job, day) */
+    select
       job, /* name of job */
-      sum(if(flaked=1,passed,runs)) consistent_builds,
-      count(distinct commit)-sum(flaked) consistent_commits,
-      sum(runs) builds,
-      count(distinct commit) commits,
+      round(sum(if(flaked=1,passed,runs))/sum(runs),3) build_consistency, /* percentage of runs that did not flake */
+      round(1-sum(flaked)/count(distinct commit),3) commit_consistency, /* percentage of commits that did not flake */
       sum(flaked) flakes, /* number of times it flaked */
-      day
+      sum(runs) runs, /* number of times the job ran */
+      count(distinct commit) commits, /* number of commits tested */
+      array_concat_agg(tests) tests /* array of flaking tests in this job */
     from (
       select
         job,
@@ -28,55 +35,59 @@ query: |
         if(passed = runs or passed = 0, 0, 1) flaked, /* consistent: always pass or always fail */
         passed,
         safe_cast(runs as int64) runs,
-        day
+        array(
+          select as struct
+            i.name n, /* test name */
+            countif(i.failed) failures /* number of times it flaked */
+          from tt.tests i
+          group by n
+          having failures > 0 and failures < tt.runs /* same consistency metric */
+          order by failures desc
+        ) tests
       from (
-        select /* for each (job, day, commit) */
+        select
           job,
           commit,
           sum(if(result='SUCCESS',1,0)) passed,
-          count(result) runs, /* count the number of times we ran a job on this commit for this PR */
-          day
+          count(result) runs,  /* count the number of times we ran a job on this commit for this PR */
+          array_concat_agg(test) tests /* create an array of tests structs */
         from (
           SELECT
             job,
+            if(substr(job, 0, 3) = 'pr:', 'pull', 'ci') kind,  /* pull or ci */
+            ifnull(repo_commit, version) version, /* git version, empty for ci  */
             if(substr(job, 0, 3) = 'pr:',
               regexp_extract(
                 repo,
                 r'[^,]+,\d+:([a-f0-9]+)"'
               ),
-              version
+              ifnull(repo_commit, version)
             ) commit,  /* repo commit for PR or version for CI */
             result,  /* SUCCESS if the build passed */
-            date_trunc(date(started), DAY) day
+            test  /* repeated tuple of tests */
           from (
                 select *,
-                       ifnull(b.repos, (select i.value from b.metadata i where i.key = 'repos')) repo from `k8s-gubernator.build.all` as b
+                       ifnull(b.repos, (select i.value from b.metadata i where i.key = 'repos')) repo from `k8s-gubernator.build.week` as b
           ) as t
           where
-            /* Select results that have occurred on or after the day of <LAST_DATA_TIME> (those results were
-               for the day before), but don't include results from today, only return results for complete days. */
-            datetime(started) >= datetime_trunc(parse_datetime("%s", cast(<LAST_DATA_TIME> as string)), DAY)
-            and datetime(started) < datetime_trunc(current_datetime(), DAY) /* Drop results from partial day */
+            datetime(started) > datetime_sub(current_datetime(), interval 1 DAY)
+            and (version != 'unknown' or repo_commit is not null)
             and (
-              (substr(job, 0, 3) = 'ci-' and version != 'unknown') or
+              substr(job, 0, 3) = 'ci-' or
               array_length(split(replace(t.repo,', ', ''), ',')) = 2 /*serial pr jobs only (# of PR refs +1 == 2)*/
             )
         )
-        group by job, day, commit
-      )
-    )
-    group by job, day /* summarize job across all commits/builds and group results by day for backfilling influxdb */
-  )
-  order by day desc, flakes desc, build_consistency, commit_consistency, job /* flakiest jobs first */
+        group by job, commit
+      ) as tt
+    ) as tt
+    group by job /* summarize info for this job across all commits/builds */
+  ) as tt
+  order by flakes desc, commit_consistency, build_consistency, job /* flakiest jobs first */
 
 jqfilter: |
-  ([(.[] | .day|tonumber)] | max) as $newestday |
-  [(.[] | select((.job | contains("pr:")) and ((.day|tonumber)==$newestday)) | {(.job): {
-    flakes: (.flakes|tonumber),
-    commit_consistency: (.commit_consistency|tonumber),
-    commits: (.commits|tonumber),
-    consistent_commits: (.consistent_commits|tonumber),
-    build_consistency: (.build_consistency|tonumber),
-    build: (.builds|tonumber),
-    consistent_builds: (.consistent_builds|tonumber)
+  [(.[] | {(.job): {
+      consistency: (.commit_consistency|tonumber),
+      flakes: (.flakes|tonumber),
+      test_flakes: ([(.flakiest[] | {
+        (.name): (.flakes|tonumber)}) ])| add
   }})] | add


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/test-infra/issues/21296

This will make http://storage.googleapis.com/k8s-metrics/flakes-daily-latest.json look like http://storage.googleapis.com/k8s-metrics/flakes-latest.json but using jobs in the last 24h instead of the last 7d

I was tempted to bump the job to run every 1h but I'd like to understand which of this and the triage job are responsible for our new bigquery spend over in k8s-infra land first...