### PR TITLE
Azure: pin CAPZ cloud provider tests to the release branch

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -274,7 +274,7 @@ presubmits:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: main
+        base_ref: release-0.5
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
     spec:


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/cloud-provider-azure/issues/834

/assign @feiskyer 