### PR TITLE
Revert "releng(kpromo): Bump images to v3.3.0-beta.0-2"

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
@@ -13,11 +13,14 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.0-2
+      - image: k8s.gcr.io/artifact-promoter/cip:v3.2.0
         command:
-        - /kpromo
-        args:
         - cip
+        args:
+        - run
+        # Pod Utilities already sets pwd to
+        # /home/prow/go/src/github.com/{{.Org}}/{{.Repo}}, so just '.' should
+        # suffice, but it's nice to be explicit.
         - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
   # Check that images to be promoted are free of fixable vulnerabilities
   - name: pull-k8sio-cip-vuln
@@ -34,11 +37,11 @@ presubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-vuln-scanning
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.0-2
+      - image: k8s.gcr.io/artifact-promoter/cip:v3.2.0
         command:
-        - /kpromo
-        args:
         - cip
+        args:
+        - run
         - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
         - --vuln-severity-threshold=1
   # Check that changes to backup scripts are valid.
@@ -77,10 +80,11 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.0-2
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.2.0-1
         command:
         - /kpromo
         args:
         - run
         - files
         - --manifests=/home/prow/go/src/github.com/kubernetes/k8s.io/artifacts/
+        - --dry-run=true

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -13,14 +13,14 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-promoter
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.0-2
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.2.0-1
         command:
         - /kpromo
         args:
         - run
         - files
         - --manifests=/home/prow/go/src/github.com/kubernetes/k8s.io/artifacts/
-        - --confirm
+        - --dry-run=false
     annotations:
       testgrid-dashboards: sig-release-releng-blocking, sig-k8s-infra-k8sio
       testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
@@ -38,11 +38,11 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-promoter
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.0-2
+      - image: k8s.gcr.io/artifact-promoter/cip:v3.2.0
         command:
-        - /kpromo
-        args:
         - cip
+        args:
+        - run
         - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
         - --confirm
     annotations:
@@ -64,14 +64,14 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-promoter
     containers:
-    - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.0-2
+    - image: k8s.gcr.io/artifact-promoter/kpromo:v3.2.0-1
       command:
       - /kpromo
       args:
       - run
       - files
       - --manifests=/home/prow/go/src/github.com/kubernetes/k8s.io/artifacts/
-      - --confirm
+      - --dry-run=false
   annotations:
     testgrid-dashboards: sig-release-releng-blocking, sig-k8s-infra-k8sio
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
@@ -102,11 +102,11 @@ periodics:
     # https://github.com/kubernetes/k8s.io/pull/695.
     serviceAccountName: k8s-infra-gcr-promoter
     containers:
-    - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.0-2
+    - image: k8s.gcr.io/artifact-promoter/cip:v3.2.0
       command:
-      - /kpromo
-      args:
       - cip
+      args:
+      - run
       - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
       - --confirm
   annotations:


### PR DESCRIPTION
This PR reverts #23896 because we're still running into the `UNAUTHORIZED` errors.
https://github.com/kubernetes-sigs/promo-tools/pull/443 might fix this issue, but let's revert for now to unblock other folks.

Part of kubernetes/k8s.io#2877.
/assign @spiffxp
cc: @kubernetes/release-engineering @CecileRobertMichon @sbueringer 
/priority critical-urgent