### PR TITLE
[sig-windows-networking] Drop WS SAC 2004 support from CNI CI

### DIFF
--- a/config/testgrids/kubernetes/sig-windows/config.yaml
+++ b/config/testgrids/kubernetes/sig-windows/config.yaml
@@ -51,12 +51,6 @@ dashboards:
   - name: ltsc2019-containerd-flannel-sdnoverlay-stable
     description: Runs Windows (LTSC 2019 with Containerd) E2E tests on stable branch K8s clusters and latest Flannel CNI release in overlay network mode.
     test_group_name: k8s-e2e-ltsc2019-containerd-flannel-sdnoverlay-stable
-  - name: sac2004-containerd-flannel-sdnbridge-stable
-    description: Runs Windows (SAC 2004 with Containerd) E2E tests on stable branch K8s clusters and latest Flannel CNI release in l2bridge network mode.
-    test_group_name: k8s-e2e-sac2004-containerd-flannel-sdnbridge-stable
-  - name: sac2004-containerd-flannel-sdnoverlay-stable
-    description: Runs Windows (SAC 2004 with Containerd) E2E tests on stable branch K8s clusters and latest Flannel CNI release in overlay network mode.
-    test_group_name: k8s-e2e-sac2004-containerd-flannel-sdnoverlay-stable
   - name: ltsc2022-containerd-flannel-sdnbridge-stable
     description: Runs Windows (LTSC 2022 with Containerd) E2E tests on stable branch K8s clusters and latest Flannel CNI release in l2bridge network mode.
     test_group_name: k8s-e2e-ltsc2022-containerd-flannel-sdnbridge-stable
@@ -94,10 +88,6 @@ test_groups:
   gcs_prefix: k8s-ovn/logs/k8s-e2e-ltsc2019-containerd-flannel-sdnbridge-stable
 - name: k8s-e2e-ltsc2019-containerd-flannel-sdnoverlay-stable
   gcs_prefix: k8s-ovn/logs/k8s-e2e-ltsc2019-containerd-flannel-sdnoverlay-stable
-- name: k8s-e2e-sac2004-containerd-flannel-sdnbridge-stable
-  gcs_prefix: k8s-ovn/logs/k8s-e2e-sac2004-containerd-flannel-sdnbridge-stable
-- name: k8s-e2e-sac2004-containerd-flannel-sdnoverlay-stable
-  gcs_prefix: k8s-ovn/logs/k8s-e2e-sac2004-containerd-flannel-sdnoverlay-stable
 - name: k8s-e2e-ltsc2022-containerd-flannel-sdnbridge-stable
   gcs_prefix: k8s-ovn/logs/k8s-e2e-ltsc2022-containerd-flannel-sdnbridge-stable
 - name: k8s-e2e-ltsc2022-containerd-flannel-sdnoverlay-stable


### PR DESCRIPTION
The Windows Server (SAC) 2004 reached end of servicing.