### PR TITLE
releng: Enable all k/publishing-bot presubmits as blocking

### DIFF
--- a/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
+++ b/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
@@ -26,9 +26,7 @@ presubmits:
       testgrid-dashboards: sig-release-publishing-bot
       testgrid-tab-name: test
   - name: pull-publishing-bot-validate-rules
-    always_run: false
-    skip_report: false
-    optional: true
+    always_run: true
     decorate: true
     path_alias: k8s.io/publishing-bot
     extra_refs:
@@ -53,9 +51,6 @@ presubmits:
     cluster: k8s-infra-prow-build
     decorate: true
     path_alias: "k8s.io/publishing-bot"
-    skip_report: false
-    # TODO(releng): Make blocking once testing is complete
-    optional: true
     always_run: true
     spec:
       serviceAccountName: gcb-builder-releng-test


### PR DESCRIPTION
Part of https://github.com/kubernetes/publishing-bot/issues/272.

Specifically, this commit updates the following jobs to blocking:
- `pull-publishing-bot-validate-rules` (might've caught [this](https://kubernetes.slack.com/archives/CJH2GBF7Y/p1638805264424700?thread_ts=1638609722.396300&cid=CJH2GBF7Y))
- `pull-publishing-bot-image`

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @dims @cpanato @puerco 
cc: @kubernetes/publishing-bot-maintainers 