### PR TITLE
OWNERS_ALIASES(releng): Create/utilize aliases for publishing-bot

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -308,3 +308,22 @@ aliases:
     - listx
     - puerco
     - saschagrunert
+
+  publishing-bot-approvers:
+    - cpanato
+    - dims
+    - justaugustus
+    - nikhita
+    - puerco
+    - saschagrunert
+    - sttts
+  publishing-bot-reviewers:
+    - cpanato
+    - dims
+    - justaugustus
+    - nikhita
+    - puerco
+    - saschagrunert
+    - sttts
+    - Verolop
+    - xmudrii

--- a/config/jobs/kubernetes/publishing-bot/OWNERS
+++ b/config/jobs/kubernetes/publishing-bot/OWNERS
@@ -1,15 +1,12 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- caesarxuchao
-- mfojtik
-- nikhita
-- sttts
+- publishing-bot-reviewers
 approvers:
-- caesarxuchao
-- mfojtik
-- nikhita
-- sttts
+- publishing-bot-approvers
+emeritus_approvers:
+- caesarxuchao    # 2021-12-07
+- mfojtik         # 2021-12-07
 labels:
 - sig/release
 - area/release-eng


### PR DESCRIPTION
Part of https://github.com/kubernetes/sig-release/issues/1772.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @dims @nikhita @sttts @spiffxp 
cc: @kubernetes/publishing-bot-maintainers
ref: https://github.com/kubernetes/test-infra/pull/24564#issuecomment-987796855