### PR TITLE
sig-k8s-infra: fix postsubmit for tf-monitoring

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-k8sio.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-k8sio.yaml
@@ -40,10 +40,8 @@ postsubmits:
     cluster: k8s-infra-prow-build-trusted
     decorate: true
     max_concurrency: 1
-    extra_refs:
-    - org: kubernetes
-      repo: k8s.io
-      base_ref: main
+    branches:
+    - ^main$
     annotations:
       testgrid-dashboards: sig-k8s-infra-k8sio
       testgrid-alert-email: ameukam@gmail.com


### PR DESCRIPTION
- Followup of : https://github.com/kubernetes/k8s.io/pull/2981

Use correct branch spec clonerefs config.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>