### PR TITLE
Add cluster-api-provider-azure periodic upgrade jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main-upgrades.yaml
@@ -1,0 +1,177 @@
+periodics:
+
+- name: periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-18-1-19-main
+  interval: 24h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
+      args:
+        - runner.sh
+        - "./scripts/ci-e2e.sh"
+      env:
+        - name: KUBERNETES_VERSION_UPGRADE_FROM
+          value: "stable-1.18"
+        - name: KUBERNETES_VERSION_UPGRADE_TO
+          value: "stable-1.19"
+        - name: ETCD_VERSION_UPGRADE_TO
+          value: "3.4.13-0"
+        - name: COREDNS_VERSION_UPGRADE_TO
+          value: "1.7.0"
+        - name: GINKGO_FOCUS
+          value: "\\[K8s-Upgrade\\]"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+    testgrid-tab-name: capi-e2e-main-1-18-1-19
+
+- name: periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-19-1-20-main
+  interval: 24h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
+      args:
+        - runner.sh
+        - "./scripts/ci-e2e.sh"
+      env:
+        - name: KUBERNETES_VERSION_UPGRADE_FROM
+          value: "stable-1.19"
+        - name: KUBERNETES_VERSION_UPGRADE_TO
+          value: "stable-1.20"
+        - name: ETCD_VERSION_UPGRADE_TO
+          value: "3.4.13-0"
+        - name: COREDNS_VERSION_UPGRADE_TO
+          value: "1.7.0"
+        - name: GINKGO_FOCUS
+          value: "\\[K8s-Upgrade\\]"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+    testgrid-tab-name: capi-e2e-main-1-19-1-20
+
+- name: periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-20-1-21-main
+  interval: 24h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
+      args:
+        - runner.sh
+        - "./scripts/ci-e2e.sh"
+      env:
+        - name: KUBERNETES_VERSION_UPGRADE_FROM
+          value: "stable-1.20"
+        - name: KUBERNETES_VERSION_UPGRADE_TO
+          value: "stable-1.21"
+        - name: ETCD_VERSION_UPGRADE_TO
+          value: "3.4.13-0"
+        - name: COREDNS_VERSION_UPGRADE_TO
+          value: "v1.8.0"
+        - name: GINKGO_FOCUS
+          value: "\\[K8s-Upgrade\\]"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+    testgrid-tab-name: capi-e2e-main-1-20-1-21
+
+- name: periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-21-1-22-main
+  interval: 24h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
+      args:
+        - runner.sh
+        - "./scripts/ci-e2e.sh"
+      env:
+        - name: KUBERNETES_VERSION_UPGRADE_FROM
+          value: "stable-1.21"
+        - name: KUBERNETES_VERSION_UPGRADE_TO
+          value: "stable-1.22"
+        - name: ETCD_VERSION_UPGRADE_TO
+          value: "3.5.1-0"
+        - name: COREDNS_VERSION_UPGRADE_TO
+          value: "v1.8.4"
+        - name: GINKGO_FOCUS
+          value: "\\[K8s-Upgrade\\]"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+    testgrid-tab-name: capi-e2e-main-1-21-1-22


### PR DESCRIPTION
Adds periodic k8s workload cluster upgrade jobs for 1.18 -> 1.19, 1.19 -> 1.20, 1.20 -> 1.21 and 1.21 -> 1.22 since https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1767 merged. Inspired from https://github.com/kubernetes/test-infra/blob/97bea9d7deb79ac438182c34221040575d90e135/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml