### PR TITLE
sig-scalability: reduce memory request for gce-scale-correctness

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -48,10 +48,10 @@ periodics:
       resources:
         requests:
           cpu: 6
-          memory: "48Gi"
+          memory: "39Gi"
         limits:
           cpu: 6
-          memory: "48Gi"
+          memory: "39Gi"
 
 # This is a sig-release-master-blocking job.
 - cron: '1 17 * * *' # Run daily at 9:01PST (17:01 UTC)


### PR DESCRIPTION
Related:
  - Part of: https://github.com/kubernetes/perf-tests/issues/1898
  - followup of: https://github.com/kubernetes/test-infra/pull/24080

Reduce memory allocation to ensure
`ci-kubernetes-e2e-gce-scale-correctness` can run on community-owned
build clusters.

Example of failure : https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-scale-correctness/1460941036204331008

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>