### PR TITLE
prow/sidecar: allow parsing INI files for censoring

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -90,6 +90,7 @@ require (
 	google.golang.org/api v0.44.0
 	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c
 	gopkg.in/fsnotify.v1 v1.4.7
+	gopkg.in/ini.v1 v1.62.0
 	gopkg.in/robfig/cron.v2 v2.0.0-20150107220207-be2e0b0deed5
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/api v0.21.3

--- a/prow/sidecar/BUILD.bazel
+++ b/prow/sidecar/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//prow/secretutil:go_default_library",
         "@com_github_mattn_go_zglob//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@in_gopkg_ini_v1//:go_default_library",
         "@io_k8s_apimachinery//pkg/util/errors:go_default_library",
         "@org_golang_x_sync//semaphore:go_default_library",
     ],

--- a/prow/sidecar/censor_test.go
+++ b/prow/sidecar/censor_test.go
@@ -163,12 +163,14 @@ func TestCensorIntegration(t *testing.T) {
 		Entries: []wrapper.Options{
 			{ProcessLog: filepath.Join(tempDir, "logs/one.log")},
 			{ProcessLog: filepath.Join(tempDir, "logs/two.log")},
+			{ProcessLog: filepath.Join(tempDir, "logs/three.log")},
 		},
 		CensoringOptions: &CensoringOptions{
 			SecretDirectories: []string{"testdata/secrets"},
 			// this will be smaller than the size of a secret, so this tests our buffer calculation
 			CensoringBufferSize: &bufferSize,
 			ExcludeDirectories:  []string{"**/exclude"},
+			IniFilenames:        []string{".awscred"},
 		},
 	}
 	if err := options.censor(); err != nil {

--- a/prow/sidecar/options.go
+++ b/prow/sidecar/options.go
@@ -122,6 +122,10 @@ type CensoringOptions struct {
 	// directory also matches a glob in IncludeDirectories. Entries in this list are
 	// parsed with the go-zglob library, allowing for globbed matches.
 	ExcludeDirectories []string `json:"exclude_directories,omitempty"`
+
+	// IniFilenames are secret filenames that should be parsed as INI files in order to
+	// censor the values in the key-value mapping as well as the full content of the file.
+	IniFilenames []string `json:"ini_filenames,omitempty"`
 }
 
 func (o Options) entries() []wrapper.Options {

--- a/prow/sidecar/testdata/input/logs/three.log
+++ b/prow/sidecar/testdata/input/logs/three.log
@@ -1,0 +1,1 @@
+I've parsed the AWS credentials and now know about the aws_access_key_id_value and aws_secret_access_key_value!

--- a/prow/sidecar/testdata/output/logs/three.log
+++ b/prow/sidecar/testdata/output/logs/three.log
@@ -1,0 +1,1 @@
+I've parsed the AWS credentials and now know about the *********************** and ***************************!

--- a/prow/sidecar/testdata/secrets/awscred/.awscred
+++ b/prow/sidecar/testdata/secrets/awscred/.awscred
@@ -1,0 +1,3 @@
+[default]
+aws_access_key_id=aws_access_key_id_value
+aws_secret_access_key=aws_secret_access_key_value


### PR DESCRIPTION
In cases where users pass complex files to the censoring system, often
they want to be able to censor not only the totality of the data in the
input file but also the sensitive fields that exist inside. We can
transparently support this for registry credentials since we know about
their file names and formats as supported natively in k8s secrets, but
for other types (like INI) we need the user to opt into this by passing
filenames.
