### PR TITLE
kOps - Run conformance tests with shorter time limit

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -677,7 +677,7 @@ def generate_conformance():
                 name_override=f"kops-aws-conformance-{version.replace('.', '-')}",
                 networking='calico',
                 test_parallelism=1,
-                test_timeout_minutes=300,
+                test_timeout_minutes=150,
                 extra_dashboards=['kops-conformance'],
                 runs_per_day=1,
                 focus_regex=r'\[Conformance\]',

--- a/config/jobs/kubernetes/kops/kops-periodics-conformance.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-conformance.yaml
@@ -11,7 +11,7 @@ periodics:
     preset-aws-credential: "true"
   decorate: true
   decoration_config:
-    timeout: 330m
+    timeout: 180m
   extra_refs:
   - org: kubernetes
     repo: kops
@@ -37,7 +37,7 @@ periodics:
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
-          --test-args="-test.timeout=300m -num-nodes=0" \
+          --test-args="-test.timeout=150m -num-nodes=0" \
           --test-package-marker=stable-1.22.txt \
           --focus-regex="\[Conformance\]" \
           --skip-regex="\[NoSkip\]" \
@@ -77,7 +77,7 @@ periodics:
     preset-aws-credential: "true"
   decorate: true
   decoration_config:
-    timeout: 330m
+    timeout: 180m
   extra_refs:
   - org: kubernetes
     repo: kops
@@ -103,7 +103,7 @@ periodics:
           --test=kops \
           -- \
           --ginkgo-args="--debug" \
-          --test-args="-test.timeout=300m -num-nodes=0" \
+          --test-args="-test.timeout=150m -num-nodes=0" \
           --test-package-marker=stable-1.21.txt \
           --focus-regex="\[Conformance\]" \
           --skip-regex="\[NoSkip\]" \


### PR DESCRIPTION
No need for more than 2h 30m at the moment.

/cc @rifelpet