### PR TITLE
Add external secret for syncing test-infra-trusted build cluster

### DIFF
--- a/config/prow/cluster/kubernetes_external_secrets.yaml
+++ b/config/prow/cluster/kubernetes_external_secrets.yaml
@@ -52,3 +52,16 @@ spec:
   - key: k8s-infra-cherrypick-robot-github-token # The name of the GSM Secret
     name: token                                  # The key to write in the K8s Secret
     version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: kubeconfig-build-test-infra-trusted
+  namespace: default
+spec:
+  backendType: gcpSecretsManager
+  projectId: k8s-prow
+  data:
+  - key: prow_build_cluster_kubeconfig_test-infra-trusted
+    name: kubeconfig
+    version: latest


### PR DESCRIPTION
The secret was already generated and stored in corresponding secret manager