### PR TITLE
Prow deployment make rule: switch back to client side apply

### DIFF
--- a/config/prow/Makefile
+++ b/config/prow/Makefile
@@ -32,8 +32,8 @@ update-plugins: get-cluster-credentials
 	kubectl create configmap plugins --from-file=plugins.yaml=plugins.yaml --dry-run -o yaml | kubectl replace configmap plugins -f -
 
 deploy-prow: get-cluster-credentials
-	kubectl apply --server-side=true -f ./cluster/prowjob-crd/legacy/prowjob-schemaless_customresourcedefinition.yaml
-	kubectl apply --server-side=true -f ./cluster/
+	kubectl apply -f ./cluster/prowjob-crd/legacy/prowjob-schemaless_customresourcedefinition.yaml
+	kubectl apply -f ./cluster/
 
 deploy-build: get-build-cluster-credentials
 	kubectl apply -f ./cluster/build/


### PR DESCRIPTION
Tried dry-run=server and saw some errors, switching back