### PR TITLE
Allow gerrit-projects args unset in crier and gerrit

### DIFF
--- a/prow/cmd/crier/main.go
+++ b/prow/cmd/crier/main.go
@@ -96,7 +96,7 @@ func (o *options) validate() error {
 
 	if o.gerritWorkers > 0 {
 		if len(o.gerritProjects) == 0 {
-			return errors.New("--gerrit-projects must be set")
+			logrus.Info("--gerrit-projects is not set, using global config")
 		}
 
 		if o.cookiefilePath == "" {

--- a/prow/cmd/crier/main_test.go
+++ b/prow/cmd/crier/main_test.go
@@ -71,10 +71,6 @@ func TestOptions(t *testing.T) {
 			},
 		},
 		{
-			name: "gerrit missing --gerrit-projects, reject",
-			args: []string{"--gerrit-workers=5", "--cookiefile=foobar", "--config-path=foo"},
-		},
-		{
 			name: "gerrit missing --cookiefile",
 			args: []string{"--gerrit-workers=5", "--gerrit-projects=foo=bar", "--config-path=foo"},
 			expected: &options{

--- a/prow/cmd/gerrit/main.go
+++ b/prow/cmd/gerrit/main.go
@@ -54,7 +54,7 @@ type options struct {
 
 func (o *options) validate() error {
 	if len(o.projects) == 0 {
-		return errors.New("--gerrit-projects must be set")
+		logrus.Info("--gerrit-projects is not set, using global config")
 	}
 
 	if o.cookiefilePath != "" && o.tokenPathOverride != "" {


### PR DESCRIPTION
These are going to be deprecated in favor of global config, for legacy reasons still allow setting them on crier and gerrit, but we shouldn't fail if they are not set