### PR TITLE
config/jobs: update 1.22 pull-kubernetes-integration to match ci

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml
@@ -1738,20 +1738,18 @@ presubmits:
           requests:
             cpu: 1500m
             memory: 7Gi
-  # TODO(spiffxp): remove when finished investigating https://github.com/kubernetes/kubernetes/issues/105436
-  - always_run: false
+  - always_run: true
     annotations:
-      testgrid-create-test-group: "true"
-    optional: true
+      job-config-differs-because: "https://github.com/kubernetes/kubernetes/issues/105436#issuecomment-937805327"
     branches:
     - release-1.22
     cluster: k8s-infra-prow-build
-    context: pull-kubernetes-integration-1-22-canary
+    context: pull-kubernetes-integration
     decorate: true
     labels:
       preset-dind-enabled: "true"
       preset-service-account: "true"
-    name: pull-kubernetes-integration-1-22-canary
+    name: pull-kubernetes-integration
     path_alias: k8s.io/kubernetes
     spec:
       containers:
@@ -1771,34 +1769,6 @@ presubmits:
           requests:
             cpu: "6"
             memory: 20Gi
-        securityContext:
-          privileged: true
-  - always_run: true
-    branches:
-    - release-1.22
-    cluster: k8s-infra-prow-build
-    context: pull-kubernetes-integration
-    decorate: true
-    labels:
-      preset-dind-enabled: "true"
-      preset-service-account: "true"
-    name: pull-kubernetes-integration
-    path_alias: k8s.io/kubernetes
-    spec:
-      containers:
-      - args:
-        - ./hack/jenkins/test-dockerized.sh
-        command:
-        - runner.sh
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211005-ca067fbd9f-1.22
-        name: ""
-        resources:
-          limits:
-            cpu: "6"
-            memory: 15Gi
-          requests:
-            cpu: "6"
-            memory: 15Gi
         securityContext:
           privileged: true
   - always_run: true

--- a/config/testgrids/kubernetes/presubmits/config.yaml
+++ b/config/testgrids/kubernetes/presubmits/config.yaml
@@ -159,9 +159,6 @@ dashboards:
   - name: pull-kubernetes-node-e2e-alpha-kubetest2
     test_group_name: pull-kubernetes-node-e2e-alpha-kubetest2
     base_options: width=10
-  - name: pull-kubernetes-integration-1-22-canary
-    test_group_name: pull-kubernetes-integration-1-22-canary
-    base_options: width=10
 - name: presubmits-kubernetes-scalability
   dashboard_tab:
   - name: pull-kubernetes-e2e-gce-100-performance


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/kubernetes/issues/105436
- Followup to: https://github.com/kubernetes/test-infra/pull/23932

Remove the pull-kubernetes-integration-1-22-canary job and migrate its config changes over to the pull-kubernetes-integration job for the release-1.22 branch. This should unblock 1.22 merges

Instead of explaining why with a comment, add an annotation with a link to the github issue/comment that led us to change the job config. This is because the job config gets stripped of comments by config-rotator, while the annotation will persist.

---

I'll summarize https://github.com/kubernetes/kubernetes/issues/105436#issuecomment-937275902 and https://github.com/kubernetes/kubernetes/issues/105436#issuecomment-937805327 here:

We think the recently improved I/O performance of the build cluster (ref: https://github.com/kubernetes/k8s.io/issues/1187#issuecomment-929466293) is causing integration tests to run faster, thus triggering etcd/apiserver connection issues that were never fully root caused during 1.22 (ref: https://github.com/kubernetes/kubernetes/issues/103512).

We think we're not seeing this in master because it's dropped a bunch of v1beta1 tests, thus below whatever threshold triggers these issues.  We think we're not seeing this in v1.22 CI because CI jobs run additional slow/expensive tests that may be spreading things out enough to avoid triggering the issues.

We're opting to make the presubmit match the CI job config for release-1.22 _only_ so as to unblock cherry picks destined for patch release.  Ultimately https://github.com/kubernetes/kubernetes/issues/103512 should be root caused.