### PR TITLE
Do not add do not merge label when PR is merged

### DIFF
--- a/prow/plugins/releasenote/releasenote.go
+++ b/prow/plugins/releasenote/releasenote.go
@@ -256,6 +256,10 @@ func handlePR(gc githubClient, log *logrus.Entry, pr *github.PullRequestEvent) e
 	labelToAdd := determineReleaseNoteLabel(pr.PullRequest.Body, prLabels)
 
 	if labelToAdd == labels.ReleaseNoteLabelNeeded {
+		//Do not add do not merge label when the PR is merged
+		if pr.PullRequest.Merged {
+			return nil
+		}
 		if !prMustFollowRelNoteProcess(gc, log, pr, prLabels, true) {
 			ensureNoRelNoteNeededLabel(gc, log, pr, prLabels)
 			return clearStaleComments(gc, log, pr, prLabels, nil)

--- a/prow/plugins/releasenote/releasenote_test.go
+++ b/prow/plugins/releasenote/releasenote_test.go
@@ -270,6 +270,7 @@ func TestReleaseNotePR(t *testing.T) {
 		issueComments      []string
 		IssueLabelsAdded   []string
 		IssueLabelsRemoved []string
+		merged             bool
 	}{
 		{
 			name:          "LGTM with release-note",
@@ -456,12 +457,26 @@ func TestReleaseNotePR(t *testing.T) {
 			body:             "",
 			IssueLabelsAdded: []string{labels.ReleaseNoteLabelNeeded},
 		},
+		{
+			name:             "Add do-not-merge/release-note-label-needed",
+			body:             "```release-note\n```",
+			initialLabels:    []string{},
+			IssueLabelsAdded: []string{labels.ReleaseNoteLabelNeeded},
+		},
+		{
+			name:             "Release note edited after merge, do not add do-not-merge/release-note-label-needed",
+			body:             "```release-note\n```",
+			merged:           true,
+			initialLabels:    []string{},
+			IssueLabelsAdded: []string{},
+		},
 	}
 	for _, test := range tests {
 		if test.branch == "" {
 			test.branch = "master"
 		}
 		fc, pr := newFakeClient(test.body, test.branch, test.initialLabels, test.issueComments, test.parentPRs)
+		pr.PullRequest.Merged = test.merged
 
 		err := handlePR(fc, logrus.WithField("plugin", PluginName), pr)
 		if err != nil {


### PR DESCRIPTION
This commit fixes the issue described in #23205. Release note plugin
should not label the PR when it is already merged.

/fixes #23205

Signed-off-by: Jakub Guzik <jguzik@redhat.com>