### PR TITLE
OWNERS(justaugustus): Prune extraneous reviewer roles

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -33,8 +33,7 @@ aliases:
   sig-apps-leads:
     - janetkuo
     - kow3ns
-    - mattfarina
-    - prydonius
+    - soltysh
   sig-architecture-leads:
     - derekwaynecarr
     - dims
@@ -44,11 +43,13 @@ aliases:
     - enj
     - liggitt
     - mikedanese
-    - tallclair
+    - ritazh
   sig-autoscaling-leads:
+    - gjtempleton
     - mwielgus
   sig-cli-leads:
-    - pwittrock
+    - KnVerey
+    - eddiezane
     - seans3
     - soltysh
   sig-cloud-provider-leads:
@@ -58,18 +59,21 @@ aliases:
     - fabriziopandini
     - justinsb
     - neolit123
-    - timothysc
+    - vincepri
   sig-contributor-experience-leads:
-    - castrojo
+    - alisondy
     - cblecker
     - mrbobbytables
     - nikhita
   sig-docs-leads:
+    - divya-mohan0209
     - jimangel
     - kbhawkey
+    - onlydole
     - sftim
   sig-instrumentation-leads:
     - brancz
+    - dashpole
     - ehashman
     - logicalhan
   sig-k8s-infra-leads:
@@ -78,8 +82,8 @@ aliases:
     - spiffxp
     - thockin
   sig-multicluster-leads:
+    - jeremyot
     - pmorie
-    - quinton-hoole
   sig-network-leads:
     - caseydavenport
     - dcbw
@@ -100,9 +104,13 @@ aliases:
   sig-scheduling-leads:
     - Huang-Wei
     - ahg-g
+    - alculquicondor
+  sig-security-leads:
+    - IanColdwater
+    - tabbysable
   sig-service-catalog-leads:
     - jberkhahn
-    - mszostok
+    - jhvhs
   sig-storage-leads:
     - jsafrane
     - msau42
@@ -119,21 +127,17 @@ aliases:
     - maciaszczykm
     - shu-mutou
   sig-usability-leads:
-    - Rajakavitha1
     - hpandeycodeit
+    - morengab
     - tashimi
-    - vllry
   sig-windows-leads:
-    - benmoss
-    - ddebroy
+    - claudiubelu
+    - jayunit100
+    - jsturtevant
     - marosset
-    - michmike
-  wg-apply-leads:
-    - lavalamp
-  wg-component-standard-leads:
-    - mtaufen
-    - stealthybox
-    - sttts
+  wg-api-expression-leads:
+    - apelisse
+    - kwiesmueller
   wg-data-protection-leads:
     - xing-yang
     - yuxiangqian
@@ -141,29 +145,19 @@ aliases:
     - cantbewong
     - cindyxing
     - dejanb
-  wg-lts-leads:
-    - imkin
-    - quinton-hoole
-    - tpepper
-    - youngnick
-  wg-machine-learning-leads:
-    - k82cn
-    - kow3ns
-    - vishh
   wg-multitenancy-leads:
     - srampal
     - tashimi
   wg-policy-leads:
-    - ericavonb
-    - hannibalhuang
-  wg-resource-management-leads:
-    - derekwaynecarr
-    - vishh
-  wg-security-audit-leads:
-    - aasmall
-    - cji
-    - jaybeale
-    - joelsmith
+    - JimBugwadia
+    - rficcaglia
+  wg-reliability-leads:
+    - deads2k
+    - stevekuznetsov
+    - wojtek-t
+  wg-structured-logging-leads:
+    - pohly
+    - serathius
   ug-big-data-leads:
     - erikerlandson
     - foxish
@@ -174,35 +168,34 @@ aliases:
     - mylesagray
     - phenixblue
   committee-code-of-conduct:
-    - AevaOnline
     - celestehorgan
     - karenhchu
-    - tashimi
+    - palnabarun
     - tpepper
-  committee-product-security:
+    - vllry
+  committee-security-response:
     - cjcullen
     - joelsmith
-    - jonpulsifer
-    - liggitt
     - lukehinds
-    - philips
+    - micahhausler
+    - swamymsft
+    - tabbysable
     - tallclair
   committee-steering:
     - cblecker
-    - derekwaynecarr
     - dims
-    - nikhita
+    - justaugustus
+    - liggitt
+    - mrbobbytables
     - parispittman
-    - spiffxp
-    - timothysc
+    - tpepper
 ## BEGIN CUSTOM CONTENT
   provider-aws:
-    - d-nishi
     - justinsb
-    - kris-nova
+    - nckturner
+    - wongma7
   provider-azure:
     - craiglpeters
-    - justaugustus
     - feiskyer
     - khenidak
   provider-gcp:

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/OWNERS
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/OWNERS
@@ -4,7 +4,6 @@ reviewers:
 - andyzhangx
 - brendandburns
 - feiskyer
-- justaugustus
 - karataliu
 - khenidak
 - chewong
@@ -12,7 +11,6 @@ approvers:
 - andyzhangx
 - brendandburns
 - feiskyer
-- justaugustus
 - karataliu
 - khenidak
 - chewong

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/OWNERS
@@ -7,7 +7,6 @@ approvers:
 - CecileRobertMichon
 - feiskyer
 - devigned
-- justaugustus
 - karataliu
 - khenidak
 - nader-ziada

--- a/config/jobs/kubernetes/generated/OWNERS
+++ b/config/jobs/kubernetes/generated/OWNERS
@@ -2,11 +2,10 @@
 
 reviewers:
 - release-engineering-reviewers
-- justaugustus
 approvers:
 - release-engineering-approvers
-- justaugustus
 emeritus_approvers:
+- justaugustus    # 2021-11-15: https://github.com/kubernetes/test-infra/pull/24328
 - Katharine
 - krzyzacy
 - yguo0905

--- a/config/jobs/kubernetes/sig-cloud-provider/OWNERS
+++ b/config/jobs/kubernetes/sig-cloud-provider/OWNERS
@@ -3,11 +3,9 @@
 reviewers:
 - andrewsykim
 - cheftako
-- justaugustus
 approvers:
 - andrewsykim
 - cheftako
-- justaugustus
 
 labels:
 - sig/cloud-provider

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/OWNERS
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/OWNERS
@@ -6,7 +6,6 @@ reviewers:
 - CecileRobertMichon
 - chewong
 - feiskyer
-- justaugustus
 - karataliu
 - khenidak
 approvers:
@@ -14,7 +13,6 @@ approvers:
 - brendandburns
 - chewong
 - feiskyer
-- justaugustus
 - karataliu
 - khenidak
 

--- a/config/testgrids/kubernetes/sig-cloud-provider/OWNERS
+++ b/config/testgrids/kubernetes/sig-cloud-provider/OWNERS
@@ -3,11 +3,9 @@
 reviewers:
 - andrewsykim
 - cheftako
-- justaugustus
 approvers:
 - andrewsykim
 - cheftako
-- justaugustus
 
 labels:
 - sig/cloud-provider

--- a/config/testgrids/kubernetes/sig-cloud-provider/azure/OWNERS
+++ b/config/testgrids/kubernetes/sig-cloud-provider/azure/OWNERS
@@ -6,7 +6,6 @@ reviewers:
 - CecileRobertMichon
 - chewong
 - feiskyer
-- justaugustus
 - karataliu
 - khenidak
 approvers:
@@ -14,7 +13,6 @@ approvers:
 - brendandburns
 - chewong
 - feiskyer
-- justaugustus
 - karataliu
 - khenidak
 


### PR DESCRIPTION
Taking an opportunity to prune myself from some aliases/review paths
to reduce my workload.

If:
- I am no longer reviewing in an area, prune
- I was already an approver for the area, prune from review path

OWNERS_ALIASES are also updated to match their analogs in k/community.

Signed-off-by: Stephen Augustus <foo@auggie.dev>