### PR TITLE
Upload build cluster status file with options to serve with 'Cache-Control: no-cache'.

### DIFF
--- a/prow/io/option.go
+++ b/prow/io/option.go
@@ -30,6 +30,7 @@ type WriterOptions struct {
 	ContentType              *string
 	Metadata                 map[string]string
 	PreconditionDoesNotExist *bool
+	CacheControl             *string
 }
 
 func (wo WriterOptions) Apply(opts *WriterOptions) {
@@ -47,6 +48,9 @@ func (wo WriterOptions) Apply(opts *WriterOptions) {
 	}
 	if wo.PreconditionDoesNotExist != nil {
 		opts.PreconditionDoesNotExist = wo.PreconditionDoesNotExist
+	}
+	if wo.CacheControl != nil {
+		opts.CacheControl = wo.CacheControl
 	}
 }
 
@@ -67,6 +71,9 @@ func (wo WriterOptions) apply(writer *storage.Writer, o *blob.WriterOptions) {
 		}
 		if wo.Metadata != nil {
 			writer.ObjectAttrs.Metadata = wo.Metadata
+		}
+		if wo.CacheControl != nil {
+			writer.ObjectAttrs.CacheControl = *wo.CacheControl
 		}
 	}
 
@@ -91,6 +98,9 @@ func (wo WriterOptions) apply(writer *storage.Writer, o *blob.WriterOptions) {
 	}
 	if wo.Metadata != nil {
 		o.Metadata = wo.Metadata
+	}
+	if wo.CacheControl != nil {
+		o.CacheControl = *wo.CacheControl
 	}
 }
 

--- a/prow/plank/reconciler.go
+++ b/prow/plank/reconciler.go
@@ -232,7 +232,9 @@ func (r *reconciler) syncClusterStatus(interval time.Duration) func(context.Cont
 					r.log.WithError(err).Error("Error marshaling cluster status info.")
 					continue
 				}
-				if err := util.WriteContent(ctx, r.log, util.StorageAuthor{Opener: r.opener}, bucket, subPath, true, payload); err != nil {
+				noCache := "no-cache"
+				author := util.StorageAuthor{Opener: r.opener, Opts: &io.WriterOptions{CacheControl: &noCache}}
+				if err := util.WriteContent(ctx, r.log, author, bucket, subPath, true, payload); err != nil {
 					r.log.WithError(err).Error("Error writing cluster status info.")
 				}
 			}


### PR DESCRIPTION
By default GCS sets `Cache-Control:  max-age=3600` which allows the status file to be cached for an hour. This is a small file and we want to be checking the latest value whenever we GET it so lets disable caching entirely for this object.

/assign @chaodaiG 
/sig testing
/kind bug