### PR TITLE
sig-contribex: Fix SECURITY_CONTACTS issue creation

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
@@ -412,13 +412,9 @@ periodics:
     description: files bugs for SECURITY_CONTACTS
     testgrid-tab-name: secping
   extra_refs:
-  - base_ref: master
-    org: jessfraz
+  - base_ref: main
+    org: justaugustus
     repo: secping
-  - org: fejta
-    repo: go-github
-    base_ref: master
-    path_alias: github.com/jessfraz/go-github # https://github.com/google/go-github/pull/1076
   spec:
     containers:
     - command:
@@ -432,7 +428,7 @@ periodics:
       env:
       - name: GO111MODULE
         value: "on"
-      image: golang:1.11
+      image: golang:latest
       volumeMounts:
       - name: token
         mountPath: /etc/github-token


### PR DESCRIPTION
The `secping` tool was erroneously creating new issues for repos
that were either:

- newly created
- recently had their default branch names changed

This is because `secping` expects the default branch for all repos
to be `master`.

This commit:

- switches to using a fork of jessfraz/secping with addresses the
  issue (https://github.com/justaugustus/secping/pull/1)
- references the correct `base_ref` for the fork
- updates the job image to `golang:latest`

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @BenTheElder @cblecker @fejta 
ref: https://kubernetes.slack.com/archives/C01672LSZL0/p1638917859087100