### PR TITLE
releng(prow-image-promo): Use kpromo:v3.3.0-beta.1-3 image

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -496,15 +496,15 @@ postsubmits:
     spec:
       serviceAccountName: pusher
       containers:
-      - image: k8s.gcr.io/artifact-promoter/cip:v3.2.0
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.1-3
         command:
-        - cip
+        - /kpromo
         args:
-        - run
+        - cip
         - --manifest=prow/cip-manifest.yaml
         - --confirm
     annotations:
-      testgrid-dashboards: sig-testing-prow
+      testgrid-dashboards: sig-testing-prow, sig-release-releng-blocking
       testgrid-tab-name: cip-prow
       testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
       testgrid-num-failures-to-alert: '1'


### PR DESCRIPTION
Part of [kubernetes-sigs/promo-tools#444](https://github.com/kubernetes-sigs/promo-tools/issues/444).

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/hold until https://github.com/kubernetes/test-infra/pull/23937 has merged and the main periodic (`ci-k8sio-image-promo`) has had a few successful runs