### PR TITLE
cluster-api bump to etcd 3.5.1

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
@@ -159,7 +159,7 @@ periodics:
         - name: KUBERNETES_VERSION_UPGRADE_TO
           value: "stable-1.22"
         - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.0-0"
+          value: "3.5.1-0"
         - name: COREDNS_VERSION_UPGRADE_TO
           value: "v1.8.4"
         - name: GINKGO_FOCUS
@@ -203,7 +203,7 @@ periodics:
         - name: KUBERNETES_VERSION_UPGRADE_TO
           value: "ci/latest-1.23"
         - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.0-0"
+          value: "3.5.1-0"
         - name: COREDNS_VERSION_UPGRADE_TO
           value: "v1.8.4"
         - name: GINKGO_FOCUS

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-4-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-4-upgrades.yaml
@@ -159,7 +159,7 @@ periodics:
         - name: KUBERNETES_VERSION_UPGRADE_TO
           value: "stable-1.22"
         - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.0-0"
+          value: "3.5.1-0"
         - name: COREDNS_VERSION_UPGRADE_TO
           value: "v1.8.4"
         - name: GINKGO_FOCUS
@@ -203,7 +203,7 @@ periodics:
         - name: KUBERNETES_VERSION_UPGRADE_TO
           value: "ci/latest-1.23"
         - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.0-0"
+          value: "3.5.1-0"
         - name: COREDNS_VERSION_UPGRADE_TO
           value: "v1.8.4"
         - name: GINKGO_FOCUS

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-0-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-0-upgrades.yaml
@@ -159,7 +159,7 @@ periodics:
         - name: KUBERNETES_VERSION_UPGRADE_TO
           value: "stable-1.22"
         - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.0-0"
+          value: "3.5.1-0"
         - name: COREDNS_VERSION_UPGRADE_TO
           value: "v1.8.4"
         - name: GINKGO_FOCUS
@@ -203,7 +203,7 @@ periodics:
         - name: KUBERNETES_VERSION_UPGRADE_TO
           value: "ci/latest-1.23"
         - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.0-0"
+          value: "3.5.1-0"
         - name: COREDNS_VERSION_UPGRADE_TO
           value: "v1.8.4"
         - name: GINKGO_FOCUS

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -257,7 +257,7 @@ presubmits:
           - name: KUBERNETES_VERSION_UPGRADE_TO
             value: "ci/latest-1.23"
           - name: ETCD_VERSION_UPGRADE_TO
-            value: "3.5.0-0"
+            value: "3.5.1-0"
           - name: COREDNS_VERSION_UPGRADE_TO
             value: "v1.8.4"
           - name: GINKGO_FOCUS

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-0-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-0-4.yaml
@@ -263,7 +263,7 @@ presubmits:
           - name: KUBERNETES_VERSION_UPGRADE_TO
             value: "ci/latest-1.23"
           - name: ETCD_VERSION_UPGRADE_TO
-            value: "3.5.0-0"
+            value: "3.5.1-0"
           - name: COREDNS_VERSION_UPGRADE_TO
             value: "v1.8.4"
           - name: GINKGO_FOCUS

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-0.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-0.yaml
@@ -257,7 +257,7 @@ presubmits:
           - name: KUBERNETES_VERSION_UPGRADE_TO
             value: "ci/latest-1.23"
           - name: ETCD_VERSION_UPGRADE_TO
-            value: "3.5.0-0"
+            value: "3.5.1-0"
           - name: COREDNS_VERSION_UPGRADE_TO
             value: "v1.8.4"
           - name: GINKGO_FOCUS


### PR DESCRIPTION
Bumps etcd version in CAPI jobs to v3.5.1 as per https://github.com/kubernetes/kubernetes/pull/105706

Rif https://github.com/kubernetes-sigs/cluster-api/pull/5797