### PR TITLE
Clean up Windows release jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.20-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.20-windows.yaml
@@ -3,7 +3,7 @@ periodics:
   name: ci-kubernetes-e2e-aks-engine-azure-1-20-windows
   decorate: true
   decoration_config:
-    timeout: 3h
+    timeout: 12h
   labels:
     preset-service-account: "true"
     preset-azure-cred: "true"

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.21-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.21-windows.yaml
@@ -3,7 +3,7 @@ periodics:
   name: ci-kubernetes-e2e-aks-engine-azure-1-21-windows
   decorate: true
   decoration_config:
-    timeout: 3h
+    timeout: 12h
   labels:
     preset-service-account: "true"
     preset-azure-cred: "true"

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.22-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.22-windows.yaml
@@ -11,7 +11,7 @@ periodics:
     org: kubernetes
     path_alias: k8s.io/kubernetes
     repo: kubernetes
-  interval: 3h
+  interval: 12h
   labels:
     preset-azure-cred: "true"
     preset-azure-windows: "true"
@@ -108,43 +108,58 @@ periodics:
     testgrid-tab-name: aks-engine-windows-containerd-serial-slow-1.22
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release serial tests on K8s 1.22 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
-- name: ci-kubernetes-e2e-capz-azure-windows-dockershim-1-22
-  interval: 12h
+- interval: 24h
+  name: ci-kubernetes-e2e-aks-engine-azure-1-22-windows
   decorate: true
   decoration_config:
-    timeout: 4h
+    timeout: 3h
   labels:
+    preset-service-account: "true"
+    preset-azure-cred: "true"
+    preset-azure-windows: "true"
+    preset-windows-repo-list-master: "true"
+    preset-windows-private-registry-cred: "true"
+    preset-k8s-ssh: "true"
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
   extra_refs:
-  - org: kubernetes-sigs
-    repo: cluster-api-provider-azure
-    base_ref: main
-    path_alias: sigs.k8s.io/cluster-api-provider-azure
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.22
+    path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-1.22
-        command:
-          - "runner.sh"
-          - "./scripts/ci-conformance.sh"
-        env:
-          - name: E2E_ARGS
-            value: "-kubetest.use-ci-artifacts"
-          - name: WINDOWS
-            value: "true"
-          # Windows isn't really conformance, we typically run at 4 to keep the time reasonable (~45 mins)
-          - name: CONFORMANCE_NODES
-            value: "4"
-          - name: "KUBERNETES_VERSION"
-            value: "latest-1.22"
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 2
-            memory: "9Gi"
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-1.22
+      command:
+      - runner.sh
+      - kubetest
+      args:
+      # Generic e2e test args
+      - --test
+      - --up
+      - --down
+      - --build=quick
+      - --dump=$(ARTIFACTS)
+      # Azure-specific test args
+      - --deployment=aksengine
+      - --provider=skeleton
+      - --aksengine-orchestratorRelease=1.22
+      - --aksengine-admin-username=azureuser
+      - --aksengine-admin-password=AdminPassw0rd
+      - --aksengine-creds=$(AZURE_CREDENTIALS)
+      - --aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz
+      - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
+      - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
+      - --aksengine-winZipBuildScript=$(WIN_BUILD)
+      - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_release_1_22.json
+      - --aksengine-win-binaries
+      - --aksengine-deploy-custom-k8s
+      # Specific test args
+      - --test_args=--node-os-distro=windows -docker-config-file=$(DOCKER_CONFIG_FILE) --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
+      - --ginkgo-parallel=4
+      securityContext:
+        privileged: true
   annotations:
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     testgrid-dashboards: sig-windows-1.22-release
-    testgrid-tab-name: capz-windows-dockershim-1.22
+    testgrid-tab-name: aks-engine-windows-dockershim-1.22
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    description: Runs SIG-Windows release tests on K8s 1.22 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.23-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.23-windows.yaml
@@ -1,7 +1,7 @@
 periodics:
 - annotations:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
-    testgrid-dashboards: sig-release-1.23-informing, sig-windows-signal, sig-windows-master-release
+    testgrid-dashboards: sig-release-1.23-informing, sig-windows-signal, sig-windows-1.23-release
     testgrid-tab-name: aks-engine-windows-containerd-1.23
   decorate: true
   decoration_config:
@@ -42,7 +42,7 @@ periodics:
       - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_1_23.json
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
-      - --test_args=--node-os-distro=windows -docker-config-file=$(DOCKER_CONFIG_FILE)
+      - --test_args=--node-os-distro=windows -docker-config-file=$(DOCKER_CONFIG_FILE) --feature-gates=WindowsHostProcessContainers=true
         --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
         --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
       - --ginkgo-parallel=4
@@ -108,3 +108,58 @@ periodics:
     testgrid-tab-name: aks-engine-windows-containerd-serial-slow-1.23
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release serial tests on K8s 1.23 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
+- interval: 24h
+  name: ci-kubernetes-e2e-aks-engine-azure-1-23-windows
+  decorate: true
+  decoration_config:
+    timeout: 3h
+  labels:
+    preset-service-account: "true"
+    preset-azure-cred: "true"
+    preset-azure-windows: "true"
+    preset-windows-repo-list-master: "true"
+    preset-windows-private-registry-cred: "true"
+    preset-k8s-ssh: "true"
+    preset-dind-enabled: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.23
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-1.23
+      command:
+      - runner.sh
+      - kubetest
+      args:
+      # Generic e2e test args
+      - --test
+      - --up
+      - --down
+      - --build=quick
+      - --dump=$(ARTIFACTS)
+      # Azure-specific test args
+      - --deployment=aksengine
+      - --provider=skeleton
+      - --aksengine-orchestratorRelease=1.23
+      - --aksengine-admin-username=azureuser
+      - --aksengine-admin-password=AdminPassw0rd
+      - --aksengine-creds=$(AZURE_CREDENTIALS)
+      - --aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz
+      - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
+      - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
+      - --aksengine-winZipBuildScript=$(WIN_BUILD)
+      - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_release_1_23.json
+      - --aksengine-win-binaries
+      - --aksengine-deploy-custom-k8s
+      # Specific test args
+      - --test_args=--node-os-distro=windows -docker-config-file=$(DOCKER_CONFIG_FILE) --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
+      - --ginkgo-parallel=4
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-windows-1.23-release
+    testgrid-tab-name: aks-engine-windows-dockershim-1.23
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    description: Runs SIG-Windows release tests on K8s 1.23 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -180,7 +180,7 @@ presubmits:
       description: Run Azure File e2e test with Azure File in-tree volume plugin in a Windows cluster with containerd runtime
 periodics:
 - name: ci-kubernetes-e2e-capz-staging-containerd-windows
-  interval: 8h
+  interval: 12h
   decorate: true
   decoration_config:
     timeout: 4h
@@ -222,7 +222,7 @@ periodics:
     testgrid-dashboards: sig-windows-master-release
     testgrid-tab-name: capz-windows-containerd-master
 - name: ci-kubernetes-e2e-capz-staging-containerd-windows-2022
-  interval: 8h
+  interval: 12h
   decorate: true
   decoration_config:
     timeout: 4h
@@ -494,7 +494,7 @@ periodics:
     testgrid-tab-name: aks-engine-windows-containerd-azure-file-master
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure File e2e test with Azure File in a Windows cluster configured with CSI proxy and containerd.
-- interval: 12h
+- interval: 24h
   name: ci-kubernetes-e2e-aks-engine-azure-master-windows-containerd-nightly
   decorate: true
   decoration_config:


### PR DESCRIPTION
some cleanup:

- Adjusts timing of some of the runs to be a bit slower since releases don't get as many changes  
- Uses aks-engine for release jobs where dockershim is being run
- moves 1.23 job to correct location
- add feature gate to the containerd job to run hostprocess containers since we are using containerd 1.6 for 1.23 aks-e jobs