### PR TITLE
Revert "Use CSI in GKE master periodics."

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -313,7 +313,3 @@ presets:
 - labels:
     preset-e2e-scalability-periodics-master: "true"
   env:
-  - name: DEPLOY_GCI_DRIVER
-    value: true
-  - name: PROMETHEUS_STORAGE_CLASS_PROVISIONER
-    value: pd.csi.storage.gke.io


### PR DESCRIPTION
Reverts kubernetes/test-infra#24351

First run with this applied: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-scalability/1460219073999671296

The test failed with
```
E1115 12:25:46.513654   15297 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
```