### PR TITLE
Enable HPAContainerMetrics in HPA CPU tests

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -290,6 +290,8 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
+      # Enable HPAContainerMetrics. Required for container metrics tests.
+      - --env=KUBE_FEATURE_GATES=HPAContainerMetrics=true
       - --extract=ci/latest
       - --timeout=100m
       - --test_args=--ginkgo.focus=\[Feature:HPA\]


### PR DESCRIPTION
Enable HPAContainerMetrics in ci-kubernetes-e2e-autoscaling-hpa-cpu tests. Required to support:
- [sig-autoscaling] [Feature:HPA] Horizontal pod autoscaling (scale resource: CPU) [Serial] [Slow] ReplicaSet with idle sidecar (ContainerResource use case) Should scale from 1 pod to 3 pods and from 3 to 5 on a busy application with an idle sidecar container
- [sig-autoscaling] [Feature:HPA] Horizontal pod autoscaling (scale resource: CPU) [Serial] [Slow] ReplicaSet with idle sidecar (ContainerResource use case) Should not scale up on a busy sidecar with an idle application