### PR TITLE
kubernetes-sigs/nfd: enable prow override plugin

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1123,6 +1123,14 @@ plugins:
     plugins:
     - milestone
 
+  kubernetes-sigs/node-feature-discovery:
+    plugins:
+    - override
+
+  kubernetes-sigs/node-feature-discovery-operator:
+    plugins:
+    - override
+
   containerd/cri:
     plugins:
     - assign


### PR DESCRIPTION
Enable override plugin in prow config for node-feature-discovery and
node-feature-discovery-operator projects. Makes it possible to ignore
some status checks of e.g. old release branches that have become
incompatible with the presubmit job configurations, for example.

Case in question:
https://github.com/kubernetes-sigs/node-feature-discovery-operator/pull/99