### PR TITLE
releng: Bump `ci-k8sio-image-promo` image to kpromo:v3.3.0-beta.1-3

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -101,11 +101,11 @@ periodics:
     # https://github.com/kubernetes/k8s.io/pull/695.
     serviceAccountName: k8s-infra-gcr-promoter
     containers:
-    - image: k8s.gcr.io/artifact-promoter/cip:v3.2.0
+    - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.1-3
       command:
-      - cip
+      - /kpromo
       args:
-      - run
+      - cip
       - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
       - --confirm
   annotations:


### PR DESCRIPTION
This reverts commit 6397f54522bfaaadb3d7b70f7a44fd6d4c71debf (ref: https://github.com/kubernetes/test-infra/pull/23917) and continues https://github.com/kubernetes/test-infra/pull/23923.

`post-k8sio-image-promo` started [passing](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-k8sio-image-promo/1446042566381277184) using the `kpromo:v3.3.0-beta.1-3` image (produced from https://github.com/kubernetes-sigs/promo-tools/pull/446), so let's bump the periodic job image to match.

Part of https://github.com/kubernetes-sigs/promo-tools/issues/444.
Prow CIP image bump to follow (once the main periodic has a few successful runs).

/assign @cpanato @Verolop @puerco @xmudrii 
cc: @kubernetes/release-engineering @spiffxp 