### PR TITLE
Remove branch protection from gh-pages for Descheduler

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -467,6 +467,10 @@ branch-protection:
           branches:
             gh-pages:
               protect: false
+        descheduler:
+          branches:
+            gh-pages:
+              protect: false
         external-dns:
           branches:
             gh-pages:


### PR DESCRIPTION
Similar to https://github.com/kubernetes/test-infra/pull/24222, this allows the Helm chart releaser action to run automatically (currently it gets blocked on the CLA check. Since we don't allow any PRs to this branch, and the action only runs after a successful merge to another branch that does have the CLA check, this shouldn't be necessary)