### PR TITLE
sig-instrumentation: increase code coverage for JSON periodic job

### DIFF
--- a/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-kind-periodics.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-kind-periodics.yaml
@@ -1,13 +1,15 @@
 periodics:
-- interval: 1h
+- interval: 6h
   cluster: k8s-infra-prow-build
+  # This combines tests from ci-kubernetes-kind-conformance and sig-storage
+  # and runs them with JSON output in all components which support that.
   name: ci-kubernetes-kind-e2e-json-logging
   annotations:
     testgrid-dashboards: sig-instrumentation-tests, sig-testing-kind
     testgrid-tab-name: kind-json-logging-master
-    description: Smoke tests Kubelet with JSON logging enabled using sigs.k8s.io/kind
+    description: Conformance and storage tests with JSON logging enabled using sigs.k8s.io/kind
     # TODO: anyone else?
-    testgrid-alert-email: bentheelder@google.com,siarkowicz@google.com
+    testgrid-alert-email: bentheelder@google.com,siarkowicz@google.com,patrick.ohly@intel.com
     testgrid-num-columns-recent: '6'
     fork-per-release: "true"
     fork-per-release-periodic-interval: 1h 2h 6h 24h
@@ -16,7 +18,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   decorate: true
   decoration_config:
-    timeout: 60m
+    timeout: 150m
   extra_refs:
   - org: kubernetes
     repo: kubernetes
@@ -31,13 +33,18 @@ periodics:
       - -c
       - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
       env:
-      # this is the key configuration
+      # Options from https://github.com/kubernetes-sigs/kind/blob/d1eecc46e30cac9d35cd32dc52677ef75ec22e18/hack/ci/e2e-k8s.sh#L79-L83
       - name: CLUSTER_LOG_FORMAT
         value: json
-      # TODO: This is a fairly arbitrary test that actually schedules some pod(s).
-      # We mostly just want cluster up/down and something that ensures the cluster is in fact up fully.
+      - name: KIND_CLUSTER_LOG_LEVEL
+        # Default is 4, but we want to exercise more log calls and get more output.
+        # TODO: go even higher, depending on log volume
+        value: "6"
+      # don't retry conformance tests
+      - name: GINKGO_TOLERATE_FLAKES
+        value: "n"
       - name: FOCUS
-        value: Job.should.run.a.job.to.completion.when.tasks.sometimes.fail.and.are.locally.restarted
+        value: \[Conformance\]|\[Driver:.csi-hostpath\]
       # TODO(bentheelder): reduce the skip list further
       # NOTE: this skip list is from the standard periodic kind job, just to ensure
       # we don't accidentally select any of these


### PR DESCRIPTION
We need to trigger more log calls to catch potential mistakes and to get
representative log output for components under load.

Storage tests were chosen because a) they exercise quite a bit of additional
code in kubelet and b) because I know them.

/wg structured-logging
/assign @serathius 