### PR TITLE
Remove NODE_IMAGE_PRELOAD env from sig-scalability-presets.

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -99,8 +99,6 @@ presets:
   # TODO(https://github.com/kubernetes/perf-tests/issues/1828): Use konnectivity in kubemark.
   - name: KUBE_ENABLE_KONNECTIVITY_SERVICE
     value: false
-  - name: NODE_PRELOAD_IMAGES
-    value: k8s.gcr.io/pause:3.1
 
 ### kubemark-gce-scale
 - labels:
@@ -238,8 +236,6 @@ presets:
     value: "containerd"
   - name: DUMP_TO_GCS_ONLY
     value: true
-  - name: NODE_PRELOAD_IMAGES
-    value: k8s.gcr.io/pause:3.1
 
   ###### Scalability Envs
   ### Common env variables for containerd scalability-related suites.


### PR DESCRIPTION
Context: https://github.com/kubernetes/perf-tests/pull/1914 implements the same functionality, but only in tests where it's actually needed.

See https://github.com/kubernetes/perf-tests/pull/1914#issue-1027217871 for reasoning why we prefer this approach.

/assign @tosi3k 