### PR TITLE
Change kubekins-e2e version for CAPA periodic main tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
@@ -17,7 +17,7 @@ periodics:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211111-d096cb0c5f-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211111-d096cb0c5f-master
       command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"


### PR DESCRIPTION
Related to https://github.com/kubernetes/test-infra/pull/24327. This PR updates the kubekins-e2e image version to master for periodic-e2e-main tests.