### PR TITLE
Apps auth: Excplicitly handle empty org and return stack if that happens

### DIFF
--- a/prow/github/app_auth_roundtripper.go
+++ b/prow/github/app_auth_roundtripper.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -114,6 +115,9 @@ func extractOrgFromContext(ctx context.Context) string {
 
 func (arr *appsRoundTripper) addAppInstallationAuth(r *http.Request) *appsAuthError {
 	org := extractOrgFromContext(r.Context())
+	if org == "" {
+		return &appsAuthError{fmt.Errorf("BUG apps auth requested but empty org, please report this to the test-infra repo. Stack: %s", string(debug.Stack()))}
+	}
 
 	token, expiresAt, err := arr.installationTokenFor(org)
 	if err != nil {


### PR DESCRIPTION
For some reason apparently sometimes it can happen that the apps auth
roundtripper doesn't get an org passed. I don't know why this happens
and it is hard to infer from the error. Handle the case explicitly and
include a stacktrace.

Motivated by https://kubernetes.slack.com/archives/CDECRSC5U/p1634742289135800

/cc @chaodaiG 