### PR TITLE
releng(kubekins, krte): Update Golang versions to go1.16.9

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -28,13 +28,13 @@ variants:
     OLD_BAZEL_VERSION: 2.2.0
   '1.22':
     CONFIG: '1.22'
-    GO_VERSION: 1.16.8
+    GO_VERSION: 1.16.9
     K8S_RELEASE: stable-1.22
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.21':
     CONFIG: '1.21'
-    GO_VERSION: 1.16.8
+    GO_VERSION: 1.16.9
     K8S_RELEASE: stable-1.21
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
Part of https://github.com/kubernetes/release/issues/2254
Ready to land, now that the k/k go1.16.9 PRs are merged: https://github.com/kubernetes/kubernetes/pull/105671 / https://github.com/kubernetes/kubernetes/pull/105672


/assign @justaugustus @saschagrunert @puerco @xmudrii @Verolop @BenTheElder 
cc: @kubernetes/release-engineering