### PR TITLE
kOps - Use server instead of minimal AMI for Ubuntu 22.04 tests

### DIFF
--- a/config/jobs/kubernetes/kops/helpers.py
+++ b/config/jobs/kubernetes/kops/helpers.py
@@ -148,7 +148,7 @@ distro_images = {
     'u2004': latest_aws_image('099720109477', 'ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*'), # pylint: disable=line-too-long
     'u2004arm64': latest_aws_image('099720109477', 'ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-*'), # pylint: disable=line-too-long
     'u2110': latest_aws_image('099720109477', 'ubuntu/images/hvm-ssd/ubuntu-impish-21.10-amd64-server-*'), # pylint: disable=line-too-long
-    'u2204': latest_aws_image('099720109477', 'ubuntu-minimal/images-testing/hvm-ssd/ubuntu-jammy-daily-amd64-*'), # pylint: disable=line-too-long
+    'u2204': latest_aws_image('099720109477', 'ubuntu/images-testing/hvm-ssd/ubuntu-jammy-daily-amd64-server-*'), # pylint: disable=line-too-long
 }
 
 distros_ssh_user = {

--- a/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
@@ -415,7 +415,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu-minimal/images-testing/hvm-ssd/ubuntu-jammy-daily-amd64-minimal-20211123' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images-testing/hvm-ssd/ubuntu-jammy-daily-amd64-server-20211127' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
           --test=kops \

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -95,7 +95,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu-minimal/images-testing/hvm-ssd/ubuntu-jammy-daily-amd64-minimal-20211123' --channel=alpha --networking=calico --container-runtime=containerd --ipv6 --zones=us-west-2a --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images-testing/hvm-ssd/ubuntu-jammy-daily-amd64-server-20211127' --channel=alpha --networking=calico --container-runtime=containerd --ipv6 --zones=us-west-2a --discovery-store=s3://k8s-kops-prow/discovery" \
           --env=KOPS_FEATURE_FLAGS=AWSIPv6 \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \

--- a/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
@@ -371,7 +371,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu-minimal/images-testing/hvm-ssd/ubuntu-jammy-daily-amd64-minimal-20211123' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images-testing/hvm-ssd/ubuntu-jammy-daily-amd64-server-20211127' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/bazel-bin/cmd/kops/linux-amd64/kops \
             --test=kops \


### PR DESCRIPTION
```
% aws ec2 describe-images --region us-east-1 --output table \
  --owners 099720109477 \
  --query "sort_by(Images, &CreationDate)[*].[CreationDate,Name,ImageId]" \
  --filters "Name=name,Values=ubuntu*jammy*"

------------------------------------------------------------------------------------------------------------------------------------------
|                                                             DescribeImages                                                             |
+--------------------------+-----------------------------------------------------------------------------------+-------------------------+
|  2021-11-13T00:47:27.000Z|  ubuntu-minimal/images-testing/hvm-ssd/ubuntu-jammy-daily-amd64-minimal-20211112  |  ami-063eb5f11c148e442  |
|  2021-11-15T01:14:00.000Z|  ubuntu-minimal/images-testing/hvm-ssd/ubuntu-jammy-daily-amd64-minimal-20211114  |  ami-03b59ef9a7d59ab19  |
|  2021-11-16T01:07:43.000Z|  ubuntu-minimal/images-testing/hvm-ssd/ubuntu-jammy-daily-amd64-minimal-20211115  |  ami-048c1a231198afa7d  |
|  2021-11-18T01:12:45.000Z|  ubuntu-minimal/images-testing/hvm-ssd/ubuntu-jammy-daily-amd64-minimal-20211117  |  ami-0ea75eac9d9f7be2d  |
|  2021-11-20T01:13:50.000Z|  ubuntu-minimal/images-testing/hvm-ssd/ubuntu-jammy-daily-amd64-minimal-20211119  |  ami-0524b29141be75c95  |
|  2021-11-21T00:39:45.000Z|  ubuntu-minimal/images-testing/hvm-ssd/ubuntu-jammy-daily-amd64-minimal-20211120  |  ami-0a9c3ac402b2dbf34  |
|  2021-11-22T01:11:37.000Z|  ubuntu-minimal/images-testing/hvm-ssd/ubuntu-jammy-daily-amd64-minimal-20211121  |  ami-02171e94353d62a60  |
|  2021-11-23T01:04:45.000Z|  ubuntu-minimal/images-testing/hvm-ssd/ubuntu-jammy-daily-amd64-minimal-20211122  |  ami-04ba359c8b7b0b3d9  |
|  2021-11-24T01:36:05.000Z|  ubuntu-minimal/images-testing/hvm-ssd/ubuntu-jammy-daily-amd64-minimal-20211123  |  ami-0086214e90b35e0a0  |
|  2021-11-24T12:01:17.000Z|  ubuntu/images-testing/hvm-ssd/ubuntu-jammy-daily-arm64-server-20211124           |  ami-04139a1569d0ef232  |
|  2021-11-24T12:01:56.000Z|  ubuntu/images-testing/hvm-ssd/ubuntu-jammy-daily-amd64-server-20211124           |  ami-099cd1112a3ee6711  |
|  2021-11-27T06:21:16.000Z|  ubuntu/images-testing/hvm-ssd/ubuntu-jammy-daily-arm64-server-20211127           |  ami-0c6fcd515eec1d8c8  |
|  2021-11-27T06:22:28.000Z|  ubuntu/images-testing/hvm-ssd/ubuntu-jammy-daily-amd64-server-20211127           |  ami-0b7f9ac8ff6981051  |
+--------------------------+-----------------------------------------------------------------------------------+-------------------------+
```
/cc @olemarkus @johngmyers @rifelpet