### PR TITLE
capz: run presubmit exp job when managed* files change

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -135,7 +135,7 @@ presubmits:
     always_run: false
     optional: true
     decorate: true
-    run_if_changed: '^((exp)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
+    run_if_changed: '^((exp)/|main\.go|go\.mod|go\.sum|managed.*\.go|Dockerfile|Makefile)'
     max_concurrency: 5
     labels:
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1alpha4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1alpha4.yaml
@@ -135,7 +135,7 @@ presubmits:
     always_run: false
     optional: true
     decorate: true
-    run_if_changed: '^((exp)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
+    run_if_changed: '^((exp)/|main\.go|go\.mod|go\.sum|managed.*\.go|Dockerfile|Makefile)'
     max_concurrency: 5
     labels:
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -173,7 +173,7 @@ presubmits:
     always_run: false
     optional: true
     decorate: true
-    run_if_changed: '^((exp)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
+    run_if_changed: '^((exp)/|main\.go|go\.mod|go\.sum|managed.*\.go|Dockerfile|Makefile)'
     max_concurrency: 5
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
This PR updates the regex match pattern for the capz `pull-cluster-api-provider-azure-e2e-exp` job to include "managed*"-named source file changes.