### PR TITLE
Fix containerd-1.5 build job

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -96,7 +96,6 @@ periodics:
           - --upload=gs://kubernetes-jenkins/logs
           - --scenario=execute
           - --
-          - --env=GO111MODULE=off
           - --env=DEPLOY_DIR=release-1.5
           - /go/src/github.com/containerd/containerd/test/build.sh
   annotations:


### PR DESCRIPTION
Containerd-1.5 jobs has been recently added, the build job is failing.
Containerd 1.5 supports go modules, removing the env GO111MODULE=off


/cc @mmiranda96 @dims 
/sig node
Signed-off-by: Aditi Sharma <adi.sky17@gmail.com>