### PR TITLE
Pin containerd ubuntu image config

### DIFF
--- a/jobs/e2e_node/containerd/image-config.yaml
+++ b/jobs/e2e_node/containerd/image-config.yaml
@@ -1,6 +1,9 @@
 images:
   ubuntu:
-    image_family: pipeline-1-20
+    # Pinning to image to as part of https://github.com/kubernetes/kubernetes/issues/105381
+    # TODO: Remove this pin, and switch back to image_family
+    image: ubuntu-gke-2004-1-20-v20210928
+    # image_family: pipeline-1-20
     project: ubuntu-os-gke-cloud
     metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"
   cos-stable:


### PR DESCRIPTION
Pinning ubuntu image as part of containerd job to last successful image. See https://github.com/kubernetes/kubernetes/issues/105381