### PR TITLE
cluster-api: Fix CAPI e2e-main 1.20=>1.21 test

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
@@ -105,7 +105,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211111-d096cb0c5f-1.21
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211111-d096cb0c5f-master
       args:
         - runner.sh
         - "./scripts/ci-e2e.sh"


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

Somehow missed that test when upgrading images to Go 1.17

xref:
* https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-e2e-workload-upgrade-1-20-1-21-main/1460675908313550848
* https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-main-1-20-1-21