### PR TITLE
updating annotations in node-e2e-kubetest2 pre-submit jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -330,7 +330,10 @@ presubmits:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
     annotations:
+      fork-per-release: "true"
+      testgrid-alert-stale-results-hours: "24"
       testgrid-create-test-group: "true"
+      testgrid-num-failures-to-alert: "10"
     spec:
       containers:
       # experimental have the kubetest2 binaries
@@ -415,7 +418,10 @@ presubmits:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
     annotations:
+      fork-per-release: "true"
+      testgrid-alert-stale-results-hours: "24"
       testgrid-create-test-group: "true"
+      testgrid-num-failures-to-alert: "10"
     spec:
       containers:
       # experimental have the kubetest2 binaries


### PR DESCRIPTION
Signed-off-by: Namanl2001 <namanlakhwani@gmail.com>

I missed adding proper annotations in some newly added kubetest2 jobs and expecting it as the cause of tests failure.

updating annotations for:
`pull-kubernetes-node-e2e-containerd-features-kubetest2` failing job: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/92316/pull-kubernetes-node-e2e-containerd-features-kubetest2/1453344092535656448

`pull-kubernetes-node-e2e-alpha-kubetest2` failing job: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/92316/pull-kubernetes-node-e2e-alpha-kubetest2/1453344092573405184

cc: @dims @amwat 