### PR TITLE
Add initial config OWNERS and testgrid tabs for kubernetes-sigs/cluster-api-provider-kubevirt

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-kubevirt/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-kubevirt/OWNERS
@@ -1,0 +1,16 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+- agradouski
+- cchengleo
+- cluster-api-admins
+- cluster-api-provider-kubevirt-maintainers
+- sig-cluster-lifecycle-leads
+approvers:
+- agradouski
+- cchengleo
+- cluster-api-admins
+- cluster-api-provider-kubevirt-maintainers
+- sig-cluster-lifecycle-leads
+labels:
+- sig/cluster-lifecycle

--- a/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
+++ b/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
@@ -15,6 +15,7 @@ dashboard_groups:
     - sig-cluster-lifecycle-cluster-api-provider-ibmcloud
     - sig-cluster-lifecycle-cluster-api-provider-openstack
     - sig-cluster-lifecycle-cluster-api-provider-nested
+    - sig-cluster-lifecycle-cluster-api-provider-kubevirt
     - sig-cluster-lifecycle-kops
     - sig-cluster-lifecycle-etcdadm
     - sig-cluster-lifecycle-image-pushes
@@ -44,6 +45,7 @@ dashboards:
 - name: sig-cluster-lifecycle-cluster-api-provider-vsphere
 - name: sig-cluster-lifecycle-cluster-api-provider-openstack
 - name: sig-cluster-lifecycle-cluster-api-provider-nested
+- name: sig-cluster-lifecycle-cluster-api-provider-kubevirt
 - name: sig-cluster-lifecycle-kops
 - name: sig-cluster-lifecycle-etcdadm
 - name: sig-cluster-lifecycle-image-pushes


### PR DESCRIPTION
This PR adds OWNERS and the testgrid tab for the a new project: https://sigs.k8s.io/cluster-api-provider-kubevirt

Signed-off-by: Cheng Cheng <chengcheng@apple.com>