### PR TITLE
prow: Update kpromo to v3.3.0-1

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -449,7 +449,7 @@ postsubmits:
     spec:
       serviceAccountName: pusher
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.1-3
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-1
         command:
         - /kpromo
         args:


### PR DESCRIPTION
Continuation of https://github.com/kubernetes/test-infra/pull/24638.
Release: https://github.com/kubernetes-sigs/promo-tools/releases/tag/v3.3.0
Promotion PR: https://github.com/kubernetes/k8s.io/pull/3171

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @puerco @cpanato 
/cc @kubernetes/release-engineering 
/hold for https://github.com/kubernetes/test-infra/pull/24638 rolling for a weekday or so