### PR TITLE
Stop gofmt and golangci-lint from bazel test

### DIFF
--- a/hack/BUILD.bazel
+++ b/hack/BUILD.bazel
@@ -218,7 +218,13 @@ test_suite(
     name = "verify-all",
     tests = [
         ":verify-linters",
-        "@io_k8s_repo_infra//hack:verify-all",
+        # Gofmt and golangci-lint have been migrated to make rules, if desired run
+        # bazel test @io_k8s_repo_infra//hack:verify-gofmt
+        # bazel test @io_k8s_repo_infra//hack:verify-golangci-lint
+        # Ref: https://github.com/kubernetes/test-infra/issues/23796
+        "@io_k8s_repo_infra//hack:verify-bazel",
+        "@io_k8s_repo_infra//hack:verify-boilerplate",
+        "@io_k8s_repo_infra//hack:verify-deps",
     ],
 )
 


### PR DESCRIPTION
These were both migrated to make rules, stop them to save some computing hours