### PR TITLE
releng: Artifact promotion job updates

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/releng/OWNERS
+++ b/config/jobs/kubernetes/sig-k8s-infra/releng/OWNERS
@@ -3,11 +3,7 @@
 approvers:
 - release-engineering-approvers
 - promo-tools-approvers
-# TODO(releng): Distill down to SIG K8s Infra leads, once the proposal to
-#               convert to a SIG is approved.
-#               ref: https://github.com/kubernetes/community/pull/5928
 - sig-k8s-infra-leads
-- thockin
 
 reviewers:
 - release-engineering-reviewers

--- a/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
@@ -13,14 +13,11 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: k8s.gcr.io/artifact-promoter/cip:v3.2.0
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.1-2
         command:
-        - cip
+        - /kpromo
         args:
-        - run
-        # Pod Utilities already sets pwd to
-        # /home/prow/go/src/github.com/{{.Org}}/{{.Repo}}, so just '.' should
-        # suffice, but it's nice to be explicit.
+        - cip
         - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
   # Check that images to be promoted are free of fixable vulnerabilities
   - name: pull-k8sio-cip-vuln
@@ -37,11 +34,11 @@ presubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-vuln-scanning
       containers:
-      - image: k8s.gcr.io/artifact-promoter/cip:v3.2.0
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.1-2
         command:
-        - cip
+        - /kpromo
         args:
-        - run
+        - cip
         - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
         - --vuln-severity-threshold=1
   # Check that changes to backup scripts are valid.

--- a/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
@@ -80,11 +80,10 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.2.0-1
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.1-2
         command:
         - /kpromo
         args:
         - run
         - files
         - --manifests=/home/prow/go/src/github.com/kubernetes/k8s.io/artifacts/
-        - --dry-run=true

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -51,7 +51,6 @@ postsubmits:
       testgrid-num-failures-to-alert: '1'
 
 periodics:
-# TODO(releng): Set this to '4h' once testing is complete
 - interval: 1h
   cluster: k8s-infra-prow-build-trusted
   max_concurrency: 1
@@ -81,9 +80,9 @@ periodics:
       - org: kubernetes
         slug: release-managers
 
-# ci-k8sio-image-promo runs every 4 hours, to make sure that the destination
+# ci-k8sio-image-promo runs every 1 hour, to make sure that the destination
 # GCRs do not deviate away from the intent of the manifest.
-- interval: 4h
+- interval: 1h
   cluster: k8s-infra-prow-build-trusted
   max_concurrency: 1
   # This name is the "job name", passed in as "--job=NAME" for mkpj.

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -13,14 +13,14 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-promoter
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.2.0-1
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.1-2
         command:
         - /kpromo
         args:
         - run
         - files
         - --manifests=/home/prow/go/src/github.com/kubernetes/k8s.io/artifacts/
-        - --dry-run=false
+        - --confirm
     annotations:
       testgrid-dashboards: sig-release-releng-blocking, sig-k8s-infra-k8sio
       testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
@@ -64,14 +64,14 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-promoter
     containers:
-    - image: k8s.gcr.io/artifact-promoter/kpromo:v3.2.0-1
+    - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.1-2
       command:
       - /kpromo
       args:
       - run
       - files
       - --manifests=/home/prow/go/src/github.com/kubernetes/k8s.io/artifacts/
-      - --dry-run=false
+      - --confirm
   annotations:
     testgrid-dashboards: sig-release-releng-blocking, sig-k8s-infra-k8sio
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -38,11 +38,11 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-promoter
       containers:
-      - image: k8s.gcr.io/artifact-promoter/cip:v3.2.0
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.1-2
         command:
-        - cip
+        - /kpromo
         args:
-        - run
+        - cip
         - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
         - --confirm
     annotations:
@@ -102,11 +102,11 @@ periodics:
     # https://github.com/kubernetes/k8s.io/pull/695.
     serviceAccountName: k8s-infra-gcr-promoter
     containers:
-    - image: k8s.gcr.io/artifact-promoter/cip:v3.2.0
+    - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.1-2
       command:
-      - cip
+      - /kpromo
       args:
-      - run
+      - cip
       - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
       - --confirm
   annotations:


### PR DESCRIPTION
Part of https://github.com/kubernetes/k8s.io/issues/2877, https://github.com/kubernetes-sigs/promo-tools/pull/443.
Image promotion PR: https://github.com/kubernetes/k8s.io/pull/2886

- file-promo: Bump images to v3.3.0-beta.1-2
- image-promo: Bump images to v3.3.0-beta.1-2 (in a separate commit, so it's easier to revert in case of failures like https://github.com/kubernetes/k8s.io/issues/2877)
- sig-k8s-infra/releng/OWNERS: Drop TODO now that WG is a SIG
- kpromo: Set periodic interval to 1 hour

/assign @xmudrii @puerco @cpanato @Verolop
cc: @kubernetes-sigs/release-engineering @spiffxp