### PR TITLE
added 2 node pre-submit jobs for kubetest2

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -818,7 +818,7 @@ presubmits:
             - name: GOPATH
               value: /go
   - name: pull-kubernetes-node-kubelet-serial-cpu-manager-kubetest2
-    # explicitly needs /test pull-kubernetes-node-kubelet-serial-cpu-manager to run
+    # explicitly needs /test pull-kubernetes-node-kubelet-serial-cpu-manager-kubetest2 to run
     always_run: false
     # if at all it is run and fails, don't block the PR
     optional: true
@@ -900,7 +900,7 @@ presubmits:
             - name: GOPATH
               value: /go
   - name: pull-kubernetes-node-kubelet-serial-topology-manager-kubetest2
-    # explicitly needs /test pull-kubernetes-node-kubelet-serial-topology-manager to run
+    # explicitly needs /test pull-kubernetes-node-kubelet-serial-topology-manager-kubetest2 to run
     always_run: false
     # if at all it is run and fails, don't block the PR
     optional: true
@@ -1020,6 +1020,56 @@ presubmits:
         resources:
           requests:
             memory: "6Gi"
+  - name: pull-kubernetes-node-crio-cgrpv2-e2e-kubetest2
+    # explicitly needs /test pull-kubernetes-node-crio-cgrpv2-e2e-kubetest2 to run
+    always_run: false
+    # if at all it is run and fails, don't block the PR
+    optional: true
+    branches:
+    - master
+    decorate: true
+    path_alias: k8s.io/kubernetes
+    extra_refs:
+    - org: kubernetes
+      repo: test-infra
+      base_ref: master
+      path_alias: k8s.io/test-infra
+    decoration_config:
+      timeout: 180m
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+    annotations:
+      testgrid-dashboards: sig-node-presubmits
+      testgrid-tab-name: pr-crio-cgrpv2-gce-e2e-kubetest2
+    spec:
+      containers:
+      # experimental have the kubetest2 binaries
+      # https://github.com/kubernetes/test-infra/blob/3c3d64f398a5e4f324200d25183c98a4bfa842ac/images/kubekins-e2e/variants.yaml#L8
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210915-5dbaf53458-experimental
+        resources:
+          requests:
+            memory: "6Gi"
+        env:
+          - name: KUBE_SSH_USER
+            value: core
+        command:
+        - runner.sh
+        args:
+        - kubetest2
+        - noop
+        - --test=node
+        - --
+        - --repo-root=.
+        - --gcp-project=k8s-jkns-pr-node-e2e
+        - --gcp-zone=us-west1-b
+        - --parallelism=8
+        - --focus-regex=\[NodeConformance\]|\[NodeFeature:.+\]|\[NodeFeature\]
+        - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]
+        - '--test-args=--container-runtime=remote --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service --non-masquerade-cidr=0.0.0.0/0" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
+        - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgrpv2.yaml
   - name: pull-kubernetes-node-kubelet-serial-crio-cgroupv1
     skip_branches:
     - release-\d+\.\d+  # per-release image
@@ -1136,6 +1186,56 @@ presubmits:
         resources:
           requests:
             memory: "6Gi"
+  - name: pull-kubernetes-node-crio-e2e-kubetest2
+    # explicitly needs /test pull-kubernetes-node-crio-e2e-kubetest2 to run
+    always_run: false
+    # if at all it is run and fails, don't block the PR
+    optional: true
+    branches:
+    - master
+    decorate: true
+    path_alias: k8s.io/kubernetes
+    extra_refs:
+    - org: kubernetes
+      repo: test-infra
+      base_ref: master
+      path_alias: k8s.io/test-infra
+    decoration_config:
+      timeout: 180m
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+    annotations:
+      testgrid-dashboards: sig-node-presubmits
+      testgrid-tab-name: pr-crio-gce-e2e-kubetest2
+    spec:
+      containers:
+      # experimental have the kubetest2 binaries
+      # https://github.com/kubernetes/test-infra/blob/3c3d64f398a5e4f324200d25183c98a4bfa842ac/images/kubekins-e2e/variants.yaml#L8
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20210915-5dbaf53458-experimental
+        resources:
+          requests:
+            memory: "6Gi"
+        env:
+          - name: KUBE_SSH_USER
+            value: core
+        command:
+        - runner.sh
+        args:
+        - kubetest2
+        - noop
+        - --test=node
+        - --
+        - --repo-root=.
+        - --gcp-project=k8s-jkns-pr-node-e2e
+        - --gcp-zone=us-west1-b
+        - --parallelism=8
+        - --focus-regex=\[NodeConformance\]|\[NodeFeature:.+\]|\[NodeFeature\]
+        - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]
+        - '--test-args=--container-runtime=remote --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service --non-masquerade-cidr=0.0.0.0/0" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
+        - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgrpv1.yaml
 
   - name: pull-kubernetes-node-kubelet-serial-memory-manager
     always_run: false


### PR DESCRIPTION
Signed-off-by: Namanl2001 <namanlakhwani@gmail.com>

This PR is part of the CI migration from kubetest to kubetest2
https://github.com/kubernetes/enhancements/tree/master/keps/sig-testing/2464-kubetest2-ci-migration

Added 2 jobs:
`pull-kubernetes-node-crio-cgrpv2-e2e-kubetest2`
`pull-kubernetes-node-crio-e2e-kubetest2`

cc: @dims @amwat @spiffxp