### PR TITLE
Re-request reviewers when LGTM is removed

### DIFF
--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -1117,6 +1117,9 @@ func (f *FakeClient) GetFailedActionRunsByHeadBranch(org, repo, branchName, head
 }
 
 func (f *FakeClient) TriggerGitHubWorkflow(org, repo string, id int) error {
+	return nil
+}
+
 func (f *FakeClient) RequestReview(org, repo string, number int, logins []string) error {
 	f.ReviewersRequested = logins
 	return nil

--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -147,6 +147,9 @@ type FakeClient struct {
 
 	// Team is a map org->teamSlug->TeamWithMembers
 	Teams map[string]map[string]TeamWithMembers
+
+	// Reviewers Requested
+	ReviewersRequested []string
 }
 
 type TeamWithMembers struct {
@@ -1114,5 +1117,7 @@ func (f *FakeClient) GetFailedActionRunsByHeadBranch(org, repo, branchName, head
 }
 
 func (f *FakeClient) TriggerGitHubWorkflow(org, repo string, id int) error {
+func (f *FakeClient) RequestReview(org, repo string, number int, logins []string) error {
+	f.ReviewersRequested = logins
 	return nil
 }

--- a/prow/plugins/lgtm/lgtm.go
+++ b/prow/plugins/lgtm/lgtm.go
@@ -136,6 +136,7 @@ type githubClient interface {
 	IsMember(org, user string) (bool, error)
 	ListTeams(org string) ([]github.Team, error)
 	ListTeamMembers(org string, id int, role string) ([]github.TeamMember, error)
+	RequestReview(org, repo string, number int, logins []string) error
 }
 
 // reviewCtx contains information about each review event
@@ -334,7 +335,7 @@ func handle(wantLGTM bool, config *plugins.Configuration, ownersClient repoowner
 	opts := config.LgtmFor(rc.repo.Owner.Login, rc.repo.Name)
 	if hasLGTM && !wantLGTM {
 		log.Info("Removing LGTM label.")
-		if err := gc.RemoveLabel(org, repoName, number, LGTMLabel); err != nil {
+		if err := removeLGTMAndRequestReview(gc, org, repoName, number, getLogins(assignees)); err != nil {
 			return err
 		}
 		if opts.StoreTreeHash {
@@ -461,7 +462,7 @@ func handlePullRequest(log *logrus.Entry, gc githubClient, config *plugins.Confi
 		}
 	}
 
-	if err := gc.RemoveLabel(org, repo, number, LGTMLabel); err != nil {
+	if err := removeLGTMAndRequestReview(gc, org, repo, number, getLogins(pe.PullRequest.Assignees)); err != nil {
 		return fmt.Errorf("failed removing lgtm label: %w", err)
 	}
 
@@ -469,6 +470,24 @@ func handlePullRequest(log *logrus.Entry, gc githubClient, config *plugins.Confi
 	// pull request changes.
 	log.Infof("Commenting with an LGTM removed notification to %s/%s#%d with a message: %s", org, repo, number, removeLGTMLabelNoti)
 	return gc.CreateComment(org, repo, number, removeLGTMLabelNoti)
+}
+
+func removeLGTMAndRequestReview(gc githubClient, org, repo string, number int, logins []string) error {
+	if err := gc.RemoveLabel(org, repo, number, LGTMLabel); err != nil {
+		return fmt.Errorf("failed removing lgtm label: %w", err)
+	}
+
+	//Re-request review because LGTM has been removed.
+	gc.RequestReview(org, repo, number, logins)
+	return nil
+}
+
+func getLogins(usrs []github.User) []string {
+	res := []string{}
+	for _, usr := range usrs {
+		res = append(res, usr.Login)
+	}
+	return res
 }
 
 func skipCollaborators(config *plugins.Configuration, org, repo string) bool {

--- a/prow/plugins/lgtm/lgtm.go
+++ b/prow/plugins/lgtm/lgtm.go
@@ -477,8 +477,11 @@ func removeLGTMAndRequestReview(gc githubClient, org, repo string, number int, l
 		return fmt.Errorf("failed removing lgtm label: %w", err)
 	}
 
-	//Re-request review because LGTM has been removed.
-	gc.RequestReview(org, repo, number, logins)
+	// Re-request review because LGTM has been removed.
+	// TODO(mpherman): Surface User errors to PR
+	if err := gc.RequestReview(org, repo, number, logins); err != nil {
+		return fmt.Errorf("failed to re-request review")
+	}
 	return nil
 }
 

--- a/prow/plugins/lgtm/lgtm_test.go
+++ b/prow/plugins/lgtm/lgtm_test.go
@@ -149,6 +149,7 @@ func TestLGTMComment(t *testing.T) {
 		shouldAssign  bool
 		skipCollab    bool
 		storeTreeHash bool
+		shouldRequest bool
 	}{
 		{
 			name:         "non-lgtm comment",
@@ -196,6 +197,7 @@ func TestLGTMComment(t *testing.T) {
 			shouldToggle:  true,
 			shouldAssign:  false,
 			shouldComment: false,
+			shouldRequest: true,
 		},
 		{
 			name:          "remove lgtm by author",
@@ -205,6 +207,7 @@ func TestLGTMComment(t *testing.T) {
 			shouldToggle:  true,
 			shouldAssign:  false,
 			shouldComment: false,
+			shouldRequest: true,
 		},
 		{
 			name:          "lgtm comment by non-reviewer",
@@ -259,6 +262,7 @@ func TestLGTMComment(t *testing.T) {
 			shouldToggle:  true,
 			shouldComment: false,
 			shouldAssign:  true,
+			shouldRequest: true,
 		},
 		{
 			name:          "remove lgtm by non-reviewer",
@@ -268,6 +272,7 @@ func TestLGTMComment(t *testing.T) {
 			shouldToggle:  true,
 			shouldComment: false,
 			shouldAssign:  true,
+			shouldRequest: true,
 		},
 		{
 			name:          "lgtm cancel by rando",
@@ -288,32 +293,36 @@ func TestLGTMComment(t *testing.T) {
 			shouldAssign:  false,
 		},
 		{
-			name:         "lgtm cancel comment by reviewer",
-			body:         "/lgtm cancel",
-			commenter:    "collab1",
-			hasLGTM:      true,
-			shouldToggle: true,
+			name:          "lgtm cancel comment by reviewer",
+			body:          "/lgtm cancel",
+			commenter:     "collab1",
+			hasLGTM:       true,
+			shouldToggle:  true,
+			shouldRequest: true,
 		},
 		{
-			name:         "remove-lgtm comment by reviewer",
-			body:         "/remove-lgtm",
-			commenter:    "collab1",
-			hasLGTM:      true,
-			shouldToggle: true,
+			name:          "remove-lgtm comment by reviewer",
+			body:          "/remove-lgtm",
+			commenter:     "collab1",
+			hasLGTM:       true,
+			shouldToggle:  true,
+			shouldRequest: true,
 		},
 		{
-			name:         "lgtm cancel comment by reviewer, with trailing space",
-			body:         "/lgtm cancel \r",
-			commenter:    "collab1",
-			hasLGTM:      true,
-			shouldToggle: true,
+			name:          "lgtm cancel comment by reviewer, with trailing space",
+			body:          "/lgtm cancel \r",
+			commenter:     "collab1",
+			hasLGTM:       true,
+			shouldToggle:  true,
+			shouldRequest: true,
 		},
 		{
-			name:         "remove lgtm comment by reviewer, with trailing space",
-			body:         "/remove-lgtm \r",
-			commenter:    "collab1",
-			hasLGTM:      true,
-			shouldToggle: true,
+			name:          "remove lgtm comment by reviewer, with trailing space",
+			body:          "/remove-lgtm \r",
+			commenter:     "collab1",
+			hasLGTM:       true,
+			shouldToggle:  true,
+			shouldRequest: true,
 		},
 		{
 			name:         "lgtm cancel comment by reviewer, no lgtm",
@@ -438,6 +447,12 @@ func TestLGTMComment(t *testing.T) {
 			t.Error("should have commented.")
 		} else if !tc.shouldComment && len(fc.IssueComments[5]) != 0 {
 			t.Error("should not have commented.")
+		}
+		if tc.shouldRequest && len(fc.ReviewersRequested) == 0 {
+			t.Error("should have re-requested reviewers")
+		}
+		if !tc.shouldRequest && len(fc.ReviewersRequested) > 0 {
+			t.Errorf("should not have re-requested reviewers, but requested these reviewers %v", fc.ReviewersRequested)
 		}
 	}
 }
@@ -815,6 +830,8 @@ func TestHandlePullRequest(t *testing.T) {
 		trustedTeam        string
 
 		expectNoComments bool
+
+		shouldRequest bool
 	}{
 		{
 			name: "pr_synchronize, no RemoveLabel error",
@@ -833,9 +850,15 @@ func TestHandlePullRequest(t *testing.T) {
 					Head: github.PullRequestBranch{
 						SHA: SHA,
 					},
+					Assignees: []github.User{
+						{
+							Login: "TestReviewer",
+						},
+					},
 				},
 			},
 			IssueLabelsRemoved: []string{LGTMLabel},
+			shouldRequest:      true,
 			issueComments: map[int][]github.IssueComment{
 				101: {
 					{
@@ -864,6 +887,11 @@ func TestHandlePullRequest(t *testing.T) {
 						Login: "sig-lead",
 					},
 					MergeSHA: &SHA,
+					Assignees: []github.User{
+						{
+							Login: "TestReviewer",
+						},
+					},
 				},
 			},
 			trustedTeam:      "Leads",
@@ -887,9 +915,15 @@ func TestHandlePullRequest(t *testing.T) {
 						Login: "sig-lead",
 					},
 					MergeSHA: &SHA,
+					Assignees: []github.User{
+						{
+							Login: "TestReviewer",
+						},
+					},
 				},
 			},
 			IssueLabelsRemoved: []string{LGTMLabel},
+			shouldRequest:      true,
 			issueComments: map[int][]github.IssueComment{
 				101: {
 					{
@@ -918,9 +952,15 @@ func TestHandlePullRequest(t *testing.T) {
 						Login: "sig-lead",
 					},
 					MergeSHA: &SHA,
+					Assignees: []github.User{
+						{
+							Login: "TestReviewer",
+						},
+					},
 				},
 			},
 			IssueLabelsRemoved: []string{LGTMLabel},
+			shouldRequest:      true,
 			issueComments: map[int][]github.IssueComment{
 				101: {
 					{
@@ -956,6 +996,11 @@ func TestHandlePullRequest(t *testing.T) {
 					Head: github.PullRequestBranch{
 						SHA: SHA,
 					},
+					Assignees: []github.User{
+						{
+							Login: "TestReviewer",
+						},
+					},
 				},
 			},
 			issueComments: map[int][]github.IssueComment{
@@ -985,9 +1030,15 @@ func TestHandlePullRequest(t *testing.T) {
 					Head: github.PullRequestBranch{
 						SHA: SHA,
 					},
+					Assignees: []github.User{
+						{
+							Login: "TestReviewer",
+						},
+					},
 				},
 			},
 			IssueLabelsRemoved: []string{LGTMLabel},
+			shouldRequest:      true,
 			issueComments: map[int][]github.IssueComment{
 				101: {
 					{
@@ -1017,6 +1068,11 @@ func TestHandlePullRequest(t *testing.T) {
 					Head: github.PullRequestBranch{
 						SHA: SHA,
 					},
+					Assignees: []github.User{
+						{
+							Login: "TestReviewer",
+						},
+					},
 				},
 			},
 			issueComments: map[int][]github.IssueComment{
@@ -1032,6 +1088,37 @@ func TestHandlePullRequest(t *testing.T) {
 				},
 			},
 			expectNoComments: true,
+		},
+		{
+			name: "pr_synchronize, no RemoveLabel error, no assignees; no requested reviewers",
+			event: github.PullRequestEvent{
+				Action: github.PullRequestActionSynchronize,
+				PullRequest: github.PullRequest{
+					Number: 101,
+					Base: github.PullRequestBranch{
+						Repo: github.Repo{
+							Owner: github.User{
+								Login: "kubernetes",
+							},
+							Name: "kubernetes",
+						},
+					},
+					Head: github.PullRequestBranch{
+						SHA: SHA,
+					},
+				},
+			},
+			IssueLabelsRemoved: []string{LGTMLabel},
+			shouldRequest:      false,
+			issueComments: map[int][]github.IssueComment{
+				101: {
+					{
+						Body: removeLGTMLabelNoti,
+						User: github.User{Login: fakegithub.Bot},
+					},
+				},
+			},
+			expectNoComments: false,
 		},
 	}
 	for _, c := range cases {
@@ -1093,6 +1180,12 @@ func TestHandlePullRequest(t *testing.T) {
 			}
 			if !c.expectNoComments && len(fakeGitHub.IssueCommentsAdded) == 0 {
 				t.Fatalf("expected comments but got none")
+			}
+			if c.shouldRequest && len(fakeGitHub.ReviewersRequested) == 0 {
+				t.Error("should have re-requested reviewers")
+			}
+			if !c.shouldRequest && len(fakeGitHub.ReviewersRequested) > 0 {
+				t.Errorf("should not have re-requested reviewers, but requested these reviewers %v", fakeGitHub.ReviewersRequested)
 			}
 		})
 	}


### PR DESCRIPTION
LGTM plugin will now re-request review from all assignees when LGTM has been removed for any reason.
Co-authored-by: Sean Chase @chases2