### PR TITLE
Remove branch protection on `gh-pages` for external-dns & metrics-server Helm chart publish

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -467,6 +467,10 @@ branch-protection:
           branches:
             gh-pages:
               protect: false
+        external-dns:
+          branches:
+            gh-pages:
+              protect: false 
         kube-batch:
           required_status_checks:
             contexts:
@@ -475,6 +479,10 @@ branch-protection:
           required_status_checks:
             contexts:
             - Kubespray CI Pipeline
+        metrics-server:
+          branches:
+            gh-pages:
+              protect: false          
         nfs-ganesha-server-and-external-provisioner:
           branches:
             gh-pages:


### PR DESCRIPTION
The Helm chart releases for external-dns & metrics-server have been failing due to the `gh-pages` branch being protected, this PR aims to follow [cluster-autoscaler](https://github.com/kubernetes/test-infra/pull/23024) (amongst others) in fixing this.