### PR TITLE
Azure: add capz tests to cherry-pick presubmit jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-0.7.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-0.7.yaml
@@ -258,6 +258,52 @@ presubmits:
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-1-20
         description: "Runs Azure specific tests with cloud-provider-azure release-0.7 (https://github.com/kubernetes-sigs/cloud-provider-azure)."
         testgrid-num-columns-recent: '30'
+    - name: pull-cloud-provider-azure-e2e-ccm-capz-1-20
+      always_run: true
+      optional: true
+      decorate: true
+      decoration_config:
+        timeout: 3h
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      branches:
+        - release-0.7
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+        preset-azure-cred-only: "true"
+        preset-azure-anonymous-pull: "true"
+      extra_refs:
+        - org: kubernetes-sigs
+          repo: cluster-api-provider-azure
+          base_ref: release-1.0
+          path_alias: sigs.k8s.io/cluster-api-provider-azure
+          workdir: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211014-7ca1952a94-1.20
+            command:
+            - runner.sh
+            - ./scripts/ci-entrypoint.sh
+            args:
+            - bash
+            - -c
+            - >-
+              cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+              make test-ccm-e2e
+            securityContext:
+              privileged: true
+            env:
+              - name: TEST_CCM
+                value: "true"
+              - name: AZURE_LOADBALANCER_SKU
+                value: "standard"
+              - name: KUBERNETES_VERSION
+                value: 1.20.9
+      annotations:
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-20-presubmit
+        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-capz-1-20
+        description: "Runs Azure specific tests with cloud-provider-azure release-0.7 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+        testgrid-num-columns-recent: '30'
     - name: pull-cloud-provider-azure-unit-1-20
       always_run: true
       decorate: true

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.0.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.0.yaml
@@ -258,6 +258,52 @@ presubmits:
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-1-21
         description: "Runs Azure specific tests with cloud-provider-azure release-1.0 (https://github.com/kubernetes-sigs/cloud-provider-azure)."
         testgrid-num-columns-recent: '30'
+    - name: pull-cloud-provider-azure-e2e-ccm-capz-1-21
+      always_run: true
+      optional: true
+      decorate: true
+      decoration_config:
+        timeout: 3h
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      branches:
+        - release-1.0
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+        preset-azure-cred-only: "true"
+        preset-azure-anonymous-pull: "true"
+      extra_refs:
+        - org: kubernetes-sigs
+          repo: cluster-api-provider-azure
+          base_ref: release-1.0
+          path_alias: sigs.k8s.io/cluster-api-provider-azure
+          workdir: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211014-7ca1952a94-1.21
+            command:
+            - runner.sh
+            - ./scripts/ci-entrypoint.sh
+            args:
+            - bash
+            - -c
+            - >-
+              cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+              make test-ccm-e2e
+            securityContext:
+              privileged: true
+            env:
+              - name: TEST_CCM
+                value: "true"
+              - name: AZURE_LOADBALANCER_SKU
+                value: "standard"
+              - name: KUBERNETES_VERSION
+                value: 1.21.5
+      annotations:
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-21-presubmit
+        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-capz-1-21
+        description: "Runs Azure specific tests with cloud-provider-azure release-1.0 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+        testgrid-num-columns-recent: '30'
     - name: pull-cloud-provider-azure-unit-1-21
       always_run: true
       decorate: true

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.1.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.1.yaml
@@ -258,6 +258,52 @@ presubmits:
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-1-22
         description: "Runs Azure specific tests with cloud-provider-azure release-1.1 (https://github.com/kubernetes-sigs/cloud-provider-azure)."
         testgrid-num-columns-recent: '30'
+    - name: pull-cloud-provider-azure-e2e-ccm-capz-1-22
+      always_run: true
+      optional: true
+      decorate: true
+      decoration_config:
+        timeout: 3h
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      branches:
+        - release-1.1
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+        preset-azure-cred-only: "true"
+        preset-azure-anonymous-pull: "true"
+      extra_refs:
+        - org: kubernetes-sigs
+          repo: cluster-api-provider-azure
+          base_ref: release-1.0
+          path_alias: sigs.k8s.io/cluster-api-provider-azure
+          workdir: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211014-7ca1952a94-1.22
+            command:
+            - runner.sh
+            - ./scripts/ci-entrypoint.sh
+            args:
+            - bash
+            - -c
+            - >-
+              cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+              make test-ccm-e2e
+            securityContext:
+              privileged: true
+            env:
+              - name: TEST_CCM
+                value: "true"
+              - name: AZURE_LOADBALANCER_SKU
+                value: "standard"
+              - name: KUBERNETES_VERSION
+                value: 1.22.2
+      annotations:
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-22-presubmit
+        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-capz-1-22
+        description: "Runs Azure specific tests with cloud-provider-azure release-1.1 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+        testgrid-num-columns-recent: '30'
     - name: pull-cloud-provider-azure-unit-1-22
       always_run: true
       decorate: true


### PR DESCRIPTION
This PR adds capz tests to cherry-pick cloud-provider-azure PRs. By setting `optional: true` we configure the jobs not to block progress of the PR into the release-branch in the event that the test fails.