### PR TITLE
Disable the pprof in main server

### DIFF
--- a/prow/cmd/admission/main.go
+++ b/prow/cmd/admission/main.go
@@ -71,12 +71,14 @@ func main() {
 	pprof.Instrument(o.instrumentationOptions)
 	health := pjutil.NewHealthOnPort(o.instrumentationOptions.HealthPort)
 
-	http.HandleFunc("/validate", handle)
+	admissionMux := http.NewServeMux()
+	admissionMux.HandleFunc("/validate", handle)
 	s := http.Server{
 		Addr: ":8443",
 		TLSConfig: &tls.Config{
 			ClientAuth: tls.NoClientCert,
 		},
+		Handler: admissionMux,
 	}
 
 	health.ServeReady()

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -266,16 +266,17 @@ func main() {
 
 	health := pjutil.NewHealthOnPort(o.instrumentationOptions.HealthPort)
 
+	hookMux := http.NewServeMux()
 	// TODO remove this health endpoint when the migration to health endpoint is done
 	// Return 200 on / for health checks.
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {})
+	hookMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {})
 
 	// For /hook, handle a webhook normally.
-	http.Handle(o.webhookPath, server)
+	hookMux.Handle(o.webhookPath, server)
 	// Serve plugin help information from /plugin-help.
-	http.Handle("/plugin-help", pluginhelp.NewHelpAgent(pluginAgent, githubClient))
+	hookMux.Handle("/plugin-help", pluginhelp.NewHelpAgent(pluginAgent, githubClient))
 
-	httpServer := &http.Server{Addr: ":" + strconv.Itoa(o.port)}
+	httpServer := &http.Server{Addr: ":" + strconv.Itoa(o.port), Handler: hookMux}
 
 	health.ServeReady()
 

--- a/prow/cmd/sub/main.go
+++ b/prow/cmd/sub/main.go
@@ -160,8 +160,9 @@ func main() {
 		Reporter:          pubsub.NewReporter(configAgent.Config), // reuse crier reporter
 	}
 
+	subMux := http.NewServeMux()
 	// Return 200 on / for health checks.
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {})
+	subMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {})
 
 	// Setting up Push Server
 	logrus.Info("Setting up Push Server")
@@ -169,7 +170,7 @@ func main() {
 		Subscriber:     s,
 		TokenGenerator: tokenGenerator,
 	}
-	http.Handle("/push", pushServer)
+	subMux.Handle("/push", pushServer)
 
 	// Setting up Pull Server
 	logrus.Info("Setting up Pull Server")
@@ -180,6 +181,6 @@ func main() {
 		}
 	})
 
-	httpServer := &http.Server{Addr: ":" + strconv.Itoa(flagOptions.port)}
+	httpServer := &http.Server{Addr: ":" + strconv.Itoa(flagOptions.port), Handler: subMux}
 	interrupts.ListenAndServe(httpServer, flagOptions.gracePeriod)
 }

--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -185,9 +185,10 @@ func main() {
 		logrus.WithError(err).Fatal("Failed to register kubeconfig change callback")
 	}
 
-	http.Handle("/", c)
-	http.Handle("/history", c.History)
-	server := &http.Server{Addr: ":" + strconv.Itoa(o.port)}
+	controllerMux := http.NewServeMux()
+	controllerMux.Handle("/", c)
+	controllerMux.Handle("/history", c.History)
+	server := &http.Server{Addr: ":" + strconv.Itoa(o.port), Handler: controllerMux}
 
 	// Push metrics to the configured prometheus pushgateway endpoint or serve them
 	metrics.ExposeMetrics("tide", cfg().PushGateway, o.instrumentationOptions.MetricsPort)


### PR DESCRIPTION
Fix: #24104 

Now the pprof can also be accessed from main server, we need to disable it, so add the mux for all the servers.

Ref: https://github.com/kubernetes/test-infra/issues/24104#issuecomment-950144134