### PR TITLE
Deflake TestDiskCachePruning

### DIFF
--- a/ghproxy/ghproxy_test.go
+++ b/ghproxy/ghproxy_test.go
@@ -48,13 +48,14 @@ func TestDiskCachePruning(t *testing.T) {
 	}
 
 	now := time.Now()
+	github.TimeNow = func() time.Time { return now }
 
 	// Five minutes so the test has sufficient time to finish
 	// but also sufficient room until the app token which is
 	// always valid for 10 minutes expires.
 	expiryDuration := 5 * time.Minute
 	roundTripper := func(r *http.Request) (*http.Response, error) {
-		t.Logf("got a reequest for path %s", r.URL.Path)
+		t.Logf("got a request for path %s", r.URL.Path)
 		switch r.URL.Path {
 		case "/app":
 			return jsonResponse(github.App{Slug: "app-slug"}, 200)
@@ -94,7 +95,7 @@ func TestDiskCachePruning(t *testing.T) {
 		t.Fatalf("failed to get number of cache paritions: %v", err)
 	}
 	if numberPartitions != 2 {
-		t.Errorf("expected two cache paritions, one for the app and one for the app installation, got %d", numberPartitions)
+		t.Fatalf("expected two cache paritions, one for the app and one for the app installation, got %d", numberPartitions)
 	}
 
 	ghcache.Prune(cacheDir, func() time.Time { return now.Add(expiryDuration).Add(time.Second) })


### PR DESCRIPTION
As mentioned in https://github.com/kubernetes/test-infra/issues/24200#issuecomment-991312622, the test was flaky because of token generated based on timestamp rounded by second

tested with `go test -count=50` and it worked

/cc @alvaroaleman 