### PR TITLE
Delete file permission check job for test-infra

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -44,22 +44,6 @@ presubmits:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: gubernator
 
-  - name: pull-test-infra-verify-file-perms
-    branches:
-    - master
-    always_run: true
-    decorate: true
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211022-00550799a0-experimental
-        command:
-        - ./hack/verify-file-perms.sh
-    annotations:
-      testgrid-dashboards: presubmits-test-infra
-      testgrid-tab-name: verify-file-perms
-
   - name: pull-test-infra-yamllint
     always_run: true
     decorate: true


### PR DESCRIPTION
This check is now part of pull-test-infra-verify-lint job via make verify, removing it so that there is one less job to run for test-infra repo