### PR TITLE
Move ppc64le results to a separate ibm dashboard group

### DIFF
--- a/config/testgrids/conformance/conformance-all.yaml
+++ b/config/testgrids/conformance/conformance-all.yaml
@@ -388,14 +388,6 @@ test_groups:
 - name: cel-go-conformance-tests
   gcs_prefix: cel-conformance/test-logs
 
-#ibm ppc64le test results
-- name: ppc64le-conformance-containerd
-  gcs_prefix: ppc64le-kubernetes/logs/periodic-kubernetes-containerd-conformance-test-ppc64le
-  days_of_results: 7
-  column_header:
-  - configuration_value: k8s-build-version
-- name: ppc64le-unit
-  gcs_prefix: ppc64le-kubernetes/logs/periodic-kubernetes-unit-test-ppc64le
 - name: pull-kubernetes-e2e-gce-100-performance
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-gce-100-performance
   days_of_results: 60

--- a/config/testgrids/kubernetes/sig-cloud-provider/ibm/OWNERS
+++ b/config/testgrids/kubernetes/sig-cloud-provider/ibm/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+- mkumatag
+- Rajalakshmi-Girish
+approvers:
+- mkumatag

--- a/config/testgrids/kubernetes/sig-cloud-provider/ibm/config.yaml
+++ b/config/testgrids/kubernetes/sig-cloud-provider/ibm/config.yaml
@@ -1,0 +1,27 @@
+dashboard_groups:
+- name: ibm
+  dashboard_names:
+    - ibm-conformance-ppc64le
+    - ibm-unit-tests-ppc64le
+
+dashboards:
+- name: ibm-conformance-ppc64le
+  dashboard_tab:
+    - name: Periodic Conformance on ppc64le with containerd as runtime
+      description: Runs conformance tests using kubetest2 against latest kubernetes nightly release on ibm ppc64le architecture with containerd as runtime
+      test_group_name: ppc64le-conformance-containerd
+- name: ibm-unit-tests-ppc64le
+  dashboard_tab:
+    - name: Periodic unit test suite on ppc64le
+      description: Runs unit tests on ibm ppc64le architecture
+      test_group_name: ppc64le-unit
+
+
+test_groups:
+- name: ppc64le-conformance-containerd
+  gcs_prefix: ppc64le-kubernetes/logs/periodic-kubernetes-containerd-conformance-test-ppc64le
+  days_of_results: 7
+  column_header:
+  - configuration_value: k8s-build-version
+- name: ppc64le-unit
+  gcs_prefix: ppc64le-kubernetes/logs/periodic-kubernetes-unit-test-ppc64le

--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -6,7 +6,6 @@ dashboard_groups:
     - sig-node-cadvisor
     - sig-node-kubelet
     - sig-node-containerd
-    - sig-node-ppc64le
     - sig-node-cri-o
     - sig-node-cri-tools
     - sig-node-node-feature-discovery
@@ -41,12 +40,6 @@ dashboards:
     - name: pull-e2e-podutil
       test_group_name: pull-kubernetes-node-e2e-podutil
       base_options: width=10
-
-- name: sig-node-ppc64le
-  dashboard_tab:
-    - name: unit-tests
-      test_group_name: ppc64le-unit
-      description: unit test results for ppc64le
 
 - name: sig-node-cri-o
   dashboard_tab:

--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -54,6 +54,7 @@ var (
 		"google",
 		"kopeio",
 		"redhat",
+		"ibm",
 		"vmware",
 		"gardener",
 		"jetstack",


### PR DESCRIPTION
This change is to move the conformance and unit test dashboards in test grid to a new ibm dashboard group.

As part of testgrid cleanup task https://github.com/kubernetes/test-infra/issues/23231, having a dashboard group for ibm ppc64le seems ideal.

@mkumatag ^^