### PR TITLE
Allow deleting gerrit projects at runtime

### DIFF
--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -107,6 +107,7 @@ func NewController(ctx context.Context, prowJobClient prowv1.ProwJobInterface, o
 				time.Sleep(time.Second)
 				continue
 			}
+			// Use globally defined gerrit repos if present
 			if err := gerritClient.UpdateClients(orgReposConfig.AllRepos()); err != nil {
 				logrus.WithError(err).Error("Updating clients.")
 			}

--- a/prow/gerrit/client/BUILD.bazel
+++ b/prow/gerrit/client/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
     tags = ["manual"],
     deps = [
         "@com_github_andygrunwald_go_gerrit//:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )


### PR DESCRIPTION
There are two problems in current implementation:
- Deleted instances are not deleted from handlers
- Updated projects list are not updated from handlers either