### PR TITLE
releng(kpromo): Bump images to v3.3.0-beta.0-2

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
@@ -13,14 +13,11 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: k8s.gcr.io/artifact-promoter/cip:v3.2.0
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.0-2
         command:
-        - cip
+        - /kpromo
         args:
-        - run
-        # Pod Utilities already sets pwd to
-        # /home/prow/go/src/github.com/{{.Org}}/{{.Repo}}, so just '.' should
-        # suffice, but it's nice to be explicit.
+        - cip
         - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
   # Check that images to be promoted are free of fixable vulnerabilities
   - name: pull-k8sio-cip-vuln
@@ -37,11 +34,11 @@ presubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-vuln-scanning
       containers:
-      - image: k8s.gcr.io/artifact-promoter/cip:v3.2.0
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.0-2
         command:
-        - cip
+        - /kpromo
         args:
-        - run
+        - cip
         - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
         - --vuln-severity-threshold=1
   # Check that changes to backup scripts are valid.
@@ -80,11 +77,10 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.2.0-1
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.0-2
         command:
         - /kpromo
         args:
         - run
         - files
         - --manifests=/home/prow/go/src/github.com/kubernetes/k8s.io/artifacts/
-        - --dry-run=true

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -13,14 +13,14 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-promoter
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.2.0-1
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.0-2
         command:
         - /kpromo
         args:
         - run
         - files
         - --manifests=/home/prow/go/src/github.com/kubernetes/k8s.io/artifacts/
-        - --dry-run=false
+        - --confirm
     annotations:
       testgrid-dashboards: sig-release-releng-blocking, sig-k8s-infra-k8sio
       testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
@@ -38,11 +38,11 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-promoter
       containers:
-      - image: k8s.gcr.io/artifact-promoter/cip:v3.2.0
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.0-2
         command:
-        - cip
+        - /kpromo
         args:
-        - run
+        - cip
         - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
         - --confirm
     annotations:
@@ -64,14 +64,14 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-promoter
     containers:
-    - image: k8s.gcr.io/artifact-promoter/kpromo:v3.2.0-1
+    - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.0-2
       command:
       - /kpromo
       args:
       - run
       - files
       - --manifests=/home/prow/go/src/github.com/kubernetes/k8s.io/artifacts/
-      - --dry-run=false
+      - --confirm
   annotations:
     testgrid-dashboards: sig-release-releng-blocking, sig-k8s-infra-k8sio
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
@@ -102,11 +102,11 @@ periodics:
     # https://github.com/kubernetes/k8s.io/pull/695.
     serviceAccountName: k8s-infra-gcr-promoter
     containers:
-    - image: k8s.gcr.io/artifact-promoter/cip:v3.2.0
+    - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.0-2
       command:
-      - cip
+      - /kpromo
       args:
-      - run
+      - cip
       - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
       - --confirm
   annotations:


### PR DESCRIPTION
Selectively reapplies https://github.com/kubernetes/test-infra/pull/23874 (which was reverted in https://github.com/kubernetes/test-infra/pull/23894) and applies container env changes (docker credential helpers) from https://github.com/kubernetes-sigs/promo-tools/pull/442.

(We'll reapply the change for prow once we've determined this is actually the fix)

Signed-off-by: Stephen Augustus <foo@auggie.dev>

Part of https://github.com/kubernetes/k8s.io/issues/2877.
/hold for the image to be pushed and promoted
/priority critical-urgent
/assign @cpanato @puerco @Verolop @xmudrii 
cc: @kubernetes/release-engineering @spiffxp 