### PR TITLE
kubeadm: prepare test jobs for the master->main transition

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-addons.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-addons.yaml
@@ -24,7 +24,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
@@ -24,7 +24,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:
@@ -64,7 +64,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:
@@ -104,7 +104,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:
@@ -144,7 +144,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-ca.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-ca.yaml
@@ -24,7 +24,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:
@@ -64,7 +64,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:
@@ -104,7 +104,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:
@@ -144,7 +144,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
@@ -24,7 +24,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:
@@ -64,7 +64,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:
@@ -104,7 +104,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:
@@ -144,7 +144,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kubelet-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kubelet-x-on-y.yaml
@@ -24,7 +24,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:
@@ -64,7 +64,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:
@@ -104,7 +104,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:
@@ -144,7 +144,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:
@@ -184,7 +184,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:
@@ -224,7 +224,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:
@@ -264,7 +264,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-patches.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-patches.yaml
@@ -24,7 +24,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:
@@ -64,7 +64,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:
@@ -104,7 +104,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:
@@ -144,7 +144,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-rootless.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-rootless.yaml
@@ -24,7 +24,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
@@ -24,7 +24,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:
@@ -64,7 +64,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:
@@ -104,7 +104,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:
@@ -144,7 +144,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
@@ -24,7 +24,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:
@@ -64,7 +64,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:
@@ -104,7 +104,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
@@ -24,7 +24,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:
@@ -64,7 +64,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:
@@ -104,7 +104,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:
@@ -144,7 +144,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   - org: kubernetes
     repo: kubeadm
-    base_ref: master
+    base_ref: main
     path_alias: k8s.io/kubeadm
   spec:
     containers:

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/manifests.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/manifests.yaml
@@ -9,7 +9,7 @@ periodics:
     containers:
     - args:
       - --timeout=60
-      - --repo=k8s.io/kubeadm=master
+      - --repo=k8s.io/kubeadm=main
       - --scenario=execute
       - --
       - ./tests/e2e/manifests/verify_manifest_lists.sh


### PR DESCRIPTION
The kubeadm repository is moving to "main" as the default branch.
https://github.com/kubernetes/kubeadm/issues/2589

The kubeadm-kinder*.yaml changes are automated by the kinder
update-workflows tool.

The mainfests.yaml change is manual.

/config/jobs/kubernetes/kubeadm/ does not require changes, it seems.
That would be true as long as prow runs these presubmit jobs on the
implied default branch.