### PR TITLE
Kops - remove kubetest2 dashboard

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -175,7 +175,6 @@ def build_test(cloud='aws',
 
     dashboards = [
         'sig-cluster-lifecycle-kops',
-        'kops-kubetest2',
         f"kops-distro-{distro}",
         f"kops-k8s-{k8s_version or 'latest'}",
         f"kops-{kops_version or 'latest'}",
@@ -302,7 +301,6 @@ def presubmit_test(branch='master',
         'presubmits-kops',
         'kops-presubmits',
         'sig-cluster-lifecycle-kops',
-        'kops-kubetest2',
         f"kops-distro-{distro}",
         f"kops-k8s-{k8s_version or 'latest'}",
     ]

--- a/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
@@ -61,7 +61,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-deb9, kops-distros, kops-k8s-stable, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb9, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-imagedebian9
 
@@ -124,7 +124,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-distros, kops-k8s-stable, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-imagedebian10
 
@@ -187,7 +187,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-deb11, kops-distros, kops-k8s-stable, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb11, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-imagedebian11
 
@@ -250,7 +250,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u1804, kops-distros, kops-k8s-stable, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u1804, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-imageubuntu1804
 
@@ -313,7 +313,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-distros, kops-k8s-stable, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-imageubuntu2004
 
@@ -376,7 +376,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2104, kops-distros, kops-k8s-stable, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2104, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-imageubuntu2104
 
@@ -439,7 +439,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-centos7, kops-distros, kops-k8s-stable, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-centos7, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-imagecentos7
 
@@ -502,7 +502,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-centos8, kops-distros, kops-k8s-stable, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-centos8, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-imagecentos8
 
@@ -565,7 +565,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-distros, kops-k8s-stable, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-imageamazonlinux2
 
@@ -628,7 +628,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-rhel7, kops-distros, kops-k8s-stable, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel7, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-imagerhel7
 
@@ -691,7 +691,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-distros, kops-k8s-stable, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-imagerhel8
 
@@ -755,6 +755,6 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-distros, kops-k8s-stable, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-imageflatcar

--- a/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
@@ -59,7 +59,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: google-kops-gce, kops-distro-u2004, kops-gce, kops-k8s-latest, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-kops-gce, kops-distro-u2004, kops-gce, kops-k8s-latest, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '40'
     testgrid-tab-name: kops-gce-stable
 
@@ -125,6 +125,6 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: google-kops-gce, kops-distro-u2004, kops-gce, kops-k8s-latest, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-kops-gce, kops-distro-u2004, kops-gce, kops-k8s-latest, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '40'
     testgrid-tab-name: kops-gce-latest

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -61,7 +61,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k20-docker
 
@@ -124,7 +124,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k20-ko21-docker
 
@@ -187,7 +187,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k20-ko22-docker
 
@@ -250,7 +250,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k21-docker
 
@@ -313,7 +313,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k21-ko21-docker
 
@@ -376,7 +376,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k21-ko22-docker
 
@@ -439,7 +439,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k22-docker
 
@@ -502,7 +502,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k22-ko22-docker
 
@@ -565,7 +565,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k20-ko21-docker
 
@@ -628,7 +628,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k20-ko22-docker
 
@@ -691,7 +691,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k21-ko21-docker
 
@@ -754,7 +754,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k21-ko22-docker
 
@@ -817,7 +817,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k22-ko22-docker
 
@@ -880,7 +880,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k20-docker
 
@@ -943,7 +943,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k20-ko21-docker
 
@@ -1006,7 +1006,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k20-ko22-docker
 
@@ -1069,7 +1069,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k21-docker
 
@@ -1132,7 +1132,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k21-ko21-docker
 
@@ -1195,7 +1195,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k21-ko22-docker
 
@@ -1258,7 +1258,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k22-docker
 
@@ -1321,7 +1321,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k22-ko22-docker
 
@@ -1385,7 +1385,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k20-docker
 
@@ -1449,7 +1449,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k20-ko21-docker
 
@@ -1513,7 +1513,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k20-ko22-docker
 
@@ -1577,7 +1577,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k21-docker
 
@@ -1641,7 +1641,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k21-ko21-docker
 
@@ -1705,7 +1705,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k21-ko22-docker
 
@@ -1769,7 +1769,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k22-docker
 
@@ -1833,7 +1833,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k22-ko22-docker
 
@@ -1896,7 +1896,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k20-ko21-docker
 
@@ -1959,7 +1959,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k20-ko22-docker
 
@@ -2022,7 +2022,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k21-ko21-docker
 
@@ -2085,7 +2085,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k21-ko22-docker
 
@@ -2148,7 +2148,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k22-ko22-docker
 
@@ -2211,7 +2211,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k20-docker
 
@@ -2274,7 +2274,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k20-ko21-docker
 
@@ -2337,7 +2337,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k20-ko22-docker
 
@@ -2400,7 +2400,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k21-docker
 
@@ -2463,7 +2463,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k21-ko21-docker
 
@@ -2526,7 +2526,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k21-ko22-docker
 
@@ -2589,7 +2589,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k22-docker
 
@@ -2652,7 +2652,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k22-ko22-docker
 
@@ -2715,7 +2715,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k20-ko21-docker
 
@@ -2778,7 +2778,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k20-ko22-docker
 
@@ -2841,7 +2841,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k21-ko21-docker
 
@@ -2904,7 +2904,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k21-ko22-docker
 
@@ -2967,7 +2967,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k22-ko22-docker
 
@@ -3030,7 +3030,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k20-docker
 
@@ -3093,7 +3093,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k20-ko21-docker
 
@@ -3156,7 +3156,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k20-ko22-docker
 
@@ -3219,7 +3219,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k21-docker
 
@@ -3282,7 +3282,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k21-ko21-docker
 
@@ -3345,7 +3345,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k21-ko22-docker
 
@@ -3408,7 +3408,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k22-docker
 
@@ -3471,7 +3471,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k22-ko22-docker
 
@@ -3534,7 +3534,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k20-docker
 
@@ -3597,7 +3597,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k20-ko21-docker
 
@@ -3660,7 +3660,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k20-ko22-docker
 
@@ -3723,7 +3723,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k21-docker
 
@@ -3786,7 +3786,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k21-ko21-docker
 
@@ -3849,7 +3849,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k21-ko22-docker
 
@@ -3912,7 +3912,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k22-docker
 
@@ -3975,7 +3975,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k22-ko22-docker
 
@@ -4038,7 +4038,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k20-ko21-docker
 
@@ -4101,7 +4101,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k20-ko22-docker
 
@@ -4164,7 +4164,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k21-ko21-docker
 
@@ -4227,7 +4227,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k21-ko22-docker
 
@@ -4290,7 +4290,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k22-ko22-docker
 
@@ -4353,7 +4353,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k20-docker
 
@@ -4416,7 +4416,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k20-ko21-docker
 
@@ -4479,7 +4479,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k20-ko22-docker
 
@@ -4542,7 +4542,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k21-docker
 
@@ -4605,7 +4605,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k21-ko21-docker
 
@@ -4668,7 +4668,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k21-ko22-docker
 
@@ -4731,7 +4731,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k22-docker
 
@@ -4794,7 +4794,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k22-ko22-docker
 
@@ -4858,7 +4858,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k20-docker
 
@@ -4922,7 +4922,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k20-ko21-docker
 
@@ -4986,7 +4986,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k20-ko22-docker
 
@@ -5050,7 +5050,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k21-docker
 
@@ -5114,7 +5114,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k21-ko21-docker
 
@@ -5178,7 +5178,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k21-ko22-docker
 
@@ -5242,7 +5242,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k22-docker
 
@@ -5306,7 +5306,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k22-ko22-docker
 
@@ -5369,7 +5369,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k20-ko21-docker
 
@@ -5432,7 +5432,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k20-ko22-docker
 
@@ -5495,7 +5495,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k21-ko21-docker
 
@@ -5558,7 +5558,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k21-ko22-docker
 
@@ -5621,7 +5621,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k22-ko22-docker
 
@@ -5684,7 +5684,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k20-docker
 
@@ -5747,7 +5747,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k20-ko21-docker
 
@@ -5810,7 +5810,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k20-ko22-docker
 
@@ -5873,7 +5873,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k21-docker
 
@@ -5936,7 +5936,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k21-ko21-docker
 
@@ -5999,7 +5999,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k21-ko22-docker
 
@@ -6062,7 +6062,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k22-docker
 
@@ -6125,7 +6125,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k22-ko22-docker
 
@@ -6188,7 +6188,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k20-ko21-docker
 
@@ -6251,7 +6251,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k20-ko22-docker
 
@@ -6314,7 +6314,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k21-ko21-docker
 
@@ -6377,7 +6377,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k21-ko22-docker
 
@@ -6440,7 +6440,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k22-ko22-docker
 
@@ -6503,7 +6503,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k20-docker
 
@@ -6566,7 +6566,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k20-ko21-docker
 
@@ -6629,7 +6629,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k20-ko22-docker
 
@@ -6692,7 +6692,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k21-docker
 
@@ -6755,7 +6755,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k21-ko21-docker
 
@@ -6818,7 +6818,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k21-ko22-docker
 
@@ -6881,7 +6881,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k22-docker
 
@@ -6944,7 +6944,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k22-ko22-docker
 
@@ -7007,7 +7007,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k20-docker
 
@@ -7070,7 +7070,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k20-ko21-docker
 
@@ -7133,7 +7133,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k20-ko22-docker
 
@@ -7196,7 +7196,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k21-docker
 
@@ -7259,7 +7259,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k21-ko21-docker
 
@@ -7322,7 +7322,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k21-ko22-docker
 
@@ -7385,7 +7385,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k22-docker
 
@@ -7448,7 +7448,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k22-ko22-docker
 
@@ -7511,7 +7511,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k20-docker
 
@@ -7574,7 +7574,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k20-ko21-docker
 
@@ -7637,7 +7637,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k20-ko22-docker
 
@@ -7700,7 +7700,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k21-docker
 
@@ -7763,7 +7763,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k21-ko21-docker
 
@@ -7826,7 +7826,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k21-ko22-docker
 
@@ -7889,7 +7889,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k22-docker
 
@@ -7952,7 +7952,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k22-ko22-docker
 
@@ -8015,7 +8015,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k20-docker
 
@@ -8078,7 +8078,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k20-ko21-docker
 
@@ -8141,7 +8141,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k20-ko22-docker
 
@@ -8204,7 +8204,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k21-docker
 
@@ -8267,7 +8267,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k21-ko21-docker
 
@@ -8330,7 +8330,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k21-ko22-docker
 
@@ -8393,7 +8393,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k22-docker
 
@@ -8456,7 +8456,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k22-ko22-docker
 
@@ -8519,7 +8519,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k20-docker
 
@@ -8582,7 +8582,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k20-ko21-docker
 
@@ -8645,7 +8645,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k20-ko22-docker
 
@@ -8708,7 +8708,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k21-docker
 
@@ -8771,7 +8771,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k21-ko21-docker
 
@@ -8834,7 +8834,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k21-ko22-docker
 
@@ -8897,7 +8897,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k22-docker
 
@@ -8960,7 +8960,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k22-ko22-docker
 
@@ -9023,7 +9023,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k20-docker
 
@@ -9086,7 +9086,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k20-ko21-docker
 
@@ -9149,7 +9149,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k20-ko22-docker
 
@@ -9212,7 +9212,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k21-docker
 
@@ -9275,7 +9275,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k21-ko21-docker
 
@@ -9338,7 +9338,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k21-ko22-docker
 
@@ -9401,7 +9401,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k22-docker
 
@@ -9464,7 +9464,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k22-ko22-docker
 
@@ -9527,7 +9527,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb10-k20-docker
 
@@ -9590,7 +9590,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb10-k20-ko21-docker
 
@@ -9653,7 +9653,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb10-k20-ko22-docker
 
@@ -9716,7 +9716,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb10-k21-docker
 
@@ -9779,7 +9779,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb10-k21-ko21-docker
 
@@ -9842,7 +9842,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb10-k21-ko22-docker
 
@@ -9905,7 +9905,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb10-k22-docker
 
@@ -9968,7 +9968,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb10-k22-ko22-docker
 
@@ -10031,7 +10031,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k20-docker
 
@@ -10094,7 +10094,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k20-ko21-docker
 
@@ -10157,7 +10157,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k20-ko22-docker
 
@@ -10220,7 +10220,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k21-docker
 
@@ -10283,7 +10283,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k21-ko21-docker
 
@@ -10346,7 +10346,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k21-ko22-docker
 
@@ -10409,7 +10409,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k22-docker
 
@@ -10472,7 +10472,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k22-ko22-docker
 
@@ -10535,7 +10535,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k20-docker
 
@@ -10598,7 +10598,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k20-ko21-docker
 
@@ -10661,7 +10661,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k20-ko22-docker
 
@@ -10724,7 +10724,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k21-docker
 
@@ -10787,7 +10787,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k21-ko21-docker
 
@@ -10850,7 +10850,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k21-ko22-docker
 
@@ -10913,7 +10913,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k22-docker
 
@@ -10976,7 +10976,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k22-ko22-docker
 
@@ -11039,7 +11039,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k20-docker
 
@@ -11102,7 +11102,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k20-ko21-docker
 
@@ -11165,7 +11165,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k20-ko22-docker
 
@@ -11228,7 +11228,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k21-docker
 
@@ -11291,7 +11291,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k21-ko21-docker
 
@@ -11354,7 +11354,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k21-ko22-docker
 
@@ -11417,7 +11417,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k22-docker
 
@@ -11480,7 +11480,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k22-ko22-docker
 
@@ -11543,7 +11543,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k20-ko21-docker
 
@@ -11606,7 +11606,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k20-ko22-docker
 
@@ -11669,7 +11669,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k21-ko21-docker
 
@@ -11732,7 +11732,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k21-ko22-docker
 
@@ -11795,7 +11795,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k22-ko22-docker
 
@@ -11858,7 +11858,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k20-docker
 
@@ -11921,7 +11921,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k20-ko21-docker
 
@@ -11984,7 +11984,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k20-ko22-docker
 
@@ -12047,7 +12047,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k21-docker
 
@@ -12110,7 +12110,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k21-ko21-docker
 
@@ -12173,7 +12173,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k21-ko22-docker
 
@@ -12236,7 +12236,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k22-docker
 
@@ -12299,7 +12299,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k22-ko22-docker
 
@@ -12363,7 +12363,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k20-docker
 
@@ -12427,7 +12427,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k20-ko21-docker
 
@@ -12491,7 +12491,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k20-ko22-docker
 
@@ -12555,7 +12555,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k21-docker
 
@@ -12619,7 +12619,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k21-ko21-docker
 
@@ -12683,7 +12683,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k21-ko22-docker
 
@@ -12747,7 +12747,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k22-docker
 
@@ -12811,7 +12811,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k22-ko22-docker
 
@@ -12874,7 +12874,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k20-ko21-docker
 
@@ -12937,7 +12937,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k20-ko22-docker
 
@@ -13000,7 +13000,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k21-ko21-docker
 
@@ -13063,7 +13063,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k21-ko22-docker
 
@@ -13126,7 +13126,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k22-ko22-docker
 
@@ -13189,7 +13189,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k20-docker
 
@@ -13252,7 +13252,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k20-ko21-docker
 
@@ -13315,7 +13315,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k20-ko22-docker
 
@@ -13378,7 +13378,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k21-docker
 
@@ -13441,7 +13441,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k21-ko21-docker
 
@@ -13504,7 +13504,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k21-ko22-docker
 
@@ -13567,7 +13567,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k22-docker
 
@@ -13630,7 +13630,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k22-ko22-docker
 
@@ -13693,7 +13693,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k20-ko21-docker
 
@@ -13756,7 +13756,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k20-ko22-docker
 
@@ -13819,7 +13819,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k21-ko21-docker
 
@@ -13882,7 +13882,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k21-ko22-docker
 
@@ -13945,7 +13945,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k22-ko22-docker
 
@@ -14008,7 +14008,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k20-docker
 
@@ -14071,7 +14071,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k20-ko21-docker
 
@@ -14134,7 +14134,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k20-ko22-docker
 
@@ -14197,7 +14197,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k21-docker
 
@@ -14260,7 +14260,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k21-ko21-docker
 
@@ -14323,7 +14323,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k21-ko22-docker
 
@@ -14386,7 +14386,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k22-docker
 
@@ -14449,7 +14449,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k22-ko22-docker
 
@@ -14512,7 +14512,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k20-docker
 
@@ -14575,7 +14575,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k20-ko21-docker
 
@@ -14638,7 +14638,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k20-ko22-docker
 
@@ -14701,7 +14701,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k21-docker
 
@@ -14764,7 +14764,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k21-ko21-docker
 
@@ -14827,7 +14827,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k21-ko22-docker
 
@@ -14890,7 +14890,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k22-docker
 
@@ -14953,7 +14953,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k22-ko22-docker
 
@@ -15016,7 +15016,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k20-ko21-docker
 
@@ -15079,7 +15079,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k20-ko22-docker
 
@@ -15142,7 +15142,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k21-ko21-docker
 
@@ -15205,7 +15205,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k21-ko22-docker
 
@@ -15268,7 +15268,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k22-ko22-docker
 
@@ -15331,7 +15331,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k20-docker
 
@@ -15394,7 +15394,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k20-ko21-docker
 
@@ -15457,7 +15457,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k20-ko22-docker
 
@@ -15520,7 +15520,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k21-docker
 
@@ -15583,7 +15583,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k21-ko21-docker
 
@@ -15646,7 +15646,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k21-ko22-docker
 
@@ -15709,7 +15709,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k22-docker
 
@@ -15772,7 +15772,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k22-ko22-docker
 
@@ -15836,7 +15836,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k20-docker
 
@@ -15900,7 +15900,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k20-ko21-docker
 
@@ -15964,7 +15964,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k20-ko22-docker
 
@@ -16028,7 +16028,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k21-docker
 
@@ -16092,7 +16092,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k21-ko21-docker
 
@@ -16156,7 +16156,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k21-ko22-docker
 
@@ -16220,7 +16220,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k22-docker
 
@@ -16284,7 +16284,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k22-ko22-docker
 
@@ -16347,7 +16347,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k20-ko21-docker
 
@@ -16410,7 +16410,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k20-ko22-docker
 
@@ -16473,7 +16473,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k21-ko21-docker
 
@@ -16536,7 +16536,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k21-ko22-docker
 
@@ -16599,7 +16599,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k22-ko22-docker
 
@@ -16662,7 +16662,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k20-docker
 
@@ -16725,7 +16725,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k20-ko21-docker
 
@@ -16788,7 +16788,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k20-ko22-docker
 
@@ -16851,7 +16851,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k21-docker
 
@@ -16914,7 +16914,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k21-ko21-docker
 
@@ -16977,7 +16977,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k21-ko22-docker
 
@@ -17040,7 +17040,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k22-docker
 
@@ -17103,7 +17103,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k22-ko22-docker
 
@@ -17166,7 +17166,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k20-ko21-docker
 
@@ -17229,7 +17229,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k20-ko22-docker
 
@@ -17292,7 +17292,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k21-ko21-docker
 
@@ -17355,7 +17355,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k21-ko22-docker
 
@@ -17418,7 +17418,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k22-ko22-docker
 
@@ -17481,7 +17481,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k20-docker
 
@@ -17544,7 +17544,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k20-ko21-docker
 
@@ -17607,7 +17607,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k20-ko22-docker
 
@@ -17670,7 +17670,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k21-docker
 
@@ -17733,7 +17733,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k21-ko21-docker
 
@@ -17796,7 +17796,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k21-ko22-docker
 
@@ -17859,7 +17859,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k22-docker
 
@@ -17922,7 +17922,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k22-ko22-docker
 
@@ -17985,7 +17985,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k20-containerd
 
@@ -18048,7 +18048,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k20-ko21-containerd
 
@@ -18111,7 +18111,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k20-ko22-containerd
 
@@ -18174,7 +18174,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k21-containerd
 
@@ -18237,7 +18237,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k21-ko21-containerd
 
@@ -18300,7 +18300,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k21-ko22-containerd
 
@@ -18363,7 +18363,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k22-containerd
 
@@ -18426,7 +18426,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k22-ko22-containerd
 
@@ -18489,7 +18489,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k20-ko21-containerd
 
@@ -18552,7 +18552,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k20-ko22-containerd
 
@@ -18615,7 +18615,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k21-ko21-containerd
 
@@ -18678,7 +18678,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k21-ko22-containerd
 
@@ -18741,7 +18741,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k22-ko22-containerd
 
@@ -18804,7 +18804,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k20-containerd
 
@@ -18867,7 +18867,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k20-ko21-containerd
 
@@ -18930,7 +18930,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k20-ko22-containerd
 
@@ -18993,7 +18993,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k21-containerd
 
@@ -19056,7 +19056,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k21-ko21-containerd
 
@@ -19119,7 +19119,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k21-ko22-containerd
 
@@ -19182,7 +19182,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k22-containerd
 
@@ -19245,7 +19245,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k22-ko22-containerd
 
@@ -19309,7 +19309,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k20-containerd
 
@@ -19373,7 +19373,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k20-ko21-containerd
 
@@ -19437,7 +19437,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k20-ko22-containerd
 
@@ -19501,7 +19501,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k21-containerd
 
@@ -19565,7 +19565,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k21-ko21-containerd
 
@@ -19629,7 +19629,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k21-ko22-containerd
 
@@ -19693,7 +19693,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k22-containerd
 
@@ -19757,7 +19757,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k22-ko22-containerd
 
@@ -19820,7 +19820,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k20-ko21-containerd
 
@@ -19883,7 +19883,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k20-ko22-containerd
 
@@ -19946,7 +19946,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k21-ko21-containerd
 
@@ -20009,7 +20009,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k21-ko22-containerd
 
@@ -20072,7 +20072,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k22-ko22-containerd
 
@@ -20135,7 +20135,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k20-containerd
 
@@ -20198,7 +20198,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k20-ko21-containerd
 
@@ -20261,7 +20261,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k20-ko22-containerd
 
@@ -20324,7 +20324,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k21-containerd
 
@@ -20387,7 +20387,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k21-ko21-containerd
 
@@ -20450,7 +20450,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k21-ko22-containerd
 
@@ -20513,7 +20513,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k22-containerd
 
@@ -20576,7 +20576,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k22-ko22-containerd
 
@@ -20639,7 +20639,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k20-ko21-containerd
 
@@ -20702,7 +20702,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k20-ko22-containerd
 
@@ -20765,7 +20765,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k21-ko21-containerd
 
@@ -20828,7 +20828,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k21-ko22-containerd
 
@@ -20891,7 +20891,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k22-ko22-containerd
 
@@ -20954,7 +20954,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k20-containerd
 
@@ -21017,7 +21017,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k20-ko21-containerd
 
@@ -21080,7 +21080,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k20-ko22-containerd
 
@@ -21143,7 +21143,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k21-containerd
 
@@ -21206,7 +21206,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k21-ko21-containerd
 
@@ -21269,7 +21269,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k21-ko22-containerd
 
@@ -21332,7 +21332,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k22-containerd
 
@@ -21395,7 +21395,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k22-ko22-containerd
 
@@ -21458,7 +21458,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k20-containerd
 
@@ -21521,7 +21521,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k20-ko21-containerd
 
@@ -21584,7 +21584,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k20-ko22-containerd
 
@@ -21647,7 +21647,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k21-containerd
 
@@ -21710,7 +21710,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k21-ko21-containerd
 
@@ -21773,7 +21773,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k21-ko22-containerd
 
@@ -21836,7 +21836,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k22-containerd
 
@@ -21899,7 +21899,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k22-ko22-containerd
 
@@ -21962,7 +21962,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k20-ko21-containerd
 
@@ -22025,7 +22025,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k20-ko22-containerd
 
@@ -22088,7 +22088,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k21-ko21-containerd
 
@@ -22151,7 +22151,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k21-ko22-containerd
 
@@ -22214,7 +22214,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k22-ko22-containerd
 
@@ -22277,7 +22277,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k20-containerd
 
@@ -22340,7 +22340,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k20-ko21-containerd
 
@@ -22403,7 +22403,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k20-ko22-containerd
 
@@ -22466,7 +22466,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k21-containerd
 
@@ -22529,7 +22529,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k21-ko21-containerd
 
@@ -22592,7 +22592,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k21-ko22-containerd
 
@@ -22655,7 +22655,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k22-containerd
 
@@ -22718,7 +22718,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k22-ko22-containerd
 
@@ -22782,7 +22782,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k20-containerd
 
@@ -22846,7 +22846,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k20-ko21-containerd
 
@@ -22910,7 +22910,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k20-ko22-containerd
 
@@ -22974,7 +22974,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k21-containerd
 
@@ -23038,7 +23038,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k21-ko21-containerd
 
@@ -23102,7 +23102,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k21-ko22-containerd
 
@@ -23166,7 +23166,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k22-containerd
 
@@ -23230,7 +23230,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k22-ko22-containerd
 
@@ -23293,7 +23293,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k20-ko21-containerd
 
@@ -23356,7 +23356,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k20-ko22-containerd
 
@@ -23419,7 +23419,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k21-ko21-containerd
 
@@ -23482,7 +23482,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k21-ko22-containerd
 
@@ -23545,7 +23545,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k22-ko22-containerd
 
@@ -23608,7 +23608,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k20-containerd
 
@@ -23671,7 +23671,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k20-ko21-containerd
 
@@ -23734,7 +23734,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k20-ko22-containerd
 
@@ -23797,7 +23797,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k21-containerd
 
@@ -23860,7 +23860,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k21-ko21-containerd
 
@@ -23923,7 +23923,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k21-ko22-containerd
 
@@ -23986,7 +23986,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k22-containerd
 
@@ -24049,7 +24049,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k22-ko22-containerd
 
@@ -24112,7 +24112,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k20-ko21-containerd
 
@@ -24175,7 +24175,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k20-ko22-containerd
 
@@ -24238,7 +24238,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k21-ko21-containerd
 
@@ -24301,7 +24301,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k21-ko22-containerd
 
@@ -24364,7 +24364,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k22-ko22-containerd
 
@@ -24427,7 +24427,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k20-containerd
 
@@ -24490,7 +24490,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k20-ko21-containerd
 
@@ -24553,7 +24553,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k20-ko22-containerd
 
@@ -24616,7 +24616,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k21-containerd
 
@@ -24679,7 +24679,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k21-ko21-containerd
 
@@ -24742,7 +24742,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k21-ko22-containerd
 
@@ -24805,7 +24805,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k22-containerd
 
@@ -24868,7 +24868,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k22-ko22-containerd
 
@@ -24931,7 +24931,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k20-containerd
 
@@ -24994,7 +24994,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k20-ko21-containerd
 
@@ -25057,7 +25057,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k20-ko22-containerd
 
@@ -25120,7 +25120,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k21-containerd
 
@@ -25183,7 +25183,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k21-ko21-containerd
 
@@ -25246,7 +25246,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k21-ko22-containerd
 
@@ -25309,7 +25309,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k22-containerd
 
@@ -25372,7 +25372,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k22-ko22-containerd
 
@@ -25435,7 +25435,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k20-containerd
 
@@ -25498,7 +25498,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k20-ko21-containerd
 
@@ -25561,7 +25561,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k20-ko22-containerd
 
@@ -25624,7 +25624,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k21-containerd
 
@@ -25687,7 +25687,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k21-ko21-containerd
 
@@ -25750,7 +25750,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k21-ko22-containerd
 
@@ -25813,7 +25813,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k22-containerd
 
@@ -25876,7 +25876,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k22-ko22-containerd
 
@@ -25939,7 +25939,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k20-containerd
 
@@ -26002,7 +26002,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k20-ko21-containerd
 
@@ -26065,7 +26065,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k20-ko22-containerd
 
@@ -26128,7 +26128,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k21-containerd
 
@@ -26191,7 +26191,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k21-ko21-containerd
 
@@ -26254,7 +26254,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k21-ko22-containerd
 
@@ -26317,7 +26317,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k22-containerd
 
@@ -26380,7 +26380,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k22-ko22-containerd
 
@@ -26443,7 +26443,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k20-containerd
 
@@ -26506,7 +26506,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k20-ko21-containerd
 
@@ -26569,7 +26569,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k20-ko22-containerd
 
@@ -26632,7 +26632,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k21-containerd
 
@@ -26695,7 +26695,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k21-ko21-containerd
 
@@ -26758,7 +26758,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k21-ko22-containerd
 
@@ -26821,7 +26821,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k22-containerd
 
@@ -26884,7 +26884,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k22-ko22-containerd
 
@@ -26947,7 +26947,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k20-containerd
 
@@ -27010,7 +27010,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k20-ko21-containerd
 
@@ -27073,7 +27073,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k20-ko22-containerd
 
@@ -27136,7 +27136,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k21-containerd
 
@@ -27199,7 +27199,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k21-ko21-containerd
 
@@ -27262,7 +27262,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k21-ko22-containerd
 
@@ -27325,7 +27325,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k22-containerd
 
@@ -27388,7 +27388,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k22-ko22-containerd
 
@@ -27451,7 +27451,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb10-k20-containerd
 
@@ -27514,7 +27514,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb10-k20-ko21-containerd
 
@@ -27577,7 +27577,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb10-k20-ko22-containerd
 
@@ -27640,7 +27640,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb10-k21-containerd
 
@@ -27703,7 +27703,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb10-k21-ko21-containerd
 
@@ -27766,7 +27766,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb10-k21-ko22-containerd
 
@@ -27829,7 +27829,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb10-k22-containerd
 
@@ -27892,7 +27892,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb10-k22-ko22-containerd
 
@@ -27955,7 +27955,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k20-containerd
 
@@ -28018,7 +28018,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k20-ko21-containerd
 
@@ -28081,7 +28081,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k20-ko22-containerd
 
@@ -28144,7 +28144,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k21-containerd
 
@@ -28207,7 +28207,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k21-ko21-containerd
 
@@ -28270,7 +28270,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k21-ko22-containerd
 
@@ -28333,7 +28333,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k22-containerd
 
@@ -28396,7 +28396,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k22-ko22-containerd
 
@@ -28459,7 +28459,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k20-containerd
 
@@ -28522,7 +28522,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k20-ko21-containerd
 
@@ -28585,7 +28585,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k20-ko22-containerd
 
@@ -28648,7 +28648,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k21-containerd
 
@@ -28711,7 +28711,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k21-ko21-containerd
 
@@ -28774,7 +28774,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k21-ko22-containerd
 
@@ -28837,7 +28837,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k22-containerd
 
@@ -28900,7 +28900,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k22-ko22-containerd
 
@@ -28963,7 +28963,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k20-containerd
 
@@ -29026,7 +29026,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k20-ko21-containerd
 
@@ -29089,7 +29089,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k20-ko22-containerd
 
@@ -29152,7 +29152,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k21-containerd
 
@@ -29215,7 +29215,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k21-ko21-containerd
 
@@ -29278,7 +29278,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k21-ko22-containerd
 
@@ -29341,7 +29341,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k22-containerd
 
@@ -29404,7 +29404,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k22-ko22-containerd
 
@@ -29467,7 +29467,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k20-ko21-containerd
 
@@ -29530,7 +29530,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k20-ko22-containerd
 
@@ -29593,7 +29593,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k21-ko21-containerd
 
@@ -29656,7 +29656,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k21-ko22-containerd
 
@@ -29719,7 +29719,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k22-ko22-containerd
 
@@ -29782,7 +29782,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k20-containerd
 
@@ -29845,7 +29845,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k20-ko21-containerd
 
@@ -29908,7 +29908,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k20-ko22-containerd
 
@@ -29971,7 +29971,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k21-containerd
 
@@ -30034,7 +30034,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k21-ko21-containerd
 
@@ -30097,7 +30097,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k21-ko22-containerd
 
@@ -30160,7 +30160,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k22-containerd
 
@@ -30223,7 +30223,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k22-ko22-containerd
 
@@ -30287,7 +30287,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k20-containerd
 
@@ -30351,7 +30351,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k20-ko21-containerd
 
@@ -30415,7 +30415,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k20-ko22-containerd
 
@@ -30479,7 +30479,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k21-containerd
 
@@ -30543,7 +30543,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k21-ko21-containerd
 
@@ -30607,7 +30607,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k21-ko22-containerd
 
@@ -30671,7 +30671,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k22-containerd
 
@@ -30735,7 +30735,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k22-ko22-containerd
 
@@ -30798,7 +30798,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k20-ko21-containerd
 
@@ -30861,7 +30861,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k20-ko22-containerd
 
@@ -30924,7 +30924,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k21-ko21-containerd
 
@@ -30987,7 +30987,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k21-ko22-containerd
 
@@ -31050,7 +31050,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k22-ko22-containerd
 
@@ -31113,7 +31113,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k20-containerd
 
@@ -31176,7 +31176,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k20-ko21-containerd
 
@@ -31239,7 +31239,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k20-ko22-containerd
 
@@ -31302,7 +31302,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k21-containerd
 
@@ -31365,7 +31365,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k21-ko21-containerd
 
@@ -31428,7 +31428,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k21-ko22-containerd
 
@@ -31491,7 +31491,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k22-containerd
 
@@ -31554,7 +31554,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k22-ko22-containerd
 
@@ -31617,7 +31617,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k20-ko21-containerd
 
@@ -31680,7 +31680,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k20-ko22-containerd
 
@@ -31743,7 +31743,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k21-ko21-containerd
 
@@ -31806,7 +31806,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k21-ko22-containerd
 
@@ -31869,7 +31869,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k22-ko22-containerd
 
@@ -31932,7 +31932,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k20-containerd
 
@@ -31995,7 +31995,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k20-ko21-containerd
 
@@ -32058,7 +32058,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k20-ko22-containerd
 
@@ -32121,7 +32121,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k21-containerd
 
@@ -32184,7 +32184,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k21-ko21-containerd
 
@@ -32247,7 +32247,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k21-ko22-containerd
 
@@ -32310,7 +32310,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k22-containerd
 
@@ -32373,7 +32373,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k22-ko22-containerd
 
@@ -32436,7 +32436,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k20-containerd
 
@@ -32499,7 +32499,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k20-ko21-containerd
 
@@ -32562,7 +32562,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k20-ko22-containerd
 
@@ -32625,7 +32625,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k21-containerd
 
@@ -32688,7 +32688,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-amzn2, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k21-ko21-containerd
 
@@ -32751,7 +32751,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k21-ko22-containerd
 
@@ -32814,7 +32814,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k22-containerd
 
@@ -32877,7 +32877,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-amzn2, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k22-ko22-containerd
 
@@ -32940,7 +32940,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k20-ko21-containerd
 
@@ -33003,7 +33003,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k20-ko22-containerd
 
@@ -33066,7 +33066,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb9, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k21-ko21-containerd
 
@@ -33129,7 +33129,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k21-ko22-containerd
 
@@ -33192,7 +33192,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb9, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k22-ko22-containerd
 
@@ -33255,7 +33255,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k20-containerd
 
@@ -33318,7 +33318,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k20-ko21-containerd
 
@@ -33381,7 +33381,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k20-ko22-containerd
 
@@ -33444,7 +33444,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k21-containerd
 
@@ -33507,7 +33507,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-deb10, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k21-ko21-containerd
 
@@ -33570,7 +33570,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k21-ko22-containerd
 
@@ -33633,7 +33633,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k22-containerd
 
@@ -33696,7 +33696,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-deb10, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k22-ko22-containerd
 
@@ -33760,7 +33760,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k20-containerd
 
@@ -33824,7 +33824,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k20-ko21-containerd
 
@@ -33888,7 +33888,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k20-ko22-containerd
 
@@ -33952,7 +33952,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k21-containerd
 
@@ -34016,7 +34016,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-flatcar, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k21-ko21-containerd
 
@@ -34080,7 +34080,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k21-ko22-containerd
 
@@ -34144,7 +34144,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k22-containerd
 
@@ -34208,7 +34208,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-flatcar, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k22-ko22-containerd
 
@@ -34271,7 +34271,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k20-ko21-containerd
 
@@ -34334,7 +34334,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k20-ko22-containerd
 
@@ -34397,7 +34397,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel7, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k21-ko21-containerd
 
@@ -34460,7 +34460,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k21-ko22-containerd
 
@@ -34523,7 +34523,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel7, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k22-ko22-containerd
 
@@ -34586,7 +34586,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k20-containerd
 
@@ -34649,7 +34649,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k20-ko21-containerd
 
@@ -34712,7 +34712,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k20-ko22-containerd
 
@@ -34775,7 +34775,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k21-containerd
 
@@ -34838,7 +34838,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-rhel8, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k21-ko21-containerd
 
@@ -34901,7 +34901,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k21-ko22-containerd
 
@@ -34964,7 +34964,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k22-containerd
 
@@ -35027,7 +35027,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-rhel8, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k22-ko22-containerd
 
@@ -35090,7 +35090,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k20-ko21-containerd
 
@@ -35153,7 +35153,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k20-ko22-containerd
 
@@ -35216,7 +35216,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u1804, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k21-ko21-containerd
 
@@ -35279,7 +35279,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k21-ko22-containerd
 
@@ -35342,7 +35342,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u1804, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k22-ko22-containerd
 
@@ -35405,7 +35405,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k20-containerd
 
@@ -35468,7 +35468,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k20-ko21-containerd
 
@@ -35531,7 +35531,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.20, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.20, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k20-ko22-containerd
 
@@ -35594,7 +35594,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k21-containerd
 
@@ -35657,7 +35657,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.21, kops-distro-u2004, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k21-ko21-containerd
 
@@ -35720,7 +35720,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.21, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k21-ko22-containerd
 
@@ -35783,7 +35783,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k22-containerd
 
@@ -35846,7 +35846,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.22, kops-kubetest2, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-1.22, kops-distro-u2004, kops-grid, kops-k8s-1.22, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k22-ko22-containerd
 
@@ -35908,7 +35908,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-gce-u2004-k22-docker
 
@@ -35970,7 +35970,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-gce-calico-u2004-k22-docker
 
@@ -36032,7 +36032,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-gce-cilium-u2004-k22-docker
 
@@ -36094,7 +36094,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-gce-u2004-k22-containerd
 
@@ -36156,7 +36156,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-gce-calico-u2004-k22-containerd
 
@@ -36218,6 +36218,6 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.22, kops-kubetest2, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.22, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-gce-cilium-u2004-k22-containerd

--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -80,6 +80,6 @@ periodics:
     test.kops.k8s.io/kops_channel: stable
     test.kops.k8s.io/kops_version: '1.21'
     test.kops.k8s.io/networking: 'calico'
-    testgrid-dashboards: google-aws, kops-1.21, kops-k8s-1.21, kops-kubetest2, sig-cluster-lifecycle-kops, kops-misc
+    testgrid-dashboards: google-aws, kops-1.21, kops-k8s-1.21, sig-cluster-lifecycle-kops, kops-misc
     testgrid-days-of-results: '90'
     testgrid-tab-name: e2e-kops-do-calico

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -62,7 +62,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-u2004arm64, kops-k8s-latest, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004arm64, kops-k8s-latest, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-scenario-arm64
 
@@ -131,7 +131,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-ipv6, kops-k8s-ci, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-ipv6, kops-k8s-ci, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-scenario-ipv6-conformance
 
@@ -199,7 +199,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-ipv6, kops-k8s-ci, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-ipv6, kops-k8s-ci, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '47'
     testgrid-tab-name: kops-grid-scenario-ipv6-calico
 
@@ -267,7 +267,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-ipv6, kops-k8s-ci, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-ipv6, kops-k8s-ci, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-scenario-ipv6-cilium
 
@@ -331,7 +331,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-latest, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-latest, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-scenario-service-account-iam
 
@@ -395,7 +395,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-latest, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-latest, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-warm-pool
 
@@ -461,7 +461,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-ci, kops-kubetest2, kops-latest, kops-misc, provider-aws-cloud-provider-aws, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-ci, kops-latest, kops-misc, provider-aws-cloud-provider-aws, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-scenario-aws-cloud-controller-manager
 
@@ -527,7 +527,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-ci, kops-kubetest2, kops-latest, kops-misc, provider-aws-cloud-provider-aws, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-ci, kops-latest, kops-misc, provider-aws-cloud-provider-aws, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-scenario-aws-cloud-controller-manager-irsa
 
@@ -592,7 +592,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.20, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.20, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-scenario-terraform
 
@@ -656,7 +656,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-misc-ha-euwest1
 
@@ -722,7 +722,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004arm64, kops-k8s-ci, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004arm64, kops-k8s-ci, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-misc-arm64-release
 
@@ -788,7 +788,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004arm64, kops-k8s-ci, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004arm64, kops-k8s-ci, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-misc-arm64-ci
 
@@ -856,7 +856,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004arm64, kops-k8s-ci, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004arm64, kops-k8s-ci, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-misc-arm64-conformance
 
@@ -924,7 +924,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-ci, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-ci, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-misc-amd64-conformance
 
@@ -990,7 +990,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '11'
     testgrid-tab-name: kops-aws-misc-updown
 
@@ -1054,7 +1054,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2004arm64, kops-k8s-latest, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004arm64, kops-k8s-latest, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-scenario-cilium10-arm64
 
@@ -1118,7 +1118,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-latest, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-latest, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-scenario-cilium10-amd64
 
@@ -1174,7 +1174,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-latest, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-latest, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-aws-ebs-csi-driver
 
@@ -1233,7 +1233,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-latest, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-latest, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-aws-ebs-csi-driver-irsa
 
@@ -1289,7 +1289,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.21, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.21, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-aws-load-balancer-controller
 
@@ -1347,7 +1347,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.21, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.21, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-aws-load-balancer-controller-irsa
 
@@ -1403,7 +1403,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-latest, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-latest, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-keypair-rotation
 
@@ -1459,7 +1459,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-latest, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-latest, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-metrics-server
 
@@ -1523,7 +1523,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-latest, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-latest, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-external-dns
 
@@ -1587,7 +1587,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-latest, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-latest, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-external-dns-irsa
 
@@ -1653,6 +1653,6 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-latest, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-latest, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-apiserver-nodes

--- a/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
@@ -62,7 +62,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: amazonvpc
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.21, kops-kubetest2, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.21, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-amazon-vpc
 
@@ -126,7 +126,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-calico
 
@@ -190,7 +190,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: canal
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.21, kops-kubetest2, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.21, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-canal
 
@@ -254,7 +254,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-cilium
 
@@ -318,7 +318,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-cilium-etcd
 
@@ -382,7 +382,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: flannel
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-flannel
 
@@ -446,7 +446,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-kopeio
 
@@ -510,7 +510,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kube-router
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-kuberouter
 
@@ -574,6 +574,6 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: weave
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-weave

--- a/config/jobs/kubernetes/kops/kops-periodics-pipeline.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-pipeline.yaml
@@ -64,7 +64,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-latest, kops-kubetest2, kops-latest, kops-versions, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-latest, kops-latest, kops-versions, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '11'
     testgrid-tab-name: kops-pipeline-updown-kopsmaster
 
@@ -130,7 +130,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.22, kops-kubetest2, kops-latest, kops-versions, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.22, kops-latest, kops-versions, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '11'
     testgrid-tab-name: kops-pipeline-updown-kops122
 
@@ -196,7 +196,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.21, kops-kubetest2, kops-latest, kops-versions, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.21, kops-latest, kops-versions, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '11'
     testgrid-tab-name: kops-pipeline-updown-kops121
 
@@ -262,6 +262,6 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.20, kops-kubetest2, kops-latest, kops-versions, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.20, kops-latest, kops-versions, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '11'
     testgrid-tab-name: kops-pipeline-updown-kops120

--- a/config/jobs/kubernetes/kops/kops-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-upgrades.yaml
@@ -62,7 +62,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '23'
     testgrid-tab-name: kops-aws-upgrade-k121-ko121-to-klatest-kolatest
 
@@ -126,7 +126,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '23'
     testgrid-tab-name: kops-aws-upgrade-k122-ko122-to-klatest-kolatest
 
@@ -190,7 +190,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '23'
     testgrid-tab-name: kops-aws-upgrade-k121-ko121-to-k122-ko122
 
@@ -254,7 +254,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '23'
     testgrid-tab-name: kops-aws-upgrade-k120-ko120-to-k121-ko121
 
@@ -318,7 +318,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '23'
     testgrid-tab-name: kops-aws-upgrade-k120-kolatest-to-k121-kolatest
 
@@ -382,7 +382,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '23'
     testgrid-tab-name: kops-aws-upgrade-k118-kolatest-to-k119-kolatest
 
@@ -446,6 +446,6 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-stable, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '23'
     testgrid-tab-name: kops-aws-upgrade-k120-ko120-to-k121-kolatest

--- a/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
@@ -64,7 +64,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-ci, kops-kubetest2, kops-latest, kops-versions, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-ci, kops-latest, kops-versions, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '35'
     testgrid-tab-name: kops-aws-k8s-latest
 
@@ -127,7 +127,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.22, kops-kubetest2, kops-latest, kops-versions, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.22, kops-latest, kops-versions, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '35'
     testgrid-tab-name: kops-aws-k8s-1-22
 
@@ -190,7 +190,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.21, kops-kubetest2, kops-latest, kops-versions, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.21, kops-latest, kops-versions, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '35'
     testgrid-tab-name: kops-aws-k8s-1-21
 
@@ -253,7 +253,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.20, kops-kubetest2, kops-latest, kops-versions, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.20, kops-latest, kops-versions, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '35'
     testgrid-tab-name: kops-aws-k8s-1-20
 
@@ -316,7 +316,7 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.19, kops-kubetest2, kops-latest, kops-versions, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.19, kops-latest, kops-versions, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '35'
     testgrid-tab-name: kops-aws-k8s-1-19
 
@@ -379,6 +379,6 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.18, kops-kubetest2, kops-latest, kops-versions, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.18, kops-latest, kops-versions, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '35'
     testgrid-tab-name: kops-aws-k8s-1-18

--- a/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
@@ -67,7 +67,7 @@ presubmits:
       test.kops.k8s.io/k8s_version: ci
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: calico
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-ci, kops-kubetest2, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-ci, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-containerd-ci
 
@@ -136,7 +136,7 @@ presubmits:
       test.kops.k8s.io/k8s_version: ci
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: calico
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-ci, kops-kubetest2, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-ci, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-containerd-ci-ha
 
@@ -201,7 +201,7 @@ presubmits:
       test.kops.k8s.io/k8s_version: '1.21'
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: kubenet
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-1.21, kops-kubetest2, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-1.21, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-docker
 
@@ -266,7 +266,7 @@ presubmits:
       test.kops.k8s.io/k8s_version: '1.21'
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: calico
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-1.21, kops-kubetest2, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-1.21, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-containerd
 
@@ -331,7 +331,7 @@ presubmits:
       test.kops.k8s.io/k8s_version: '1.21'
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: calico
-      testgrid-dashboards: kops-distro-u2010, kops-k8s-1.21, kops-kubetest2, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2010, kops-k8s-1.21, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-ubuntu2010
 
@@ -396,7 +396,7 @@ presubmits:
       test.kops.k8s.io/k8s_version: '1.21'
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: calico
-      testgrid-dashboards: kops-distro-u2104, kops-k8s-1.21, kops-kubetest2, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2104, kops-k8s-1.21, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-ubuntu2104
 
@@ -461,7 +461,7 @@ presubmits:
       test.kops.k8s.io/k8s_version: '1.21'
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: calico
-      testgrid-dashboards: kops-distro-deb11, kops-k8s-1.21, kops-kubetest2, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-deb11, kops-k8s-1.21, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-debian11
 
@@ -523,7 +523,7 @@ presubmits:
       test.kops.k8s.io/k8s_version: '1.21'
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: cilium
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-1.21, kops-kubetest2, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-1.21, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-gce
 
@@ -591,7 +591,7 @@ presubmits:
       test.kops.k8s.io/k8s_version: ci
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: kubenet
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-ci, kops-kubetest2, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-ci, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-ccm
 
@@ -659,7 +659,7 @@ presubmits:
       test.kops.k8s.io/k8s_version: ci
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: kubenet
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-ci, kops-kubetest2, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-ci, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-ccm-irsa
 
@@ -727,7 +727,7 @@ presubmits:
       test.kops.k8s.io/k8s_version: ci
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: kubenet
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-ci, kops-kubetest2, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-ci, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: pull-kops-e2e-aws-irsa
 
@@ -797,7 +797,7 @@ presubmits:
       test.kops.k8s.io/k8s_version: ci
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: calico
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-ci, kops-kubetest2, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-ci, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: ipv6-ci
 
@@ -868,7 +868,7 @@ presubmits:
       test.kops.k8s.io/k8s_version: ci
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: calico
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-ci, kops-kubetest2, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-ci, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: ipv6-conformance
 
@@ -923,7 +923,7 @@ presubmits:
       test.kops.k8s.io/k8s_version: ci
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: calico
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-ci, kops-kubetest2, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-ci, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: pull-kops-e2e-aws-ebs-csi-driver
 
@@ -979,7 +979,7 @@ presubmits:
       test.kops.k8s.io/k8s_version: ci
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: calico
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-ci, kops-kubetest2, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-ci, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: pull-kops-e2e-aws-ebs-csi-driver-irsa
 
@@ -1034,7 +1034,7 @@ presubmits:
       test.kops.k8s.io/k8s_version: ci
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: calico
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-ci, kops-kubetest2, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-ci, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: pull-kops-e2e-aws-load-balancer-controller
 
@@ -1089,7 +1089,7 @@ presubmits:
       test.kops.k8s.io/k8s_version: ci
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: calico
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-ci, kops-kubetest2, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-ci, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: pull-kops-e2e-aws-addon-resource-tracking
 
@@ -1144,7 +1144,7 @@ presubmits:
       test.kops.k8s.io/k8s_version: ci
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: calico
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-ci, kops-kubetest2, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-ci, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: pull-kops-e2e-aws-metrics-server
 
@@ -1212,7 +1212,7 @@ presubmits:
       test.kops.k8s.io/k8s_version: ci
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: calico
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-ci, kops-kubetest2, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-ci, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: pull-kops-e2e-aws-external-dns
 
@@ -1280,7 +1280,7 @@ presubmits:
       test.kops.k8s.io/k8s_version: ci
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: calico
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-ci, kops-kubetest2, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-ci, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: pull-kops-e2e-aws-external-dns-irsa
 
@@ -1348,7 +1348,7 @@ presubmits:
       test.kops.k8s.io/k8s_version: latest
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: kubenet
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-latest, kops-kubetest2, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-latest, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: pull-kops-e2e-aws-apiserver-nodes
 
@@ -1414,7 +1414,7 @@ presubmits:
       test.kops.k8s.io/k8s_version: '1.22'
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: calico
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-1.22, kops-kubetest2, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-1.22, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-1-22
 
@@ -1480,6 +1480,6 @@ presubmits:
       test.kops.k8s.io/k8s_version: '1.21'
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: calico
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-1.21, kops-kubetest2, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-1.21, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-1-21

--- a/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
@@ -66,7 +66,7 @@ presubmits:
       test.kops.k8s.io/k8s_version: '1.21'
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: amazonvpc
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-1.21, kops-kubetest2, kops-network-plugins, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-1.21, kops-network-plugins, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-amazonvpc
 
@@ -133,7 +133,7 @@ presubmits:
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: calico
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-network-plugins, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-stable, kops-network-plugins, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-calico
 
@@ -200,7 +200,7 @@ presubmits:
       test.kops.k8s.io/k8s_version: '1.21'
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: canal
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-1.21, kops-kubetest2, kops-network-plugins, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-1.21, kops-network-plugins, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-canal
 
@@ -267,7 +267,7 @@ presubmits:
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: cilium
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-network-plugins, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-stable, kops-network-plugins, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-cilium
 
@@ -333,7 +333,7 @@ presubmits:
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: cilium-etcd
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-network-plugins, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-stable, kops-network-plugins, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-cilium-etcd
 
@@ -400,7 +400,7 @@ presubmits:
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: flannel
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-network-plugins, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-stable, kops-network-plugins, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-flannel
 
@@ -467,7 +467,7 @@ presubmits:
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: kube-router
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-network-plugins, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-stable, kops-network-plugins, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-kuberouter
 
@@ -534,6 +534,6 @@ presubmits:
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: weave
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-stable, kops-kubetest2, kops-network-plugins, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-stable, kops-network-plugins, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-weave

--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -103,7 +103,7 @@ presubmits:
             cpu: "2"
             memory: "3Gi"
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits, kops-kubetest2
+      testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits
       testgrid-tab-name: e2e-do-kubetest2
   - name: pull-kops-e2e-kubernetes-aws-1-19
     branches:

--- a/config/testgrids/kubernetes/kops/config.yaml
+++ b/config/testgrids/kubernetes/kops/config.yaml
@@ -7,7 +7,6 @@ dashboard_groups:
   - kops-versions
   - kops-misc
   - kops-ipv6
-  - kops-kubetest2
   - kops-gce
   - kops-grid
   - kops-distro-amzn2
@@ -43,7 +42,6 @@ dashboards:
 - name: kops-versions
 - name: kops-misc
 - name: kops-ipv6
-- name: kops-kubetest2
 - name: kops-gce
 - name: kops-grid
 - name: kops-distro-amzn2


### PR DESCRIPTION
The vast majority of our jobs are using kubetest2 so the value of this dashboard tab has significantly diminished.

/cc @hakman 
