### PR TITLE
[DO-NOT-MERGE] Enable out-of-tree credential provider when running E2E tests on cloud-provider-gcp

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -79,4 +79,5 @@ presubmits:
           go get sigs.k8s.io/kubetest2@latest;
           go get sigs.k8s.io/kubetest2/kubetest2-gce@latest;
           go get sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
+          KUBE_ENABLE_CREDENTIAL_SIDECAR=true;
           kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo -- --test-package-version=v1.22.0 --parallel=30 --test-args='--minStartupPods=8 --container-runtime=containerd' --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'


### PR DESCRIPTION
[DO-NOT-MERGE] will be removed once support for accepting/ignoring `--feature-gates=KubeletCredentialProvider` is merged into the cloud-provider-gcp CCM (https://github.com/kubernetes/cloud-provider-gcp/pull/283); merging this PR before that happens will result in an always-failing presubmit.