### PR TITLE
Allow mkumatag to rerun the e2e test images jobs

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-e2e-test-images.sh
+++ b/config/jobs/image-pushing/k8s-staging-e2e-test-images.sh
@@ -74,6 +74,7 @@ for image in "${IMAGES[@]}"; do
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -125,6 +126,7 @@ periodics:
         - aojea
         - chewong
         - claudiubelu
+        - mkumatag
     # Since the servercore image is updated once per month, we only need to build this
     # cache once per month.
     interval: 744h

--- a/config/jobs/image-pushing/k8s-staging-e2e-test-images.yaml
+++ b/config/jobs/image-pushing/k8s-staging-e2e-test-images.yaml
@@ -13,6 +13,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -52,6 +53,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -91,6 +93,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -130,6 +133,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -169,6 +173,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -208,6 +213,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -247,6 +253,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -286,6 +293,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -325,6 +333,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -364,6 +373,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -403,6 +413,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -442,6 +453,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -481,6 +493,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -520,6 +533,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -559,6 +573,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -598,6 +613,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -637,6 +653,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -676,6 +693,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -715,6 +733,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -754,6 +773,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -793,6 +813,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -832,6 +853,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -871,6 +893,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -910,6 +933,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -949,6 +973,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -988,6 +1013,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -1027,6 +1053,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -1066,6 +1093,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -1105,6 +1133,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -1144,6 +1173,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -1183,6 +1213,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -1222,6 +1253,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -1261,6 +1293,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -1300,6 +1333,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -1339,6 +1373,7 @@ postsubmits:
           - aojea
           - chewong
           - claudiubelu
+          - mkumatag
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
@@ -1386,6 +1421,7 @@ periodics:
         - aojea
         - chewong
         - claudiubelu
+        - mkumatag
     # Since the servercore image is updated once per month, we only need to build this
     # cache once per month.
     interval: 744h


### PR DESCRIPTION
Being a [maintainer](https://github.com/kubernetes/kubernetes/blob/ae9ca48f01ddb03731e7903cfe91ef3db9ce8990/test/images/OWNERS#L8) for the `k/test/images` require access to rerun the post submit jobs when fails.