### PR TITLE
hook: fix a typo in the code (webook -> webhook)

### DIFF
--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -51,12 +51,12 @@ import (
 )
 
 const (
-	defaultWebookPath = "/hook"
+	defaultWebhookPath = "/hook"
 )
 
 type options struct {
-	webookPath string
-	port       int
+	webhookPath string
+	port        int
 
 	config        configflagutil.ConfigOptions
 	pluginsConfig pluginsflagutil.PluginOptions
@@ -86,7 +86,7 @@ func (o *options) Validate() error {
 
 func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	var o options
-	fs.StringVar(&o.webookPath, "webhook-path", defaultWebookPath, "The path of webhook events, default is '/hook'.")
+	fs.StringVar(&o.webhookPath, "webhook-path", defaultWebhookPath, "The path of webhook events, default is '/hook'.")
 	fs.IntVar(&o.port, "port", 8888, "Port to listen on.")
 
 	fs.BoolVar(&o.dryRun, "dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
@@ -271,7 +271,7 @@ func main() {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {})
 
 	// For /hook, handle a webhook normally.
-	http.Handle(o.webookPath, server)
+	http.Handle(o.webhookPath, server)
 	// Serve plugin help information from /plugin-help.
 	http.Handle("/plugin-help", pluginhelp.NewHelpAgent(pluginAgent, githubClient))
 

--- a/prow/cmd/hook/main_test.go
+++ b/prow/cmd/hook/main_test.go
@@ -83,15 +83,15 @@ func Test_gatherOptions(t *testing.T) {
 				"--webhook-path": "/random/hook",
 			},
 			expected: func(o *options) {
-				o.webookPath = "/random/hook"
+				o.webhookPath = "/random/hook"
 			},
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			expected := &options{
-				webookPath: "/hook",
-				port:       8888,
+				webhookPath: "/hook",
+				port:        8888,
 				config: configflagutil.ConfigOptions{
 					ConfigPath:                            "yo",
 					ConfigPathFlagName:                    "config-path",


### PR DESCRIPTION
Noticed when looking at https://github.com/kubernetes/test-infra/pull/23972. Code typos are annoying when searching code and hence worth fixing, IMO.