### PR TITLE
Make CAPA e2e job timeouts consistent

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
@@ -87,7 +87,7 @@ postsubmits:
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
       decorate: true
       decoration_config:
-        timeout: 3h
+        timeout: 5h
       max_concurrency: 1
       labels:
         preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -67,7 +67,7 @@ presubmits:
     optional: true
     decorate: true
     decoration_config:
-      timeout: 3h
+      timeout: 5h
     max_concurrency: 1
     extra_refs:
     - org: kubernetes-sigs
@@ -113,7 +113,7 @@ presubmits:
     optional: true
     decorate: true
     decoration_config:
-      timeout: 4h
+      timeout: 5h
     max_concurrency: 1
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
Conformance jobs are flaking as it's just on the edge of waiting for cluster cleanup

Signed-off-by: Naadir Jeewa <jeewan@vmware.com>
