### PR TITLE
Create a job verifying lint with make rules in test-infra

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -147,6 +147,22 @@ presubmits:
     annotations:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: unit-test
+  - name: pull-test-infra-verify-lint
+    branches:
+    - master
+    always_run: false
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211022-00550799a0-test-infra
+        command:
+        - runner.sh
+        args:
+        - make
+        - verify
+    annotations:
+      testgrid-dashboards: presubmits-test-infra
+      testgrid-tab-name: verify-test
 
 
   # Optional job for testing new build system.


### PR DESCRIPTION
This job is marked optional for now, will make it required and stop golang linting from bazel