### PR TITLE
configUpdater: resolve lazily

### DIFF
--- a/prow/cmd/hook/main_test.go
+++ b/prow/cmd/hook/main_test.go
@@ -34,7 +34,7 @@ import (
 // Make sure that our plugins are valid.
 func TestPlugins(t *testing.T) {
 	pa := &plugins.ConfigAgent{}
-	if err := pa.Load("../../../config/prow/plugins.yaml", nil, "", true); err != nil {
+	if err := pa.Load("../../../config/prow/plugins.yaml", nil, "", true, false); err != nil {
 		t.Fatalf("Could not load plugins: %v.", err)
 	}
 }

--- a/prow/flagutil/plugins/plugins.go
+++ b/prow/flagutil/plugins/plugins.go
@@ -30,6 +30,7 @@ type PluginOptions struct {
 	SupplementalPluginsConfigDirs            flagutil.Strings
 	SupplementalPluginsConfigsFileNameSuffix string
 	CheckUnknownPlugins                      bool
+	SkipResolveConfigUpdater                 bool
 }
 
 func (o *PluginOptions) AddFlags(fs *flag.FlagSet) {
@@ -44,7 +45,7 @@ func (o *PluginOptions) Validate(_ bool) error {
 
 func (o *PluginOptions) PluginAgent() (*plugins.ConfigAgent, error) {
 	pluginAgent := &plugins.ConfigAgent{}
-	if err := pluginAgent.Start(o.PluginConfigPath, o.SupplementalPluginsConfigDirs.Strings(), o.SupplementalPluginsConfigsFileNameSuffix, o.CheckUnknownPlugins); err != nil {
+	if err := pluginAgent.Start(o.PluginConfigPath, o.SupplementalPluginsConfigDirs.Strings(), o.SupplementalPluginsConfigsFileNameSuffix, o.CheckUnknownPlugins, o.SkipResolveConfigUpdater); err != nil {
 		return nil, fmt.Errorf("failed to start plugins agent: %w", err)
 	}
 


### PR DESCRIPTION
Context: We want to use `cluster_group`. https://github.com/openshift/release/pull/24007
However, we have a presubmit which formats the plugins' config by loading and dumping and then check the difference.
If we resolve the configUpdater as part of the unmarshal, then the above presubmit cannot pass.

This PR resolves it in `Load()` as a parameter.
By default it works as before, e.g., resolve it.

The presubmit will not resolve it as `SkipResolveConfigUpdater=true`.

/cc @alvaroaleman @petr-muller 