### PR TITLE
Fix SIG Instrumentation OWNERS

### DIFF
--- a/config/jobs/kubernetes/sig-instrumentation/OWNERS
+++ b/config/jobs/kubernetes/sig-instrumentation/OWNERS
@@ -5,8 +5,7 @@ reviewers:
 - serathius
 - dashpole
 approvers:
-- brancz
+- sig-instrumentation-leads
 - serathius
-- dashpole
 labels:
 - sig/instrumentation

--- a/config/testgrids/kubernetes/sig-instrumentation/OWNERS
+++ b/config/testgrids/kubernetes/sig-instrumentation/OWNERS
@@ -1,12 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- piosz
 - brancz
 - serathius
 - dashpole
 approvers:
-- piosz
-- brancz
+- sig-instrumentation-leads
 - serathius
-- dashpole


### PR DESCRIPTION
Cleanup - we're missing the leads alias, removing emeritus chair and any leads already on the alias.

/sig instrumentation