### PR TITLE
Allow Override PR History link

### DIFF
--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -1245,3 +1245,55 @@ func TestHttpStatusForError(t *testing.T) {
 		})
 	}
 }
+
+func TestPRHistLink(t *testing.T) {
+	tests := []struct {
+		name    string
+		tmpl    string
+		org     string
+		repo    string
+		number  int
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "default",
+			tmpl:    defaultPRHistLinkTemplate,
+			org:     "org",
+			repo:    "repo",
+			number:  0,
+			want:    "/pr-history?org=org&repo=repo&pr=0",
+			wantErr: false,
+		},
+		{
+			name:    "different-template",
+			tmpl:    "/pull={{.Number}}",
+			org:     "org",
+			repo:    "repo",
+			number:  0,
+			want:    "/pull=0",
+			wantErr: false,
+		},
+		{
+			name:    "invalid-template",
+			tmpl:    "doesn't matter {{.NotExist}}",
+			org:     "org",
+			repo:    "repo",
+			number:  0,
+			want:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, gotErr := prHistLinkFromTemplate(tc.tmpl, tc.org, tc.repo, tc.number)
+			if (tc.wantErr && (gotErr == nil)) || (!tc.wantErr && (gotErr != nil)) {
+				t.Fatalf("Error mismatch. Want: %v, got: %v", tc.wantErr, gotErr)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatalf("Template mismatch. Want: (-), got: (+). \n%s", diff)
+			}
+		})
+	}
+}

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -999,6 +999,9 @@ type Spyglass struct {
 	// prow instances that only serves gerrit.
 	// This might become obsolete once https://github.com/kubernetes/test-infra/issues/24130 is fixed.
 	HidePRHistLink bool `json:"hide_pr_history_link,omitempty"`
+	// PRHistLinkTemplate is the template for constructing href of `PR History` button,
+	// by default it's "/pr-history?org={{.Org}}&repo={{.Repo}}&pr={{.Number}}"
+	PRHistLinkTemplate string `json:"pr_history_link_template,omitempty"`
 }
 
 type GCSBrowserPrefixes map[string]string

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -396,6 +396,10 @@ deck:
             required_files:
               - ""
 
+        # PRHistLinkTemplate is the template for constructing href of `PR History` button,
+        # by default it's "/pr-history?org={{.Org}}&repo={{.Repo}}&pr={{.Number}}"
+        pr_history_link_template: ' '
+
         # TestGridConfig is the path to the TestGrid config proto. If the path begins with
         # "gs://" it is assumed to be a GCS reference, otherwise it is read from the local filesystem.
         # If left blank, TestGrid links will not appear.


### PR DESCRIPTION
PR history link /pr-history from deck is currently only supported for GitHub repos, which turned out to be internal error for gerrit based prow. Allow overriding the template could possibly let users pointing to `/repo=<REPO>&pull=<PULL>` etc