### PR TITLE
Fix kubekins-e2e image version for E2E jobs for CAPA release-0.7

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-0-7.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-0-7.yaml
@@ -17,7 +17,7 @@ periodics:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211104-c3a88263fc-1.20
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211104-c3a88263fc-1.21
       command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -55,7 +55,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211104-c3a88263fc-1.20
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211104-c3a88263fc-1.21
         command:
           - "runner.sh"
           - "./scripts/ci-e2e.sh"
@@ -95,7 +95,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211104-c3a88263fc-1.20
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211104-c3a88263fc-1.21
         command:
           - "runner.sh"
           - "./scripts/ci-conformance.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-0.7.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-0.7.yaml
@@ -10,7 +10,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211104-c3a88263fc-1.20
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211104-c3a88263fc-1.21
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -26,7 +26,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211104-c3a88263fc-1.20
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211104-c3a88263fc-1.21
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -42,7 +42,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211104-c3a88263fc-1.20
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211104-c3a88263fc-1.21
         command:
         - "make"
         - "verify"
@@ -80,7 +80,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211104-c3a88263fc-1.20
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211104-c3a88263fc-1.21
           command:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"
@@ -123,7 +123,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211104-c3a88263fc-1.20
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211104-c3a88263fc-1.21
           command:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"
@@ -163,7 +163,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211104-c3a88263fc-1.20
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211104-c3a88263fc-1.21
           command:
             - "runner.sh"
             - "./scripts/ci-e2e.sh"
@@ -201,7 +201,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211104-c3a88263fc-1.20
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211104-c3a88263fc-1.21
           command:
             - "runner.sh"
             - "./scripts/ci-e2e-eks.sh"


### PR DESCRIPTION
Fixes the CAPA release 0.7 testgrid failures for incompatible version of golang in kubekins-e2e image