### PR TITLE
improve github token error message in dry-run mode

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -4597,6 +4597,10 @@ func (c *client) getAppInstallationToken(installationId int64) (*AppInstallation
 	durationLogger := c.log("AppInstallationToken")
 	defer durationLogger()
 
+	if c.dry {
+		return nil, fmt.Errorf("not requesting GitHub App access_token in dry-run mode")
+	}
+
 	var token AppInstallationToken
 	if _, err := c.request(&request{
 		method:    http.MethodPost,


### PR DESCRIPTION
Tide (and presumably other controllers depending on GitHub App access_token) fail with the following error message in dry-run mode:

    Post "http://ghproxy/graphql": failed to get an installation token for org myorg: failed to get installation token from GitHub: unexpected end of JSON input

<details>

```
{"client":"github","component":"tide","duration":"108.977673ms","file":"prow/github/client.go:891","func":"k8s.io/test-infra/prow/github.(*client).log.func2","level":"debug","msg":"AppInstallation() finished","severity":"debug","time":"2021-10-18T20:30:27Z"}
{"client":"github","component":"tide","file":"prow/github/client.go:889","func":"k8s.io/test-infra/prow/github.(*client).log","level":"info","msg":"AppInstallationToken()","severity":"info","time":"2021-10-18T20:30:27Z"}
{"client":"github","component":"tide","duration":"27.159µs","file":"prow/github/client.go:891","func":"k8s.io/test-infra/prow/github.(*client).log.func2","level":"debug","msg":"AppInstallationToken() finished","severity":"debug","time":"2021-10-18T20:30:27Z"}

{"component":"tide","controller":"sync","error":"Post \"http://ghproxy/graphql\": failed to get an installation token for org myorg: failed to get installation token from GitHub: unexpected end of JSON input","file":"prow/tide/tide.go:440","func":"k8s.io/test-infra/prow/tide.(*Controller).query.func1","level":"warning","msg":"Failed to execute query.","query":"is:pr state:open archived:false -label:\"do-not-merge/hold\" -label:\"do-not-merge/invalid-owners-file\" -label:\"do-not-merge/release-note-label-needed\" -label:\"do-not-merge/wip\" -label:\"do-not-merge/work-in-progress\" -label:\"needs-rebase\" org:\"myorg\"","severity":"warning","time":"2021-10-18T20:30:27Z"}
{"client":"github","component":"tide","file":"prow/github/client.go:889","func":"k8s.io/test-infra/prow/github.(*client).log","level":"info","msg":"AppInstallationToken()","severity":"info","time":"2021-10-18T20:30:27Z"}
{"client":"github","component":"tide","duration":"101.336µs","file":"prow/github/client.go:891","func":"k8s.io/test-infra/prow/github.(*client).log.func2","level":"debug","msg":"AppInstallationToken() finished","severity":"debug","time":"2021-10-18T20:30:27Z"}
```

</details>

The error message is confusing, because it's not the graphql endpoint that is failing, but rather the rest endpoint for `access_tokens`.

/area prow