### PR TITLE
Create a periodic job running make test and verify for test-infra repo

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -27,6 +27,33 @@ periodics:
     testgrid-tab-name: ci-bazel
     description: Runs bazel test //... on the test-infra repo every hour
 
+- name: ci-test-infra-continuous-test
+  decorate: true
+  extra_refs:
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+  interval: 1h
+  labels:
+    # Enable dind for linters that required docker to run, for example typescript.
+    preset-dind-enabled: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211208-9473f90198-test-infra
+      command:
+      - runner.sh
+      args:
+      - make
+      - test
+      - verify
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-testing-misc
+    testgrid-tab-name: continuous
+    description: Runs `make test verify` on the test-infra repo every hour
+
 - name: metrics-kettle
   interval: 1h
   decorate: true


### PR DESCRIPTION
existing ci-test-infra-bazel job runs bazel test, which now only runs part of the tests, adding this one for the rest

/cc @cjwagner @alvaroaleman 