### PR TITLE
Remove single quote literals in kubetest2 arg

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -134,7 +134,7 @@ presubmits:
         - --focus-regex='\[NodeConformance\]'
         - --skip-regex='\[Flaky\]|\[Slow\]|\[Serial\]'
         - --test-args='--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"'
-        - --image-config-file='/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/image-config.yaml'
+        - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/image-config.yaml
   - name: pull-kubernetes-e2e-containerd-gce
     always_run: false
     optional: true
@@ -266,7 +266,7 @@ presubmits:
         - --focus-regex='\[NodeConformance\]'
         - --skip-regex='\[Flaky\]|\[Slow\]|\[Serial\]'
         - '--test-args=--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
-        - --image-config-file='/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config.yaml'
+        - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config.yaml
   - name: pull-kubernetes-node-e2e-containerd-features
     branches:
     - master
@@ -438,7 +438,7 @@ presubmits:
         - --focus-regex='\[NodeConformance\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]'
         - --skip-regex='\[Flaky\]|\[Serial\]'
         - --test-args='--feature-gates=AllAlpha=true,CSIMigration=false,RotateKubeletServerCertificate=false,InTreePluginGCEUnregister=false --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"'
-        - --image-config-file='/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/image-config.yaml'
+        - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/image-config.yaml
   - name: pull-kubernetes-node-kubelet-serial
     always_run: false
     optional: true


### PR DESCRIPTION
Image config file path seems to be including the single quote in the arg.

https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/92316/pull-kubernetes-node-e2e-kubetest2/1446473648251604992#1:build-log.txt%3A43

/cc @dims @Namanl2001 