### PR TITLE
Kops - Migrate presubmit jobs from k8s 1.21 to stable

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -901,14 +901,14 @@ def generate_presubmits_e2e():
         ),
         presubmit_test(
             container_runtime='docker',
-            k8s_version='1.21',
+            k8s_version='stable',
             kops_channel='alpha',
             name='pull-kops-e2e-k8s-docker',
             tab_name='e2e-docker',
             always_run=False,
         ),
         presubmit_test(
-            k8s_version='1.21',
+            k8s_version='stable',
             kops_channel='alpha',
             name='pull-kops-e2e-kubernetes-aws',
             networking='calico',
@@ -918,7 +918,7 @@ def generate_presubmits_e2e():
         presubmit_test(
             distro="u2010",
             networking='calico',
-            k8s_version='1.21',
+            k8s_version='stable',
             kops_channel='alpha',
             name='pull-kops-e2e-k8s-ubuntu2010',
             tab_name='e2e-ubuntu2010',
@@ -927,7 +927,7 @@ def generate_presubmits_e2e():
         presubmit_test(
             distro="u2104",
             networking='calico',
-            k8s_version='1.21',
+            k8s_version='stable',
             kops_channel='alpha',
             name='pull-kops-e2e-k8s-ubuntu2104',
             tab_name='e2e-ubuntu2104',
@@ -936,7 +936,7 @@ def generate_presubmits_e2e():
         presubmit_test(
             distro="deb11",
             networking='calico',
-            k8s_version='1.21',
+            k8s_version='stable',
             kops_channel='alpha',
             name='pull-kops-e2e-k8s-debian11',
             tab_name='e2e-debian11',
@@ -944,7 +944,7 @@ def generate_presubmits_e2e():
         ),
         presubmit_test(
             cloud='gce',
-            k8s_version='1.21',
+            k8s_version='stable',
             kops_channel='alpha',
             name='pull-kops-e2e-k8s-gce',
             networking='cilium',
@@ -954,7 +954,7 @@ def generate_presubmits_e2e():
         ),
         presubmit_test(
             cloud='gce',
-            k8s_version='1.22',
+            k8s_version='stable',
             kops_channel='alpha',
             name='pull-kops-e2e-k8s-gce-calico-u2004-k22-containerd',
             networking='calico',

--- a/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
@@ -346,7 +346,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-hirsute-21.04-amd64-server-20211017' --channel=alpha --networking=calico --container-runtime=containerd" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-hirsute-21.04-amd64-server-20211028' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
           --test=kops \

--- a/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
@@ -367,7 +367,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-hirsute-21.04-amd64-server-20211017' --channel=alpha --networking=calico --container-runtime=containerd" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-hirsute-21.04-amd64-server-20211028' --channel=alpha --networking=calico --container-runtime=containerd" \
             --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.21.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/bazel-bin/cmd/kops/linux-amd64/kops \
             --test=kops \

--- a/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
@@ -140,7 +140,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-containerd-ci-ha
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.21", "kops_channel": "alpha", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "stable", "kops_channel": "alpha", "networking": "kubenet"}
   - name: pull-kops-e2e-k8s-docker
     branches:
     - master
@@ -173,13 +173,13 @@ presubmits:
             --up --build --down \
             --cloud-provider=aws \
             --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20211021' --channel=alpha --networking=kubenet --container-runtime=docker" \
-            --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.21.txt \
+            --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/bazel-bin/cmd/kops/linux-amd64/kops \
             --test=kops \
             -- \
             --ginkgo-args="--debug" \
             --test-args="-test.timeout=60m -num-nodes=0" \
-            --test-package-marker=stable-1.21.txt \
+            --test-package-marker=stable.txt \
             --parallel=25
         securityContext:
           privileged: true
@@ -198,14 +198,14 @@ presubmits:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/container_runtime: docker
       test.kops.k8s.io/distro: u2004
-      test.kops.k8s.io/k8s_version: '1.21'
+      test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: kubenet
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-1.21, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-stable, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-docker
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.21", "kops_channel": "alpha", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-e2e-kubernetes-aws
     branches:
     - master
@@ -238,13 +238,13 @@ presubmits:
             --up --build --down \
             --cloud-provider=aws \
             --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20211021' --channel=alpha --networking=calico --container-runtime=containerd" \
-            --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.21.txt \
+            --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/bazel-bin/cmd/kops/linux-amd64/kops \
             --test=kops \
             -- \
             --ginkgo-args="--debug" \
             --test-args="-test.timeout=60m -num-nodes=0" \
-            --test-package-marker=stable-1.21.txt \
+            --test-package-marker=stable.txt \
             --parallel=25
         securityContext:
           privileged: true
@@ -263,14 +263,14 @@ presubmits:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/container_runtime: containerd
       test.kops.k8s.io/distro: u2004
-      test.kops.k8s.io/k8s_version: '1.21'
+      test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: calico
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-1.21, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-stable, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2010", "k8s_version": "1.21", "kops_channel": "alpha", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2010", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-e2e-k8s-ubuntu2010
     branches:
     - master
@@ -303,13 +303,13 @@ presubmits:
             --up --build --down \
             --cloud-provider=aws \
             --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-groovy-20.10-amd64-server-20210720' --channel=alpha --networking=calico --container-runtime=containerd" \
-            --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.21.txt \
+            --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/bazel-bin/cmd/kops/linux-amd64/kops \
             --test=kops \
             -- \
             --ginkgo-args="--debug" \
             --test-args="-test.timeout=60m -num-nodes=0" \
-            --test-package-marker=stable-1.21.txt \
+            --test-package-marker=stable.txt \
             --parallel=25
         securityContext:
           privileged: true
@@ -328,14 +328,14 @@ presubmits:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/container_runtime: containerd
       test.kops.k8s.io/distro: u2010
-      test.kops.k8s.io/k8s_version: '1.21'
+      test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: calico
-      testgrid-dashboards: kops-distro-u2010, kops-k8s-1.21, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2010, kops-k8s-stable, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-ubuntu2010
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2104", "k8s_version": "1.21", "kops_channel": "alpha", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2104", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-e2e-k8s-ubuntu2104
     branches:
     - master
@@ -368,13 +368,13 @@ presubmits:
             --up --build --down \
             --cloud-provider=aws \
             --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-hirsute-21.04-amd64-server-20211028' --channel=alpha --networking=calico --container-runtime=containerd" \
-            --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.21.txt \
+            --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/bazel-bin/cmd/kops/linux-amd64/kops \
             --test=kops \
             -- \
             --ginkgo-args="--debug" \
             --test-args="-test.timeout=60m -num-nodes=0" \
-            --test-package-marker=stable-1.21.txt \
+            --test-package-marker=stable.txt \
             --parallel=25
         securityContext:
           privileged: true
@@ -393,14 +393,14 @@ presubmits:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/container_runtime: containerd
       test.kops.k8s.io/distro: u2104
-      test.kops.k8s.io/k8s_version: '1.21'
+      test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: calico
-      testgrid-dashboards: kops-distro-u2104, kops-k8s-1.21, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2104, kops-k8s-stable, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-ubuntu2104
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb11", "k8s_version": "1.21", "kops_channel": "alpha", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb11", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-e2e-k8s-debian11
     branches:
     - master
@@ -433,13 +433,13 @@ presubmits:
             --up --build --down \
             --cloud-provider=aws \
             --create-args="--image='136693071363/debian-11-amd64-20211011-792' --channel=alpha --networking=calico --container-runtime=containerd" \
-            --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.21.txt \
+            --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/bazel-bin/cmd/kops/linux-amd64/kops \
             --test=kops \
             -- \
             --ginkgo-args="--debug" \
             --test-args="-test.timeout=60m -num-nodes=0" \
-            --test-package-marker=stable-1.21.txt \
+            --test-package-marker=stable.txt \
             --parallel=25
         securityContext:
           privileged: true
@@ -458,14 +458,14 @@ presubmits:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/container_runtime: containerd
       test.kops.k8s.io/distro: deb11
-      test.kops.k8s.io/k8s_version: '1.21'
+      test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: calico
-      testgrid-dashboards: kops-distro-deb11, kops-k8s-1.21, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-deb11, kops-k8s-stable, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-debian11
 
-# {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.21", "kops_channel": "alpha", "networking": "cilium"}
+# {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
   - name: pull-kops-e2e-k8s-gce
     branches:
     - master
@@ -494,13 +494,13 @@ presubmits:
             --up --build --down \
             --cloud-provider=gce \
             --create-args="--channel=alpha --networking=cilium --container-runtime=containerd" \
-            --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.21.txt \
+            --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/bazel-bin/cmd/kops/linux-amd64/kops \
             --test=kops \
             -- \
             --ginkgo-args="--debug" \
             --test-args="-test.timeout=60m -num-nodes=0" \
-            --test-package-marker=stable-1.21.txt \
+            --test-package-marker=stable.txt \
             --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|\[Driver:.nfs\]|Firewall|Dashboard|RuntimeClass|RuntimeHandler|kube-dns|run.a.Pod.requesting.a.RuntimeClass|should.set.TCP.CLOSE_WAIT|Services.*rejected.*endpoints" \
             --parallel=25
         securityContext:
@@ -520,14 +520,14 @@ presubmits:
       test.kops.k8s.io/cloud: gce
       test.kops.k8s.io/container_runtime: containerd
       test.kops.k8s.io/distro: u2004
-      test.kops.k8s.io/k8s_version: '1.21'
+      test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: cilium
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-1.21, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-stable, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-gce
 
-# {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "feature_flags": "GoogleCloudBucketACL", "k8s_version": "1.22", "kops_channel": "alpha", "networking": "calico"}
+# {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "feature_flags": "GoogleCloudBucketACL", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-e2e-k8s-gce-calico-u2004-k22-containerd
     branches:
     - master
@@ -557,13 +557,13 @@ presubmits:
             --cloud-provider=gce \
             --create-args="--channel=alpha --networking=calico --container-runtime=containerd" \
             --env=KOPS_FEATURE_FLAGS=GoogleCloudBucketACL \
-            --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
+            --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/bazel-bin/cmd/kops/linux-amd64/kops \
             --test=kops \
             -- \
             --ginkgo-args="--debug" \
             --test-args="-test.timeout=60m -num-nodes=0" \
-            --test-package-marker=stable-1.22.txt \
+            --test-package-marker=stable.txt \
             --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|\[Driver:.nfs\]|Firewall|Dashboard|RuntimeClass|RuntimeHandler|kube-dns|run.a.Pod.requesting.a.RuntimeClass|should.set.TCP.CLOSE_WAIT|Services.*rejected.*endpoints" \
             --parallel=25
         securityContext:
@@ -584,10 +584,10 @@ presubmits:
       test.kops.k8s.io/container_runtime: containerd
       test.kops.k8s.io/distro: u2004
       test.kops.k8s.io/feature_flags: GoogleCloudBucketACL
-      test.kops.k8s.io/k8s_version: '1.22'
+      test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: calico
-      testgrid-dashboards: kops-distro-u2004, kops-k8s-1.22, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-u2004, kops-k8s-stable, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: pull-kops-e2e-k8s-gce-calico-u2004-k22-containerd
 


### PR DESCRIPTION
This way we're testing presubmits with k8s 1.22 for now. I anticipate us cutting the release-1.23 branch before k8s 1.23.0 is released, so the impact should be fairly minimal.

ref: https://github.com/kubernetes/kops/pull/12664#issuecomment-957514551