### PR TITLE
checkconfig: fix disabled validations when GH Apps are checked

### DIFF
--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -256,7 +256,7 @@ func validate(o options) error {
 		}
 	}
 	if o.github.AppID != "" && o.github.AppPrivateKeyPath != "" {
-		o.warnings.Set(validateGitHubAppInstallationWarning)
+		o.warnings.Add(validateGitHubAppInstallationWarning)
 	}
 
 	configAgent, err := o.config.ConfigAgent()

--- a/prow/flagutil/strings.go
+++ b/prow/flagutil/strings.go
@@ -51,7 +51,7 @@ func (s *Strings) String() string {
 	return strings.Join(s.vals, ",")
 }
 
-// Set records the value passed
+// Set records the value passed, overwriting the defaults (if any)
 func (s *Strings) Set(value string) error {
 	if !s.beenSet {
 		s.beenSet = true
@@ -60,4 +60,9 @@ func (s *Strings) Set(value string) error {
 	}
 	s.vals = append(s.vals, value)
 	return nil
+}
+
+// Add records the value passes, adding to the defaults (if any)
+func (s *Strings) Add(value string) {
+	s.vals = append(s.vals, value)
 }


### PR DESCRIPTION
The previously used `Set()` cleans up the underlying slice when called
for the first time. So when GH App check was enabled, it actually disabled
all other checks.
