### PR TITLE
config/jobs: run no-stage on k8s-infra, drop extract

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -62,6 +62,7 @@ presubmits:
           privileged: true
   - name: pull-kubernetes-e2e-gce-no-stage
     always_run: false
+    cluster: k8s-infra-prow-build
     annotations:
       testgrid-dashboards: presubmits-kubernetes-nonblocking
       testgrid-tab-name: pull-kubernetes-e2e-gce-no-stage
@@ -83,7 +84,6 @@ presubmits:
         - --
         - --build=quick
         - --cluster=
-        - --extract=local
         - --gcp-node-image=gci
         - --gcp-zone=us-west1-b
         - --ginkgo-parallel=30
@@ -100,6 +100,8 @@ presubmits:
           limits:
             cpu: 4
             memory: 14Gi
+        securityContext:
+          privileged: true
   - name: pull-kubernetes-e2e-gce-kubetest2
     # explicitly needs /test pull-kubernetes-e2e-gce to run
     always_run: false


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/test-infra/issues/18789

It's unclear to me why this job isn't working on the default build cluster due to a lack of docker.  That's the only difference I can see vs. the normal job, so let's try reconciling that.

Also drop the --extract=local flag, because my read of the bash deployer is it should work with what's been built locally