### PR TITLE
images/bootstrap: allow disabling mtu workaround via env var

### DIFF
--- a/images/bootstrap/runner.sh
+++ b/images/bootstrap/runner.sh
@@ -85,8 +85,11 @@ if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
     echo "Done setting up docker in docker."
 
     # https://github.com/kubernetes/test-infra/issues/23741
-    echo "configure iptables to set MTU"
-    iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+    # TODO: default to false if this is proven unnecessary
+    if [[ "${BOOTSTRAP_MTU_WORKAROUND:-"true"}" == "true" ]]; then
+        echo "configure iptables to set MTU"
+        iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+    fi
 fi
 
 trap early_exit_handler INT TERM


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/test-infra/issues/23741
- Followup to: https://github.com/kubernetes/test-infra/pull/23757
- For troubleshooting: https://github.com/kubernetes/kubernetes/issues/105436

This was annoying to roll out to all jobs.  Gate it behind an env var
and default it to true.  We can set the env var to false in the same
preset that sets DOCKER_IN_DOCKER_ENABLED true to roll this out to all
jobs at once without waiting for a bootstrap->bump->kubekins->bump
deployment cycle