### PR TITLE
Fix env config in periodic e2e capi tests in CAPA release 0.7

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-0-7.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-0-7.yaml
@@ -65,7 +65,7 @@ periodics:
           - name: AWS_REGION
             value: "us-west-2"
           - name: E2E_UNMANAGED_FOCUS
-            value: "Cluster API E2E tests"
+            value: "Cluster API Framework"
         securityContext:
           privileged: true
         resources:


### PR DESCRIPTION
The test cases for [periodic-cluster-api-provider-aws-capi-e2e-release-0-7](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-provider-aws-capi-e2e-release-0-7/1457983642461540352) is skipped in the runs because of env `E2E_UNMANAGED_FOCUS` set as `Cluster API E2E tests`. This PR updates this env so that tests runs properly in testgrid