### PR TITLE
CAPZ: update milestone plugin for v1.0 release

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -364,8 +364,10 @@ milestone_applier:
     release-0.7: v0.7.x
     release-0.6: v0.6.x
   kubernetes-sigs/cluster-api-provider-azure:
-    main: v0.5
-    release-0.4: v0.4.16
+    main: v1.1
+    release-1.0: v1.0
+    release-0.5: v0.5
+    release-0.4: v0.4
   kubernetes-sigs/cluster-api-provider-digitalocean:
     main: v1.0.0
     release-0.5: v0.5.1


### PR DESCRIPTION
Update the milestone plugin to match release branches and milestones in cluster-api-provider-azure:

https://github.com/kubernetes-sigs/cluster-api-provider-azure/milestones