### PR TITLE
Add a switch in deck for hiding PR History button

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -1021,7 +1021,7 @@ lensesLoop:
 
 	prHistLink := ""
 	org, repo, number, err := sg.RunToPR(src)
-	if err == nil {
+	if err == nil && !cfg().Deck.Spyglass.HidePRHistLink {
 		prHistLink = "/pr-history?org=" + org + "&repo=" + repo + "&pr=" + strconv.Itoa(number)
 	}
 

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -995,6 +995,10 @@ type Spyglass struct {
 	// TestGridRoot is the root URL to the TestGrid frontend, e.g. "https://testgrid.k8s.io/".
 	// If left blank, TestGrid links will not appear.
 	TestGridRoot string `json:"testgrid_root,omitempty"`
+	// HidePRHistLink allows prow hiding PR History link from deck, this is handy especially for
+	// prow instances that only serves gerrit.
+	// This might become obsolete once https://github.com/kubernetes/test-infra/issues/24130 is fixed.
+	HidePRHistLink bool `json:"hide_pr_history_link,omitempty"`
 }
 
 type GCSBrowserPrefixes map[string]string


### PR DESCRIPTION
The current implementation of PR History link only works for github, for gerrit based instance there are some work required to make it work that is tracked in https://github.com/kubernetes/test-infra/issues/24130. For now add a switch in spyglass config to allow omitting the button on the page to avoid confusion