### PR TITLE
Configure liveness and readiness probes for prow-controller-manager.

### DIFF
--- a/config/prow/cluster/prow_controller_manager_deployment.yaml
+++ b/config/prow/cluster/prow_controller_manager_deployment.yaml
@@ -22,6 +22,11 @@ metadata:
 spec:
   # Mutually exclusive with plank. Only one of them may have more than zero replicas.
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
   revisionHistoryLimit: 2
   selector:
     matchLabels:
@@ -57,6 +62,18 @@ spec:
         - name: job-config
           mountPath: /etc/job-config
           readOnly: true
+        livenessProbe: # Pod is killed if this fails 3 times.
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 10
+          periodSeconds: 5
+        readinessProbe: # Pod is not considered ready (for rolling deploy and request routing) if this fails 3 times.
+          httpGet:
+            path: /healthz/ready
+            port: 8081
+          initialDelaySeconds: 10
+          periodSeconds: 3
       volumes:
       - name: kubeconfig
         secret:


### PR DESCRIPTION
Follow up to https://github.com/kubernetes/test-infra/pull/24042

Since the previous PR, `prow-controller-manager` can now have a slower startup due to retrying build manager creation. This PR should change the deployment strategy to allow two pods to coexist during deployment and it should make the rolling deployment strategy aware of when the build managers are ready for use so that the old pod is not removed until the new pod is ready.

I just ready all the k8s docs I could find on liveness/readiness probes and a couple articles about potential pitfalls. I think this configuration should give us the behavior we want without risk of crashlooping.
/assign @alvaroaleman @chaodaiG 
/hold