### PR TITLE
Revert "Revert "Prow deployment job uses make rule""

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -132,10 +132,11 @@ postsubmits:
       containers:
       - image: gcr.io/k8s-testimages/gcloud-bazel:v20210128-v0.6-11-gf1c6399
         command:
-        - prow/deploy.sh
+        - make
         args:
-        - --confirm
-        - --config=trusted
+        - -C
+        - config/prow
+        - deploy-all
     annotations:
       testgrid-dashboards: sig-testing-prow
       testgrid-tab-name: deploy-prow


### PR DESCRIPTION
This reverts commit 77dc9f8e78315d28bd3e61a6581564eac6c415e4.

depend on #24615 

Should be an easy migration since make rule deploys the same set of yamls from before

/cc @cjwagner @alvaroaleman 