### PR TITLE
Renamed CL2 experimental-prometheus-snapshot-to-artifacts to experimental-prometheus-snapshot-to-report-dir

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -326,7 +326,7 @@ presubmits:
         - --test-cmd-args=cluster-loader2
         - --test-cmd-args=--experimental-gcp-snapshot-prometheus-disk=true
         - --test-cmd-args=--experimental-prometheus-disk-snapshot-name=$(JOB_NAME)-$(BUILD_ID)
-        - --test-cmd-args=--experimental-prometheus-snapshot-to-artifacts=true
+        - --test-cmd-args=--experimental-prometheus-snapshot-to-report-dir=true
         - --test-cmd-args=--nodes=500
         - --test-cmd-args=--provider=kubemark
         - --env=CL2_ENABLE_PVS=false # TODO(https://github.com/kubernetes/perf-tests/issues/803): Fix me


### PR DESCRIPTION
Follow up from https://github.com/kubernetes/perf-tests/pull/1923