### PR TITLE
Add label refactor to plugins.yaml

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -129,6 +129,8 @@ label:
     - tide/merge-method-squash
     # This label, for k/website, identifies issues relevant to https://katacoda.com/
     - team/katacoda
+    # This label, for k/website, identifies PRs with large refactoring changes
+    - refactor
 
 lgtm:
 - repos:


### PR DESCRIPTION
This PR adds the `refactor` label to be used with the `label` command for k/website
This is a follow-up to PR https://github.com/kubernetes/test-infra/pull/23959