### PR TITLE
kOps - Switch Cilium IPv6 jobs to run on Debian 11

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -74,7 +74,7 @@ def build_test(cloud='aws',
 
 
     # https://github.com/cilium/cilium/blob/f7a3f59fd74983c600bfce9cac364b76d20849d9/Documentation/operations/system_requirements.rst
-    if networking in ("cilium", "cilium-etcd") and distro not in ["u2004", "u2004arm64", "deb10", "rhel8", "amzn2"]: # pylint: disable=line-too-long
+    if networking in ("cilium", "cilium-etcd") and distro not in ["u2004", "u2004arm64", "deb10", "deb11", "rhel8", "amzn2"]: # pylint: disable=line-too-long
         return None
     if should_skip_newer_k8s(k8s_version, kops_version):
         return None
@@ -453,7 +453,7 @@ def generate_misc():
         # A special test for IPv6 using Cilium CNI
         build_test(name_override="kops-grid-scenario-ipv6-cilium",
                    cloud="aws",
-                   distro="u2004",
+                   distro="deb11",
                    k8s_version="ci",
                    networking="cilium",
                    feature_flags=["AWSIPv6"],
@@ -1059,7 +1059,7 @@ def generate_presubmits_e2e():
         presubmit_test(
             name="pull-kops-e2e-ipv6-cilium",
             cloud="aws",
-            distro="u2004",
+            distro="deb11",
             k8s_version="ci",
             networking="cilium",
             feature_flags=["AWSIPv6"],

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -203,7 +203,7 @@ periodics:
     testgrid-days-of-results: '47'
     testgrid-tab-name: kops-grid-scenario-ipv6-calico
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--ipv6 --zones=eu-west-1a", "feature_flags": "AWSIPv6", "k8s_version": "ci", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb11", "extra_flags": "--ipv6 --zones=eu-west-1a", "feature_flags": "AWSIPv6", "k8s_version": "ci", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-scenario-ipv6-cilium
   cron: '9 4-23/8 * * *'
   labels:
@@ -232,7 +232,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20211021' --channel=alpha --networking=cilium --container-runtime=containerd --ipv6 --zones=eu-west-1a" \
+          --create-args="--image='136693071363/debian-11-amd64-20211011-792' --channel=alpha --networking=cilium --container-runtime=containerd --ipv6 --zones=eu-west-1a" \
           --env=KOPS_FEATURE_FLAGS=AWSIPv6 \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
@@ -248,7 +248,7 @@ periodics:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
-        value: ubuntu
+        value: admin
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211022-00550799a0-master
       imagePullPolicy: Always
       resources:
@@ -260,14 +260,14 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
-    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/distro: deb11
     test.kops.k8s.io/extra_flags: --ipv6 --zones=eu-west-1a
     test.kops.k8s.io/feature_flags: AWSIPv6
     test.kops.k8s.io/k8s_version: ci
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-ipv6, kops-k8s-ci, kops-latest, kops-misc, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-deb11, kops-ipv6, kops-k8s-ci, kops-latest, kops-misc, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-scenario-ipv6-cilium
 

--- a/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
@@ -1076,7 +1076,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: pull-kops-e2e-ipv6-conformance
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--ipv6 --zones=eu-west-1a", "feature_flags": "AWSIPv6", "k8s_version": "ci", "kops_channel": "alpha", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb11", "extra_flags": "--ipv6 --zones=eu-west-1a", "feature_flags": "AWSIPv6", "k8s_version": "ci", "kops_channel": "alpha", "networking": "cilium"}
   - name: pull-kops-e2e-ipv6-cilium
     branches:
     - master
@@ -1108,7 +1108,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20211021' --channel=alpha --networking=cilium --container-runtime=containerd --ipv6 --zones=eu-west-1a" \
+            --create-args="--image='136693071363/debian-11-amd64-20211011-792' --channel=alpha --networking=cilium --container-runtime=containerd --ipv6 --zones=eu-west-1a" \
             --env=KOPS_FEATURE_FLAGS=AWSIPv6 \
             --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/bazel-bin/cmd/kops/linux-amd64/kops \
@@ -1126,7 +1126,7 @@ presubmits:
         - name: KUBE_SSH_KEY_PATH
           value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
-          value: ubuntu
+          value: admin
         - name: GOPATH
           value: /home/prow/go
         resources:
@@ -1136,13 +1136,13 @@ presubmits:
     annotations:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/container_runtime: containerd
-      test.kops.k8s.io/distro: u2004
+      test.kops.k8s.io/distro: deb11
       test.kops.k8s.io/extra_flags: --ipv6 --zones=eu-west-1a
       test.kops.k8s.io/feature_flags: AWSIPv6
       test.kops.k8s.io/k8s_version: ci
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: cilium
-      testgrid-dashboards: kops-distro-u2004, kops-ipv6, kops-k8s-ci, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
+      testgrid-dashboards: kops-distro-deb11, kops-ipv6, kops-k8s-ci, kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
       testgrid-tab-name: pull-kops-e2e-ipv6-cilium
 


### PR DESCRIPTION
Until we get an official Ubuntu release with the systemd-networkd fix we should use Debian 11 in tests and recommend it in the IPv6 docs.

/cc @olemarkus @johngmyers @rifelpet 