### PR TITLE
Use golang 1.15 and golangci-lint v1.31 in perf-tests presubmits.

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -707,7 +707,7 @@ presubmits:
       testgrid-tab-name: pull-perf-tests-verify-test
     spec:
       containers:
-      - image: golang:1.13
+      - image: golang:1.15
         command:
         - verify/test.sh
         resources:
@@ -753,7 +753,7 @@ presubmits:
       testgrid-tab-name: pull-perf-tests-verify-lint
     spec:
       containers:
-      - image: golangci/golangci-lint:v1.26
+      - image: golangci/golangci-lint:v1.31
         command:
         - make
         args:


### PR DESCRIPTION
In https://github.com/kubernetes/perf-tests/pull/1936, we saw some failures due to an older golang version and golangci-lint version:

```
./main.go:117:11: ticker.Reset undefined (type *time.Ticker has no field or method Reset)
note: module requires Go 1.15
```

Upgrading to a golangci-lint version that uses go 1.15. (bumped in [this commit](https://github.com/golangci/golangci-lint/commit/18fd36bdd12fcc085559c933d489cf6fdff019a2#diff-5aecd73bbcb9b7410938673269f0d4e676dd18509277b0ff2f2787c9d3e22604))

/assign @wojtek-t 

