### PR TITLE
fix: pull-kubernetes-node-e2e-containerd-features-kubetest2

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -364,7 +364,7 @@ presubmits:
         - --focus-regex=\[NodeFeature:.+\]
         - --skip-regex=\[Flaky\]|\[Serial\]
         - '--test-args=--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
-        - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-master/image-config.yaml
+        - --image-config-file=/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-master/image-config.yaml
         - --image-config-dir=/home/prow
   - name: pull-kubernetes-node-e2e-alpha
     branches:


### PR DESCRIPTION
Signed-off-by: Namanl2001 <namanlakhwani@gmail.com>

Adding `--image-config-dir` parameter in `pull-kubernetes-node-e2e-containerd-features-kubetest2` job so that prow look for files at correct path

cc: @dims @amwat 