### PR TITLE
test(secrets-store-csi-driver): add upgrade test for release-1.0

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-release-0.3-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-release-0.3-config.yaml
@@ -1,6 +1,6 @@
 periodics:
 - interval: 12h
-  name: periodic-secrets-store-csi-driver-upgrade-test-azure-release-0-1
+  name: periodic-secrets-store-csi-driver-upgrade-test-azure-release-0-3
   decorate: true
   decoration_config:
     timeout: 30m
@@ -14,7 +14,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: secrets-store-csi-driver
-    base_ref: release-0.1
+    base_ref: release-0.3
     path_alias: sigs.k8s.io/secrets-store-csi-driver
   spec:
     containers:
@@ -28,7 +28,7 @@ periodics:
           privileged: true
   annotations:
     testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-periodic
-    testgrid-tab-name: secrets-store-csi-driver-upgrade-test-azure-release-0-1
+    testgrid-tab-name: secrets-store-csi-driver-upgrade-test-azure-release-0-3
     testgrid-alert-email: kubernetes-secrets-store-csi-driver@googlegroups.com
     description: "Run driver upgrade test with azure provider for Secrets Store CSI driver."
     testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-release-1.0-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-release-1.0-config.yaml
@@ -1,0 +1,34 @@
+periodics:
+- interval: 12h
+  name: periodic-secrets-store-csi-driver-upgrade-test-azure-release-1-0
+  decorate: true
+  decoration_config:
+    timeout: 30m
+  labels:
+    # this is required because we want to run kind in docker
+    preset-dind-enabled: "true"
+    # this is required to make CNI installation to succeed for kind
+    preset-kind-volume-mounts: "true"
+    # sets up the azure keyvault parameters used for testing
+    preset-azure-secrets-store-creds: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: secrets-store-csi-driver
+    base_ref: release-1.0
+    path_alias: sigs.k8s.io/secrets-store-csi-driver
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211022-00550799a0-master
+        command:
+          - runner.sh
+        args:
+          - HELM_CHART_DIR=$(ls -h charts/*.tgz | sort --version-sort --field-separator=- --key=5 | tail -n 1) make e2e-bootstrap e2e-helm-deploy-release e2e-azure && HELM_CHART_DIR=manifest_staging/charts/secrets-store-csi-driver make e2e-helm-upgrade e2e-azure
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+  annotations:
+    testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-periodic
+    testgrid-tab-name: secrets-store-csi-driver-upgrade-test-azure-release-1-0
+    testgrid-alert-email: kubernetes-secrets-store-csi-driver@googlegroups.com
+    description: "Run driver upgrade test with azure provider for Secrets Store CSI driver."
+    testgrid-num-columns-recent: '30'


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

- Adds upgrade test config for `release-1.0` and `release-0.3`
- Removes `release-0.1` upgrade tests

Current supported releases: https://secrets-store-csi-driver.sigs.k8s.io/introduction.html#project-status