### PR TITLE
GracefulNodeShutdown is a beta feature now. Temporarily use both tags

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -424,7 +424,8 @@ periodics:
           - --node-test-args=--feature-gates=DynamicKubeletConfig=true --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
           - --node-tests=true
           - --provider=gce
-          - --test_args=--nodes=1 --focus="\[NodeAlphaFeature:GracefulNodeShutdown\]"
+          # Remove NodeAlphaFeature:GracefulNodeShutdown once the k/k code is submitted
+          - --test_args=--nodes=1 --focus="\[NodeAlphaFeature:GracefulNodeShutdown\]|\[NodeFeature:GracefulNodeShutdown\]"
           - --timeout=60m
         env:
           - name: GOPATH


### PR DESCRIPTION
Replaces this: https://github.com/kubernetes/test-infra/pull/22728
Unblocks this: https://github.com/kubernetes/kubernetes/pull/105482


/sig node
/kind cleanup
/cc @bobbypage @wzshiming 
