### PR TITLE
1.23: update kubekins e2e image variants

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -50,15 +50,3 @@ variants:
     K8S_RELEASE: stable-1.20
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
-  '1.19':
-    CONFIG: '1.19'
-    GO_VERSION: 1.15.15
-    K8S_RELEASE: stable-1.19
-    BAZEL_VERSION: 2.2.0
-    OLD_BAZEL_VERSION: 0.23.2
-  '1.18':
-    CONFIG: '1.18'
-    GO_VERSION: 1.13.15
-    K8S_RELEASE: stable-1.18
-    BAZEL_VERSION: 2.2.0
-    OLD_BAZEL_VERSION: 0.23.2

--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -26,6 +26,12 @@ variants:
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
+  '1.23':
+    CONFIG: '1.23'
+    GO_VERSION: 1.17.3
+    K8S_RELEASE: latest-1.23
+    BAZEL_VERSION: 3.4.1
+    OLD_BAZEL_VERSION: 2.2.0
   '1.22':
     CONFIG: '1.22'
     GO_VERSION: 1.16.10


### PR DESCRIPTION
Commits:
- Add configuration for 1.23
- Drop configuration for unsupported 1.18 and 1.19

**IMPORTANT**
/hold for until the release-1.23 branch is cut
**IMPORTANT**

/sig release
/area release-eng
/milestone v1.23
/priority critical-urgent

/assign @Verolop @puerco 
/cc @kubernetes/release-engineering 
