### PR TITLE
releng: Revert `ci-k8sio-image-promo` image to cip:v3.2.0

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -101,11 +101,11 @@ periodics:
     # https://github.com/kubernetes/k8s.io/pull/695.
     serviceAccountName: k8s-infra-gcr-promoter
     containers:
-    - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.1-2
+    - image: k8s.gcr.io/artifact-promoter/cip:v3.2.0
       command:
-      - /kpromo
-      args:
       - cip
+      args:
+      - run
       - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
       - --confirm
   annotations:


### PR DESCRIPTION
Unfortunately, this is still failing: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-k8sio-image-promo/1445870860970758144

Here we selectively revert https://github.com/kubernetes/test-infra/pull/23913.
The `ci-k8sio-image-promo` job (which on average will run more frequently than the postsubmit) is reverted to a known working image to ensure promotions are happening, while the postsubmit will be rolled forward as we attempt to solve https://github.com/kubernetes-sigs/promo-tools/issues/444.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @puerco @xmudrii @Verolop @cpanato 
cc: @kubernetes/release-engineering 