### PR TITLE
Move docker-based CPU, memory and topology manager tests to CRI

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -1133,3 +1133,34 @@ periodics:
     testgrid-dashboards: google-gce, sig-storage-kubernetes
     testgrid-tab-name: gce-containerd
     description: node gce e2e tests for master branch using containerd
+- name: ci-kubernetes-node-kubelet-containerd-resource-managers
+  interval: 4h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211214-291c9e67f9-master
+        args:
+          - --repo=k8s.io/kubernetes=master
+          - --timeout=120
+          - --root=/go/src
+          - --scenario=kubernetes_e2e
+          - --
+          - --deployment=node
+          - --gcp-project-type=node-e2e-project
+          - --gcp-zone=us-west1-b
+          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
+          - '--node-test-args=--feature-gates=LocalStorageCapacityIsolation=true --container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+          - --node-tests=true
+          - --provider=gce
+          - --test_args=--nodes=1 --focus="\[Feature:CPUManager\]|\[Feature:MemoryManager\]|\[Feature:TopologyManager\]"
+          - --timeout=90m
+        env:
+          - name: GOPATH
+            value: /go
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    testgrid-tab-name: node-kubelet-containerd-resource-managers
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    description: "Executes CPU, Memory and Topology manager e2e tests"

--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -224,3 +224,35 @@ periodics:
     testgrid-tab-name: ci-crio-cgroupv2-node-e2e-conformance
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "OWNER: sig-node; runs NodeConformance e2e tests with crio master and cgroup v2"
+- name: ci-crio-cgroupv1-node-e2e-resource-managers
+  interval: 4h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211214-291c9e67f9-master
+        args:
+          - --repo=k8s.io/kubernetes=master
+          - --timeout=120
+          - --root=/go/src
+          - --scenario=kubernetes_e2e
+          - -- # end bootstrap args, scenario args below
+          - --deployment=node
+          - --env=KUBE_SSH_USER=core
+          - --gcp-project-type=node-e2e-project
+          - --gcp-zone=us-west1-b
+          - '--node-test-args=--feature-gates=LocalStorageCapacityIsolation=true --container-runtime=remote --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service --non-masquerade-cidr=0.0.0.0/0" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
+          - --node-tests=true
+          - --provider=gce
+          - --test_args=--nodes=1 --focus="\[Feature:CPUManager\]|\[Feature:MemoryManager\]|\[Feature:TopologyManager\]"
+          - --timeout=90m
+          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/crio/latest/image-config-cgrpv1-serial.yaml
+        env:
+          - name: GOPATH
+            value: /go
+  annotations:
+    testgrid-dashboards: sig-node-cri-o
+    testgrid-tab-name: ci-crio-cgroupv1-node-e2e-resource-managers
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    description: "Executes CPU, Memory and Topology manager e2e tests"

--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -78,70 +78,6 @@ periodics:
     testgrid-alert-email: skclark@redhat.com
     description: "Uses kubetest to run serial node-e2e tests (+Serial, -Flaky|Benchmark|Node*Feature)"
 
-# TODO: migrate CPU manager special config tests to containerd/cri-o
-#- name: ci-kubernetes-node-kubelet-serial-cpu-manager
-#  interval: 4h
-#  labels:
-#    preset-service-account: "true"
-#    preset-k8s-ssh: "true"
-#  spec:
-#    containers:
-#    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211214-291c9e67f9-master
-#      args:
-#      - --repo=k8s.io/kubernetes=master
-#      - --timeout=240
-#      - --root=/go/src
-#      - --scenario=kubernetes_e2e
-#      - --
-#      - --deployment=node
-#      - --gcp-project-type=node-e2e-project
-#      - --gcp-zone=us-west1-b
-#      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial-cpu-manager.yaml
-#      - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
-#      - --node-tests=true
-#      - --provider=gce
-#      - --test_args=--nodes=1 --focus="\[Feature:CPUManager\]"
-#      - --timeout=180m
-#      env:
-#      - name: GOPATH
-#        value: /go
-#  annotations:
-#    testgrid-dashboards: sig-node-kubelet
-#    testgrid-tab-name: kubelet-serial-gce-e2e-cpu-manager
-#    testgrid-alert-email: balaji.warft@gmail.com, connor.p.d@gmail.com
-#
-# TODO: migrate CPU manager special config tests to containerd/cri-o
-#- name: ci-kubernetes-node-kubelet-serial-topology-manager
-#  interval: 4h
-#  labels:
-#    preset-service-account: "true"
-#    preset-k8s-ssh: "true"
-#  spec:
-#    containers:
-#      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211214-291c9e67f9-master
-#        args:
-#          - --repo=k8s.io/kubernetes=master
-#          - --timeout=240
-#          - --root=/go/src
-#          - --scenario=kubernetes_e2e
-#          - --
-#          - --deployment=node
-#          - --gcp-project-type=node-e2e-project
-#          - --gcp-zone=us-west1-b
-#          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial-cpu-manager.yaml
-#          - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
-#          - --node-tests=true
-#          - --provider=gce
-#          - --test_args=--nodes=1 --focus="\[Feature:TopologyManager\]"
-#          - --timeout=180m
-#        env:
-#          - name: GOPATH
-#            value: /go
-#  annotations:
-#    testgrid-dashboards: sig-node-kubelet
-#    testgrid-tab-name: kubelet-serial-gce-e2e-topology-manager
-#    testgrid-alert-email: vpickard@redhat.com, klueska@gmail.com
-#
 # TODO: migrate hugepages special config tests to containerd/cri-o
 #- name: ci-kubernetes-node-kubelet-serial-hugepages
 #  interval: 4h
@@ -173,39 +109,6 @@ periodics:
 #    testgrid-dashboards: sig-node-kubelet
 #    testgrid-tab-name: kubelet-serial-gce-e2e-hugepages
 #    testgrid-alert-email: alukiano@redhat.com, eduard.bartosh@intel.com
-#
-# TODO: migrate CPU manager special config tests to containerd/cri-o
-#- name: ci-kubernetes-node-kubelet-serial-memory-manager
-#  interval: 4h
-#  labels:
-#    preset-service-account: "true"
-#    preset-k8s-ssh: "true"
-#  spec:
-#    containers:
-#      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211214-291c9e67f9-master
-#        args:
-#          - --repo=k8s.io/kubernetes=master
-#          - --timeout=240
-#          - --root=/go/src
-#          - --scenario=kubernetes_e2e
-#          - --
-#          - --deployment=node
-#          - --gcp-project-type=node-e2e-project
-#          - --gcp-zone=us-west1-b
-#          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial-cpu-manager.yaml
-#          - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
-#          - --node-tests=true
-#          - --provider=gce
-#          - --test_args=--nodes=1 --focus="\[Feature:MemoryManager\]"
-#          - --timeout=180m
-#        env:
-#          - name: GOPATH
-#            value: /go
-#  annotations:
-#    testgrid-dashboards: sig-node-kubelet
-#    testgrid-tab-name: kubelet-serial-gce-e2e-memory-manager
-#    testgrid-alert-email: alukiano@redhat.com
-#    description: Executes memory manager e2e node tests
 #
 # TODO: migrate swap+docker special config tests to containerd
 #- name: ci-kubernetes-node-swap-ubuntu

--- a/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
+++ b/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
@@ -1,0 +1,16 @@
+# To copy an image between projects:
+# `gcloud compute --project <to-project> disks create <image name> --image=https://www.googleapis.com/compute/v1/projects/<from-project>/global/images/<image-name>`
+# `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
+images:
+  ubuntu:
+    image_family: pipeline-1-20
+    project: ubuntu-os-gke-cloud
+    # Using `n1-standard-4` to enable CPU manager node e2e tests.
+    machine: n1-standard-4
+    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"
+  cos-stable1:
+    image_family: cos-89-lts # deprecated after March 2023 (https://cloud.google.com/container-optimized-os/docs/release-notes)
+    project: cos-cloud
+    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"
+    # Using `n1-standard-4` to enable CPU manager node e2e tests.
+    machine: n1-standard-4

--- a/jobs/e2e_node/crio/latest/image-config-cgrpv1-resource-managers.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-cgrpv1-resource-managers.yaml
@@ -1,0 +1,7 @@
+images:
+  fedora:
+    image_family: fedora-coreos-stable
+    project: fedora-coreos-cloud
+    # Using `n1-standard-4` to enable CPU manager node e2e tests.
+    machine: n1-standard-4
+    metadata: "user-data</workspace/test-infra/jobs/e2e_node/crio/crio.ign"


### PR DESCRIPTION
Fixes: #24654

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>