### PR TITLE
config/jobs: add pull-kubernetes-integration-1-22-canary

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml
@@ -1738,6 +1738,41 @@ presubmits:
           requests:
             cpu: 1500m
             memory: 7Gi
+  # TODO(spiffxp): remove when finished investigating https://github.com/kubernetes/kubernetes/issues/105436
+  - always_run: false
+    annotations:
+      testgrid-create-test-group: "true"
+    optional: true
+    branches:
+    - release-1.22
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-integration-1-22-canary
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-integration-1-22-canary
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - ./hack/jenkins/test-dockerized.sh
+        command:
+        - runner.sh
+        env:
+        - name: BOOTSTRAP_MTU_WORKAROUND
+          value: "false"
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211004-0ab10d5444-1.22
+        name: ""
+        resources:
+          limits:
+            cpu: "6"
+            memory: 15Gi
+          requests:
+            cpu: "6"
+            memory: 15Gi
+        securityContext:
+          privileged: true
   - always_run: true
     branches:
     - release-1.22

--- a/config/testgrids/kubernetes/presubmits/config.yaml
+++ b/config/testgrids/kubernetes/presubmits/config.yaml
@@ -159,6 +159,9 @@ dashboards:
   - name: pull-kubernetes-node-e2e-alpha-kubetest2
     test_group_name: pull-kubernetes-node-e2e-alpha-kubetest2
     base_options: width=10
+  - name: pull-kubernetes-integration-1-22-canary
+    test_group_name: pull-kubernetes-integration-1-22-canary
+    base_options: width=10
 - name: presubmits-kubernetes-scalability
   dashboard_tab:
   - name: pull-kubernetes-e2e-gce-100-performance


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/test-infra/issues/23741
- Followup to: https://github.com/kubernetes/test-infra/pull/23885
- For troubleshooting: https://github.com/kubernetes/kubernetes/issues/105436

canary job specifically for kubernetes/kubernetes release-1.22 to verify whether disabling the MTU workaround in bootstrap's runner.sh will unblock integration tests