### PR TITLE
capg: update presubmits capg jobs for conformance tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
@@ -124,7 +124,6 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-e2e-test
-  # conformance test against kubernetes master branch with `kind` + cluster-api-provider-gcp
   - name: pull-cluster-api-provider-gcp-conformance-ci-artifacts
     labels:
       preset-service-account: "true"
@@ -145,20 +144,20 @@ presubmits:
       repo: image-builder
       base_ref: master
       path_alias: "sigs.k8s.io/image-builder"
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
           env:
             - name: "BOSKOS_HOST"
               value: "boskos.test-pods.svc.cluster.local"
+            - name: E2E_ARGS
+              value: "-kubetest.use-ci-artifacts"
+            - name: USE_CI_ARTIFACTS
+              value: "true"
           command:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"
-            - "--use-ci-artifacts"
+            - "--init-image"
           # we need privileged mode in order to do docker in docker
           securityContext:
             privileged: true
@@ -187,14 +186,9 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 3h
-    extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: release-1.22
-      path_alias: k8s.io/kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-1.22
           env:
             - name: "BOSKOS_HOST"
               value: "boskos.test-pods.svc.cluster.local"
@@ -231,7 +225,7 @@ presubmits:
       timeout: 3h
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211124-2ed05120f3-1.22
           env:
             - name: "BOSKOS_HOST"
               value: "boskos.test-pods.svc.cluster.local"


### PR DESCRIPTION
update capg conformance tests

needed for this PR https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/469

after we merge the capg pr I will update the periodic

/assign @dims 