### PR TITLE
Prow jobs defined in .yml files are also respected

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -513,7 +513,7 @@ config_updater:
       clusters:
         test-infra-trusted:
           - default
-    config/jobs/**/*.yaml:
+    config/jobs/**/*.{yaml,yml}:
       name: job-config
       gzip: true
       clusters:


### PR DESCRIPTION
This is already feasible from prow side, just need to update config_updater glob to respect yml

/cc @cjwagner 