### PR TITLE
Add zone back for node-kubelet-serial-containerd

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -314,6 +314,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --deployment=node
+      - --gcp-zone=us-west1-b
       - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/image-config-serial.yaml
       - '--node-test-args=--feature-gates=LocalStorageCapacityIsolation=true --container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
       - --node-tests=true


### PR DESCRIPTION
Tests starts failing if zone is not added, If there isn't a zone requirement & still test is failing will debug it later

```
W1118 00:46:11.709] F1118 00:46:11.699879    6622 run_remote.go:308] Must specify --zone flag
```
https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-serial-containerd/1461072402778689536/build-log.txt

for now running it is important as in one run some tests are failing with the error, need to look at those
```
rpc error: code = Unimplemented desc = unknown service runtime.v1alpha2.ImageService
W1117 20:52:35.446]   occurred
```
https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-serial-containerd/1461072402778689536/build-log.txt

cc @SergeyKanzhelev @dims 