### PR TITLE
Prow deployment job uses gcr.io/k8s-testimages/gcloud-in-go

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -130,7 +130,7 @@ postsubmits:
     spec:
       serviceAccountName: deployer
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-bazel:v20210128-v0.6-11-gf1c6399
+      - image: gcr.io/k8s-testimages/gcloud-in-go:v20200824-5d057db
         command:
         - make
         args:


### PR DESCRIPTION
The current image is one with bazel that's no longer required, use a new image that has Go, which is required for installing Go packages on the go

/cc @cjwagner 