### PR TITLE
Fix containerd 1.5 canary jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -97,7 +97,7 @@ periodics:
           - --scenario=execute
           - --
           - --env=GO111MODULE=off
-          - --env=DEPLOY_DIR=containerd/release-1.5
+          - --env=DEPLOY_DIR=release-1.5
           - /go/src/github.com/containerd/containerd/test/build.sh
   annotations:
     testgrid-dashboards: sig-node-containerd
@@ -283,10 +283,11 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210915-5dbaf53-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211014-7ca1952a94-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes=release-1.22
+      - --repo=github.com/containerd/containerd=release/1.5
       - --timeout=90
       - --scenario=kubernetes_e2e
       - --
@@ -342,10 +343,11 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20210915-5dbaf53-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211014-7ca1952a94-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes=release-1.22
+      - --repo=github.com/containerd/containerd=release/1.5
       - --timeout=90
       - --scenario=kubernetes_e2e
       - --


### PR DESCRIPTION
Update config for containerd 1.5 canaries:
- Update images to match the ones used in 1.4 jobs.
- Fix `DEPLOY_DIR` var (see [containerd's `run.sh`](https://github.com/containerd/containerd/blob/006b44181a28999a0b56bffc26447dead9d0c28b/test/build.sh#L58) vs [cri's `run.sh`](https://github.com/containerd/cri/blob/f6026296a3991010429db91e7e677f9c9d4861ab/test/build.sh#L31)).
- Include containerd repo in non-build jobs (init.yaml is present in that repo).

/cc @adisky @dims @endocrimes 
/sig node
/sig testing