### PR TITLE
Correct a tiny mistake in README.md

### DIFF
--- a/prow/plugins/updateconfig/README.md
+++ b/prow/plugins/updateconfig/README.md
@@ -10,7 +10,8 @@ Update your `plugins.yaml` file to something along the following lines:
 ```yaml
 plugins:
   my-github/repo:
-  - config-updater
+    plugins:
+    - config-updater
 
 config_updater:
   maps:


### PR DESCRIPTION
# Some error in README.md.
Before declare the specific plugin, there should have a `plugins:` upon it.
