### PR TITLE
Configurable hook webhook path

### DIFF
--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -50,8 +50,13 @@ import (
 	"k8s.io/test-infra/prow/slack"
 )
 
+const (
+	defaultWebookPath = "/hook"
+)
+
 type options struct {
-	port int
+	webookPath string
+	port       int
 
 	config        configflagutil.ConfigOptions
 	pluginsConfig pluginsflagutil.PluginOptions
@@ -81,6 +86,7 @@ func (o *options) Validate() error {
 
 func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	var o options
+	fs.StringVar(&o.webookPath, "webhook-path", defaultWebookPath, "The path of webhook events, default is '/hook'.")
 	fs.IntVar(&o.port, "port", 8888, "Port to listen on.")
 
 	fs.BoolVar(&o.dryRun, "dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
@@ -265,7 +271,7 @@ func main() {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {})
 
 	// For /hook, handle a webhook normally.
-	http.Handle("/hook", server)
+	http.Handle(o.webookPath, server)
 	// Serve plugin help information from /plugin-help.
 	http.Handle("/plugin-help", pluginhelp.NewHelpAgent(pluginAgent, githubClient))
 

--- a/prow/cmd/hook/main_test.go
+++ b/prow/cmd/hook/main_test.go
@@ -77,11 +77,21 @@ func Test_gatherOptions(t *testing.T) {
 				o.pluginsConfig.PluginConfigPath = "/random/value"
 			},
 		},
+		{
+			name: "explicitly set --webhook-path",
+			args: map[string]string{
+				"--webhook-path": "/random/hook",
+			},
+			expected: func(o *options) {
+				o.webookPath = "/random/hook"
+			},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			expected := &options{
-				port: 8888,
+				webookPath: "/hook",
+				port:       8888,
 				config: configflagutil.ConfigOptions{
 					ConfigPath:                            "yo",
 					ConfigPathFlagName:                    "config-path",


### PR DESCRIPTION
It used to be hardcoded as /hook, would be nice to be configurable, so that it's possible for prow to handle webhooks from different paths.