### PR TITLE
update capz ccm job to use capz 1.0

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -274,7 +274,7 @@ presubmits:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-0.5
+        base_ref: release-1.0
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
     spec:


### PR DESCRIPTION
This PR updates the CCM job that validates capz so that it uses the latest release of capz (1.0).