### PR TITLE
fixing prow getting started docs and yamls

### DIFF
--- a/config/prow/cluster/starter/starter-gcs.yaml
+++ b/config/prow/cluster/starter/starter-gcs.yaml
@@ -96,7 +96,7 @@ data:
       default_decoration_configs:
         "*":
           gcs_configuration:
-            bucket: gs://bucket-name
+            bucket: gs://your-bucket-name
             path_strategy: explicit
           gcs_credentials_secret: gcs-credentials
           utility_images:
@@ -423,8 +423,8 @@ spec:
         - --github-endpoint=https://api.github.com
         - --github-graphql-endpoint=http://ghproxy/graphql
         - --gcs-credentials-file=/etc/gcs-credentials/service-account.json
-        - --status-path=gs://tide/tide-status
-        - --history-uri=gs://tide/tide-history.json
+        - --status-path=gs://your-bucket-name/tide-status
+        - --history-uri=gs://your-bucket-name/tide-history.json
         - --github-app-id=$(GITHUB_APP_ID)
         - --github-app-private-key-path=/etc/github/cert
         env:
@@ -491,14 +491,14 @@ spec:
     http:
       paths:
       - path: /
-        pathType: Prefix
+        pathType: ImplementationSpecific
         backend:
           service:
             name: deck
             port:
               number: 80
       - path: /hook
-        pathType: Prefix
+        pathType: ImplementationSpecific
         backend:
           service:
             name: hook
@@ -535,7 +535,7 @@ spec:
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --gcs-credentials-file=/etc/gcs-credentials/service-account.json
-        - --status-path=gs://status-reconciler/status-reconciler-status
+        - --status-path=gs://your-bucket-name/status-reconciler-status
         - --github-app-id=$(GITHUB_APP_ID)
         - --github-app-private-key-path=/etc/github/cert
         env:

--- a/prow/getting_started_deploy.md
+++ b/prow/getting_started_deploy.md
@@ -336,14 +336,17 @@ In order to configure the bucket, follow the following steps:
 After [downloading](https://cloud.google.com/sdk/gcloud/) the `gcloud` tool and authenticating,
 the following collection of commands will execute the above steps for you:
 
+> You will need to change the bucket name from `gs://your-bucket-name/` to a globally unique one and use that instead in [`starter-gcs.yaml`](/config/prow/cluster/starter/starter-gcs.yaml) too.
+
 ```sh
 $ gcloud iam service-accounts create prow-gcs-publisher
-identifier="$(  gcloud iam service-accounts list --filter 'name:prow-gcs-publisher' --format 'value(email)' )"
-$ gsutil mb gs://prow-artifacts/ # step 2
+$ identifier="$(gcloud iam service-accounts list --filter 'name:prow-gcs-publisher' --format 'value(email)')"
+$ gsutil mb gs://your-bucket-name/ # step 2
 $ gsutil iam ch allUsers:objectViewer gs://prow-artifacts # step 3
 $ gsutil iam ch "serviceAccount:${identifier}:objectAdmin" gs://prow-artifacts # step 4
 $ gcloud iam service-accounts keys create --iam-account "${identifier}" service-account.json # step 5
 $ kubectl -n test-pods create secret generic gcs-credentials --from-file=service-account.json # step 6
+$ kubectl -n prow create secret generic gcs-credentials --from-file=service-account.json # this secret is also needed by deployments in the prow namespace 
 ```
 
 #### Configure the version of plank's utility images


### PR DESCRIPTION
Signed-off-by: RinkiyaKeDad <arshsharma461@gmail.com>

Changes introduced:

1. The `starter-gcs.yaml` was referring to buckets that are not created when following the getting started readme. I fixed that by having a single consistent bucket name in the YAMLs and the guide.
2. Following the guide the Ingress IP doesn't show because the GCP doesn't support `pathType: Prefix` for Ingress. Switching to `pathType: ImplementationSpecific` fixes this.
3. Other minor fixes.