### PR TITLE
Kops - fix k8s 1.22 patch version used in upgrade tests

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -734,7 +734,7 @@ def generate_upgrades():
     versions_list = [
         #  kops    k8s          kops      k8s
         (('1.21', 'v1.21.7'), ('latest', 'latest')),
-        (('1.22', 'v1.22.7'), ('latest', 'latest')),
+        (('1.22', 'v1.22.4'), ('latest', 'latest')),
         (('1.21', 'v1.21.7'), ('1.22', 'v1.22.4')),
         (('1.20', 'v1.20.13'), ('1.21', 'v1.21.7')),
         (('latest', 'v1.20.6'), ('latest', 'v1.21.7')),

--- a/config/jobs/kubernetes/kops/kops-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-upgrades.yaml
@@ -95,7 +95,7 @@ periodics:
       - name: KOPS_VERSION_A
         value: "1.22"
       - name: K8S_VERSION_A
-        value: "v1.22.7"
+        value: "v1.22.4"
       - name: KOPS_VERSION_B
         value: "latest"
       - name: K8S_VERSION_B


### PR DESCRIPTION
followup to https://github.com/kubernetes/test-infra/pull/24534