### PR TITLE
fix: fetch error with depth 1

### DIFF
--- a/prow/pod-utils/clone/clone.go
+++ b/prow/pod-utils/clone/clone.go
@@ -238,18 +238,22 @@ func (g *gitCtx) commandsForBaseRef(refs prowapi.Refs, gitUserName, gitUserEmail
 		commands = append(commands, g.gitFetch(fetchArgs...))
 	}
 
+	var fetchRef string
+	var target string
+	if refs.BaseSHA != "" {
+		fetchRef = refs.BaseSHA
+		target = refs.BaseSHA
+	} else {
+		fetchRef = refs.BaseRef
+		target = "FETCH_HEAD"
+	}
+
 	{
 		fetchArgs := append([]string{}, depthArgs...)
-		fetchArgs = append(fetchArgs, g.repositoryURI, refs.BaseRef)
+		fetchArgs = append(fetchArgs, g.repositoryURI, fetchRef)
 		commands = append(commands, g.gitFetch(fetchArgs...))
 	}
 
-	var target string
-	if refs.BaseSHA != "" {
-		target = refs.BaseSHA
-	} else {
-		target = "FETCH_HEAD"
-	}
 	// we need to be "on" the target branch after the sync
 	// so we need to set the branch to point to the base ref,
 	// but we cannot update a branch we are on, so in case we

--- a/prow/pod-utils/clone/clone_test.go
+++ b/prow/pod-utils/clone/clone_test.go
@@ -425,7 +425,7 @@ func TestCommandsForRefs(t *testing.T) {
 					fetchRetries,
 				},
 				retryCommand{
-					cloneCommand{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "master"}},
+					cloneCommand{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "abcdef"}},
 					fetchRetries,
 				},
 				cloneCommand{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"checkout", "abcdef"}},
@@ -635,7 +635,7 @@ func TestCommandsForRefs(t *testing.T) {
 					fetchRetries,
 				},
 				retryCommand{
-					cloneCommand{dir: "/go/src/github.enterprise.com/org/repo", command: "git", args: []string{"fetch", "https://github.enterprise.com/org/repo.git", "master"}},
+					cloneCommand{dir: "/go/src/github.enterprise.com/org/repo", command: "git", args: []string{"fetch", "https://github.enterprise.com/org/repo.git", "abcdef"}},
 					fetchRetries,
 				},
 				cloneCommand{dir: "/go/src/github.enterprise.com/org/repo", command: "git", args: []string{"checkout", "abcdef"}},
@@ -661,7 +661,7 @@ func TestCommandsForRefs(t *testing.T) {
 				cloneCommand{dir: "/", command: "mkdir", args: []string{"-p", "/go/src/github.enterprise.com/org/repo"}},
 				cloneCommand{dir: "/go/src/github.enterprise.com/org/repo", command: "git", args: []string{"init"}},
 				retryCommand{
-					cloneCommand{dir: "/go/src/github.enterprise.com/org/repo", command: "git", args: []string{"fetch", "https://github.enterprise.com/org/repo.git", "master"}},
+					cloneCommand{dir: "/go/src/github.enterprise.com/org/repo", command: "git", args: []string{"fetch", "https://github.enterprise.com/org/repo.git", "abcdef"}},
 					fetchRetries,
 				},
 				cloneCommand{dir: "/go/src/github.enterprise.com/org/repo", command: "git", args: []string{"checkout", "abcdef"}},
@@ -688,7 +688,7 @@ func TestCommandsForRefs(t *testing.T) {
 				cloneCommand{dir: "/", command: "mkdir", args: []string{"-p", "/go/src/github.enterprise.com/org/repo"}},
 				cloneCommand{dir: "/go/src/github.enterprise.com/org/repo", command: "git", args: []string{"init"}},
 				retryCommand{
-					cloneCommand{dir: "/go/src/github.enterprise.com/org/repo", command: "git", args: []string{"fetch", "--depth", "2", "https://github.enterprise.com/org/repo.git", "master"}},
+					cloneCommand{dir: "/go/src/github.enterprise.com/org/repo", command: "git", args: []string{"fetch", "--depth", "2", "https://github.enterprise.com/org/repo.git", "abcdef"}},
 					fetchRetries,
 				},
 				cloneCommand{dir: "/go/src/github.enterprise.com/org/repo", command: "git", args: []string{"checkout", "abcdef"}},


### PR DESCRIPTION
`clonerefs` failed when BaseRef is ahead of the BaseSHA. it is common when rerunning the post jobs.

job config:
```yaml
postsubmits:
  xxx/xxx:
  - name: post-job
    decorate: true
    clone_depth: 1
    skip_fetch_head: true
    skip_submodules: true
```
previous:
```
git fetch --depth 1 https://github.com/kubernetes/test-infra.git master
git checkout ed929b919c4b460353f867e055066e1ef8c522e2
fatal: reference is not a tree: ed929b919c4b460353f867e055066e1ef8c522e2
# Error: exit status 128
```
current:
```
git fetch --depth 1 https://github.com/kubernetes/test-infra.git ed929b919c4b460353f867e055066e1ef8c522e2
git checkout ed929b919c4b460353f867e055066e1ef8c522e2
```