### PR TITLE
Remove the post-release-push-image-vulndash job

### DIFF
--- a/config/jobs/image-pushing/releng/k8s-staging-artifact-promoter.yaml
+++ b/config/jobs/image-pushing/releng/k8s-staging-artifact-promoter.yaml
@@ -1,35 +1,4 @@
 postsubmits:
-  kubernetes/release:
-    - name: post-release-push-image-vulndash
-      cluster: k8s-infra-prow-build-trusted
-      annotations:
-        testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes, sig-k8s-infra-gcb
-        testgrid-alert-email: release-managers+alerts@kubernetes.io
-        testgrid-num-failures-to-alert: '1'
-      decorate: true
-      run_if_changed: '^cmd\/vulndash\/'
-      branches:
-        - ^main$
-        # TODO(releng): Remove once repo default branch has been renamed
-        - ^master$
-      spec:
-        serviceAccountName: gcb-builder
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/image-builder:v20211014-7ca1952a94
-            command:
-              - /run.sh
-            args:
-              - --project=k8s-staging-artifact-promoter
-              - --scratch-bucket=gs://k8s-staging-artifact-promoter-gcb
-              - --build-dir=.
-              - cmd/vulndash
-            env:
-              - name: LOG_TO_STDOUT
-                value: "y"
-      rerun_auth_config:
-        github_team_slugs:
-          - org: kubernetes
-            slug: release-managers
   kubernetes-sigs/promo-tools:
     # TODO(releng): Rename to 'kpromo' once tools are merged
     - name: post-cip-push-image-cip


### PR DESCRIPTION
/kind cleanup
/area release-eng/security

The vulndash tool has been removed in https://github.com/kubernetes/release/pull/2322, so this PR removes the job used to push the vulndash image.

/assign @justaugustus @cpanato @Verolop 
cc: @kubernetes/release-engineering 