### PR TITLE
Use squash method for kubernetes-sigs/cluster-api

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -628,6 +628,7 @@ tide:
   merge_method:
     kubernetes-client/csharp: squash
     kubernetes-client/gen: squash
+    kubernetes-sigs/cluster-api: squash
     kubernetes-sigs/cluster-api-provider-digitalocean: squash
     kubernetes-sigs/cluster-api-provider-ibmcloud: squash
     kubernetes-sigs/ibm-vpc-block-csi-driver: squash


### PR DESCRIPTION
While working on https://github.com/kubernetes-sigs/cluster-api/pull/5593, I realized that the `cluster-api` don't have the `squash` method enabled. After the PR was merged, it ended up with 3 commits instead of 1.

@fabriziopandini Is there any reason not to use `squash` for PR merge?