### PR TITLE
cluster-api: rename clusterctl upgrade jobs, add v1.0-to-main

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -22,7 +22,7 @@ periodics:
     testgrid-tab-name: capi-test-main
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
-- name: periodic-cluster-api-e2e-v1alpha3-v1beta1-upgrade-main
+- name: periodic-cluster-api-e2e-upgrade-v0-3-to-main
   interval: 1h
   decorate: true
   labels:
@@ -61,7 +61,49 @@ periodics:
             cpu: 7300m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-    testgrid-tab-name: capi-e2e-v1alpha3-v1beta1-upgrade-main
+    testgrid-tab-name: capi-e2e-upgrade-v0-3-to-main
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "2"
+- name: periodic-cluster-api-e2e-upgrade-v1-0-to-main
+  interval: 1h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211111-d096cb0c5f-master
+      args:
+      - runner.sh
+      - "./scripts/ci-e2e.sh"
+      env:
+      - name: GINKGO_FOCUS
+        value: "\\[clusterctl-Upgrade\\]"
+      - name: INIT_WITH_BINARY
+        value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.1/clusterctl-{OS}-{ARCH}
+      - name: INIT_WITH_PROVIDERS_CONTRACT
+        value: v1beta1
+      - name: INIT_WITH_KUBERNETES_VERSION
+        value: v1.22.0
+
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+    testgrid-tab-name: capi-e2e-upgrade-v1-0-to-main
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-e2e-main

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-0.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-0.yaml
@@ -22,7 +22,7 @@ periodics:
     testgrid-tab-name: capi-test-release-1-0
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
-- name: periodic-cluster-api-e2e-v1alpha3-v1beta1-upgrade-release-1-0
+- name: periodic-cluster-api-e2e-upgrade-v0-3-to-release-1-0
   interval: 4h
   decorate: true
   labels:
@@ -61,7 +61,7 @@ periodics:
             cpu: 7300m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.0
-    testgrid-tab-name: capi-e2e-v1alpha3-v1beta1-upgrade-release-1-0
+    testgrid-tab-name: capi-e2e-upgrade-v0-3-to-release-1-0
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-e2e-release-1-0


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

xref: https://github.com/kubernetes-sigs/cluster-api/pull/5680