### PR TITLE
releng: Update kpromo to v3.3.0-1

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.1-3
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-1
         command:
         - /kpromo
         args:
@@ -34,7 +34,7 @@ presubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-vuln-scanning
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.1-3
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-1
         command:
         - /kpromo
         args:
@@ -77,7 +77,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.1-3
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-1
         command:
         - /kpromo
         args:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -13,7 +13,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-promoter
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.1-3
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-1
         command:
         - /kpromo
         args:
@@ -38,7 +38,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-promoter
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.1-3
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-1
         command:
         - /kpromo
         args:
@@ -63,7 +63,7 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-promoter
     containers:
-    - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.1-3
+    - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-1
       command:
       - /kpromo
       args:
@@ -101,7 +101,7 @@ periodics:
     # https://github.com/kubernetes/k8s.io/pull/695.
     serviceAccountName: k8s-infra-gcr-promoter
     containers:
-    - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.1-3
+    - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-1
       command:
       - /kpromo
       args:


### PR DESCRIPTION
Release: https://github.com/kubernetes-sigs/promo-tools/releases/tag/v3.3.0
Promotion PR: https://github.com/kubernetes/k8s.io/pull/3171

I'll issue the Prow promoter update in a [separate PR](https://github.com/kubernetes/test-infra/pull/24640), once this has been running successfully for a bit.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @puerco @cpanato 
/cc @kubernetes/release-engineering 