### PR TITLE
Updating multiarch-qemu-static image for qemu-binfmt binary support

### DIFF
--- a/images/gcb-docker-gcloud/Dockerfile
+++ b/images/gcb-docker-gcloud/Dockerfile
@@ -14,7 +14,7 @@
 
 ARG GO_VERSION
 
-FROM multiarch/qemu-user-static:5.1.0-2 as qemu-image
+FROM multiarch/qemu-user-static:5.2.0-2 as qemu-image
 
 # Includes bash, docker, and gcloud
 FROM golang:${GO_VERSION}-alpine


### PR DESCRIPTION
Updating multiarch-qemu-static image for qemu-binfmt binary support for s390x

issue: https://gitlab.alpinelinux.org/alpine/aports/-/issues/12406
Follow-up for https://github.com/kubernetes/test-infra/pull/23412

cc @hbrueckner @spiffxp 
