### PR TITLE
Tide documentation: branches are queried by `base:` not `branch:`

### DIFF
--- a/prow/cmd/tide/config.md
+++ b/prow/cmd/tide/config.md
@@ -65,8 +65,8 @@ The field to search token correspondence is based on the following mapping:
 * `repos` -> `repo:kubernetes/test-infra`
 * `labels` -> `label:lgtm`
 * `missingLabels` -> `-label:do-not-merge`
-* `excludedBranches` -> `-branch:dev`
-* `includedBranches` -> `branch:master`
+* `excludedBranches` -> `-base:dev`
+* `includedBranches` -> `base:master`
 * `author` -> `author:batman`
 * `reviewApprovedRequired` -> `review:approved`
 


### PR DESCRIPTION
See https://github.com/kubernetes/test-infra/blob/2db919950187b4e2e9f41ac5100c8b0320c192d8/prow/config/tide.go#L349-L354