### PR TITLE
config/prow/cluster: remove gke-project boskos pool

### DIFF
--- a/config/prow/cluster/boskos-janitor.yaml
+++ b/config/prow/cluster/boskos-janitor.yaml
@@ -1,35 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: boskos-janitor
-  labels:
-    app: boskos-janitor
-  namespace: test-pods
-spec:
-  replicas: 4  # 4 distributed janitor instances for gke
-  selector:
-    matchLabels:
-      app: boskos-janitor
-  template:
-    metadata:
-      labels:
-        app: boskos-janitor
-    spec:
-      terminationGracePeriodSeconds: 300
-      serviceAccountName: boskos-janitor
-      containers:
-      - name: boskos-janitor
-        image: gcr.io/k8s-staging-boskos/janitor:v20210929-121128f
-        args:
-        - --boskos-url=http://boskos.test-pods.svc.cluster.local.
-        - --resource-type=gke-project
-        - --pool-size=20
-        - --
-        - --hours=0
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
   name: boskos-janitor-nongke
   labels:
     app: boskos-janitor-nongke

--- a/config/prow/cluster/boskos-reaper_deployment.yaml
+++ b/config/prow/cluster/boskos-reaper_deployment.yaml
@@ -21,4 +21,4 @@ spec:
         image: gcr.io/k8s-staging-boskos/reaper:v20210929-121128f
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.
-        - --resource-type=gce-project,gke-project,gpu-project,ingress-project,istio-project,scalability-presubmit-project,scalability-project,aws-account,node-e2e-project
+        - --resource-type=gce-project,gpu-project,ingress-project,istio-project,scalability-presubmit-project,scalability-project,aws-account,node-e2e-project

--- a/config/prow/cluster/boskos-resources.yaml
+++ b/config/prow/cluster/boskos-resources.yaml
@@ -1,15 +1,5 @@
 resources:
 - names:
-  - e2e-gke-gci-ci-master
-  - kubernetes-e2e-gci-gke-updown
-  - kubernetes-e2e-gke-updown
-  - kubernetes-gci-gke-ingress
-  - kubernetes-gci-gke-ingress-1-2
-  - kubernetes-gci-gke-ingress-1-3
-  - kubernetes-gke-ingress
-  state: dirty
-  type: gke-project
-- names:
   - ci-k8s-e2e-gci-tip-gce
   - ci-kubernetes-e2e-gke-gpu
   - e2e-gce-gci-ci-1-4

--- a/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
@@ -67,7 +67,6 @@ local config = {
     {instance: "104.197.27.114:9090", job: "k8s-prow-builds-new-boskos", type: "aws-account", friendly: "AWS account"},
     {instance: "104.197.27.114:9090", job: "k8s-prow-builds-new-boskos", type: "gce-project", friendly: "GCE project"},
     {instance: "35.225.208.117:9090", job: "k8s-infra-prow-builds-boskos", type: "gce-project", friendly: "GCE project (k8s-infra)"},
-    {instance: "104.197.27.114:9090", job: "k8s-prow-builds-new-boskos", type: "gke-project", friendly: "GKE project"},
     {instance: "104.197.27.114:9090", job: "k8s-prow-builds-new-boskos", type: "gpu-project", friendly: "GPU project"},
     {instance: "35.225.208.117:9090", job: "k8s-infra-prow-builds-boskos", type: "gpu-project", friendly: "GPU project (k8s-infra)"},
     {instance: "104.197.27.114:9090", job: "k8s-prow-builds-new-boskos", type: "ingress-project", friendly: "Ingress project"},

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -204,14 +204,6 @@ cloudProviders:
     - --check-leaked-resources
     - --provider=gce
     - --gcp-zone=us-west1-b
-  gke:
-    args:
-    - --check-leaked-resources
-    - --provider=gke
-    - --deployment=gke
-    - --gcp-zone=us-west1-c
-    - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
-    - --gke-environment=test
 
 images:
   cos1:


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/test-infra/issues/23778
- Followup to: https://github.com/kubernetes/test-infra/pull/23818

The remaining jobs that were using gke-project have been removed.

Remove the pool entirely, and reconfigure boskos and the monitoring dashboard to stop referencing it.