### PR TITLE
Increase pull-kops-bazel-build timeout to 15m

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     decorate: true
     decoration_config:
-      timeout: 10m
+      timeout: 15m
     path_alias: k8s.io/kops
     spec:
       containers:


### PR DESCRIPTION
See failures: https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-kops-bazel-build

/cc @olemarkus @rifelpet 