### PR TITLE
Adds ppc64le-kubernetes bucket to the additional_allowed_buckets list

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -97,6 +97,7 @@ deck:
   additional_allowed_buckets:
     - k8s-ovn
     - containerd-integration
+    - ppc64le-kubernetes
 
 prowjob_namespace: default
 pod_namespace: test-pods


### PR DESCRIPTION
Fixes https://github.com/kubernetes/test-infra/issues/24190
Also there was an [Announcement](https://github.com/kubernetes/test-infra/blob/master/prow/ANNOUNCEMENTS.md) on `April 12th, 2021` that reads
```
End of grace period for storage bucket validation, additional buckets have to be allowed by adding them to the deck.additional_allowed_buckets list.
```