### PR TITLE
Remove always_run:false in Cloud Provider vSphere release job

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
@@ -252,7 +252,6 @@ postsubmits:
     max_concurrency: 1
     branches:
     - ^v\d+\.\d+\.\d+(-(alpha|beta|rc)\.(\d)+)?$
-    always_run: false
     path_alias: k8s.io/cloud-provider-vsphere
     skip_submodules: true
     spec:


### PR DESCRIPTION
Currently the release job in CPV is not triggered automatically, it's because the `always_run: false` in the job now takes effect due to the new feature according to the [announce on Aug 24th 2021](https://github.com/kubernetes/test-infra/blob/a3eefb553f51d500e1f0f9671169ce6e0475a167/prow/ANNOUNCEMENTS.md#L6)
```
August 24, 2021 Postsubmit Prow jobs now support the always_run field. 
```


Fix https://github.com/kubernetes/test-infra/issues/23604