### PR TITLE
config/jobs: use k8s.gcr.io for octodns image

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-dns.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-dns.yaml
@@ -23,7 +23,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-dns-updater
       containers:
-      - image: us.gcr.io/k8s-artifacts-prod/infra-tools/octodns:v20200616-67ce585
+      - image: k8s.gcr.io/infra-tools/octodns:v20200616-67ce585
         command:
         - bash
         args:
@@ -56,7 +56,7 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-dns-updater
     containers:
-    - image: us.gcr.io/k8s-artifacts-prod/infra-tools/octodns:v20200616-67ce585
+    - image: k8s.gcr.io/infra-tools/octodns:v20200616-67ce585
       command:
       - bash
       args:


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1523

Don't need to explicitly call out us.gcr.io/k8s-artifacts-prod when we have k8s.gcr.io available to us