### PR TITLE
k8s-ci-robot bypass for security-profiles-operator

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -513,6 +513,9 @@ branch-protection:
           required_linear_history: true
           required_pull_request_reviews:
             required_approving_review_count: 1
+          restrictions:
+            users:
+            - k8s-ci-robot
 
 tide:
   sync_period: 2m


### PR DESCRIPTION
Allow `k8s-ci-robot` to bypass current branch protection rules, which are enforced to all other users.

Fixes regression from kubernetes-sigs/security-profiles-operator#660