### PR TITLE
Promote CSI changes to all periodic jobs

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -274,6 +274,8 @@ periodics:
       - --kubemark-nodes=500
       - --provider=gce
       - --env=CL2_ENABLE_CLUSTER_OOMS_TRACKER=true
+      - --env=DEPLOY_GCI_DRIVER=false
+      - --env=PROMETHEUS_STORAGE_CLASS_PROVISIONER=kubernetes.io/gce-pd
       - --test=false
       - --test_args=--ginkgo.focus=xxxx
       - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
@@ -348,6 +350,8 @@ periodics:
       - --env=CL2_ENABLE_CLUSTER_OOMS_TRACKER=true
       - --env=CL2_ENABLE_VIOLATIONS_FOR_SCHEDULING_THROUGHPUT=false
       - --env=CL2_ENABLE_HUGE_SERVICES=true
+      - --env=DEPLOY_GCI_DRIVER=false
+      - --env=PROMETHEUS_STORAGE_CLASS_PROVISIONER=kubernetes.io/gce-pd
       - --test=false
       - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
       - --test-cmd-args=cluster-loader2

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
@@ -278,6 +278,8 @@ periodics:
       - --test-cmd-args=--nodes=500
       - --test-cmd-args=--provider=kubemark
       - --env=CL2_ENABLE_PVS=false
+      - --env=DEPLOY_GCI_DRIVER=false
+      - --env=PROMETHEUS_STORAGE_CLASS_PROVISIONER=kubernetes.io/gce-pd
       - --test-cmd-args=--report-dir=$(ARTIFACTS)
       - --test-cmd-args=--testconfig=testing/load/config.yaml
       - --test-cmd-args=--testconfig=testing/access-tokens/config.yaml
@@ -347,6 +349,8 @@ periodics:
       - --env=CL2_ENABLE_DNS_PROGRAMMING=true
       - --env=CL2_SCHEDULER_THROUGHPUT_THRESHOLD=0
       - --env=CL2_ENABLE_HUGE_SERVICES=true
+      - --env=DEPLOY_GCI_DRIVER=false
+      - --env=PROMETHEUS_STORAGE_CLASS_PROVISIONER=kubernetes.io/gce-pd
       - --test=false
       - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
       - --test-cmd-args=cluster-loader2

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.21.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.21.yaml
@@ -323,6 +323,8 @@ periodics:
       - --test-cmd-args=--nodes=500
       - --test-cmd-args=--provider=kubemark
       - --env=CL2_ENABLE_PVS=false
+      - --env=DEPLOY_GCI_DRIVER=false
+      - --env=PROMETHEUS_STORAGE_CLASS_PROVISIONER=kubernetes.io/gce-pd
       - --test-cmd-args=--report-dir=$(ARTIFACTS)
       - --test-cmd-args=--testconfig=testing/load/config.yaml
       - --test-cmd-args=--testconfig=testing/access-tokens/config.yaml
@@ -392,6 +394,8 @@ periodics:
       - --env=CL2_ENABLE_DNS_PROGRAMMING=true
       - --env=CL2_SCHEDULER_THROUGHPUT_THRESHOLD=0
       - --env=CL2_ENABLE_HUGE_SERVICES=true
+      - --env=DEPLOY_GCI_DRIVER=false
+      - --env=PROMETHEUS_STORAGE_CLASS_PROVISIONER=kubernetes.io/gce-pd
       - --test=false
       - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
       - --test-cmd-args=cluster-loader2

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml
@@ -317,6 +317,8 @@ periodics:
       - --metadata-sources=cl2-metadata.json
       - --provider=gce
       - --env=CL2_ENABLE_HUGE_SERVICES=true
+      - --env=DEPLOY_GCI_DRIVER=false
+      - --env=PROMETHEUS_STORAGE_CLASS_PROVISIONER=kubernetes.io/gce-pd
       - --test=false
       - --test_args=--ginkgo.focus=xxxx
       - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
@@ -395,6 +397,8 @@ periodics:
       - --env=CL2_ENABLE_HUGE_SERVICES=true
       - --env=CL2_ENABLE_API_AVAILABILITY_MEASUREMENT=true
       - --env=CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD=99.5
+      - --env=DEPLOY_GCI_DRIVER=false
+      - --env=PROMETHEUS_STORAGE_CLASS_PROVISIONER=kubernetes.io/gce-pd
       - --test=false
       - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
       - --test-cmd-args=cluster-loader2
@@ -858,6 +862,8 @@ periodics:
       - --test-cmd-args=--nodes=500
       - --test-cmd-args=--provider=kubemark
       - --env=CL2_ENABLE_PVS=false
+      - --env=DEPLOY_GCI_DRIVER=false
+      - --env=PROMETHEUS_STORAGE_CLASS_PROVISIONER=kubernetes.io/gce-pd
       - --test-cmd-args=--report-dir=$(ARTIFACTS)
       - --test-cmd-args=--testconfig=testing/load/config.yaml
       - --test-cmd-args=--testconfig=testing/access-tokens/config.yaml

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -309,11 +309,11 @@ presets:
 - labels:
     preset-e2e-scalability-periodics: "true"
   env:
-
-- labels:
-    preset-e2e-scalability-periodics-master: "true"
-  env:
   - name: DEPLOY_GCI_DRIVER
     value: true
   - name: PROMETHEUS_STORAGE_CLASS_PROVISIONER
     value: pd.csi.storage.gke.io
+
+- labels:
+    preset-e2e-scalability-periodics-master: "true"
+  env:


### PR DESCRIPTION
Promotes https://github.com/kubernetes/test-infra/pull/24356 to preset-e2e-scalability-periodics to enable in all periodics tests (but not 1.19, 1.20, 1.21, 1.22 where we don't want to enable this).

**Why this approach vs simply keeping this in preset-e2e-scalability-periodics-master forever?**
Here we explicitly say which versions should use old logic. Once we start running tests for 1.23 (so the current master), we will use the new logic (which is desired), while the previous approach would require us to manually remember to migrate some env that time (and each time we add a new k8s version).


/assign @tosi3k 

/hold
Hold for now, until we soak https://github.com/kubernetes/test-infra/pull/24356.
Feel free to unhold once we see at least 1 successful run for both:
* https://k8s-testgrid.appspot.com/sig-scalability-kubemark#kubemark-100
* https://k8s-testgrid.appspot.com/sig-scalability-gce#gce-cos-master-scalability-100

Including https://github.com/kubernetes/test-infra/pull/24356 (you can check by going to a yaml file for a given test and checking env variables).

/cc @leiyiz