### PR TITLE
releng(kpromo): Reduce alert sensitivity for prod jobs

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -24,7 +24,7 @@ postsubmits:
     annotations:
       testgrid-dashboards: sig-release-releng-blocking, sig-k8s-infra-k8sio
       testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
-      testgrid-num-failures-to-alert: '1'
+      testgrid-num-failures-to-alert: '2'
   - name: post-k8sio-image-promo
     cluster: k8s-infra-prow-build-trusted
     decorate: true
@@ -48,7 +48,7 @@ postsubmits:
     annotations:
       testgrid-dashboards: sig-release-releng-blocking, sig-k8s-infra-k8sio
       testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
-      testgrid-num-failures-to-alert: '1'
+      testgrid-num-failures-to-alert: '2'
 
 periodics:
 - interval: 1h
@@ -74,7 +74,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-release-releng-blocking, sig-k8s-infra-k8sio
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
-    testgrid-num-failures-to-alert: '1'
+    testgrid-num-failures-to-alert: '2'
   rerun_auth_config:
     github_team_slugs:
       - org: kubernetes
@@ -111,7 +111,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-release-releng-blocking, sig-k8s-infra-k8sio
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
-    testgrid-num-failures-to-alert: '1'
+    testgrid-num-failures-to-alert: '2'
   rerun_auth_config:
     github_team_slugs:
       - org: kubernetes

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -507,7 +507,7 @@ postsubmits:
       testgrid-dashboards: sig-testing-prow
       testgrid-tab-name: cip-prow
       testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
-      testgrid-num-failures-to-alert: '1'
+      testgrid-num-failures-to-alert: '2'
       description: Uses the Container Image Promoter to promote images from gcr.io/k8s-prow-edge to gcr.io/k8s-prow.
 
   kubernetes/community:


### PR DESCRIPTION
From @BenTheElder in https://github.com/kubernetes-sigs/promo-tools/issues/286#issuecomment-873244154:
> ref: https://kubernetes.slack.com/archives/CCK68P2Q2/p1625257913214300?thread_ts=1625175618.211200&cid=CCK68P2Q2
>
> I think we should reduce the sensitivity on these alerts, sending
> emails for a single non-consecutive flake seems excessive.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @puerco @cpanato @Verolop @xmudrii 
cc: @kubernetes/release-engineering

Closes https://github.com/kubernetes-sigs/promo-tools/issues/448.