### PR TITLE
Fix env config in periodic capi tests for CAPA release 0.7 testgrid

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-0-7.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-0-7.yaml
@@ -64,8 +64,8 @@ periodics:
             value: "boskos.test-pods.svc.cluster.local"
           - name: AWS_REGION
             value: "us-west-2"
-          - name: E2E_UNMANAGED_FOCUS
-            value: "[unmanaged] [Cluster API Framework]"
+          - name: E2E_FOCUS
+            value: "\\[Cluster API Framework\\]"
         securityContext:
           privileged: true
         resources:


### PR DESCRIPTION
The test cases for periodic-cluster-api-provider-aws-capi-e2e-release-0-7 is skipped in the runs. 
This PR updates env `E2E_UNMANAGED_FOCUS` as `E2E_FOCUS` so that tests runs properly in testgrid.