### PR TITLE
match ci and presubmit config for integration-1.22 jobs

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml
@@ -1759,6 +1759,9 @@ presubmits:
         - ./hack/jenkins/test-dockerized.sh
         command:
         - runner.sh
+        env:
+        - name: SHORT
+          value: --short=false
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211005-ca067fbd9f-1.22
         name: ""
         resources:


### PR DESCRIPTION
this matches the configuration between the presubmit job , that fails, and the periodic job that succeeds 