### PR TITLE
Promote CSI changes to all presubmit jobs

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -1149,6 +1149,8 @@ presubmits:
         - --tear-down-previous
         - --env=CL2_ENABLE_CLUSTER_OOMS_TRACKER=true
         - --env=CL2_ENABLE_VIOLATIONS_FOR_SCHEDULING_THROUGHPUT=false
+        - --env=DEPLOY_GCI_DRIVER=false
+        - --env=PROMETHEUS_STORAGE_CLASS_PROVISIONER=kubernetes.io/gce-pd
         - --test=false
         - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
         - --test-cmd-args=cluster-loader2
@@ -1227,6 +1229,8 @@ presubmits:
         - --test-cmd-args=cluster-loader2
         - --test-cmd-args=--nodes=500
         - --test-cmd-args=--provider=kubemark
+        - --env=DEPLOY_GCI_DRIVER=false
+        - --env=PROMETHEUS_STORAGE_CLASS_PROVISIONER=kubernetes.io/gce-pd
         - --env=CL2_ENABLE_PVS=false
         - --env=CL2_ENABLE_CLUSTER_OOMS_TRACKER=true
         - --test-cmd-args=--report-dir=$(ARTIFACTS)

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
@@ -1223,6 +1223,8 @@ presubmits:
         - --provider=gce
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-100-performance
         - --tear-down-previous
+        - --env=DEPLOY_GCI_DRIVER=false
+        - --env=PROMETHEUS_STORAGE_CLASS_PROVISIONER=kubernetes.io/gce-pd
         - --env=CL2_SCHEDULER_THROUGHPUT_THRESHOLD=0
         - --test=false
         - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
@@ -1301,6 +1303,8 @@ presubmits:
         - --test-cmd-args=--nodes=500
         - --test-cmd-args=--provider=kubemark
         - --env=CL2_ENABLE_PVS=false
+        - --env=DEPLOY_GCI_DRIVER=false
+        - --env=PROMETHEUS_STORAGE_CLASS_PROVISIONER=kubernetes.io/gce-pd
         - --test-cmd-args=--report-dir=$(ARTIFACTS)
         - --test-cmd-args=--testconfig=testing/load/config.yaml
         - --test-cmd-args=--testconfig=testing/access-tokens/config.yaml

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.21.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.21.yaml
@@ -1346,6 +1346,8 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-100-performance
         - --tear-down-previous
         - --env=CL2_SCHEDULER_THROUGHPUT_THRESHOLD=0
+        - --env=DEPLOY_GCI_DRIVER=false
+        - --env=PROMETHEUS_STORAGE_CLASS_PROVISIONER=kubernetes.io/gce-pd
         - --test=false
         - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
         - --test-cmd-args=cluster-loader2
@@ -1424,6 +1426,8 @@ presubmits:
         - --test-cmd-args=--nodes=500
         - --test-cmd-args=--provider=kubemark
         - --env=CL2_ENABLE_PVS=false
+        - --env=DEPLOY_GCI_DRIVER=false
+        - --env=PROMETHEUS_STORAGE_CLASS_PROVISIONER=kubernetes.io/gce-pd
         - --test-cmd-args=--report-dir=$(ARTIFACTS)
         - --test-cmd-args=--testconfig=testing/load/config.yaml
         - --test-cmd-args=--testconfig=testing/access-tokens/config.yaml

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml
@@ -1538,6 +1538,8 @@ presubmits:
         - --tear-down-previous
         - --env=CL2_ENABLE_HUGE_SERVICES=true
         - --env=CL2_SCHEDULER_THROUGHPUT_THRESHOLD=0
+        - --env=DEPLOY_GCI_DRIVER=false
+        - --env=PROMETHEUS_STORAGE_CLASS_PROVISIONER=kubernetes.io/gce-pd
         - --test=false
         - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
         - --test-cmd-args=cluster-loader2
@@ -1618,6 +1620,8 @@ presubmits:
         - --test-cmd-args=--nodes=500
         - --test-cmd-args=--provider=kubemark
         - --env=CL2_ENABLE_PVS=false
+        - --env=DEPLOY_GCI_DRIVER=false
+        - --env=PROMETHEUS_STORAGE_CLASS_PROVISIONER=kubernetes.io/gce-pd
         - --test-cmd-args=--report-dir=$(ARTIFACTS)
         - --test-cmd-args=--testconfig=testing/load/config.yaml
         - --test-cmd-args=--testconfig=testing/access-tokens/config.yaml

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -309,6 +309,10 @@ presets:
 - labels:
     preset-e2e-scalability-presubmits: "true"
   env:
+  - name: DEPLOY_GCI_DRIVER
+    value: true
+  - name: PROMETHEUS_STORAGE_CLASS_PROVISIONER
+    value: pd.csi.storage.gke.io
 
 - labels:
     preset-e2e-scalability-periodics: "true"


### PR DESCRIPTION
Same logic with https://github.com/kubernetes/test-infra/pull/24357, promote to preset-e2e-scalability-presubmits to enable in all presubmit tests (but not 1.19, 1.20, 1.21, 1.22 where we don't want to enable this).

@mborsz 