### PR TITLE
Fix containerd 1.4 node e2e

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -206,7 +206,7 @@ periodics:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211014-7ca1952a94-master
       args:
       - --root=/go/src
-      - --repo=k8s.io/kubernetes=release-1.21
+      - --repo=k8s.io/kubernetes=release-1.22
       - --repo=github.com/containerd/cri=release/1.4
       - --timeout=90
       - --scenario=kubernetes_e2e
@@ -266,7 +266,7 @@ periodics:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211014-7ca1952a94-master
       args:
       - --root=/go/src
-      - --repo=k8s.io/kubernetes=release-1.21
+      - --repo=k8s.io/kubernetes=release-1.22
       - --repo=github.com/containerd/cri=release/1.4
       - --timeout=90
       - --scenario=kubernetes_e2e

--- a/jobs/e2e_node/containerd/containerd-release-1.3/env
+++ b/jobs/e2e_node/containerd/containerd-release-1.3/env
@@ -1,8 +1,0 @@
-CONTAINERD_TEST: 'true'
-CONTAINERD_LOG_LEVEL: 'debug'
-CONTAINERD_DEPLOY_PATH: 'cri-containerd-staging/containerd/release-1.3'
-CONTAINERD_PKG_PREFIX: 'containerd-cni'
-
-CONTAINERD_EXTRA_RUNTIME_HANDLER: 'test-handler'
-CONTAINERD_EXTRA_RUNTIME_OPTIONS: |
-  BinaryName = "/home/containerd/usr/local/sbin/runc"

--- a/jobs/e2e_node/containerd/containerd-release-1.3/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-release-1.3/image-config.yaml
@@ -1,9 +1,0 @@
-images:
-  ubuntu:
-    image: ubuntu-gke-1804-1-17-v20200729 # docker 19.03.2 / containerd 1.2.10
-    project: ubuntu-os-gke-cloud
-    metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.3/env"
-  cos-stable:
-    image_family: cos-81-lts
-    project: cos-cloud
-    metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.3/env,gci-update-strategy=update_disabled"


### PR DESCRIPTION
- Update the k8s version for the job to 1.22 to avoid go error
- remove containerd 1.3 config files


May fix: https://github.com/kubernetes/test-infra/issues/23915
Signed-off-by: Aditi Sharma <adi.sky17@gmail.com>