### PR TITLE
Remove kubelet-serial-containerd from node-e2e-project

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -265,7 +265,6 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --deployment=node
-      - --gcp-project-type=node-e2e-project
       - --gcp-zone=us-west1-b
       - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/image-config-serial.yaml
       - '--node-test-args=--feature-gates=LocalStorageCapacityIsolation=true --container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'


### PR DESCRIPTION
The job [ node-kubelet-serial-containerd ](https://testgrid.k8s.io/sig-node-release-blocking#node-kubelet-serial-containerd) is failing since log with the error 

```
Something went wrong: failed to prepare test environment: --provider=gce boskos failed to acquire project: resources not found
```

I have seen boskos releated constraint issues [here](https://github.com/kubernetes/test-infra/issues/23291)  and [here](https://github.com/kubernetes/test-infra/pull/23777) . I am not sure the exact reason why this job is failing, from the discussions above we want to migrate away from `node-e2e-project`, Since this job is anyways failing with boskos issue we can try to migrate it

/cc @spiffxp @endocrimes 
/sig node