### PR TITLE
external-plugins/cherrypicker: add an option to push directly to upstream instead of using a fork

### DIFF
--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -480,7 +480,20 @@ func (r *Repo) Push(branch string, force bool) error {
 	return r.PushToNamedFork(r.user, branch, force)
 }
 
+// PushToNamedFork is used for when the fork has a different name than the original repp
 func (r *Repo) PushToNamedFork(forkName, branch string, force bool) error {
+	remote := remoteFromBase(r.base, r.user, r.pass, r.host, r.user, forkName)
+	return r.pushToRemote(remote, branch, force)
+}
+
+// PushToCentral pushes the local state to the central remote
+func (r *Repo) PushToCentral(branch string, force bool) error {
+	remote := remoteFromBase(r.base, r.user, r.pass, r.host, r.org, r.repo)
+	return r.pushToRemote(remote, branch, force)
+}
+
+// pushToRemote pushes a branch to the given upstream repository
+func (r *Repo) pushToRemote(remote, branch string, force bool) error {
 	if err := r.refreshRepoAuth(); err != nil {
 		return err
 	}
@@ -488,7 +501,6 @@ func (r *Repo) PushToNamedFork(forkName, branch string, force bool) error {
 		return errors.New("cannot push without credentials - configure your git client")
 	}
 	r.logger.WithFields(logrus.Fields{"user": r.user, "repo": r.repo, "branch": branch}).Info("Pushing.")
-	remote := remoteFromBase(r.base, r.user, r.pass, r.host, r.user, forkName)
 	var co *exec.Cmd
 	if !force {
 		co = r.gitCommand("push", remote, branch)

--- a/prow/git/v2/adapter.go
+++ b/prow/git/v2/adapter.go
@@ -83,7 +83,7 @@ func (a *repoClientAdapter) PushToNamedFork(forkName, branch string, force bool)
 }
 
 func (a *repoClientAdapter) PushToCentral(branch string, force bool) error {
-	return errors.New("no PushToCentral implementation exists in the v1 repo client")
+	return a.Repo.PushToCentral(branch, force)
 }
 
 func (a *repoClientAdapter) MirrorClone() error {


### PR DESCRIPTION
The current implementation of the `cherrypicker` plugin is failing to retrieve successfully the list of user repositories when running as a Github app

```console
{"client":"github","component":"cherrypicker","error":"Get \"http://ghproxy/users/prow/repos?per_page=100\": failed to get installation id for org prow: the github app is not installed in organization prow","file":"prow/github/client.go:1116","func":"k8s.io/test-infra/prow/github.(*client).requestRetryWithContext","level":"error","msg":"Stopping retry due to appsAuthError","severity":"error","time":"2021-12-08T15:11:24Z"}
{"client":"github","component":"cherrypicker","duration":"90.238202ms","file":"prow/github/client.go:891","func":"k8s.io/test-infra/prow/github.(*client).log.func2","level":"debug","msg":"GetRepos(prow, true) finished","severity":"debug","time":"2021-12-08T15:11:24Z"}
{"component":"cherrypicker","error":"Get \"http://ghproxy/users/prow/repos?per_page=100\": failed to get installation id for org prow: the github app is not installed in organization prow","file":"prow/external-plugins/cherrypicker/main.go:133","func":"main.main","level":"fatal","msg":"Error listing bot repositories.","plugin":"cherrypick","severity":"fatal","time":"2021-12-08T15:11:24Z"}
```  

As a workaround, this PR is implement a new option for the `cherrypicker` plugin to not fork the upstream repositories but instead push the cherry-pick commits directly to the upstream.

```yaml
[...]
    spec:
      containers:
      - args:
        - --allow-all=true
        - --push-to-upstream=true
        - --dry-run=false
        - --github-host=$(GITHUB_HOST)
        - --github-endpoint=http://ghproxy
        - --github-graphql-endpoint=http://ghproxy/graphql
        - --github-app-id=$(GITHUB_APP_ID)
        - --github-app-private-key-path=/etc/github/cert
        env:
        - name: GITHUB_APP_ID
          valueFrom:
            secretKeyRef:
              key: appid
              name: github-token
[...]
```

Setting the option to `false` will result in the cherry-pick branches being created directly to the upstream

```console
"component":"cherrypicker","event-GUID":"0826f100-583a-11ec-9469-ebf44eb07c7c","event-type":"issue_comment","file":"prow/external-plugins/cherrypicker/server.go:251","func":"main.(*Server).handleIssueComment","level":"debug","msg":"Cherrypick request.","org":"test","pr":28856,"repo":"test","requestor":"atosatto","severity":"debug","target_branch":"stability","time":"2021-12-08T15:18:01Z"}
{"client":"git","component":"cherrypicker","file":"prow/git/git.go:170","func":"k8s.io/test-infra/prow/git.(*Client).Clone","level":"info","msg":"Cloning for the first time.","repo":"test/test","severity":"info","time":"2021-12-08T15:18:01Z"}
{"args":["gc.auto","0"],"client":"git","component":"cherrypicker","file":"prow/git/git.go:494","func":"k8s.io/test-infra/prow/git.(*Repo).Config","level":"info","msg":"Running git config.","severity":"info","time":"2021-12-08T15:20:36Z"}
{"args":["/usr/bin/git","config","gc.auto","0"],"client":"git","component":"cherrypicker","dir":"/tmp/git952699221","file":"prow/git/git.go:294","func":"k8s.io/test-infra/prow/git.(*Repo).gitCommand","level":"debug","msg":"Constructed git command","severity":"debug","time":"2021-12-08T15:20:36Z"}
{"client":"git","commitlike":"stability","component":"cherrypicker","file":"prow/git/git.go:300","func":"k8s.io/test-infra/prow/git.(*Repo).Checkout","level":"info","msg":"Checkout.","severity":"info","time":"2021-12-08T15:20:36Z"}
{"args":["/usr/bin/git","checkout","stability"],"client":"git","component":"cherrypicker","dir":"/tmp/git952699221","file":"prow/git/git.go:294","func":"k8s.io/test-infra/prow/git.(*Repo).gitCommand","level":"debug","msg":"Constructed git command","severity":"debug","time":"2021-12-08T15:20:36Z"}
{"component":"cherrypicker","duration":156057078084,"event-GUID":"0826f100-583a-11ec-9469-ebf44eb07c7c","event-type":"issue_comment","file":"prow/external-plugins/cherrypicker/server.go:428","func":"main.(*Server).handle","level":"info","msg":"Cloned and checked out target branch.","org":"test","pr":28856,"repo":"test","requestor":"atosatto","severity":"info","target_branch":"stability","time":"2021-12-08T15:20:37Z"}
{"client":"github","component":"cherrypicker","file":"prow/github/client.go:889","func":"k8s.io/test-infra/prow/github.(*client).log","level":"info","msg":"GetPullRequestPatch(test, test, 28856)","severity":"info","time":"2021-12-08T15:20:37Z"}
{"client":"github","component":"cherrypicker","duration":"110.972831ms","file":"prow/github/client.go:891","func":"k8s.io/test-infra/prow/github.(*client).log.func2","level":"debug","msg":"GetPullRequestPatch(test, test, 28856) finished","severity":"debug","time":"2021-12-08T15:20:37Z"}
{"args":["user.name","prow"],"client":"git","component":"cherrypicker","file":"prow/git/git.go:494","func":"k8s.io/test-infra/prow/git.(*Repo).Config","level":"info","msg":"Running git config.","severity":"info","time":"2021-12-08T15:20:37Z"}
{"args":["/usr/bin/git","config","user.name","prow"],"client":"git","component":"cherrypicker","dir":"/tmp/git952699221","file":"prow/git/git.go:294","func":"k8s.io/test-infra/prow/git.(*Repo).gitCommand","level":"debug","msg":"Constructed git command","severity":"debug","time":"2021-12-08T15:20:37Z"}
{"args":["user.email","prow@users.noreply.github.com"],"client":"git","component":"cherrypicker","file":"prow/git/git.go:494","func":"k8s.io/test-infra/prow/git.(*Repo).Config","level":"info","msg":"Running git config.","severity":"info","time":"2021-12-08T15:20:37Z"}
{"args":["/usr/bin/git","config","user.email","prow@users.noreply.github.com"],"client":"git","component":"cherrypicker","dir":"/tmp/git952699221","file":"prow/git/git.go:294","func":"k8s.io/test-infra/prow/git.(*Repo).gitCommand","level":"debug","msg":"Constructed git command","severity":"debug","time":"2021-12-08T15:20:37Z"}
{"branch":"cherry-pick-28856-to-stability","client":"git","component":"cherrypicker","file":"prow/git/git.go:321","func":"k8s.io/test-infra/prow/git.(*Repo).BranchExists","heads":"origin","level":"info","msg":"Checking if branch exists.","severity":"info","time":"2021-12-08T15:20:37Z"}
{"args":["/usr/bin/git","ls-remote","--exit-code","--heads","origin","cherry-pick-28856-to-stability"],"client":"git","component":"cherrypicker","dir":"/tmp/git952699221","file":"prow/git/git.go:294","func":"k8s.io/test-infra/prow/git.(*Repo).gitCommand","level":"debug","msg":"Constructed git command","severity":"debug","time":"2021-12-08T15:20:37Z"}
{"branch":"cherry-pick-28856-to-stability","client":"git","component":"cherrypicker","file":"prow/git/git.go:328","func":"k8s.io/test-infra/prow/git.(*Repo).CheckoutNewBranch","level":"info","msg":"Create and checkout.","severity":"info","time":"2021-12-08T15:20:37Z"}
{"args":["/usr/bin/git","checkout","-b","cherry-pick-28856-to-stability"],"client":"git","component":"cherrypicker","dir":"/tmp/git952699221","file":"prow/git/git.go:294","func":"k8s.io/test-infra/prow/git.(*Repo).gitCommand","level":"debug","msg":"Constructed git command","severity":"debug","time":"2021-12-08T15:20:37Z"}
{"client":"git","component":"cherrypicker","file":"prow/git/git.go:422","func":"k8s.io/test-infra/prow/git.(*Repo).Am","level":"info","msg":"Applying.","path":"/tmp/test_test_28856_stability.patch","severity":"info","time":"2021-12-08T15:20:37Z"}
{"args":["/usr/bin/git","am","--3way","/tmp/test_test_28856_stability.patch"],"client":"git","component":"cherrypicker","dir":"/tmp/git952699221","file":"prow/git/git.go:294","func":"k8s.io/test-infra/prow/git.(*Repo).gitCommand","level":"debug","msg":"Constructed git command","severity":"debug","time":"2021-12-08T15:20:37Z"}
{"branch":"cherry-pick-28856-to-stability","client":"git","component":"cherrypicker","file":"prow/git/git.go:464","func":"k8s.io/test-infra/prow/git.(*Repo).pushToRemote","level":"info","msg":"Pushing.","repo":"test","severity":"info","time":"2021-12-08T15:20:38Z","user":"x-access-token"}
{"args":["/usr/bin/git","push","--force","https://x-access-token:REDACTED@REDACTED/test/test,”cherry-pick-28856-to-stability"],"client":"git","component":"cherrypicker","dir":"/tmp/git952699221","file":"prow/git/git.go:294","func":"k8s.io/test-infra/prow/git.(*Repo).gitCommand","level":"debug","msg":"Constructed git command","severity":"debug","time":"2021-12-08T15:20:38Z"}
{"client":"github","component":"cherrypicker","file":"prow/github/client.go:889","func":"k8s.io/test-infra/prow/github.(*client).log","level":"info","msg":"CreatePullRequest(test, test, [stability] Test)”,”severity":"info","time":"2021-12-08T15:20:41Z"}
{"client":"github","component":"cherrypicker","duration":"954.772763ms","file":"prow/github/client.go:891","func":"k8s.io/test-infra/prow/github.(*client).log.func2","level":"debug","msg":"CreatePullRequest(test, test, [stability] Test) finished","severity":"debug","time":"2021-12-08T15:20:42Z"}
{"component":"cherrypicker","event-GUID":"0826f100-583a-11ec-9469-ebf44eb07c7c","event-type":"issue_comment","file":"prow/external-plugins/cherrypicker/server.go:529","func":"main.(*Server).handle","level":"info","msg":"new pull request created","new_pull_request_number":29182,"org":"test","pr":28856,"repo":"test","requestor":"atosatto","severity":"info","target_branch":"stability","time":"2021-12-08T15:20:42Z"}
{"client":"github","component":"cherrypicker","file":"prow/github/client.go:889","func":"k8s.io/test-infra/prow/github.(*client).log","level":"info","msg":"CreateComment(test, test, 28856, @atosatto: new pull request created: #29182\n\n\u003cdetails\u003e\n\nIn response to [this](https://REDACTED/test/test/pull/28856#issuecomment-13410430):\n\n\u003e/cherrypick stability).\n\u003c/details\u003e)","severity":"info","time":"2021-12-08T15:20:42Z"}
{"component":"cherrypicker","file":"prow/external-plugins/cherrypicker/server.go:560","func":"main.(*Server).createComment","level":"debug","msg":"Created comment","severity":"debug","time":"2021-12-08T15:20:42Z"}
```

