### PR TITLE
enable e2e-provider test in release-1.* branch and set it as required for csi-secrets-store

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -181,42 +181,6 @@ presubmits:
       testgrid-tab-name: pr-secrets-store-csi-driver-e2e-azure
       description: "Run e2e test with azure provider for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
-  # TODO(aramase): remove this job after the e2e-provider tests with the kind k8s matrix is made required
-  - name: pull-secrets-store-csi-driver-e2e-provider
-    decorate: true
-    decoration_config:
-      timeout: 25m
-    always_run: true
-    optional: true # change to false once the provider job is stable
-    path_alias: sigs.k8s.io/secrets-store-csi-driver
-    branches:
-    - ^main$
-    labels:
-      # this is required because we want to run kind in docker
-      preset-dind-enabled: "true"
-      # this is required to make CNI installation to succeed for kind
-      preset-kind-volume-mounts: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211001-9bdcb71308-master
-        command:
-          - runner.sh
-        args:
-          - bash
-          - -c
-          - >-
-            ./test/scripts/e2e_provider.sh
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: "4"
-            memory: "4Gi"
-    annotations:
-      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
-      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider
-      description: "Run e2e test with e2e-provider for Secrets Store CSI driver."
-      testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-e2e-deploy-manifest-azure
     decorate: true
     decoration_config:
@@ -418,10 +382,12 @@ presubmits:
     decoration_config:
       timeout: 25m
     always_run: true
-    optional: true # change to false once the provider job is stable
+    optional: false
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
     - ^main$
+    # e2e-provider is only available in release-1.* branches
+    - ^release-1.*
     labels:
       # this is required because we want to run kind in docker
       preset-dind-enabled: "true"
@@ -456,10 +422,12 @@ presubmits:
     decoration_config:
       timeout: 25m
     always_run: true
-    optional: true # change to false once the provider job is stable
+    optional: false
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
     - ^main$
+    # e2e-provider is only available in release-1.* branches
+    - ^release-1.*
     labels:
       # this is required because we want to run kind in docker
       preset-dind-enabled: "true"
@@ -494,10 +462,12 @@ presubmits:
     decoration_config:
       timeout: 25m
     always_run: true
-    optional: true # change to false once the provider job is stable
+    optional: false
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
     - ^main$
+    # e2e-provider is only available in release-1.* branches
+    - ^release-1.*
     labels:
       # this is required because we want to run kind in docker
       preset-dind-enabled: "true"
@@ -532,10 +502,12 @@ presubmits:
     decoration_config:
       timeout: 25m
     always_run: true
-    optional: true # change to false once the provider job is stable
+    optional: false
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
     - ^main$
+    # e2e-provider is only available in release-1.* branches
+    - ^release-1.*
     labels:
       # this is required because we want to run kind in docker
       preset-dind-enabled: "true"


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

- Remove the `pull-secrets-store-csi-driver-e2e-provider` as we now have the same job run as a matrix with 4 kubernetes versions.
- Set all the e2e-provider jobs as required for PR
- Enable e2e-provider jobs to run on `release-1.*` branches in addition to `main`
