### PR TITLE
Display testsuite name if defined in junit spyglass lens.

### DIFF
--- a/prow/spyglass/lenses/junit/lens.go
+++ b/prow/spyglass/lenses/junit/lens.go
@@ -89,6 +89,7 @@ func (lens Lens) Callback(artifacts []api.Artifact, resourceDir string, data str
 
 type JunitResult struct {
 	junit.Result
+	SuiteName string
 }
 
 func (jr JunitResult) Duration() time.Duration {
@@ -178,7 +179,7 @@ func (lens Lens) getJvd(artifacts []api.Artifact) JVD {
 					// Deduplicate them here in this case, and classify a test as being
 					// flaky if it both succeeded and failed
 					k := testIdentifier{suite.Name, test.ClassName, test.Name}
-					groups[k] = append(groups[k], JunitResult{Result: test})
+					groups[k] = append(groups[k], JunitResult{SuiteName: suite.Name, Result: test})
 					if len(groups[k]) == 1 {
 						testsSequence = append(testsSequence, k)
 					}

--- a/prow/spyglass/lenses/junit/lens_test.go
+++ b/prow/spyglass/lenses/junit/lens_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/testgrid/metadata/junit"
 	"github.com/google/go-cmp/cmp"
-
 	"k8s.io/test-infra/prow/spyglass/api"
 	"k8s.io/test-infra/prow/spyglass/lenses"
 )
@@ -121,7 +120,7 @@ func TestGetJvd(t *testing.T) {
 					{
 						Junit: []JunitResult{
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
 									Failure:   &failureMsgs[0],
@@ -154,7 +153,7 @@ func TestGetJvd(t *testing.T) {
 					{
 						Junit: []JunitResult{
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
 									Errored:   &errorMsgs[0],
@@ -184,7 +183,7 @@ func TestGetJvd(t *testing.T) {
 					{
 						Junit: []JunitResult{
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
 									Failure:   nil,
@@ -219,7 +218,7 @@ func TestGetJvd(t *testing.T) {
 					{
 						Junit: []JunitResult{
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
 									Failure:   nil,
@@ -255,14 +254,14 @@ func TestGetJvd(t *testing.T) {
 					{
 						Junit: []JunitResult{
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
 									Failure:   &failureMsgs[0],
 								},
 							},
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
 									Failure:   nil,
@@ -277,14 +276,14 @@ func TestGetJvd(t *testing.T) {
 					{
 						Junit: []JunitResult{
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
 									Failure:   &failureMsgs[0],
 								},
 							},
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
 									Failure:   nil,
@@ -317,7 +316,7 @@ func TestGetJvd(t *testing.T) {
 					{
 						Junit: []JunitResult{
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_1",
 									Failure:   nil,
@@ -331,7 +330,7 @@ func TestGetJvd(t *testing.T) {
 					{
 						Junit: []JunitResult{
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
 									Failure:   &failureMsgs[0],
@@ -370,7 +369,7 @@ func TestGetJvd(t *testing.T) {
 					{
 						Junit: []JunitResult{
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_1",
 									Failure:   nil,
@@ -384,7 +383,7 @@ func TestGetJvd(t *testing.T) {
 					{
 						Junit: []JunitResult{
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
 									Failure:   &failureMsgs[0],
@@ -422,14 +421,14 @@ func TestGetJvd(t *testing.T) {
 					{
 						Junit: []JunitResult{
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
 									Failure:   &failureMsgs[0],
 								},
 							},
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
 									Failure:   &failureMsgs[1],
@@ -462,14 +461,14 @@ func TestGetJvd(t *testing.T) {
 					{
 						Junit: []JunitResult{
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
 									Failure:   nil,
 								},
 							},
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
 									Failure:   nil,
@@ -502,14 +501,14 @@ func TestGetJvd(t *testing.T) {
 					{
 						Junit: []JunitResult{
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
 									Failure:   nil,
 								},
 							},
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
 									Failure:   nil,
@@ -548,14 +547,14 @@ func TestGetJvd(t *testing.T) {
 					{
 						Junit: []JunitResult{
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
 									Failure:   &failureMsgs[0],
 								},
 							},
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
 									Failure:   nil,
@@ -591,14 +590,14 @@ func TestGetJvd(t *testing.T) {
 					{
 						Junit: []JunitResult{
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
 									Failure:   nil,
 								},
 							},
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
 									Failure:   &failureMsgs[0],
@@ -639,21 +638,21 @@ func TestGetJvd(t *testing.T) {
 					{
 						Junit: []JunitResult{
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
 									Failure:   &failureMsgs[0],
 								},
 							},
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
 									Failure:   &failureMsgs[1],
 								},
 							},
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
 									Failure:   nil,
@@ -690,7 +689,7 @@ func TestGetJvd(t *testing.T) {
 					{
 						Junit: []JunitResult{
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
 									Failure:   nil,
@@ -704,7 +703,7 @@ func TestGetJvd(t *testing.T) {
 					{
 						Junit: []JunitResult{
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
 									Failure:   &failureMsgs[0],
@@ -746,7 +745,7 @@ func TestGetJvd(t *testing.T) {
 					{
 						Junit: []JunitResult{
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
 									Failure:   nil,
@@ -758,7 +757,7 @@ func TestGetJvd(t *testing.T) {
 					{
 						Junit: []JunitResult{
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_1",
 									ClassName: "fake_class_1",
 									Failure:   nil,
@@ -770,7 +769,7 @@ func TestGetJvd(t *testing.T) {
 					{
 						Junit: []JunitResult{
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_2",
 									ClassName: "fake_class_2",
 									Failure:   nil,
@@ -782,7 +781,7 @@ func TestGetJvd(t *testing.T) {
 					{
 						Junit: []JunitResult{
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_3",
 									ClassName: "fake_class_3",
 									Failure:   nil,
@@ -794,7 +793,7 @@ func TestGetJvd(t *testing.T) {
 					{
 						Junit: []JunitResult{
 							{
-								junit.Result{
+								Result: junit.Result{
 									Name:      "fake_test_4",
 									ClassName: "fake_class_4",
 									Failure:   nil,
@@ -805,6 +804,61 @@ func TestGetJvd(t *testing.T) {
 					},
 				},
 				Failed:  nil,
+				Skipped: nil,
+				Flaky:   nil,
+			},
+		}, {
+			"Same test name fails in two different files and suites",
+			[][]byte{
+				[]byte(`
+				<testsuites>
+					<testsuite name="suite1">
+						<testcase classname="fake_class_0" name="fake_test_0">
+							<failure message="Failed" type=""> failure message 0 </failure>
+						</testcase>
+					</testsuite>
+				</testsuites>
+				`),
+				[]byte(`
+				<testsuites>
+					<testsuite name="suite2">
+						<testcase classname="fake_class_0" name="fake_test_0">
+							<failure message="Failed" type=""> failure message 1 </failure>
+						</testcase>
+					</testsuite>
+				</testsuites>
+				`),
+			},
+			JVD{
+				NumTests: 2,
+				Failed: []TestResult{
+					{
+						Junit: []JunitResult{
+							{
+								Result: junit.Result{
+									Name:      "fake_test_0",
+									ClassName: "fake_class_0",
+									Failure:   &failureMsgs[1],
+								},
+								SuiteName: "suite2",
+							},
+						},
+						Link: "linknotfound.io/404",
+					},
+					{
+						Junit: []JunitResult{
+							{
+								Result: junit.Result{
+									Name:      "fake_test_0",
+									ClassName: "fake_class_0",
+									Failure:   &failureMsgs[0],
+								},
+								SuiteName: "suite1",
+							},
+						},
+						Link: "linknotfound.io/404",
+					},
+				},
 				Skipped: nil,
 				Flaky:   nil,
 			},

--- a/prow/spyglass/lenses/junit/template.html
+++ b/prow/spyglass/lenses/junit/template.html
@@ -29,7 +29,7 @@
         <td colspan="2" style="padding: 0;">
           <table class="failed-layout">
             <tr class="failure-name">
-              <td class="mdl-data-table__cell--non-numeric test-name">{{$firstTest.ClassName}}: {{$firstTest.Name}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
+              <td class="mdl-data-table__cell--non-numeric test-name">{{if ne $firstTest.SuiteName ""}}{{$firstTest.SuiteName}}.{{end}}{{if ne $firstTest.ClassName ""}}{{$firstTest.ClassName}}: {{end}}{{$firstTest.Name}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
               <td class="mdl-data-table__cell--non-numeric" style="text-align: right;">{{$firstTest.Duration}}</td>
             </tr>
             <tr class="hidden failure-text">
@@ -49,7 +49,7 @@
         <td colspan="2" style="padding: 0;">
           <table class="failed-layout">
             <tr class="failure-name">
-              <td class="mdl-data-table__cell--non-numeric test-name">{{$firstTest.ClassName}}: {{$firstTest.Name}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
+              <td class="mdl-data-table__cell--non-numeric test-name">{{if ne $firstTest.SuiteName ""}}{{$firstTest.SuiteName}}.{{end}}{{if ne $firstTest.ClassName ""}}{{$firstTest.ClassName}}: {{end}}{{$firstTest.Name}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
             </tr>
             <tr class="hidden">
               <td>
@@ -97,7 +97,7 @@
         <td colspan="2" style="padding: 0;">
           <table class="flaky-layout">
             <tr class="flaky-name">
-              <td class="mdl-data-table__cell--non-numeric test-name">{{$firstTest.ClassName}}: {{$firstTest.Name}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
+              <td class="mdl-data-table__cell--non-numeric test-name">{{if ne $firstTest.SuiteName ""}}{{$firstTest.SuiteName}}.{{end}}{{if ne $firstTest.ClassName ""}}{{$firstTest.ClassName}}: {{end}}{{$firstTest.Name}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
             </tr>
             <tr class="hidden">
               <td>


### PR DESCRIPTION

We found cases in openshift where the same test was run in different suites, but we could not easily tell which we were seeing in the prow output.

This change will now display a prefix of "suitename." if the suite name is defined, otherwise nothing.

Also removed the leading : when a junit classname is not in use. (which we also hit in OpenShift)
