### PR TITLE
Fix a test that flakes with gotestsum

### DIFF
--- a/gopherage/cmd/metadata/metadata.go
+++ b/gopherage/cmd/metadata/metadata.go
@@ -201,7 +201,7 @@ func ValidateAbs(Flags *Flags, r gitRunner) error {
 		ref, err := r("branch", "--show-current")
 
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to fetch ref from within covered repo: %v. Defaulting to HEAD", err)
+			fmt.Fprintf(os.Stderr, "Failed to fetch ref from within covered repo: %v. Defaulting to HEAD\n", err)
 			ref = "HEAD"
 		}
 		Flags.ref = ref


### PR DESCRIPTION
The t.Parallel here could possibly cause test output swallow --- PASS, which is basically what all go test result to json output relies on.

Related: https://github.com/gotestyourself/gotestsum/issues/141