### PR TITLE
releng(kpromo): Bump images to v3.3.0-beta.1-3

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.1-2
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.1-3
         command:
         - /kpromo
         args:
@@ -34,7 +34,7 @@ presubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-vuln-scanning
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.1-2
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.1-3
         command:
         - /kpromo
         args:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -38,7 +38,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-promoter
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.1-2
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.1-3
         command:
         - /kpromo
         args:


### PR DESCRIPTION
Image bump for https://github.com/kubernetes-sigs/promo-tools/pull/446, https://github.com/kubernetes/k8s.io/pull/2888.
Part of https://github.com/kubernetes-sigs/promo-tools/issues/444.

- releng(file-promo): Bump images to v3.3.0-beta.1-3
- releng(image-promo): Bump images to v3.3.0-beta.1-3

/assign @puerco @xmudrii @Verolop @cpanato
cc: @kubernetes/release-engineering