### PR TITLE
Move CSI presets to *-common presets

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -99,6 +99,10 @@ presets:
   # TODO(https://github.com/kubernetes/perf-tests/issues/1828): Use konnectivity in kubemark.
   - name: KUBE_ENABLE_KONNECTIVITY_SERVICE
     value: false
+  - name: DEPLOY_GCI_DRIVER
+    value: true
+  - name: PROMETHEUS_STORAGE_CLASS_PROVISIONER
+    value: pd.csi.storage.gke.io
 
 ### kubemark-gce-scale
 - labels:
@@ -236,6 +240,10 @@ presets:
     value: "containerd"
   - name: DUMP_TO_GCS_ONLY
     value: true
+  - name: DEPLOY_GCI_DRIVER
+    value: true
+  - name: PROMETHEUS_STORAGE_CLASS_PROVISIONER
+    value: pd.csi.storage.gke.io
 
   ###### Scalability Envs
   ### Common env variables for containerd scalability-related suites.
@@ -305,18 +313,10 @@ presets:
 - labels:
     preset-e2e-scalability-presubmits: "true"
   env:
-  - name: DEPLOY_GCI_DRIVER
-    value: true
-  - name: PROMETHEUS_STORAGE_CLASS_PROVISIONER
-    value: pd.csi.storage.gke.io
 
 - labels:
     preset-e2e-scalability-periodics: "true"
   env:
-  - name: DEPLOY_GCI_DRIVER
-    value: true
-  - name: PROMETHEUS_STORAGE_CLASS_PROVISIONER
-    value: pd.csi.storage.gke.io
 
 - labels:
     preset-e2e-scalability-periodics-master: "true"


### PR DESCRIPTION
Promotes CSI driver to all scalability jobs by putting this to preset-e2e-kubemark-common and preset-e2e-scalability-common.

It should be no-op: the current set of presets (preset-e2e-scalability-presubmits and preset-e2e-scalability-periodics) already covers all tests. I submit this to set this env variables like all other presets.

/assign @wojtek-t 
/cc @leiyiz