### PR TITLE
Add tide integration tests infra

### DIFF
--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -367,6 +367,22 @@ func (f *FakeClient) GetPullRequest(owner, repo string, number int) (*github.Pul
 	return val, nil
 }
 
+// GetPullRequest returns details about the PR.
+func (f *FakeClient) GetPullRequests(owner, repo string) ([]github.PullRequest, error) {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+
+	val := make([]github.PullRequest, 0)
+	for number, pr := range f.PullRequests {
+		if pr == nil {
+			return nil, fmt.Errorf("pull request number key %d exist, but no data", number)
+		}
+		val = append(val, *pr)
+	}
+
+	return val, nil
+}
+
 // EditPullRequest edits the pull request.
 func (f *FakeClient) EditPullRequest(org, repo string, number int, issue *github.PullRequest) (*github.PullRequest, error) {
 	f.lock.Lock()
@@ -996,6 +1012,12 @@ func (f *FakeClient) CreatePullRequest(org, repo, title, body, head, base string
 		}
 		f.PullRequests[i] = &github.PullRequest{
 			Number: i,
+			Title:  title,
+			Body:   body,
+			Head: github.PullRequestBranch{
+				Ref:  head,
+				Repo: github.Repo{Owner: github.User{Login: org}, Name: repo},
+			},
 			Base: github.PullRequestBranch{
 				Ref:  base,
 				Repo: github.Repo{Owner: github.User{Login: org}, Name: repo},

--- a/prow/test/integration/fakeghserver/BUILD.bazel
+++ b/prow/test/integration/fakeghserver/BUILD.bazel
@@ -30,7 +30,9 @@ go_library(
         "//prow/interrupts:go_default_library",
         "//prow/logrusutil:go_default_library",
         "//prow/pjutil:go_default_library",
+        "//prow/tide:go_default_library",
         "@com_github_gorilla_mux//:go_default_library",
+        "@com_github_shurcool_githubv4//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )

--- a/prow/test/integration/prow/cluster/tide_deployment.yaml
+++ b/prow/test/integration/prow/cluster/tide_deployment.yaml
@@ -38,6 +38,7 @@ spec:
         args:
         - --dry-run=true
         - --github-endpoint=http://fakeghserver
+        - --github-graphql-endpoint=http://fakeghserver/graphql
         - --github-token-path=/etc/github/oauth
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/test/integration/prow/config.yaml
+++ b/prow/test/integration/prow/config.yaml
@@ -7,6 +7,12 @@ sinker:
 horologium:
   tick_interval: 5s
 
+tide:
+  sync_period: 10s
+  queries:
+  - repos:
+    - fake-org-tide/fake-repo-tide
+
 prowjob_namespace: default
 pod_namespace: test-pods
 log_level: debug

--- a/prow/test/integration/setup-local-registry.sh
+++ b/prow/test/integration/setup-local-registry.sh
@@ -17,8 +17,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly DEFAULT_CLUSTER_NAME="kind-prow-integration"
-readonly DEFAULT_CONTEXT="kind-${DEFAULT_CLUSTER_NAME}"
 readonly DEFAULT_REGISTRY_NAME="kind-registry"
 readonly DEFAULT_REGISTRY_PORT="5000"
 

--- a/prow/test/integration/test/BUILD.bazel
+++ b/prow/test/integration/test/BUILD.bazel
@@ -11,6 +11,7 @@ go_test(
         "horologium_test.go",
         "overall_test.go",
         "sinker_test.go",
+        "tide_test.go",
     ],
     data = [
         "//prow/test/integration/test:all-srcs",

--- a/prow/test/integration/test/tide_test.go
+++ b/prow/test/integration/test/tide_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	prowjobv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/github"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestTide(t *testing.T) {
+	const (
+		baseRef = "master"
+		// matches tide deployment configurating in //prow/test/integration/prow/config.yaml
+		// for tide to query the right org/repo
+		org  = "fake-org-tide"
+		repo = "fake-repo-tide"
+	)
+
+	clusterContext := getClusterContext()
+	t.Logf("Creating client for cluster: %s", clusterContext)
+
+	kubeClient, err := NewClients("", clusterContext)
+	if err != nil {
+		t.Fatalf("Failed creating clients for cluster %q: %v", clusterContext, err)
+	}
+
+	githubClient := github.NewClient(func() []byte { return nil }, func(b []byte) []byte { return b }, "", "http://localhost/fakeghserver")
+
+	t.Run("merge single job", func(t *testing.T) {
+		ctx := context.Background()
+		title := RandomString(t)
+		sha := RandomString(t)
+		baseSHA := RandomString(t)
+
+		prowJob, err := createPR(ctx, githubClient, kubeClient, org, repo, title, sha, baseSHA, baseRef)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t.Cleanup(func() {
+			if err := kubeClient.Delete(ctx, prowJob); err != nil {
+				t.Logf("Failed cleanup resource %q: %v", prowJob.Name, err)
+			}
+		})
+
+		// TODO: Test tide handling
+		// Currently a PR is being created on fakeghserver, and a successful presubmit prowjob.
+		// tide manages to query it. The fakeghserver gets a correct query for fake-org-tide/fake-repo-tide
+		// and sends a response accordingly, with the already created pull request info.
+		// But from some reason it is being returned to `tide` empty,
+		// so tide does nothing with an empty response.
+	})
+}
+
+func createPR(ctx context.Context, githubClient github.Client, kubeClient ctrlruntimeclient.Client,
+	org, repo, title, sha, baseSHA, baseRef string) (*prowjobv1.ProwJob, error) {
+	prID, err := githubClient.CreatePullRequest(org, repo, title, "body", baseSHA, baseRef, true)
+	if err != nil {
+		return nil, fmt.Errorf("Failed creating pull request: %v", err)
+	}
+
+	podName := fmt.Sprintf("tide-%s", title)
+
+	prowJob := prowjobv1.ProwJob{
+		ObjectMeta: v1.ObjectMeta{
+			Annotations: map[string]string{
+				"prow.k8s.io/job":       podName,
+				"prow.k8s.io/refs.org":  org,
+				"prow.k8s.io/refs.pull": strconv.Itoa(prID),
+				"prow.k8s.io/refs.repo": repo,
+				"prow.k8s.io/type":      "presubmit",
+			},
+			Labels: map[string]string{
+				"created-by-prow":  "true",
+				"prow.k8s.io/type": "presubmit",
+			},
+			Name:      podName,
+			Namespace: defaultNamespace,
+		},
+		Spec: prowjobv1.ProwJobSpec{
+			Type:      prowjobv1.PresubmitJob,
+			Namespace: "test-pods",
+			Job:       podName,
+			Refs: &prowjobv1.Refs{
+				Org:     org,
+				Repo:    repo,
+				BaseRef: baseRef,
+				BaseSHA: baseSHA,
+				Pulls: []prowjobv1.Pull{
+					{
+						Author: "fake_author",
+						Number: prID,
+						SHA:    sha,
+					},
+				},
+			},
+			Report: true,
+		},
+		Status: prowjobv1.ProwJobStatus{
+			State:          "success",
+			StartTime:      v1.NewTime(time.Now().Add(-1 * time.Second)),
+			CompletionTime: &v1.Time{Time: time.Now()},
+		},
+	}
+
+	if err := kubeClient.Create(ctx, &prowJob); err != nil {
+		return nil, fmt.Errorf("Failed creating prowjob: %v", err)
+	}
+
+	return &prowJob, nil
+}

--- a/prow/tide/search.go
+++ b/prow/tide/search.go
@@ -57,17 +57,18 @@ func search(query querier, log *logrus.Entry, q string, start, end time.Time, or
 
 	var totalCost, remaining int
 	var ret []PullRequest
-	var sq searchQuery
+	var sq SearchQuery
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 	for {
-		log.Debug("Sending query")
+		log.Debugf("Sending query %#v %#v", sq, vars)
 		if err := query(ctx, &sq, vars, org); err != nil {
 			if cursor != nil {
 				err = fmt.Errorf("cursor: %q, err: %w", *cursor, err)
 			}
 			return ret, err
 		}
+
 		totalCost += int(sq.RateLimit.Cost)
 		remaining = int(sq.RateLimit.Remaining)
 		for _, n := range sq.Search.Nodes {

--- a/prow/tide/search_test.go
+++ b/prow/tide/search_test.go
@@ -40,8 +40,8 @@ func TestSearch(t *testing.T) {
 		}
 		return prs
 	}
-	makeQuery := func(more bool, cursor string, numbers ...int) searchQuery {
-		var sq searchQuery
+	makeQuery := func(more bool, cursor string, numbers ...int) SearchQuery {
+		var sq SearchQuery
 		sq.Search.PageInfo.HasNextPage = githubql.Boolean(more)
 		sq.Search.PageInfo.EndCursor = githubql.String(cursor)
 		for _, pr := range makePRs(numbers...) {
@@ -56,7 +56,7 @@ func TestSearch(t *testing.T) {
 		end      time.Time
 		q        string
 		cursors  []*githubql.String
-		sqs      []searchQuery
+		sqs      []SearchQuery
 		errs     []error
 		expected []PullRequest
 		err      bool
@@ -67,7 +67,7 @@ func TestSearch(t *testing.T) {
 			end:     now,
 			q:       datedQuery(q, earlier, now),
 			cursors: []*githubql.String{nil},
-			sqs: []searchQuery{
+			sqs: []SearchQuery{
 				makeQuery(false, "", 1, 2),
 			},
 			errs:     []error{nil},
@@ -79,7 +79,7 @@ func TestSearch(t *testing.T) {
 			end:     now,
 			q:       datedQuery(q, earlier, now),
 			cursors: []*githubql.String{nil},
-			sqs: []searchQuery{
+			sqs: []SearchQuery{
 				{},
 			},
 			errs: []error{errors.New("injected error")},
@@ -91,7 +91,7 @@ func TestSearch(t *testing.T) {
 			end:     now,
 			q:       datedQuery(q, floor(time.Time{}), now),
 			cursors: []*githubql.String{nil},
-			sqs: []searchQuery{
+			sqs: []SearchQuery{
 				makeQuery(false, "", 1, 2),
 			},
 			errs:     []error{nil},
@@ -107,7 +107,7 @@ func TestSearch(t *testing.T) {
 				githubql.NewString("first"),
 				githubql.NewString("second"),
 			},
-			sqs: []searchQuery{
+			sqs: []SearchQuery{
 				makeQuery(true, "first", 1, 2),
 				makeQuery(true, "second", 3, 4),
 				makeQuery(false, "", 5, 6),
@@ -124,7 +124,7 @@ func TestSearch(t *testing.T) {
 				nil,
 				githubql.NewString("first"),
 			},
-			sqs: []searchQuery{
+			sqs: []SearchQuery{
 				makeQuery(true, "first", 1, 2),
 				{},
 			},
@@ -145,7 +145,7 @@ func TestSearch(t *testing.T) {
 				if !equality.Semantic.DeepEqual(expected, actual) {
 					t.Errorf("call %d vars do not match:\n%s", i, diff.ObjectReflectDiff(expected, actual))
 				}
-				ret := result.(*searchQuery)
+				ret := result.(*SearchQuery)
 				err := tc.errs[i]
 				sq := tc.sqs[i]
 				i++

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -1894,7 +1894,7 @@ type PRNode struct {
 	PullRequest PullRequest `graphql:"... on PullRequest"`
 }
 
-type searchQuery struct {
+type SearchQuery struct {
 	RateLimit struct {
 		Cost      githubql.Int
 		Remaining githubql.Int

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -720,7 +720,7 @@ func (f *fgc) GetRef(o, r, ref string) (string, error) {
 }
 
 func (f *fgc) QueryWithGitHubAppsSupport(ctx context.Context, q interface{}, vars map[string]interface{}, org string) error {
-	sq, ok := q.(*searchQuery)
+	sq, ok := q.(*SearchQuery)
 	if !ok {
 		return errors.New("unexpected query type")
 	}


### PR DESCRIPTION
Part of #23025 solution

- Add a new `tide_test.go` integration test module. Currently it just creates
a dummy PR and a prowjob that matches it (presubmit type) in a org/repo that tide queries.
Tide asks the `fakeghserver` for its status via GitHubv4 API using the `SearchQuery`.
- make `tide.searchQuery` public to be used by the integration
`fakeghserver` module.