### PR TITLE
cluster-api-provider-openstack: rename base_ref to main

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics.yaml
@@ -13,7 +13,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-openstack
-    base_ref: master
+    base_ref: main
     path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
   - org: kubernetes-sigs
     repo: image-builder
@@ -59,7 +59,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-openstack
-    base_ref: master
+    base_ref: main
     path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
   - org: kubernetes-sigs
     repo: image-builder


### PR DESCRIPTION
Part of https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/855

/cc @sbueringer @jichenjc @hidekazuna

<sub>Tobias Giese <tobias.giese@daimler.com>, Daimler TSS GmbH, [legal info/Impressum](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)</sub>