### PR TITLE
ingress-nginx: Removed .go and other file changes retaining only TAG

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-ingress-nginx.yaml
+++ b/config/jobs/image-pushing/k8s-staging-ingress-nginx.yaml
@@ -7,7 +7,7 @@ postsubmits:
       annotations:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
       decorate: true
-      run_if_changed: '\.go$|^rootfs/.*|TAG|go.mod|go.sum'
+      run_if_changed: 'TAG'
       branches:
         - ^main$
         - ^legacy$


### PR DESCRIPTION
Cloud builds optimization: Build the staging image only when TAG has been changed 
Issue reference: [#7773](https://github.com/kubernetes/ingress-nginx/issues/7773)
Removed the .go and others in the yaml file [here ](https://github.com/kubernetes/test-infra/blob/0e0007912d8c555e0b7b699128ac0cbc3b61fc5e/config/jobs/image-pushing/k8s-staging-ingress-nginx.yaml#L10)and keep only the tag