### PR TITLE
sig-k8s-infra: auto-deploy k8s-infra-prow

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-prow.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-prow.yaml
@@ -75,6 +75,44 @@ postsubmits:
 
 periodics:
 - name: ci-k8sio-autobump-prow-build-clusters
+  cron: "15 14-20/5 * * 1-5"  # Run at :15 every hour between 9:15 and 6:15 PM PST Mon-Fri
+  cluster: k8s-infra-prow-build-trusted
+  decorate: true
+  max_concurrency: 1
+  extra_refs:
+  - org: kubernetes
+    repo: k8s.io
+    base_ref: main
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-k8sio
+    testgrid-alert-email: k8s-infra-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: '3'
+    description: runs autobumper to create/update a PR that updates prow build cluster component images
+  rerun_auth_config:
+    github_team_slugs:
+    # proxy for sig-k8s-infra-oncall
+    - org: kubernetes
+      slug: sig-k8s-infra-leads
+    # proxy for test-infra-oncall
+    - org: kubernetes
+      slug: test-infra-admins
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/generic-autobumper:v20211008-3728cda754
+      command:
+      - /app/prow/cmd/generic-autobumper/app.binary
+      args:
+      - --config=hack/autobump-config.yaml
+      volumeMounts:
+      - name: github
+        mountPath: /etc/github-token
+        readOnly: true
+    volumes:
+    - name: github
+      secret:
+        secretName: k8s-infra-ci-robot-github-token
+
+- name: ci-k8sio-autobump-prow-build-clusters-for-autodeploy
   # This is arbitrarily 3h earlier than test-infra-oncall's prow autobump job
   cron: "30 14-19/5 * * 1-5"  # Run at 7:30 and 12:30 PST Mon-Fri
   cluster: k8s-infra-prow-build-trusted


### PR DESCRIPTION
Followup of https://github.com/kubernetes/test-infra/pull/23467.

Add a second prowjob that doesn't had the label `skip-review`.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>