### PR TITLE
apiserver-network-proxy-presubmits: use Go 1.17.

### DIFF
--- a/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: sigs.k8s.io/apiserver-network-proxy
     spec:
       containers:
-      - image: golang:1.13
+      - image: golang:1.17
         command:
         - make
         args:


### PR DESCRIPTION
Make ANP tests consistent with
https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/275

This ~likely~ does unblock: https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/282