### PR TITLE
Update azuredisk-csi-driver-config.yaml

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -336,6 +336,7 @@ presubmits:
         - --aksengine-admin-username=azureuser
         - --aksengine-creds=$(AZURE_CREDENTIALS)
         - --aksengine-orchestratorRelease=1.19
+        - --aksengine-location=westus2
         - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
         - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
         - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/test/e2e/manifest/windows.json


### PR DESCRIPTION
specify location for azure disk windows e2e test

```
Details=[{"code":"InvalidTemplateDeployment","message":"The template deployment failed with error: 'The resource with id: '/subscriptions/0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e/resourceGroups/kubetest-6rwqvpox/providers/Microsoft.Compute/virtualMachineScaleSets/8344k8s00' failed validation with message: 'The zone(s) '1,2' for resource 'Microsoft.Compute/virtualMachineScaleSets/8344k8s00' is not supported. The supported zones for location 'northcentralus' are '''.'."},{"code":"InvalidTemplateDeployment","message":"The template deployment failed with error: 'The resource with id: '/subscriptions/0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e/resourceGroups/kubetest-6rwqvpox/providers/Microsoft.Compute/virtualMachineScaleSets/k8s-master-83441399-vmss' failed validation with message: 'The zone(s) '1,2' for resource 'Microsoft.Compute/virtualMachineScaleSets/k8s-master-83441399-vmss' is not supported. The supported zones for location 'northcentralus' are '''.'."}]
```