### PR TITLE
kubernetes-sigs/descheduler: bump go to 1.17.2

### DIFF
--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
@@ -13,7 +13,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.7
+      - image: golang:1.17.3
         command:
         - make
         args:
@@ -30,7 +30,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.7
+      - image: golang:1.17.3
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
     run_if_changed: '\.go$'
     spec:
       containers:
-      - image: golang:1.16.7
+      - image: golang:1.17.3
         command:
         - make
         args:


### PR DESCRIPTION
Based on https://github.com/kubernetes/release/pull/2285

- https://github.com/kubernetes/kubernetes/blob/release-1.22/build/dependencies.yaml#L104: 1.16.10
- https://github.com/kubernetes/kubernetes/blob/release-1.23/build/dependencies.yaml#L90: 1.17.3
- https://github.com/kubernetes/kubernetes/blob/master/build/dependencies.yaml#L90: 1.17.3
