### PR TITLE
sig-instrumentation: increase code coverage for JSON periodic job

### DIFF
--- a/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-kind-periodics.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-kind-periodics.yaml
@@ -38,8 +38,7 @@ periodics:
         value: json
       - name: KIND_CLUSTER_LOG_LEVEL
         # Default is 4, but we want to exercise more log calls and get more output.
-        # TODO: go even higher, depending on log volume
-        value: "6"
+        value: "10"
       # don't retry conformance tests
       - name: GINKGO_TOLERATE_FLAKES
         value: "n"


### PR DESCRIPTION
We need to trigger more log calls to catch potential mistakes and to get
representative log output for components under load.

Previous runs at level 6 produced reasonably sized logs and there aren't that
many log calls with higher levels, so it should be save to also enable
those - unless those end up being called frequently...