### PR TITLE
Add area/elections label to community repo

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -291,6 +291,7 @@ larger set of contributors to apply/remove them.
 | <a id="area/developer-guide" href="#area/developer-guide">`area/developer-guide`</a> | Issues or PRs related to the developer guide| label | |
 | <a id="area/devstats" href="#area/devstats">`area/devstats`</a> | Issues or PRs related to the devstats subproject| label | |
 | <a id="area/e2e-test-framework" href="#area/e2e-test-framework">`area/e2e-test-framework`</a> | Issues or PRs related to refactoring the kubernetes e2e test framework| label | |
+| <a id="area/elections" href="#area/elections">`area/elections`</a> | Issues or PRs related to community elections| label | |
 | <a id="area/enhancements" href="#area/enhancements">`area/enhancements`</a> | Issues or PRs related to the Enhancements subproject| label | |
 | <a id="area/eu-summit" href="#area/eu-summit">`area/eu-summit`</a> | Issues or PRs related to the Contributor Summit in Europe| label | |
 | <a id="area/github-management" href="#area/github-management">`area/github-management`</a> | Issues or PRs related to GitHub Management subproject| label | |

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -761,6 +761,11 @@ repos:
         target: both
         addedBy: label
       - color: 0052cc
+        description: Issues or PRs related to community elections
+        name: area/elections
+        target: both
+        addedBy: label
+      - color: 0052cc
         description: Issues or PRs related to GitHub Management subproject
         name: area/github-management
         target: both


### PR DESCRIPTION
fixes https://github.com/kubernetes/community/issues/6083

Adds a label to the community repo for `area/elections`