### PR TITLE
Removes printing of snyk scan results

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-security-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-security-trusted.yaml
@@ -38,14 +38,13 @@ periodics:
         EXIT_CODE=0
         RESULT_UNFILTERED=$(snyk test -d --json) || EXIT_CODE=$?
         if [ $EXIT_CODE -gt 1 ]; then
-          echo "Failed to run snyk scan with exit code $EXIT_CODE . Error message: $RESULT_UNFILTERED"
+          echo "Failed to run snyk scan with exit code $EXIT_CODE "
           exit 1
         fi
         RESULT=$(echo $RESULT_UNFILTERED | jq \
         '{vulnerabilities: .vulnerabilities | map(select((.type != "license") and (.version !=  "0.0.0"))) | select(length > 0) }')
         if [[ ${RESULT} ]]; then
           echo "Vulnerability filtering failed"
-          echo "Snyk tool output:\n $RESULT_UNFILTERED"
           exit 1
         else
           echo "Scan completed"
@@ -66,8 +65,7 @@ periodics:
           '{vulnerabilities: .vulnerabilities | map(select(.isUpgradable == true or .isPatchable == true)) | select(length > 0) }')
           if [[ ${RESULT} ]]; then
             echo "Vulnerability filtering failed"
-            echo "Snyk tool output:\n $RESULT_UNFILTERED"
-            #exit 1
+            # exit 1 (To allow other images to be scanned even if one fails)
           else
             echo "Scan completed image $image"
           fi


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/24443 added scan result printing which is not needed for debugging purposes. Confirmed this by running locally.

- Reverting that change but keeping the debug flag
- Added a comment on why `exit 1` is commented for image scanning

/sig security testing
/cc @nehaLohia27 (fyi)
/assign @spiffxp 