### PR TITLE
amending repo-root for kubetest2 jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -128,7 +128,7 @@ presubmits:
         - noop
         - --test=node
         - --
-        - --repo-root=k8s.io/$(REPO_NAME)=$(PULL_REFS)
+        - --repo-root=.
         - --gcp-zone=us-west1-b
         - --parallelism=8
         - --focus-regex='\[NodeConformance\]'
@@ -260,7 +260,7 @@ presubmits:
         - noop
         - --test=node
         - --
-        - --repo-root=k8s.io/$(REPO_NAME)=$(PULL_REFS)
+        - --repo-root=.
         - --gcp-zone=us-west1-b
         - --parallelism=8
         - --focus-regex='\[NodeConformance\]'
@@ -353,7 +353,7 @@ presubmits:
         - noop
         - --test=node
         - --
-        - --repo-root=k8s.io/$(REPO_NAME)=$(PULL_REFS)
+        - --repo-root=.
         - --gcp-project=cri-containerd-node-e2e
         - --gcp-zone=us-central1-b
         - --parallelism=8
@@ -431,7 +431,7 @@ presubmits:
         - noop
         - --test=node
         - --
-        - --repo-root=k8s.io/$(REPO_NAME)=$(PULL_REFS)
+        - --repo-root=.
         - --gcp-project=k8s-jkns-pr-node-e2e
         - --gcp-zone=us-west1-b
         - --parallelism=8


### PR DESCRIPTION
Signed-off-by: Namanl2001 <namanlakhwani@gmail.com>

`k8s.io/$(REPO_NAME)=$(PULL_REFS)` was the old way to set repo-root.
In presubmit jobs prow checkout PR commit in the working directory.

error ref: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/92316/pull-kubernetes-node-e2e-kubetest2/1445004255562829824#1:build-log.txt%3A7

cc: @amwat 