### PR TITLE
CAPZ: skip GPU test for alpha3 tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-release-v1alpha3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-release-v1alpha3.yaml
@@ -128,7 +128,7 @@ periodics:
         - name: GINKGO_FOCUS
           value: "Workload cluster creation"
         - name: GINKGO_SKIP
-          value: ""
+          value: "Creating a GPU-enabled cluster"
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1alpha3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1alpha3.yaml
@@ -89,7 +89,7 @@ presubmits:
           - name: GINKGO_FOCUS
             value: "Workload cluster creation"
           - name: GINKGO_SKIP
-            value: ""
+            value: "Creating a GPU-enabled cluster"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
Since the GPU test is currently broken and failing 100% of the time in the v1alpha3 release branch, temporarily skip it in the tests to remove some noise.

Should be removed once https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/1354 is fixed.

/assign @mboersma @shysank 