### PR TITLE
crier/gh reporter: only create comment for valid PJs

### DIFF
--- a/prow/github/report/report.go
+++ b/prow/github/report/report.go
@@ -172,7 +172,7 @@ func ReportComment(ctx context.Context, ghc GitHubClient, reportTemplate *templa
 	// whether to report or not.
 	refs := validPjs[0].Spec.Refs
 	// we are not reporting for batch jobs, we can consider support that in the future
-	if len(refs.Pulls) != 1 {
+	if refs == nil || len(refs.Pulls) != 1 {
 		return nil
 	}
 
@@ -184,14 +184,14 @@ func ReportComment(ctx context.Context, ghc GitHubClient, reportTemplate *templa
 	if err != nil {
 		return fmt.Errorf("error getting bot name checker: %w", err)
 	}
-	deletes, entries, updateID := parseIssueComments(pjs, botNameChecker, ics)
+	deletes, entries, updateID := parseIssueComments(validPjs, botNameChecker, ics)
 	for _, delete := range deletes {
 		if err := ghc.DeleteCommentWithContext(ctx, refs.Org, refs.Repo, delete); err != nil {
 			return fmt.Errorf("error deleting comment: %w", err)
 		}
 	}
 	if len(entries) > 0 || mustCreate {
-		comment, err := createComment(reportTemplate, pjs, entries)
+		comment, err := createComment(reportTemplate, validPjs, entries)
 		if err != nil {
 			return fmt.Errorf("generating comment: %w", err)
 		}


### PR DESCRIPTION
The code contains several assumptions that the entering ProwJob slice
always contains non-nil `Refs` (which is not true for periodics). The
code filters the valid prowjobs but then uses the unfiltered slice,
leaving the not-to-be-reported Prowjobs in. This only happens in
summary_comment mode though: in default mode the slice always contains
exactly one prowjob and the existing safety checks are sufficient.

This is not a full fix for the case when someone deliberately enables GH
reporter for `periodics`, but it eliminates the problem for the default
case.

Fixes: https://github.com/kubernetes/test-infra/issues/24698