### PR TITLE
Remove graceful node shutdown e2e job

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -402,40 +402,6 @@ periodics:
     testgrid-alert-email: alukiano@redhat.com
     description: Executes memory manager e2e node tests
 
-- name: ci-kubernetes-node-kubelet-serial-graceful-node-shutdown
-  interval: 4h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211104-c3a88263fc-master
-        args:
-          - --repo=k8s.io/kubernetes=master
-          - --timeout=240
-          - --root=/go/src
-          - --scenario=kubernetes_e2e
-          - --
-          - --deployment=node
-          - --gcp-project-type=node-e2e-project
-          - --gcp-zone=us-west1-b
-          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial.yaml
-          # Remove DynamicKubeletConfig feature gate once https://github.com/kubernetes/kubernetes/issues/105047 is completed
-          - --node-test-args=--feature-gates=DynamicKubeletConfig=true --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
-          - --node-tests=true
-          - --provider=gce
-          # Remove NodeAlphaFeature:GracefulNodeShutdown once the k/k code is submitted
-          - --test_args=--nodes=1 --focus="\[NodeAlphaFeature:GracefulNodeShutdown\]|\[NodeFeature:GracefulNodeShutdown\]"
-          - --timeout=60m
-        env:
-          - name: GOPATH
-            value: /go
-  annotations:
-    testgrid-dashboards: sig-node-kubelet
-    testgrid-tab-name: kubelet-serial-gce-e2e-graceful-node-shutdown
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
-    description: Executes graceful node shutdown e2e node tests
-
 - name: ci-kubernetes-node-kubelet-lock-contention
   interval: 4h
   labels:


### PR DESCRIPTION
The graceful shutdown feature is now beta and the test is running under
existing node-kubelet-serial job. As a result, the dedicated graceful
node shutdown e2e job is no longer necessary. Followup to
https://github.com/kubernetes/test-infra/pull/24154