### PR TITLE
job_states_to_report should not be a required field

### DIFF
--- a/config/prow/cluster/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob_customresourcedefinition.yaml
@@ -19955,8 +19955,6 @@ spec:
                         type: array
                       report_template:
                         type: string
-                    required:
-                    - job_states_to_report
                     type: object
                 type: object
               rerun_auth_config:

--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -305,7 +305,7 @@ type ReporterConfig struct {
 type SlackReporterConfig struct {
 	Host              string         `json:"host,omitempty"`
 	Channel           string         `json:"channel,omitempty"`
-	JobStatesToReport []ProwJobState `json:"job_states_to_report"`
+	JobStatesToReport []ProwJobState `json:"job_states_to_report,omitempty"`
 	ReportTemplate    string         `json:"report_template,omitempty"`
 }
 

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -81,13 +81,27 @@ func TestReporterConfigRoundtrip(t *testing.T) {
 		{
 			content: `name: abc
 reporter_config:
-  slack:
-    job_states_to_report: []`,
+  slack: {}`,
 			expectedPJ: JobBase{
 				Name: "abc",
 				ReporterConfig: &prowapi.ReporterConfig{
 					Slack: &prowapi.SlackReporterConfig{
-						JobStatesToReport: []prowapi.ProwJobState{},
+						JobStatesToReport: nil,
+					},
+				},
+			},
+		},
+		{
+			content: `name: abc
+reporter_config:
+  slack:
+    job_states_to_report:
+    - test`,
+			expectedPJ: JobBase{
+				Name: "abc",
+				ReporterConfig: &prowapi.ReporterConfig{
+					Slack: &prowapi.SlackReporterConfig{
+						JobStatesToReport: []prowapi.ProwJobState{"test"},
 					},
 				},
 			},


### PR DESCRIPTION
The new CRDs marked `job_states_to_report` to be a required field to ProwJobs. This however leads to jobs generated by mkpj not being applyable anymore, if the job definition does not include `job_states_to_report` (but only the Slack channel), for example a job with

```yaml
      reporter_config:
        slack:
          channel: dev-something
```

would lead to a ProwJob which reads

```yaml
  reporter_config:
    slack:
      channel: dev-something
      job_states_to_report: null
```

Causing 

> error: error validating "foo.yaml": error validating data: ValidationError(ProwJob.spec.reporter_config.slack): missing required field "job_states_to_report" in io.k8s.prow.v1.ProwJob.spec.reporter_config.slack; if you choose to ignore these errors, turn validation off with --validate=false

Prow merges the job-supplied reporter config later with the global configuration, so having no explicit `job_states_to_report` is absolutely fine.