### PR TITLE
Enable milestone plugin in ingress-nginx repo

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -832,6 +832,7 @@ plugins:
   kubernetes/ingress-nginx:
     plugins:
     - require-matching-label
+    - milestone
 
   kubernetes/k8s.io:
     plugins:


### PR DESCRIPTION
Enable milestone plugin in ingress-nginx repo to be used by other approvers