### PR TITLE
Use 1.21 kubekins-e2e image for cluster-api-provider-ibmcom-presubmits

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits.yaml
@@ -15,7 +15,7 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211014-7ca1952a94-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211014-7ca1952a94-1.21
         imagePullPolicy: Always
         resources:
           requests:
@@ -31,7 +31,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211014-7ca1952a94-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211014-7ca1952a94-1.21
         imagePullPolicy: Always
         command:
         - "./scripts/ci-test.sh"
@@ -45,7 +45,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211014-7ca1952a94-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211014-7ca1952a94-1.21
         command:
         - "./scripts/ci-build.sh"
         resources:


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/365

Have run the prow jobs locally on x86 kind cluster to ensure jobs are running fine.
Attached are the successful build logs.

[pull-cluster-api-provider-ibmcloud-build_build-log.txt](https://github.com/kubernetes/test-infra/files/7369886/pull-cluster-api-provider-ibmcloud-build_build-log.txt)
[pull-cluster-api-provider-ibmcloud-make_build-log.txt](https://github.com/kubernetes/test-infra/files/7369887/pull-cluster-api-provider-ibmcloud-make_build-log.txt)
[pull-cluster-api-provider-ibmcloud-test_build-log.txt](https://github.com/kubernetes/test-infra/files/7369888/pull-cluster-api-provider-ibmcloud-test_build-log.txt)

