### PR TITLE
config/jobs: disable mtu workaround for secrets-store-csi-driver presubmits

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -18,6 +18,9 @@ presubmits:
         args:
           - make
           - test-style
+        env:
+        - name: BOOTSTRAP_MTU_WORKAROUND
+          value: "false"
         securityContext:
           privileged: true
     annotations:
@@ -43,6 +46,9 @@ presubmits:
         args:
           - make
           - test
+        env:
+        - name: BOOTSTRAP_MTU_WORKAROUND
+          value: "false"
         securityContext:
           privileged: true
     annotations:
@@ -68,6 +74,9 @@ presubmits:
         args:
           - make
           - sanity-test
+        env:
+        - name: BOOTSTRAP_MTU_WORKAROUND
+          value: "false"
         securityContext:
           privileged: true
     annotations:
@@ -98,6 +107,9 @@ presubmits:
             - -c
             - >-
               make container image-scan
+          env:
+          - name: BOOTSTRAP_MTU_WORKAROUND
+            value: "false"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/test-infra/issues/23741
- Followup to: https://github.com/kubernetes/test-infra/pull/23885

Disabling the workaround for jobs that were previously known to be affected, per https://github.com/kubernetes/test-infra/issues/23741#issuecomment-933901984