### PR TITLE
e2e: disable auto-updates on all Fedora CoreOS jobs

### DIFF
--- a/jobs/e2e_node/crio/crio.ign
+++ b/jobs/e2e_node/crio/crio.ign
@@ -7,6 +7,17 @@
       "systemd.unified_cgroup_hierarchy=0"
     ]
   },
+  "storage": {
+    "files": [
+      {
+        "path": "/etc/zincati/config.d/90-disable-auto-updates.toml",
+        "contents": {
+          "source": "data:,%5Bupdates%5D%0Aenabled%20%3D%20false%0A"
+        },
+        "mode": 420
+      }
+    ]
+  },
   "systemd": {
     "units": [
       {

--- a/jobs/e2e_node/crio/crio_cgrpv2.ign
+++ b/jobs/e2e_node/crio/crio_cgrpv2.ign
@@ -1,6 +1,17 @@
 {
   "ignition": {
-    "version": "3.1.0"
+    "version": "3.3.0"
+  },
+  "storage": {
+    "files": [
+      {
+        "path": "/etc/zincati/config.d/90-disable-auto-updates.toml",
+        "contents": {
+          "source": "data:,%5Bupdates%5D%0Aenabled%20%3D%20false%0A"
+        },
+        "mode": 420
+      }
+    ]
   },
   "systemd": {
     "units": [

--- a/jobs/e2e_node/swap/crio_swap1g.ign
+++ b/jobs/e2e_node/swap/crio_swap1g.ign
@@ -7,6 +7,17 @@
       "systemd.unified_cgroup_hierarchy=0"
     ]
   },
+  "storage": {
+    "files": [
+      {
+        "path": "/etc/zincati/config.d/90-disable-auto-updates.toml",
+        "contents": {
+          "source": "data:,%5Bupdates%5D%0Aenabled%20%3D%20false%0A"
+        },
+        "mode": 420
+      }
+    ]
+  },
   "systemd": {
     "units": [
       {


### PR DESCRIPTION
This tweaks nodes configurations in order to disable auto-updates
on all jobs running on Fedora CoreOS (FCOS).
An auto-update agent (Zincati) is active by default on all FCOS nodes,
but we don't actually want those machines to perform updates in the
middle of a CI run.
This avoids any possible race between the test-runner and the
machine rebooting itself and switching to a different OS version
during a test run.

Signed-off-by: Luca BRUNO <luca.bruno@coreos.com>

/cc @harche @haircommander @mrunalp