### PR TITLE
Add branch restrictions for Kubernetes 1.23 Code Freeze

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -563,6 +563,31 @@ tide:
     - needs-rebase
   - repos:
     - kubernetes/kubernetes
+    excludedBranches:
+    - master
+    - release-1.23
+    labels:
+    - lgtm
+    - approved
+    - "cncf-cla: yes"
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/blocked-paths
+    - do-not-merge/cherry-pick-not-approved
+    - do-not-merge/hold
+    - do-not-merge/invalid-commit-message
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/needs-kind
+    - do-not-merge/needs-sig
+    - do-not-merge/release-note-label-needed
+    - do-not-merge/work-in-progress
+    - needs-rebase
+  - repos:
+    - kubernetes/kubernetes
+    milestone: v1.23
+    includedBranches:
+    - master
+    - release-1.23
     labels:
     - lgtm
     - approved


### PR DESCRIPTION
The Kubernetes 1.23 Code Freeze is scheduled to start at 18:00 Pacific Time on November 16th, 2021.

/hold
**The hold should ONLY be cancelled by the Release Leads when the 1.23 Release Team is ready around the Code Freeze deadline**

/cc @Verolop @puerco 
/cc @kubernetes/release-team-leads @kubernetes/release-engineering
/assign @dims @spiffxp 