### PR TITLE
capdo: add experimental job to use boskos to be able to push temporary container images

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
@@ -154,3 +154,37 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
       testgrid-tab-name: capdo-pr-conformance
+  - name: pull-cluster-api-provider-digitalocean-capi-e2e-experimental
+    always_run: false
+    optional: true
+    decorate: true
+    path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
+    decoration_config:
+      timeout: 5h
+    max_concurrency: 1
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-do-credential: "true"
+    branches:
+    - ^main$
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211111-d096cb0c5f-master
+        command:
+          - "runner.sh"
+          - "./scripts/ci-e2e-experimental.sh"
+        env:
+          - name: "BOSKOS_HOST"
+            value: "boskos.test-pods.svc.cluster.local"
+          - name: GINKGO_FOCUS
+            value: "Cluster API E2E tests"
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1
+            memory: "4Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
+      testgrid-tab-name: capdo-pr-capi-e2e-experimental


### PR DESCRIPTION
in order to test the cluster-api api upgrades, we need to push the capdo-controller to the registry and that need to be available to pull.

Looks like we can push temporary images when using boskos (https://kubernetes.slack.com/archives/C09QZ4DQB/p1637516130115600)  but not sure

this is needed by the WIP work here https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/pull/282

/assign @spiffxp 