### PR TITLE
releng: Re-enable `ci-k8sio-gcr-prod-backup` job

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -130,19 +130,18 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-gcr-promoter-bak
     containers:
-    - image: k8s.gcr.io/releng/releng-ci:v0.1.1
+    - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
+      imagePullPolicy: Always
       command:
-      - infra/gcp/backup_tools/backup.sh
+      - infra/gcp/bash/backup_tools/backup.sh
       env:
-      # Even though GOPATH is set to /go in the kubekins-e2e image, we set it
-      # here anyway in case the underlying image changes (the backup.sh script
-      # needs it to be defined).
+      # The backup script needs GOPATH to be explicitly defined.
       - name: GOPATH
         value: /go
   annotations:
     testgrid-dashboards: sig-release-releng-blocking
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
-    testgrid-num-failures-to-alert: '1'
+    testgrid-num-failures-to-alert: '2'
   rerun_auth_config:
     github_team_slugs:
       - org: kubernetes


### PR DESCRIPTION
- Fix backup script location (ref: https://github.com/kubernetes/k8s.io/pull/2632, https://github.com/kubernetes/k8s.io/issues/516)
- Loosen failure threshold for alerting (1 --> 2)
- Use `latest-go1.17` variant for releng-ci image

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/priority critical-urgent
/assign @cpanato @ameukam @puerco 
cc: @kubernetes/release-engineering @kubernetes/sig-k8s-infra-leads 