### PR TITLE
Add liveness and readiness endpoint to prow-controller-manager.

### DIFF
--- a/prow/cmd/prow-controller-manager/BUILD.bazel
+++ b/prow/cmd/prow-controller-manager/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//prow/io:go_default_library",
         "//prow/logrusutil:go_default_library",
         "//prow/metrics:go_default_library",
+        "//prow/pjutil:go_default_library",
         "//prow/pjutil/pprof:go_default_library",
         "//prow/plank:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",


### PR DESCRIPTION
Creating `health` starts the liveness endpoint, calling `health.ServeReady()` adds the handling for the readiness endpoint.
Once this is deployed we can configure the liveness/readiness probes in the deployment file.

We may also need to tweak the rolling update strategy settings to ensure we allow 2 pods to exist during the update. It looks like the manager is already configured for leader election though.

/assign @alvaroaleman @chaodaiG 