### PR TITLE
skip gcepd test for ci-kubernetes-e2e-gci-gce-containerd

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -1124,7 +1124,9 @@ periodics:
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=30
       - --provider=gce
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
+      # [Driver: gcepd] tests are skipped because CSIMigrationGCE is on in 1.23 and can be un-skipped once the cluster-up process
+      # uses cloud-provider-gcp. see issue https://github.com/kubernetes/cloud-provider-gcp/issues/293
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
       - --timeout=50m
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211210-0c6ec8feca-master
   annotations:


### PR DESCRIPTION
failing testgrid: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-containerd/1462622526948511744

Fix: the reason these test failed is due to `CSIMigrationGCE` turned on and no pdcsi driver installed in clusters brought up by k/k/kube-up. We can't install pdcsi driver by default in k/k due to ongoing effort to extract cloud-provider specific components and we don't want to maintain multiple sets of manifests all over places. So we need to skip them for now and eventually migrate these tests to use cloud-provider-gcp for cluster-up.