### PR TITLE
etcdadm: build etcd-manager tags

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-etcdadm.yaml
+++ b/config/jobs/image-pushing/k8s-staging-etcdadm.yaml
@@ -8,9 +8,11 @@ postsubmits:
       branches:
         - ^master$
         - ^release-.*
-        # Build tags also
+        # Build (root) tags also
         # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
         - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+        # Build etcd-manager tags
+        - ^etcd-manager/.*$
       spec:
         serviceAccountName: gcb-builder
         containers:


### PR DESCRIPTION
We want to be able to tag an etcd-manager specific version, and trigger a build.