### PR TITLE
Update kops upgrade jobs to latest k8s patch versions

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -733,13 +733,13 @@ def generate_network_plugins():
 def generate_upgrades():
     versions_list = [
         #  kops    k8s          kops      k8s
-        (('1.21', 'v1.21.0'), ('latest', 'latest')),
-        (('1.22', 'v1.22.0'), ('latest', 'latest')),
-        (('1.21', 'v1.21.0'), ('1.22', 'v1.22.0')),
-        (('1.20', 'v1.20.7'), ('1.21', 'v1.21.0')),
-        (('latest', 'v1.20.6'), ('latest', 'v1.21.0')),
-        (('latest', 'v1.18.6'), ('latest', 'v1.19.0')),
-        (('1.20', 'v1.20.6'), ('latest', 'v1.21.0')),
+        (('1.21', 'v1.21.7'), ('latest', 'latest')),
+        (('1.22', 'v1.22.7'), ('latest', 'latest')),
+        (('1.21', 'v1.21.7'), ('1.22', 'v1.22.4')),
+        (('1.20', 'v1.20.13'), ('1.21', 'v1.21.7')),
+        (('latest', 'v1.20.6'), ('latest', 'v1.21.7')),
+        (('latest', 'v1.18.20'), ('latest', 'v1.19.16')),
+        (('1.20', 'v1.20.13'), ('latest', 'v1.21.7')),
     ]
     def shorten(version):
         version = re.sub(r'^v', '', version)

--- a/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
@@ -415,7 +415,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images-testing/hvm-ssd/ubuntu-jammy-daily-amd64-server-20211201' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images-testing/hvm-ssd/ubuntu-jammy-daily-amd64-server-20211203' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
           --test=kops \

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -95,7 +95,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images-testing/hvm-ssd/ubuntu-jammy-daily-amd64-server-20211201' --channel=alpha --networking=calico --container-runtime=containerd --ipv6 --zones=us-west-2a --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images-testing/hvm-ssd/ubuntu-jammy-daily-amd64-server-20211203' --channel=alpha --networking=calico --container-runtime=containerd --ipv6 --zones=us-west-2a --discovery-store=s3://k8s-kops-prow/discovery" \
           --env=KOPS_FEATURE_FLAGS=AWSIPv6 \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \

--- a/config/jobs/kubernetes/kops/kops-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-upgrades.yaml
@@ -31,7 +31,7 @@ periodics:
       - name: KOPS_VERSION_A
         value: "1.21"
       - name: K8S_VERSION_A
-        value: "v1.21.0"
+        value: "v1.21.7"
       - name: KOPS_VERSION_B
         value: "latest"
       - name: K8S_VERSION_B
@@ -95,7 +95,7 @@ periodics:
       - name: KOPS_VERSION_A
         value: "1.22"
       - name: K8S_VERSION_A
-        value: "v1.22.0"
+        value: "v1.22.7"
       - name: KOPS_VERSION_B
         value: "latest"
       - name: K8S_VERSION_B
@@ -161,11 +161,11 @@ periodics:
       - name: KOPS_VERSION_A
         value: "1.21"
       - name: K8S_VERSION_A
-        value: "v1.21.0"
+        value: "v1.21.7"
       - name: KOPS_VERSION_B
         value: "1.22"
       - name: K8S_VERSION_B
-        value: "v1.22.0"
+        value: "v1.22.4"
       - name: CLOUD_PROVIDER
         value: "aws"
       - name: CLUSTER_NAME
@@ -225,11 +225,11 @@ periodics:
       - name: KOPS_VERSION_A
         value: "1.20"
       - name: K8S_VERSION_A
-        value: "v1.20.7"
+        value: "v1.20.13"
       - name: KOPS_VERSION_B
         value: "1.21"
       - name: K8S_VERSION_B
-        value: "v1.21.0"
+        value: "v1.21.7"
       - name: CLOUD_PROVIDER
         value: "aws"
       - name: CLUSTER_NAME
@@ -293,7 +293,7 @@ periodics:
       - name: KOPS_VERSION_B
         value: "latest"
       - name: K8S_VERSION_B
-        value: "v1.21.0"
+        value: "v1.21.7"
       - name: CLOUD_PROVIDER
         value: "aws"
       - name: CLUSTER_NAME
@@ -353,11 +353,11 @@ periodics:
       - name: KOPS_VERSION_A
         value: "latest"
       - name: K8S_VERSION_A
-        value: "v1.18.6"
+        value: "v1.18.20"
       - name: KOPS_VERSION_B
         value: "latest"
       - name: K8S_VERSION_B
-        value: "v1.19.0"
+        value: "v1.19.16"
       - name: CLOUD_PROVIDER
         value: "aws"
       - name: CLUSTER_NAME
@@ -417,11 +417,11 @@ periodics:
       - name: KOPS_VERSION_A
         value: "1.20"
       - name: K8S_VERSION_A
-        value: "v1.20.6"
+        value: "v1.20.13"
       - name: KOPS_VERSION_B
         value: "latest"
       - name: K8S_VERSION_B
-        value: "v1.21.0"
+        value: "v1.21.7"
       - name: CLOUD_PROVIDER
         value: "aws"
       - name: CLUSTER_NAME

--- a/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
@@ -371,7 +371,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images-testing/hvm-ssd/ubuntu-jammy-daily-amd64-server-20211201' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images-testing/hvm-ssd/ubuntu-jammy-daily-amd64-server-20211203' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/bazel-bin/cmd/kops/linux-amd64/kops \
             --test=kops \


### PR DESCRIPTION
/cc @hakman 

maybe we could update these to use release markers, to avoid having to do this in the future.