### PR TITLE
fix: pull-kubernetes-node-e2e-containerd-features-kubetest2

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -324,6 +324,10 @@ presubmits:
       repo: test-infra
       base_ref: master
       path_alias: k8s.io/test-infra
+    - org: containerd
+      repo: containerd
+      base_ref: main
+      path_alias: github.com/containerd/containerd
     decoration_config:
       timeout: 65m
     labels:


### PR DESCRIPTION
Signed-off-by: Namanl2001 <namanlakhwani@gmail.com>

this line checks out the containerd repository - https://github.com/kubernetes/test-infra/blob/0f07bd2b50de95167ee41d92d85f3255a184e5a8/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml#L288

adding it in `extra-refs` for pull-kubernetes-node-e2e-containerd-features-kubetest2

cc: @dims @amwat 