### PR TITLE
add debug flag in snyk cli command

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-security-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-security-trusted.yaml
@@ -36,7 +36,7 @@ periodics:
         fi
         echo "Running snyk scan .."
         EXIT_CODE=0
-        RESULT_UNFILTERED=$(snyk test --json) || EXIT_CODE=$?
+        RESULT_UNFILTERED=$(snyk test -d --json) || EXIT_CODE=$?
         if [ $EXIT_CODE -gt 1 ]; then
           echo "Failed to run snyk scan with exit code $EXIT_CODE . Error message: $RESULT_UNFILTERED"
           exit 1
@@ -45,6 +45,7 @@ periodics:
         '{vulnerabilities: .vulnerabilities | map(select((.type != "license") and (.version !=  "0.0.0"))) | select(length > 0) }')
         if [[ ${RESULT} ]]; then
           echo "Vulnerability filtering failed"
+          echo "Snyk tool output:\n $RESULT_UNFILTERED"
           exit 1
         else
           echo "Scan completed"
@@ -56,7 +57,7 @@ periodics:
         while read image; do
           echo "Running container image scan.."
           EXIT_CODE=0
-          RESULT_UNFILTERED=$(snyk container test $image --json) || EXIT_CODE=$?
+          RESULT_UNFILTERED=$(snyk container test $image -d --json) || EXIT_CODE=$?
           if [ $EXIT_CODE -gt 1 ]; then
             echo "Failed to run snyk scan with exit code $EXIT_CODE . Error message: $RESULT_UNFILTERED"
             exit 1
@@ -65,6 +66,7 @@ periodics:
           '{vulnerabilities: .vulnerabilities | map(select(.isUpgradable == true or .isPatchable == true)) | select(length > 0) }')
           if [[ ${RESULT} ]]; then
             echo "Vulnerability filtering failed"
+            echo "Snyk tool output:\n $RESULT_UNFILTERED"
             #exit 1
           else
             echo "Scan completed image $image"


### PR DESCRIPTION
Signed-off-by: Neha Lohia <nehapithadiya444@gmail.com>

The security scan prow job is continously failing. See the testgrid results:
 https://testgrid.k8s.io/sig-security-snyk-scan#ci-kubernetes-snyk-master

This PR  adds the debug flag in the snyk command bcz it fails only on prow and runs fine locally and existing output / error is not helpful. 