### PR TITLE
[scheduler-plugins] merge verification-related Makefile entries

### DIFF
--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-master.yaml
@@ -1,7 +1,7 @@
 # sigs.k8s.io/scheduler-plugins presubmits
 presubmits:
   kubernetes-sigs/scheduler-plugins:
-  - name: pull-scheduler-plugins-verify-gofmt-master
+  - name: pull-scheduler-plugins-verify
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
@@ -13,7 +13,7 @@ presubmits:
         command:
         - make
         args:
-        - verify-gofmt
+        - verify
   - name: pull-scheduler-plugins-verify-build-master
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
@@ -53,16 +53,3 @@ presubmits:
         - make
         args:
         - integration-test
-  - name: pull-scheduler-plugins-verify-crdgen-master
-    decorate: true
-    path_alias: sigs.k8s.io/scheduler-plugins
-    branches:
-    - ^master$
-    always_run: true
-    spec:
-      containers:
-      - image: golang:1.16.7
-        command:
-        - make
-        args:
-        - verify-crdgen


### PR DESCRIPTION
The number of verification scripts grows as time goes. It's neat to have a unified Makefile entry to include all individual verification scripts.