### PR TITLE
fix crd installation command in prow start guidance

### DIFF
--- a/prow/getting_started_deploy.md
+++ b/prow/getting_started_deploy.md
@@ -177,7 +177,7 @@ Regardless of which object storage you choose, the below adjustments are always 
 First you need to create the ProwJob custom resource:
 
 ```
-kubectl apply --server-side=true config/prow/cluster/prowjob_customresourcedefinition.yaml
+kubectl apply --server-side=true -f config/prow/cluster/prowjob_customresourcedefinition.yaml
 ```
 
 Apply the manifest you edited above by executing one of the following two commands:


### PR DESCRIPTION
Seems the documentation miss `-f` in the start and command doesn't work.  I add  `-f` to fix the problem

```
$ kubectl apply --server-side=true config/prow/cluster/prowjob_customresourcedefinition.yaml
error: must specify one of -f and -k

$ kubectl apply --server-side=true -f config/prow/cluster/prowjob_customresourcedefinition.yaml
customresourcedefinition.apiextensions.k8s.io/prowjobs.prow.k8s.ui serverside-applied
```