### PR TITLE
kubekins-e2e: bump 1.23 version marker to stable-1.23

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -29,7 +29,7 @@ variants:
   '1.23':
     CONFIG: '1.23'
     GO_VERSION: 1.17.3
-    K8S_RELEASE: latest-1.23
+    K8S_RELEASE: stable-1.23
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.22':


### PR DESCRIPTION
Part of the 1.23 Stable Release tasks

/cc @kubernetes/release-managers 
/priority critical-urgent
/kind feature