### PR TITLE
Change to the n2-standard-2 instance

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner.yaml
+++ b/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner.yaml
@@ -87,9 +87,8 @@ presubmits:
         - --test-cmd-args=--allowed-not-ready-nodes=10
         - --test-cmd-args=--node-os-distro=windows
         env:
-        # minimum size that supports Hyper-V
         - name: NODE_SIZE
-          value: "e2-standard-2"
+          value: "n2-standard-2"
         - name: NODE_LOCAL_SSDS
           value: "2"
         # added in https://github.com/kubernetes/kubernetes/pull/105999


### PR DESCRIPTION
Followup of #24241, in the e2e output I saw that the combination e2-standard-2 & local-SSDs is not compatible

```
ERROR: (gcloud.compute.instance-groups.managed.create) Could not fetch resource:
 - [e2-standard-2, local-ssd] features are not compatible for creating instance.
```

I created an n2-standard-2 VM with local-SSDs and I was able to install Hyper-V there

/assign @msau42 