### PR TITLE
Remove Azure (capz) 1.19 and add 1.23 jobs

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/azure/README.md
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/README.md
@@ -2,8 +2,8 @@
 
 Job configurations for https://testgrid.k8s.io/provider-azure.
 
-To generate the job configurations for 1.18, 1.19, 1.20, and master branch:
+To generate the job configurations for 1.20, 1.21, 1.22, 1.23 and master branch:
 
 ```bash
-./generate.sh 1.18 1.19 1.20 master
+./generate.sh 1.20 1.21 1.22 1.23 master
 ```

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/generate.sh
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/generate.sh
@@ -40,6 +40,7 @@ EOF
 # we need to define the full image URL so it can be autobumped
 tmp="gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211208-9473f90198-master"
 kubekins_e2e_image="${tmp/\-master/}"
+installCSIdrivers=""
 
 for release in "$@"; do
   output="${dir}/release-${release}.yaml"
@@ -50,6 +51,10 @@ for release in "$@"; do
   else
     branch="release-${release}"
     kubernetes_version+="-${release}"
+  fi
+
+  if [[ "${release}" == "master" || "${release}" == "1.23" ]]; then
+    installCSIdrivers=" ./deploy/install-driver.sh master local,snapshot,enable-avset &&"
   fi
 
   cat >"${output}" <<EOF
@@ -89,7 +94,7 @@ presubmits:
             - bash
             - -c
             - >-
-              cd \${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver &&
+              cd \${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver &&${installCSIdrivers}
               make e2e-test
           env:
             - name: AZURE_STORAGE_DRIVER
@@ -134,7 +139,7 @@ $(generate_presubmit_annotations ${branch} pull-kubernetes-e2e-capz-azure-disk)
             - bash
             - -c
             - >-
-              cd \${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver &&
+              cd \${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver &&${installCSIdrivers}
               make e2e-test
           env:
             - name: AZURE_STORAGE_DRIVER
@@ -182,7 +187,7 @@ $(generate_presubmit_annotations ${branch} pull-kubernetes-e2e-capz-azure-disk-v
             - -c
             - >-
               kubectl apply -f templates/addons/azurefile-role.yaml &&
-              cd \${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&
+              cd \${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&${installCSIdrivers}
               make e2e-test
           env:
             - name: AZURE_STORAGE_DRIVER
@@ -228,7 +233,7 @@ $(generate_presubmit_annotations ${branch} pull-kubernetes-e2e-capz-azure-file)
             - -c
             - >-
               kubectl apply -f templates/addons/azurefile-role.yaml &&
-              cd \${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&
+              cd \${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&${installCSIdrivers}
               make e2e-test
           env:
             - name: AZURE_STORAGE_DRIVER
@@ -332,7 +337,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-0.5
+    base_ref: main
     path_alias: sigs.k8s.io/cluster-api-provider-azure
   spec:
     containers:
@@ -392,7 +397,7 @@ periodics:
       - -c
       - >-
         kubectl apply -f templates/addons/azurefile-role.yaml &&
-        cd \${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&
+        cd \${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&${installCSIdrivers}
         make e2e-test
       env:
       - name: USE_CI_ARTIFACTS
@@ -444,7 +449,7 @@ periodics:
       - -c
       - >-
         kubectl apply -f templates/addons/azurefile-role.yaml &&
-        cd \${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&
+        cd \${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&${installCSIdrivers}
         make e2e-test
       env:
       - name: USE_CI_ARTIFACTS
@@ -497,7 +502,7 @@ periodics:
       - bash
       - -c
       - >-
-        cd \${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver &&
+        cd \${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver &&${installCSIdrivers}
         make e2e-test
       env:
       - name: USE_CI_ARTIFACTS
@@ -548,7 +553,7 @@ periodics:
       - bash
       - -c
       - >-
-        cd \${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver &&
+        cd \${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver &&${installCSIdrivers}
         make e2e-test
       env:
       - name: USE_CI_ARTIFACTS

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.23.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.23.yaml
@@ -8,7 +8,7 @@ presubmits:
     run_if_changed: 'azure.*\.go'
     path_alias: k8s.io/kubernetes
     branches:
-      - release-1.19
+      - release-1.23
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -34,7 +34,7 @@ presubmits:
             - bash
             - -c
             - >-
-              cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver &&
+              cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
           env:
             - name: AZURE_STORAGE_DRIVER
@@ -53,7 +53,7 @@ presubmits:
     run_if_changed: 'azure.*\.go'
     path_alias: k8s.io/kubernetes
     branches:
-      - release-1.19
+      - release-1.23
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -79,7 +79,7 @@ presubmits:
             - bash
             - -c
             - >-
-              cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver &&
+              cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
           env:
             - name: AZURE_STORAGE_DRIVER
@@ -100,7 +100,7 @@ presubmits:
     run_if_changed: 'azure.*\.go'
     path_alias: k8s.io/kubernetes
     branches:
-      - release-1.19
+      - release-1.23
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -127,7 +127,7 @@ presubmits:
             - -c
             - >-
               kubectl apply -f templates/addons/azurefile-role.yaml &&
-              cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&
+              cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
           env:
             - name: AZURE_STORAGE_DRIVER
@@ -146,7 +146,7 @@ presubmits:
     run_if_changed: 'azure.*\.go'
     path_alias: k8s.io/kubernetes
     branches:
-      - release-1.19
+      - release-1.23
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -173,7 +173,7 @@ presubmits:
             - -c
             - >-
               kubectl apply -f templates/addons/azurefile-role.yaml &&
-              cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&
+              cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
           env:
             - name: AZURE_STORAGE_DRIVER
@@ -194,7 +194,7 @@ presubmits:
     run_if_changed: 'azure.*\.go'
     path_alias: k8s.io/kubernetes
     branches:
-      - release-1.19
+      - release-1.23
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -232,7 +232,7 @@ presubmits:
     optional: true
     path_alias: k8s.io/kubernetes
     branches:
-      - release-1.19
+      - release-1.23
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -266,7 +266,7 @@ presubmits:
 
 periodics:
 - interval: 3h
-  name: capz-conformance-1-19
+  name: capz-conformance-1-23
   decorate: true
   decoration_config:
     timeout: 3h
@@ -289,7 +289,7 @@ periodics:
       - name: E2E_ARGS
         value: "-kubetest.use-ci-artifacts"
       - name: KUBERNETES_VERSION
-        value: "latest-1.19"
+        value: "latest-1.23"
       - name: CONFORMANCE_WORKER_MACHINE_COUNT
         value: "2"
       securityContext:
@@ -299,13 +299,13 @@ periodics:
           cpu: 1
           memory: "4Gi"
   annotations:
-    testgrid-dashboards: provider-azure-1.19-signal
+    testgrid-dashboards: provider-azure-1.23-signal
     testgrid-tab-name: capz-conformance
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     testgrid-num-columns-recent: '30'
 
 - interval: 24h
-  name: capz-azure-file-1-19
+  name: capz-azure-file-1-23
   decorate: true
   decoration_config:
     timeout: 3h
@@ -324,7 +324,7 @@ periodics:
     path_alias: sigs.k8s.io/azurefile-csi-driver
   - org: kubernetes
     repo: kubernetes
-    base_ref: release-1.19
+    base_ref: release-1.23
     path_alias: k8s.io/kubernetes
   spec:
     containers:
@@ -337,7 +337,7 @@ periodics:
       - -c
       - >-
         kubectl apply -f templates/addons/azurefile-role.yaml &&
-        cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&
+        cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
         make e2e-test
       env:
       - name: USE_CI_ARTIFACTS
@@ -351,13 +351,13 @@ periodics:
           cpu: 1
           memory: "4Gi"
   annotations:
-    testgrid-dashboards: provider-azure-1.19-signal
+    testgrid-dashboards: provider-azure-1.23-signal
     testgrid-tab-name: capz-azure-file
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     testgrid-num-columns-recent: '30'
 
 - interval: 24h
-  name: capz-azure-file-vmss-1-19
+  name: capz-azure-file-vmss-1-23
   decorate: true
   decoration_config:
     timeout: 3h
@@ -376,7 +376,7 @@ periodics:
     path_alias: sigs.k8s.io/azurefile-csi-driver
   - org: kubernetes
     repo: kubernetes
-    base_ref: release-1.19
+    base_ref: release-1.23
     path_alias: k8s.io/kubernetes
   spec:
     containers:
@@ -389,7 +389,7 @@ periodics:
       - -c
       - >-
         kubectl apply -f templates/addons/azurefile-role.yaml &&
-        cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&
+        cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
         make e2e-test
       env:
       - name: USE_CI_ARTIFACTS
@@ -405,13 +405,13 @@ periodics:
           cpu: 1
           memory: "4Gi"
   annotations:
-    testgrid-dashboards: provider-azure-1.19-signal
+    testgrid-dashboards: provider-azure-1.23-signal
     testgrid-tab-name: capz-azure-file-vmss
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     testgrid-num-columns-recent: '30'
 
 - interval: 24h
-  name: capz-azure-disk-1-19
+  name: capz-azure-disk-1-23
   decorate: true
   decoration_config:
     timeout: 3h
@@ -430,7 +430,7 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   - org: kubernetes
     repo: kubernetes
-    base_ref: release-1.19
+    base_ref: release-1.23
     path_alias: k8s.io/kubernetes
   spec:
     containers:
@@ -442,7 +442,7 @@ periodics:
       - bash
       - -c
       - >-
-        cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver &&
+        cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
         make e2e-test
       env:
       - name: USE_CI_ARTIFACTS
@@ -456,13 +456,13 @@ periodics:
           cpu: 1
           memory: "4Gi"
   annotations:
-    testgrid-dashboards: provider-azure-1.19-signal
+    testgrid-dashboards: provider-azure-1.23-signal
     testgrid-tab-name: capz-azure-disk
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     testgrid-num-columns-recent: '30'
 
 - interval: 24h
-  name: capz-azure-disk-vmss-1-19
+  name: capz-azure-disk-vmss-1-23
   decorate: true
   decoration_config:
     timeout: 3h
@@ -481,7 +481,7 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   - org: kubernetes
     repo: kubernetes
-    base_ref: release-1.19
+    base_ref: release-1.23
     path_alias: k8s.io/kubernetes
   spec:
     containers:
@@ -493,7 +493,7 @@ periodics:
       - bash
       - -c
       - >-
-        cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver &&
+        cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
         make e2e-test
       env:
       - name: USE_CI_ARTIFACTS
@@ -509,7 +509,7 @@ periodics:
           cpu: 1
           memory: "4Gi"
   annotations:
-    testgrid-dashboards: provider-azure-1.19-signal
+    testgrid-dashboards: provider-azure-1.23-signal
     testgrid-tab-name: capz-azure-disk-vmss
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
@@ -34,8 +34,7 @@ presubmits:
             - bash
             - -c
             - >-
-              cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver &&
-              ./deploy/install-driver.sh master local,snapshot,enable-avset &&
+              cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
           env:
             - name: AZURE_STORAGE_DRIVER
@@ -84,8 +83,7 @@ presubmits:
             - bash
             - -c
             - >-
-              cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver &&
-              ./deploy/install-driver.sh master local,snapshot &&
+              cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
           env:
             - name: AZURE_STORAGE_DRIVER
@@ -137,8 +135,7 @@ presubmits:
             - -c
             - >-
               kubectl apply -f templates/addons/azurefile-role.yaml &&
-              cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&
-              ./deploy/install-driver.sh master local,snapshot &&
+              cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
           env:
             - name: AZURE_STORAGE_DRIVER
@@ -188,8 +185,7 @@ presubmits:
             - -c
             - >-
               kubectl apply -f templates/addons/azurefile-role.yaml &&
-              cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&
-              ./deploy/install-driver.sh master local,snapshot &&
+              cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
           env:
             - name: AZURE_STORAGE_DRIVER
@@ -365,8 +361,7 @@ periodics:
       - -c
       - >-
         kubectl apply -f templates/addons/azurefile-role.yaml &&
-        cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&
-        ./deploy/install-driver.sh master local,snapshot &&
+        cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
         make e2e-test
       env:
       - name: USE_CI_ARTIFACTS
@@ -418,8 +413,7 @@ periodics:
       - -c
       - >-
         kubectl apply -f templates/addons/azurefile-role.yaml &&
-        cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&
-        ./deploy/install-driver.sh master local,snapshot &&
+        cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
         make e2e-test
       env:
       - name: USE_CI_ARTIFACTS
@@ -472,8 +466,7 @@ periodics:
       - bash
       - -c
       - >-
-        cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver &&
-        ./deploy/install-driver.sh master local,snapshot,enable-avset &&
+        cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
         make e2e-test
       env:
       - name: USE_CI_ARTIFACTS
@@ -524,8 +517,7 @@ periodics:
       - bash
       - -c
       - >-
-        cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver &&
-        ./deploy/install-driver.sh master local,snapshot &&
+        cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
         make e2e-test
       env:
       - name: USE_CI_ARTIFACTS

--- a/config/testgrids/kubernetes/sig-cloud-provider/azure/config.yaml
+++ b/config/testgrids/kubernetes/sig-cloud-provider/azure/config.yaml
@@ -17,7 +17,6 @@ dashboard_groups:
     - provider-azure-1.22-signal
     - provider-azure-1.21-signal
     - provider-azure-1.20-signal
-    - provider-azure-1.19-signal
 
 dashboards:
 - name: provider-azure-azuredisk-csi-driver
@@ -36,4 +35,3 @@ dashboards:
 - name: provider-azure-1.22-signal
 - name: provider-azure-1.21-signal
 - name: provider-azure-1.20-signal
-- name: provider-azure-1.19-signal


### PR DESCRIPTION
The 1.23 signal dashboard was missing the [jobs](https://testgrid.k8s.io/provider-azure-1.23-signal) for the 1.23 branch which was cut last week.  this adds them and removes the 1.19 jobs which EOL last month.

This uses the generate script which required a change due a [direct edit awhile back](https://github.com/kubernetes/test-infra/commit/e90c5c14785eda939f587ecf6c820e9abb02d0ee)

/assign @CecileRobertMichon @chewong @andyzhangx 