### PR TITLE
SPO: Switch to `main` for image pushes

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-security-profiles-operator.yaml
+++ b/config/jobs/image-pushing/k8s-staging-security-profiles-operator.yaml
@@ -7,7 +7,7 @@ postsubmits:
       decorate: true
       always_run: true
       branches:
-        - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:


### PR DESCRIPTION
Changing the post submit to `main` as well as aligning the filename.

/assign @pjbgf 