### PR TITLE
plugins/milestone-applier: update for release-1.23

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -328,23 +328,23 @@ slack:
 
 milestone_applier:
   kubernetes/enhancements:
-    master: v1.23
+    master: v1.24
   kubernetes/kubernetes:
-    master: v1.23
+    master: v1.24
+    release-1.23: v1.23
     release-1.22: v1.22
     release-1.21: v1.21
     release-1.20: v1.20
-    release-1.19: v1.19
   kubernetes/org:
-    main: v1.23
+    main: v1.24
   kubernetes/release:
-    master: v1.23
+    master: v1.24
   kubernetes/sig-release:
-    master: v1.23
+    master: v1.24
   kubernetes/test-infra:
-    master: v1.23
+    master: v1.24
   kubernetes/k8s.io:
-    main: v1.23
+    main: v1.24
   kubernetes/kops:
     master: v1.23
     release-1.22: v1.22


### PR DESCRIPTION
Part of kubernetes/sig-release#1757

/hold for https://github.com/kubernetes/test-infra/pull/24450

/sig release
/area release-eng
/milestone v1.23
/priority critical-urgent

/assign @Verolop @puerco
/cc @kubernetes/release-engineering