### PR TITLE
Move GPU tests out of blocking serial lane

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -248,7 +248,7 @@ periodics:
       - --provider=gce
       # Feature:DynamicKubeletConfig is deprecated and soon will be removed so tests are skipped.
       # If we want to run these tests, we need a separate job for it.
-      - --test_args=--nodes=1 --focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]|\[Feature:DynamicKubeletConfig\]|\[Feature:Docker\]"
+      - --test_args=--nodes=1 --focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]|\[Feature:DynamicKubeletConfig\]|\[Feature:Docker\]|\[NodeFeature:DevicePluginProbe\]"
       - --timeout=240m
       env:
       - name: GOPATH
@@ -264,7 +264,7 @@ periodics:
     testgrid-dashboards: sig-node-kubelet
     testgrid-tab-name: node-kubelet-serial
 
-- name: ci-kubernetes-node-kubelet-serial-docker
+- name: ci-kubernetes-node-kubelet-serial-flaky
   interval: 4h
   labels:
     preset-service-account: "true"
@@ -285,7 +285,10 @@ periodics:
       - --node-test-args=--feature-gates=LocalStorageCapacityIsolation=true --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
       - --node-tests=true
       - --provider=gce
-      - --test_args=--nodes=1 --focus="\[Feature:Docker\]" --skip=""
+      # These are tests SIG Node has determined are flaky and blocking the serial lane
+      # TODO: remove Docker tests in 1.24 (http://kep.k8s.io/2221)
+      # TODO: fix GPU tests (https://issues.k8s.io/106635)
+      - --test_args=--nodes=1 --focus="\[Feature:Docker\]|\[NodeFeature:DevicePluginProbe\]" --skip=""
       - --timeout=240m
       env:
       - name: GOPATH
@@ -299,7 +302,7 @@ periodics:
           memory: 6Gi
   annotations:
     testgrid-dashboards: sig-node-kubelet
-    testgrid-tab-name: node-kubelet-serial-docker
+    testgrid-tab-name: node-kubelet-serial-flaky
 
 - name: ci-kubernetes-node-kubelet-serial-containerd
   cluster: k8s-infra-prow-build


### PR DESCRIPTION
Addresses https://github.com/kubernetes/kubernetes/issues/106635 enough to get it out of the 1.23 milestone.

/sig node