### PR TITLE
Cherrypicker plugin for cluster-api-provider-ibmcloud

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1244,6 +1244,12 @@ external_plugins:
     - issue_comment
     - pull_request
     endpoint: http://cherrypicker
+  kubernetes-sigs/cluster-api-provider-ibmcloud:
+  - name: cherrypicker
+    events:
+    - issue_comment
+    - pull_request
+    endpoint: http://cherrypicker
   kubernetes-sigs/controller-tools:
   - name: cherrypicker
     events:


### PR DESCRIPTION
This change is to enable the cherrypicker external plugin for the repo `cluster-api-provider-ibmcloud`
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/453