### PR TITLE
Get Windows cluster def from kubernetes-sigs/azuredisk-csi-driver

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-v2-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-v2-config.yaml
@@ -371,7 +371,7 @@ presubmits:
         - --aksengine-orchestratorRelease=1.21
         - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
         - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
-        - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_csi_proxy.json
+        - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/main_v2/test/e2e/manifest/windows.json
         - --aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz
         - --timeout=180m
         # Specific test args


### PR DESCRIPTION
Gets the Windows cluster definition from kubernetes-sigs/azuredisk-csi-driver. The cluster definition from kubernetes-sigs/windows-testing uses an old version of CSI Proxy.