### PR TITLE
Adjust CAPI job frequency on old branches

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-3.yaml
@@ -1,6 +1,6 @@
 periodics:
 - name: periodic-cluster-api-test-release-0-3
-  interval: 1h
+  interval: 4h
   decorate: true
   labels:
     preset-service-account: "true"
@@ -23,7 +23,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-e2e-release-0-3
-  interval: 1h
+  interval: 4h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -51,7 +51,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-verify-book-links-release-0-3
-  interval: 6h
+  interval: 24h
   decorate: true
   extra_refs:
   - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-4-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-4-upgrades.yaml
@@ -1,7 +1,7 @@
 periodics:
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-18-1-19-release-0-4
-  interval: 48h
+  interval: 24h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -45,7 +45,7 @@ periodics:
     testgrid-num-failures-to-alert: "2"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-19-1-20-release-0-4
-  interval: 48h
+  interval: 24h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -89,7 +89,7 @@ periodics:
     testgrid-num-failures-to-alert: "2"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-20-1-21-release-0-4
-  interval: 48h
+  interval: 24h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -133,7 +133,7 @@ periodics:
     testgrid-num-failures-to-alert: "2"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-21-1-22-release-0-4
-  interval: 48h
+  interval: 24h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -177,7 +177,7 @@ periodics:
     testgrid-num-failures-to-alert: "2"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-22-latest-release-0-4
-  interval: 48h
+  interval: 24h
   decorate: true
   labels:
     preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-4.yaml
@@ -1,6 +1,6 @@
 periodics:
 - name: periodic-cluster-api-test-release-0-4
-  interval: 1h
+  interval: 4h
   decorate: true
   labels:
     preset-service-account: "true"
@@ -23,7 +23,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-e2e-release-0-4
-  interval: 1h
+  interval: 4h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -58,7 +58,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-e2e-mink8s-release-0-4
-  interval: 1h
+  interval: 4h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -97,7 +97,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-verify-book-links-release-0-4
-  interval: 6h
+  interval: 24h
   decorate: true
   extra_refs:
   - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-0-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-0-upgrades.yaml
@@ -1,7 +1,7 @@
 periodics:
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-18-1-19-release-1-0
-  interval: 48h
+  interval: 24h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -45,7 +45,7 @@ periodics:
     testgrid-num-failures-to-alert: "2"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-19-1-20-release-1-0
-  interval: 48h
+  interval: 24h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -89,7 +89,7 @@ periodics:
     testgrid-num-failures-to-alert: "2"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-20-1-21-release-1-0
-  interval: 48h
+  interval: 24h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -133,7 +133,7 @@ periodics:
     testgrid-num-failures-to-alert: "2"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-21-1-22-release-1-0
-  interval: 48h
+  interval: 24h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -177,7 +177,7 @@ periodics:
     testgrid-num-failures-to-alert: "2"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-22-latest-release-1-0
-  interval: 48h
+  interval: 24h
   decorate: true
   labels:
     preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-0.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-0.yaml
@@ -1,6 +1,6 @@
 periodics:
 - name: periodic-cluster-api-test-release-1-0
-  interval: 1h
+  interval: 4h
   decorate: true
   labels:
     preset-service-account: "true"
@@ -23,7 +23,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-e2e-v1alpha3-v1beta1-upgrade-release-1-0
-  interval: 1h
+  interval: 4h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -65,7 +65,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-e2e-release-1-0
-  interval: 1h
+  interval: 4h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -100,7 +100,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-e2e-mink8s-release-1-0
-  interval: 1h
+  interval: 4h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -139,7 +139,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-verify-book-links-release-1-0
-  interval: 6h
+  interval: 24h
   decorate: true
   extra_refs:
   - org: kubernetes-sigs


### PR DESCRIPTION
Adjusting  job frequency on old branches
- periodic jobs from 1h to 4h (link check from 6h to 24h)
- upgrade jobs from 48h to 24h