### PR TITLE
Remove testgrid dashboard to conformance job on ppc64le with docker runtime

### DIFF
--- a/config/testgrids/conformance/conformance-all.yaml
+++ b/config/testgrids/conformance/conformance-all.yaml
@@ -158,9 +158,6 @@ dashboards:
 # ppc64le dashboard
 - name: conformance-ppc64le
   dashboard_tab:
-    - name: Periodic ppc64le conformance test on local cluster
-      test_group_name: ppc64le-conformance
-      description: Runs conformance tests against latest version of kubernetes on local ppc64le cluster"
     - name: Periodic ppc64le conformance test on local cluster with containerd as runtime
       test_group_name: ppc64le-conformance-containerd
       description: Runs conformance tests against latest version of kubernetes with containerd as runtime on local ppc64le cluster"
@@ -392,11 +389,6 @@ test_groups:
   gcs_prefix: cel-conformance/test-logs
 
 #ibm ppc64le test results
-- name: ppc64le-conformance
-  gcs_prefix: ppc64le-kubernetes/logs/periodic-kubernetes-conformance-test-ppc64le
-  days_of_results: 7
-  column_header:
-  - configuration_value: k8s-build-version
 - name: ppc64le-conformance-containerd
   gcs_prefix: ppc64le-kubernetes/logs/periodic-kubernetes-containerd-conformance-test-ppc64le
   days_of_results: 7

--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -44,9 +44,6 @@ dashboards:
 
 - name: sig-node-ppc64le
   dashboard_tab:
-    - name: conformance
-      test_group_name: ppc64le-conformance
-      description: conformance test results for ppc64le ****This is moved under conformance dashboard, WILL BE REMOVED FROM HERE IN THE FUTURE****
     - name: unit-tests
       test_group_name: ppc64le-unit
       description: unit test results for ppc64le


### PR DESCRIPTION
With the recent [change](https://github.com/kubernetes/kubernetes/pull/97252) in Kubernetes that deprecated dockershim from kubelet, we stopped using docker as runtime in our CI jobs and test environments.
Reference: https://kubernetes.io/blog/2020/12/02/dont-panic-kubernetes-and-docker/
Hence removing this mapping in test-infra testgrid to conformance job on ppc64le with docker runtime.