### PR TITLE
Bump k8s to 1.20 1.21 and 1.22 for Kuberbuilder e2e tests

### DIFF
--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -19,7 +19,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
       testgrid-tab-name: kubebuilder
-  - name: pull-kubebuilder-e2e-k8s-1-19-4
+  - name: pull-kubebuilder-e2e-k8s-1-22-2
     decorate: true
     always_run: true
     optional: true
@@ -37,7 +37,7 @@ presubmits:
         - ./test_e2e.sh
         env:
         - name: KIND_K8S_VERSION
-          value: "v1.19.4"
+          value: "v1.22.2"
         resources:
           requests:
             cpu: 4000m
@@ -45,11 +45,11 @@ presubmits:
           privileged: true
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
-      testgrid-tab-name: kubebuilder-e2e-1-19-4
+      testgrid-tab-name: kubebuilder-e2e-1-12-2
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-  - name: pull-kubebuilder-e2e-k8s-1-18-8
+  - name: pull-kubebuilder-e2e-k8s-1-21-5
     decorate: true
     always_run: true
     optional: true
@@ -67,7 +67,7 @@ presubmits:
         - ./test_e2e.sh
         env:
         - name: KIND_K8S_VERSION
-          value: "v1.18.8"
+          value: "v1.21.5"
         resources:
           requests:
             cpu: 4000m
@@ -75,11 +75,11 @@ presubmits:
           privileged: true
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
-      testgrid-tab-name: kubebuilder-e2e-1-18-8
+      testgrid-tab-name: kubebuilder-e2e-1-21-5
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-  - name: pull-kubebuilder-e2e-k8s-1-17-11
+  - name: pull-kubebuilder-e2e-k8s-1-20-11
     decorate: true
     always_run: true
     optional: true
@@ -97,7 +97,7 @@ presubmits:
         - ./test_e2e.sh
         env:
         - name: KIND_K8S_VERSION
-          value: "v1.17.11"
+          value: "v1.20.11"
         resources:
           requests:
             cpu: 4000m
@@ -105,97 +105,7 @@ presubmits:
           privileged: true
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
-      testgrid-tab-name: kubebuilder-e2e-1-17-11
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-  - name: pull-kubebuilder-e2e-k8s-1-16-15
-    decorate: true
-    always_run: true
-    optional: false
-    path_alias: sigs.k8s.io/kubebuilder
-    branches:
-    - ^master$
-    - ^feature/plugins-.+$
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211005-ca067fbd9f-master
-        command:
-        # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
-        - runner.sh
-        # this MUST be a relative directory with "./" or the runner will fail to find the file
-        - ./test_e2e.sh
-        env:
-        - name: KIND_K8S_VERSION
-          value: "v1.16.15"
-        resources:
-          requests:
-            cpu: 4000m
-        securityContext:
-          privileged: true
-    annotations:
-      testgrid-dashboards: sig-api-machinery-kubebuilder
-      testgrid-tab-name: kubebuilder-e2e-1-16-15
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-  - name: pull-kubebuilder-e2e-k8s-1-15-12
-    decorate: true
-    always_run: true
-    optional: false
-    path_alias: sigs.k8s.io/kubebuilder
-    branches:
-    - ^master$
-    - ^feature/plugins-.+$
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211005-ca067fbd9f-master
-        command:
-        # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
-        - runner.sh
-        # this MUST be a relative directory with "./" or the runner will fail to find the file
-        - ./test_e2e.sh
-        env:
-        - name: KIND_K8S_VERSION
-          value: "v1.15.12"
-        resources:
-          requests:
-            cpu: 4000m
-        securityContext:
-          privileged: true
-    annotations:
-      testgrid-dashboards: sig-api-machinery-kubebuilder
-      testgrid-tab-name: kubebuilder-e2e-1-15-12
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-  - name: pull-kubebuilder-e2e-k8s-1-14-10
-    decorate: true
-    always_run: true
-    optional: false
-    path_alias: sigs.k8s.io/kubebuilder
-    branches:
-    - ^master$
-    - ^feature/plugins-.+$
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211005-ca067fbd9f-master
-        command:
-        # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
-        - runner.sh
-        # this MUST be a relative directory with "./" or the runner will fail to find the file
-        - ./test_e2e.sh
-        env:
-        - name: KIND_K8S_VERSION
-          value: "v1.14.10"
-        resources:
-          requests:
-            cpu: 4000m
-        securityContext:
-          privileged: true
-    annotations:
-      testgrid-dashboards: sig-api-machinery-kubebuilder
-      testgrid-tab-name: kubebuilder-e2e-1-14-10
+      testgrid-tab-name: kubebuilder-e2e-1-20-11
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"


### PR DESCRIPTION
Also remove older k8s versions

**Note:** e2e test will not pass for Kubernetes 1.22 until https://github.com/kubernetes-sigs/kubebuilder/pull/2371 is merged. That PR is waiting on this PR to be merged first.

Signed-off-by: Martin Hickey <martin.hickey@ie.ibm.com>