### PR TITLE
Increase timeout for etcd-manager builds

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-etcdadm.yaml
+++ b/config/jobs/image-pushing/k8s-staging-etcdadm.yaml
@@ -5,6 +5,9 @@ postsubmits:
       annotations:
         testgrid-dashboards: sig-cluster-lifecycle-etcdadm, sig-k8s-infra-gcb
       decorate: true
+      decoration_config:
+        timeout: 20m
+        grace_period: 5m
       branches:
         - ^master$
         - ^release-.*


### PR DESCRIPTION
Ref: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/etcdadm-postsubmit-push-to-staging/1463409644176150528
```
Your build timed out. Use the [--timeout=DURATION] flag to change the timeout threshold.
ERROR: (gcloud.builds.submit) build 1db08305-a42d-4157-9693-867479336fcf completed with status "TIMEOUT"
```