### PR TITLE
(secrets-store-csi-driver): bump kubernetes version to v1.22.4 and remove v1.19

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -377,46 +377,6 @@ presubmits:
       testgrid-tab-name: pr-secrets-store-csi-driver-build
       description: "Run make build build-windows for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
-  - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-19-11
-    decorate: true
-    decoration_config:
-      timeout: 25m
-    always_run: true
-    optional: false
-    path_alias: sigs.k8s.io/secrets-store-csi-driver
-    branches:
-    - ^main$
-    # e2e-provider is only available in release-1.* branches
-    - ^release-1.*
-    labels:
-      # this is required because we want to run kind in docker
-      preset-dind-enabled: "true"
-      # this is required to make CNI installation to succeed for kind
-      preset-kind-volume-mounts: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
-        command:
-          - runner.sh
-        args:
-          - bash
-          - -c
-          - >-
-            ./test/scripts/e2e_provider.sh
-        securityContext:
-          privileged: true
-        env:
-        - name: KUBERNETES_VERSION
-          value: "1.19.11"
-        resources:
-          requests:
-            cpu: "4"
-            memory: "4Gi"
-    annotations:
-      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
-      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-19-11
-      description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.19.11"
-      testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-e2e-provider-k8s-1-20-7
     decorate: true
     decoration_config:
@@ -527,15 +487,15 @@ presubmits:
           privileged: true
         env:
         - name: KUBERNETES_VERSION
-          value: "1.22.2"
+          value: "1.22.4"
         resources:
           requests:
             cpu: "4"
             memory: "4Gi"
     annotations:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
-      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-22-2
-      description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.22.2"
+      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-22-4
+      description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.22.4"
       testgrid-num-columns-recent: '30'
 
   # release jobs


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

- Bumps to kubernetes version `v1.22.4` for 1.22
- 1.19 is EOL, so removing 1.19 tests
