### PR TITLE
Prow deployment job uses make rule

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -132,10 +132,11 @@ postsubmits:
       containers:
       - image: gcr.io/k8s-testimages/gcloud-bazel:v20210128-v0.6-11-gf1c6399
         command:
-        - prow/deploy.sh
+        - make
         args:
-        - --confirm
-        - --config=trusted
+        - -C
+        - config/prow
+        - deploy-all
     annotations:
       testgrid-dashboards: sig-testing-prow
       testgrid-tab-name: deploy-prow


### PR DESCRIPTION
/hold
This also changes from schemaless CRD to full CRD, kubectl apply would fail, will need to do it manually before merging this PR