### PR TITLE
enabling blockade for sig docs blogs

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -213,8 +213,10 @@ blockades:
   explanation: "We do not accept changes directly against this repository, unless the change is to the `README.md` itself. Please see `CONTRIBUTING.md` for information on where and how to contribute instead."
 - repos:
   - kubernetes/website
+  # The below regex isn't perfect and needs to be updated with another rule to match 2020 in some time.
   blockregexps:
-  - ^content/*/blog/_posts/201*
+  - ^content/\w\w/blog/_posts/201
+  # We (SIG Docs) do sometimes access changes to blogs that are more than two years old. The policy is that we usually don't update, but we can if there's a good reason.
   explanation: "We do not accept changes to blogs older than two years."
 
 

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -211,6 +211,12 @@ blockades:
   exceptionregexps:
   - ^README\.md$
   explanation: "We do not accept changes directly against this repository, unless the change is to the `README.md` itself. Please see `CONTRIBUTING.md` for information on where and how to contribute instead."
+- repos:
+  - kubernetes/website
+  blockregexps:
+  - ^content/*/blog/_posts/201*
+  explanation: "We do not accept changes to blogs older than two years."
+
 
 blunderbuss:
   max_request_count: 2


### PR DESCRIPTION
Signed-off-by: RinkiyaKeDad <arshsharma461@gmail.com>

Enabling the blockade plugin which will label PRs changing blogs that are more than 2 years old with `do-not-merge/blocked-paths`.

/cc @sftim @mrbobbytables 