### PR TITLE
Add subsystem jobs to assisted-installer testgrid dashboard 

### DIFF
--- a/config/testgrids/openshift/assisted-installer.yaml
+++ b/config/testgrids/openshift/assisted-installer.yaml
@@ -1,6 +1,60 @@
 dashboards:
 - name: redhat-assisted-installer
   dashboard_tab:
+  - name: periodic-ci-openshift-assisted-service-master-subsystem-aws-periodic
+    test_group_name: periodic-ci-openshift-assisted-service-master-subsystem-aws-periodic
+    base_options: width=10
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    file_bug_template:
+      options:
+      - key: classification
+        value: Red Hat
+      - key: product
+        value: OpenShift Container Platform
+      - key: cf_internal_whiteboard
+        value: buildcop
+      - key: short_desc
+        value: 'test: <test-name>'
+      - key: cf_environment
+        value: 'test: <test-name>'
+      - key: comment
+        value: 'test: <test-name> failed, see job: <test-url>'
+      url: https://bugzilla.redhat.com/enter_bug.cgi
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+  - name: periodic-ci-openshift-assisted-service-master-subsystem-kubeapi-aws-periodic
+    test_group_name: periodic-ci-openshift-assisted-service-master-subsystem-kubeapi-aws-periodic
+    base_options: width=10
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    file_bug_template:
+      options:
+      - key: classification
+        value: Red Hat
+      - key: product
+        value: OpenShift Container Platform
+      - key: cf_internal_whiteboard
+        value: buildcop
+      - key: short_desc
+        value: 'test: <test-name>'
+      - key: cf_environment
+        value: 'test: <test-name>'
+      - key: comment
+        value: 'test: <test-name> failed, see job: <test-url>'
+      url: https://bugzilla.redhat.com/enter_bug.cgi
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
   - name: periodic-ci-openshift-release-master-nightly-4.6-e2e-metal-assisted
     test_group_name: periodic-ci-openshift-release-master-nightly-4.6-e2e-metal-assisted
     base_options: width=10
@@ -217,3 +271,8 @@ dashboards:
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+test_groups:
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-assisted-service-master-subsystem-aws-periodic
+  name: periodic-ci-openshift-assisted-service-master-subsystem-aws-periodic
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-assisted-service-master-subsystem-kubeapi-aws-periodic
+  name: periodic-ci-openshift-assisted-service-master-subsystem-kubeapi-aws-periodic


### PR DESCRIPTION
Add our 2 subsystem jobs to testgrid dashboard, so we can track failed tests.