### PR TITLE
Removing remaining Windows SAC 2004 jobs targeting master

### DIFF
--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-windows.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-windows.yaml
@@ -89,50 +89,6 @@ periodics:
     testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver
     testgrid-tab-name: ci-win20h2-containerd-gcp-compute-persistent-disk-csi-driver
     description: Kubernetes Integration tests for Kubernetes Master branch and Driver latest on Windows 20H2 with Containerd
-- name: ci-gce-pd-csi-driver-latest-k8s-master-windows-2004
-  decorate: true
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: gcp-compute-persistent-disk-csi-driver
-    base_ref: master
-    path_alias: sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
-  interval: 4h
-  labels:
-    preset-k8s-ssh: "true"
-    preset-service-account: "true"
-    preset-common-gce-windows: "true"
-    preset-e2e-gce-windows: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-dind-enabled: "true"
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --check-leaked-resources
-      - --cluster=
-      - --extract=ci/latest
-      - --gcp-zone=us-west1-b
-      - --ginkgo-parallel=8
-      - --provider=gce
-      - --gcp-nodes=2
-      - --test=false
-      - --test-cmd=$GOPATH/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/test/run-windows-k8s-integration.sh
-      - --timeout=120m
-      env:
-      - name: WINDOWS_NODE_OS_DISTRIBUTION
-        value: "win2004"
-      - name: PREPULL_YAML
-        value: "prepull-head.yaml"
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211217-ea95cec1d4-master
-      securityContext:
-          privileged: true
-  annotations:
-    testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver
-    testgrid-tab-name: ci-win2004-provider-gcp-compute-persistent-disk-csi-driver
-    description: Kubernetes Integration tests for Kubernetes Master branch and Driver latest
 - name: ci-gce-pd-csi-driver-latest-k8s-master-windows-20h2
   decorate: true
   extra_refs:
@@ -220,52 +176,6 @@ periodics:
   annotations:
     testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver
     testgrid-tab-name: ci-win2019-provider-gcp-compute-persistent-disk-csi-driver
-    description: Kubernetes Integration tests for Kubernetes Master branch and Driver latest
-- name: ci-gce-pd-csi-driver-latest-k8s-master-windows-2004-migration
-  decorate: true
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: gcp-compute-persistent-disk-csi-driver
-    base_ref: master
-    path_alias: sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
-  interval: 4h
-  labels:
-    preset-k8s-ssh: "true"
-    preset-service-account: "true"
-    preset-common-gce-windows: "true"
-    preset-e2e-gce-windows: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-dind-enabled: "true"
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --check-leaked-resources
-      - --cluster=
-      - --extract=ci/latest
-      - --gcp-zone=us-west1-b
-      - --ginkgo-parallel=8
-      - --provider=gce
-      - --gcp-nodes=2
-      - --test=false
-      - --test-cmd=$GOPATH/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/test/run-k8s-windows-migration.sh
-      - --timeout=120m
-      env:
-      - name: WINDOWS_NODE_OS_DISTRIBUTION
-        value: "win2004"
-      - name: PREPULL_YAML
-        value: "prepull-head.yaml"
-      - name: KUBE_FEATURE_GATES
-        value: "CSIMigrationGCE=true"
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211217-ea95cec1d4-master
-      securityContext:
-          privileged: true
-  annotations:
-    testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver
-    testgrid-tab-name: ci-win2004-provider-gcp-compute-persistent-disk-csi-driver-migration
     description: Kubernetes Integration tests for Kubernetes Master branch and Driver latest
 - name: ci-gce-pd-csi-driver-latest-k8s-master-windows-20h2-migration
   decorate: true

--- a/config/testgrids/kubernetes/sig-windows/config.yaml
+++ b/config/testgrids/kubernetes/sig-windows/config.yaml
@@ -59,9 +59,6 @@ dashboards:
     test_group_name: k8s-e2e-ltsc2022-containerd-flannel-sdnoverlay-stable
 - name: sig-windows-containerd-runtime-signal
   dashboard_tab:
-  - name: win-2004-containerd-master-integration
-    description: Runs containerd integration & cri-integration tests on Windows (SAC 2004)
-    test_group_name: integration-containerd-windows-sac2004
   - name: win-2019-containerd-master-integration
     description: Runs containerd integration & cri-integration tests on Windows (LTSC 2019)
     test_group_name: integration-containerd-windows-ltsc2019
@@ -93,9 +90,6 @@ test_groups:
 - name: k8s-e2e-ltsc2022-containerd-flannel-sdnoverlay-stable
   gcs_prefix: k8s-ovn/logs/k8s-e2e-ltsc2022-containerd-flannel-sdnoverlay-stable
 # Containerd Runtime integration test groups
-- name: integration-containerd-windows-sac2004
-  gcs_prefix: containerd-integration/logs/windows-sac2004
-  disable_prowjob_analysis: true
 - name: integration-containerd-windows-ltsc2019
   gcs_prefix: containerd-integration/logs/windows-ltsc2019
   disable_prowjob_analysis: true


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

Removing Windows Server 2004 jobs that target master since it is no longer supported.

/sig windows
/assign @jsturtevant @pjh @ibabou @jingxu97 

Related to https://github.com/kubernetes/kubernetes/pull/107055

