### PR TITLE
WIP: Move eviction job to a swap environment.

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -239,7 +239,7 @@ periodics:
       - --deployment=node
       - --gcp-project-type=node-e2e-project
       - --gcp-zone=us-west1-b
-      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial.yaml
+      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial-swap.yaml
       - --node-test-args=--feature-gates=LocalStorageCapacityIsolation=true --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
       - --node-tests=true
       - --provider=gce
@@ -354,7 +354,7 @@ periodics:
       - --deployment=node
       - --gcp-project-type=node-e2e-project
       - --gcp-zone=us-west1-b
-      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial.yaml
+      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial-swap.yaml
       - --node-test-args=--feature-gates=LocalStorageCapacityIsolation=true --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
       - --node-tests=true
       - --provider=gce

--- a/images/gcb-docker-gcloud/Dockerfile
+++ b/images/gcb-docker-gcloud/Dockerfile
@@ -44,7 +44,7 @@ RUN echo http://dl-cdn.alpinelinux.org/alpine/latest-stable/community >> /etc/ap
 # Install docker Buildx for fast docker builds
 ENV HOME=/root
 RUN mkdir -p  $HOME/.docker/cli-plugins \
-    && curl -fsSL "https://github.com/docker/buildx/releases/download/v0.6.0/buildx-v0.6.0.linux-amd64" --output $HOME/.docker/cli-plugins/docker-buildx \
+    && curl -fsSL "https://github.com/docker/buildx/releases/download/v0.7.0/buildx-v0.7.0.linux-amd64" --output $HOME/.docker/cli-plugins/docker-buildx \
     && chmod a+x $HOME/.docker/cli-plugins/docker-buildx
 
 # Copy qemu static binaries.

--- a/jobs/e2e_node/image-config-serial-swap.yaml
+++ b/jobs/e2e_node/image-config-serial-swap.yaml
@@ -1,0 +1,23 @@
+# To copy an image between projects:
+# `gcloud compute --project <to-project> disks create <image name> --image=https://www.googleapis.com/compute/v1/projects/<from-project>/global/images/<image-name>`
+# `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
+images:
+  ubuntu:
+    image: ubuntu-gke-2004-1-20-v20210401 # docker 19.03.8 / containerd 1.4.3
+    machine: n1-standard-2 # These tests need a lot of memory
+    project: ubuntu-os-gke-cloud
+  ubuntu-swap:
+    image: ubuntu-gke-2004-1-20-v20210401 # docker 19.03.8 / containerd 1.4.3
+    machine: n1-standard-2 # These tests need a lot of memory
+    metadata: "user-data</workspace/test-infra/jobs/e2e_node/swap/ubuntu-swap-1G-allocation.yaml"
+    project: ubuntu-os-gke-cloud
+  cos:
+    image_family: cos-89-lts # deprecated after 2021-12-17
+    project: cos-cloud
+    machine: n1-standard-2 # These tests need a lot of memory
+    metadata: "user-data<test/e2e_node/jenkins/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"
+  cos-swap:
+    image_family: cos-89-lts # deprecated after 2021-12-17
+    project: cos-cloud
+    machine: n1-standard-2 # These tests need a lot of memory
+    metadata: "user-data<test/e2e_node/jenkins/cos-init-live-restore.yaml,gci-update-strategy=update_disabled,user-data</workspace/test-infra/jobs/e2e_node/swap/cos-swap-1G-allocation.yaml"

--- a/jobs/e2e_node/swap/cos-swap-1G-allocation.yaml
+++ b/jobs/e2e_node/swap/cos-swap-1G-allocation.yaml
@@ -1,0 +1,25 @@
+#cloud-config
+
+runcmd:
+ - cp /usr/lib/systemd/system/docker.service /etc/systemd/system/docker.service
+ - sed -i '/^ExecStart=\/usr\/bin\/dockerd/ s/$/ --live-restore=false/' /etc/systemd/system/docker.service
+ - systemctl daemon-reload
+ - systemctl restart docker
+ - mount /tmp /tmp -o remount,exec,suid
+ - usermod -a -G docker jenkins
+ - mkdir -p /var/lib/kubelet
+ - mkdir -p /home/kubernetes/containerized_mounter/rootfs
+ - mount --bind /home/kubernetes/containerized_mounter/ /home/kubernetes/containerized_mounter/
+ - mount -o remount, exec /home/kubernetes/containerized_mounter/
+ - wget https://dl.k8s.io/gci-mounter/mounter.tar -O /tmp/mounter.tar
+ - tar xvf /tmp/mounter.tar -C /home/kubernetes/containerized_mounter/rootfs
+ - mkdir -p /home/kubernetes/containerized_mounter/rootfs/var/lib/kubelet
+ - mount --rbind /var/lib/kubelet /home/kubernetes/containerized_mounter/rootfs/var/lib/kubelet
+ - mount --make-rshared /home/kubernetes/containerized_mounter/rootfs/var/lib/kubelet
+ - mount --bind /proc /home/kubernetes/containerized_mounter/rootfs/proc
+ - mount --bind /dev /home/kubernetes/containerized_mounter/rootfs/dev
+ - rm /tmp/mounter.tar
+ - sudo fallocate -l 1G /mnt/stateful_partition/swapfile
+ - sudo chmod 600 /mnt/stateful_partition/swapfile
+ - sudo mkswap /mnt/stateful_partition/swapfile
+ - sudo swapon /mnt/stateful_partition/swapfile

--- a/jobs/e2e_node/swap/ubuntu-swap-1G-allocation.yaml
+++ b/jobs/e2e_node/swap/ubuntu-swap-1G-allocation.yaml
@@ -3,7 +3,7 @@
 runcmd:
   - 'echo current swappiness: $(sysctl vm.swappiness)'
   - 'echo create swap file'
-  - 'fallocate -l 1G /swapfile || true'
+  - 'fallocate -l 1G /swapfile || true' # TODO: replace with dd (see http://manpages.ubuntu.com/manpages/xenial/en/man8/mkswap.8.html)
   - 'chmod 600 /swapfile'
   - 'mkswap /swapfile'
   - 'swapon /swapfile'


### PR DESCRIPTION
Use a swap environment for eviction tests.

In order to run eviction tests with swap enabled, we need a swap environment. These are the main reasons to use the same job for existing eviction tests and future eviction-on-swap tests:
- They cover the same logic.
- Running non-swap test under such environment is ok, since access to swap is limited by a featureGate.
- We can reduce the number of jobs to be maintained and monitored.

Currently swap is only configured on Ubuntu, I still need to figure out if configuring it on COS is the same or if it requires some additional setup.

This work is related to https://github.com/kubernetes/kubernetes/issues/105023

/cc @ehashman @endocrimes
/kind feature
/priority important-soon
/sig node