### PR TITLE
cluster api: upgrade Jobs to use/test Kubernetes 1.23

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
@@ -159,7 +159,7 @@ periodics:
         - name: KUBERNETES_VERSION_UPGRADE_TO
           value: "stable-1.22"
         - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.0-0"
+          value: "3.5.1-0"
         - name: COREDNS_VERSION_UPGRADE_TO
           value: "v1.8.4"
         - name: GINKGO_FOCUS
@@ -176,7 +176,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 
-- name: periodic-cluster-api-e2e-workload-upgrade-1-22-latest-main
+- name: periodic-cluster-api-e2e-workload-upgrade-1-22-1-23-main
   interval: 24h
   decorate: true
   labels:
@@ -201,9 +201,9 @@ periodics:
         - name: KUBERNETES_VERSION_UPGRADE_FROM
           value: "stable-1.22"
         - name: KUBERNETES_VERSION_UPGRADE_TO
-          value: "ci/latest-1.23"
+          value: "stable-1.23"
         - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.0-0"
+          value: "3.5.1-0"
         - name: COREDNS_VERSION_UPGRADE_TO
           value: "v1.8.4"
         - name: GINKGO_FOCUS
@@ -216,6 +216,50 @@ periodics:
           cpu: 7300m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-    testgrid-tab-name: capi-e2e-main-1-22-latest
+    testgrid-tab-name: capi-e2e-main-1-22-1-23
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "2"
+
+- name: periodic-cluster-api-e2e-workload-upgrade-1-23-latest-main
+  interval: 24h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
+      args:
+      - runner.sh
+      - "./scripts/ci-e2e.sh"
+      env:
+      - name: KUBERNETES_VERSION_UPGRADE_FROM
+        value: "stable-1.23"
+      - name: KUBERNETES_VERSION_UPGRADE_TO
+        value: "ci/latest-1.24"
+      - name: ETCD_VERSION_UPGRADE_TO
+        value: "3.5.1-0"
+      - name: COREDNS_VERSION_UPGRADE_TO
+        value: "v1.8.4"
+      - name: GINKGO_FOCUS
+        value: "\\[K8s-Upgrade\\]"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+    testgrid-tab-name: capi-e2e-main-1-23-latest
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
@@ -17,7 +17,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-1.23
       args:
         - runner.sh
         - "./scripts/ci-e2e.sh"
@@ -61,7 +61,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-1.23
       args:
         - runner.sh
         - "./scripts/ci-e2e.sh"
@@ -105,7 +105,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-1.23
       args:
         - runner.sh
         - "./scripts/ci-e2e.sh"
@@ -149,7 +149,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-1.23
       args:
         - runner.sh
         - "./scripts/ci-e2e.sh"
@@ -193,7 +193,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-1.23
       args:
         - runner.sh
         - "./scripts/ci-e2e.sh"
@@ -237,7 +237,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-1.23
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -93,7 +93,7 @@ periodics:
       - name: INIT_WITH_PROVIDERS_CONTRACT
         value: v1beta1
       - name: INIT_WITH_KUBERNETES_VERSION
-        value: v1.22.0
+        value: v1.23.0
 
       # we need privileged mode in order to do docker in docker
       securityContext:

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -11,7 +11,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-1.23
       command:
       - "./scripts/ci-test.sh"
       resources:
@@ -39,7 +39,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-1.23
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -81,7 +81,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-1.23
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"
@@ -123,7 +123,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-1.23
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -158,7 +158,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-1.23
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"
@@ -190,7 +190,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-1.23
       command:
       - "runner.sh"
       - "make"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-4-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-4-upgrades.yaml
@@ -159,7 +159,7 @@ periodics:
         - name: KUBERNETES_VERSION_UPGRADE_TO
           value: "stable-1.22"
         - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.0-0"
+          value: "3.5.1-0"
         - name: COREDNS_VERSION_UPGRADE_TO
           value: "v1.8.4"
         - name: GINKGO_FOCUS
@@ -176,7 +176,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 
-- name: periodic-cluster-api-e2e-workload-upgrade-1-22-latest-release-0-4
+- name: periodic-cluster-api-e2e-workload-upgrade-1-22-1-23-release-0-4
   interval: 24h
   decorate: true
   labels:
@@ -201,9 +201,9 @@ periodics:
         - name: KUBERNETES_VERSION_UPGRADE_FROM
           value: "stable-1.22"
         - name: KUBERNETES_VERSION_UPGRADE_TO
-          value: "ci/latest-1.23"
+          value: "stable-1.23"
         - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.0-0"
+          value: "3.5.1-0"
         - name: COREDNS_VERSION_UPGRADE_TO
           value: "v1.8.4"
         - name: GINKGO_FOCUS
@@ -216,6 +216,50 @@ periodics:
           cpu: 7300m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.4
-    testgrid-tab-name: capi-e2e-release-0-4-1-22-latest
+    testgrid-tab-name: capi-e2e-release-0-4-1-22-1-23
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "2"
+
+- name: periodic-cluster-api-e2e-workload-upgrade-1-23-latest-release-0-4
+  interval: 24h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api
+    base_ref: release-0.4
+    path_alias: sigs.k8s.io/cluster-api
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-1.21
+      args:
+      - runner.sh
+      - "./scripts/ci-e2e.sh"
+      env:
+      - name: KUBERNETES_VERSION_UPGRADE_FROM
+        value: "stable-1.23"
+      - name: KUBERNETES_VERSION_UPGRADE_TO
+        value: "ci/latest-1.24"
+      - name: ETCD_VERSION_UPGRADE_TO
+        value: "3.5.1-0"
+      - name: COREDNS_VERSION_UPGRADE_TO
+        value: "v1.8.4"
+      - name: GINKGO_FOCUS
+        value: "\\[K8s-Upgrade\\]"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.4
+    testgrid-tab-name: capi-e2e-release-0-4-1-23-latest
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-0-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-0-upgrades.yaml
@@ -159,7 +159,7 @@ periodics:
         - name: KUBERNETES_VERSION_UPGRADE_TO
           value: "stable-1.22"
         - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.0-0"
+          value: "3.5.1-0"
         - name: COREDNS_VERSION_UPGRADE_TO
           value: "v1.8.4"
         - name: GINKGO_FOCUS
@@ -176,7 +176,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
 
-- name: periodic-cluster-api-e2e-workload-upgrade-1-22-latest-release-1-0
+- name: periodic-cluster-api-e2e-workload-upgrade-1-22-1-23-release-1-0
   interval: 24h
   decorate: true
   labels:
@@ -201,9 +201,9 @@ periodics:
         - name: KUBERNETES_VERSION_UPGRADE_FROM
           value: "stable-1.22"
         - name: KUBERNETES_VERSION_UPGRADE_TO
-          value: "ci/latest-1.23"
+          value: "stable-1.23"
         - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.0-0"
+          value: "3.5.1-0"
         - name: COREDNS_VERSION_UPGRADE_TO
           value: "v1.8.4"
         - name: GINKGO_FOCUS
@@ -216,6 +216,50 @@ periodics:
           cpu: 7300m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.0
-    testgrid-tab-name: capi-e2e-release-1-0-1-22-latest
+    testgrid-tab-name: capi-e2e-release-1-0-1-22-1-23
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "2"
+
+- name: periodic-cluster-api-e2e-workload-upgrade-1-23-latest-release-1-0
+  interval: 24h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api
+    base_ref: release-1.0
+    path_alias: sigs.k8s.io/cluster-api
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-1.22
+      args:
+      - runner.sh
+      - "./scripts/ci-e2e.sh"
+      env:
+      - name: KUBERNETES_VERSION_UPGRADE_FROM
+        value: "stable-1.23"
+      - name: KUBERNETES_VERSION_UPGRADE_TO
+        value: "ci/latest-1.24"
+      - name: ETCD_VERSION_UPGRADE_TO
+        value: "3.5.1-0"
+      - name: COREDNS_VERSION_UPGRADE_TO
+        value: "v1.8.4"
+      - name: GINKGO_FOCUS
+        value: "\\[K8s-Upgrade\\]"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.0
+    testgrid-tab-name: capi-e2e-release-1-0-1-23-latest
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -229,7 +229,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-e2e-full-main
-  - name: pull-cluster-api-e2e-workload-upgrade-1-22-latest-main
+  - name: pull-cluster-api-e2e-workload-upgrade-1-23-latest-main
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -253,11 +253,11 @@ presubmits:
           - "./scripts/ci-e2e.sh"
         env:
           - name: KUBERNETES_VERSION_UPGRADE_FROM
-            value: "stable-1.22"
+            value: "stable-1.23"
           - name: KUBERNETES_VERSION_UPGRADE_TO
-            value: "ci/latest-1.23"
+            value: "ci/latest-1.24"
           - name: ETCD_VERSION_UPGRADE_TO
-            value: "3.5.0-0"
+            value: "3.5.1-0"
           - name: COREDNS_VERSION_UPGRADE_TO
             value: "v1.8.4"
           - name: GINKGO_FOCUS
@@ -270,4 +270,4 @@ presubmits:
             cpu: 7300m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-      testgrid-tab-name: capi-pr-e2e-main-1-22-latest
+      testgrid-tab-name: capi-pr-e2e-main-1-23-latest

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -11,7 +11,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-1.23
         command:
         - runner.sh
         - ./scripts/ci-build.sh
@@ -37,7 +37,7 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-1.23
         resources:
           requests:
             cpu: 7300m
@@ -59,7 +59,7 @@ presubmits:
       - command:
         - runner.sh
         - ./scripts/ci-apidiff.sh
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-1.23
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-apidiff-main
@@ -74,7 +74,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-1.23
         command:
         - "runner.sh"
         - ./scripts/ci-verify.sh
@@ -95,7 +95,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-1.23
         args:
         - runner.sh
         - ./scripts/ci-test.sh
@@ -116,7 +116,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-1.23
         args:
         - runner.sh
         - ./scripts/ci-test.sh
@@ -146,7 +146,7 @@ presubmits:
     run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|errors|exp|feature|hack|scripts|test|third_party|util)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-1.23
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -175,7 +175,7 @@ presubmits:
     run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|errors|exp|feature|hack|scripts|test|third_party|util)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-1.23
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -210,7 +210,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-1.23
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -247,7 +247,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-1.23
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-0-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-0-4.yaml
@@ -235,7 +235,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.4
       testgrid-tab-name: capi-pr-e2e-full-release-0-4
-  - name: pull-cluster-api-e2e-workload-upgrade-1-22-latest-release-0-4
+  - name: pull-cluster-api-e2e-workload-upgrade-1-23-latest-release-0-4
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -259,11 +259,11 @@ presubmits:
           - "./scripts/ci-e2e.sh"
         env:
           - name: KUBERNETES_VERSION_UPGRADE_FROM
-            value: "stable-1.22"
+            value: "stable-1.23"
           - name: KUBERNETES_VERSION_UPGRADE_TO
-            value: "ci/latest-1.23"
+            value: "ci/latest-1.24"
           - name: ETCD_VERSION_UPGRADE_TO
-            value: "3.5.0-0"
+            value: "3.5.1-0"
           - name: COREDNS_VERSION_UPGRADE_TO
             value: "v1.8.4"
           - name: GINKGO_FOCUS
@@ -276,4 +276,4 @@ presubmits:
             cpu: 7300m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.4
-      testgrid-tab-name: capi-pr-e2e-release-0-4-1-22-latest
+      testgrid-tab-name: capi-pr-e2e-release-0-4-1-23-latest

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-0.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-0.yaml
@@ -229,7 +229,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.0
       testgrid-tab-name: capi-pr-e2e-full-release-1-0
-  - name: pull-cluster-api-e2e-workload-upgrade-1-22-latest-release-1-0
+  - name: pull-cluster-api-e2e-workload-upgrade-1-23-latest-release-1-0
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -253,11 +253,11 @@ presubmits:
           - "./scripts/ci-e2e.sh"
         env:
           - name: KUBERNETES_VERSION_UPGRADE_FROM
-            value: "stable-1.22"
+            value: "stable-1.23"
           - name: KUBERNETES_VERSION_UPGRADE_TO
-            value: "ci/latest-1.23"
+            value: "ci/latest-1.24"
           - name: ETCD_VERSION_UPGRADE_TO
-            value: "3.5.0-0"
+            value: "3.5.1-0"
           - name: COREDNS_VERSION_UPGRADE_TO
             value: "v1.8.4"
           - name: GINKGO_FOCUS
@@ -270,4 +270,4 @@ presubmits:
             cpu: 7300m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.0
-      testgrid-tab-name: capi-pr-e2e-release-1-0-1-22-latest
+      testgrid-tab-name: capi-pr-e2e-release-1-0-1-23-latest


### PR DESCRIPTION
This PR:
* adds new jobs to test Kubernetes 1.23 and against 1.24 latest for CAPI 
* switches our jobs for the main branches from the master to the 1.23 image

Partially implements https://github.com/kubernetes-sigs/cluster-api/issues/5793

Related: https://github.com/kubernetes-sigs/cluster-api/pull/5800