### PR TITLE
Update configuration post-1.23 release

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -411,6 +411,8 @@ branch-protection:
               protect: true
             release-1.21:
               protect: true
+            release-1.22:
+              protect: true
     kubernetes-client:
       protect: true
       required_status_checks:

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -400,7 +400,7 @@ milestone_applier:
     release-0.6: v0.6.x
     release-0.5: v0.5.x
   kubernetes/website:
-    dev-1.23: 1.23
+    dev-1.24: 1.24
 
 repo_milestone:
   # Default maintainer


### PR DESCRIPTION
This PR updates prow config as part of 1.23 post-release work:

* Add branch protection for the `release-1.22` branch on k/website
* Update the milestone applier for the `dev-1.24` branch on k/website 

/cc @kubernetes/sig-docs-leads
