### PR TITLE
Git client rotates token when needed

### DIFF
--- a/prow/git/BUILD.bazel
+++ b/prow/git/BUILD.bazel
@@ -35,7 +35,10 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["git_test.go"],
+    srcs = [
+        "git_test.go",
+        "git_unit_test.go",
+    ],
     embed = [":go_default_library"],
     tags = ["manual"],
     deps = [

--- a/prow/git/git_test.go
+++ b/prow/git/git_test.go
@@ -14,6 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// This test imports "k8s.io/test-infra/prow/git/localgit", which also reference
+// "k8s.io/test-infra/prow/git", has to be a separate package to avoid
+// circular dependency(however this file implicitly referencing "k8s.io/test-infra/prow/git")
 package git_test
 
 import (

--- a/prow/git/git_unit_test.go
+++ b/prow/git/git_unit_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package git
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestRefreshRepoAuth(t *testing.T) {
+	g, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name       string
+		repo       *Repo
+		wantPass   string
+		wantRemote string
+		wantErr    bool
+	}{
+		{
+			name: "base",
+			repo: &Repo{
+				base: "git",
+				user: "foo",
+				pass: "preset",
+				org:  "valid-org",
+				repo: "repo",
+			},
+			wantPass:   "valid-token",
+			wantRemote: "https://foo:valid-token@/valid-org/repo",
+			wantErr:    false,
+		},
+		{
+			name: "empty-user",
+			repo: &Repo{
+				base: "git",
+				pass: "preset",
+				org:  "valid-org",
+				repo: "repo",
+			},
+			wantPass:   "valid-token",
+			wantRemote: "git/valid-org/repo",
+			wantErr:    false,
+		},
+		{
+			name: "token-still-fresh",
+			repo: &Repo{
+				base: "git",
+				user: "foo",
+				pass: "valid-token",
+				org:  "valid-org",
+				repo: "repo",
+			},
+			wantPass:   "valid-token",
+			wantRemote: "preset/remote",
+			wantErr:    false,
+		},
+		{
+			name: "token-fetch-failed",
+			repo: &Repo{
+				base: "git",
+				user: "foo",
+				pass: "preset",
+				org:  "random-org",
+				repo: "repo",
+			},
+			wantPass:   "preset",
+			wantRemote: "preset/remote",
+			wantErr:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tc.repo
+			r.logger = logrus.WithContext(context.Background())
+			r.git = g
+			r.dir = t.TempDir()
+			r.tokenGenerator = func(org string) (string, error) {
+				switch org {
+				case "valid-org":
+					return "valid-token", nil
+				case "invalid-org":
+					return "invalid-token", nil
+				default:
+					return "", errors.New("error")
+				}
+			}
+
+			// Prepare for the workspace so that git command won't fail.
+			b, err := r.gitCommand("init").CombinedOutput()
+			if err != nil {
+				t.Fatalf("Failed init: %v. output: %s", err, string(b))
+			}
+			if b, err = r.gitCommand("remote", "add", "origin", "preset/remote").CombinedOutput(); err != nil {
+				t.Fatalf("Failed set origin: %v. output: %s", err, string(b))
+			}
+
+			if gotErr := r.refreshRepoAuth(); (gotErr != nil && !tc.wantErr) || (gotErr == nil && tc.wantErr) {
+				t.Fatalf("Error mismatch. Want: %v, got: %v", tc.wantErr, gotErr)
+			}
+
+			if wantPass, gotPass := tc.wantPass, r.pass; wantPass != gotPass {
+				t.Fatalf("Wrong token. Want: %q, got: %q", wantPass, gotPass)
+			}
+
+			b, err = r.gitCommand("remote", "get-url", "origin").CombinedOutput()
+			if err != nil {
+				t.Fatalf("Failed git config: %v. output: %s", err, string(b))
+			}
+			if wantRemote, gotRemote := tc.wantRemote, strings.TrimSpace(string(b)); wantRemote != gotRemote {
+				t.Fatalf("Wrong remote. Want: %q, got: %q", wantRemote, gotRemote)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Git client sets token when initialized, and doesn't refresh. This works for inrepoconfig because a git clone is used only once and then discarded, but this doesn't work for cached client that reuses cloned repos. This error was encountered one hour after the cached git client was created.