### PR TITLE
Attempt to fix node-kubelet-serial-containerd

### DIFF
--- a/jobs/e2e_node/containerd/config.toml
+++ b/jobs/e2e_node/containerd/config.toml
@@ -17,5 +17,5 @@ disabled_plugins = ["restart"]
   endpoint = ["https://mirror.gcr.io","https://registry-1.docker.io"]
 
 # Runtime handler used for runtime class test.
-[plugins.cri.containerd.runtimes.test-handler]
-  runtime_type = "io.containerd.runtime.v1.linux"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler]
+  runtime_type = "io.containerd.runc.v2"


### PR DESCRIPTION
Update containerd config.toml 

As discussed here https://kubernetes.slack.com/archives/C0BP8PW9G/p1637210501213700
for cos93 images new syntax required for runtime classes

/cc @SergeyKanzhelev 
/sig node 