### PR TITLE
Added entry in testgrid for v1.23 conformance results of s390x

### DIFF
--- a/config/testgrids/conformance/conformance-all.yaml
+++ b/config/testgrids/conformance/conformance-all.yaml
@@ -347,6 +347,9 @@ dashboards:
     - name: Periodic s390x conformance test on local cluster
       test_group_name: s390x-conformance
       description: Runs conformance tests by using kubetest against latest master version of kubernetes on local s390x cluster
+    - name: Periodic s390x conformance test on local cluster , v1.23
+      test_group_name: s390x-conformance-v1.23
+      description: Runs conformance tests by using kubetest against latest v1.23 branch HEAD of kubernetes on local s390x cluster
     - name: Periodic s390x conformance test on local cluster , v1.22
       test_group_name: s390x-conformance-v1.22
       description: Runs conformance tests by using kubetest against latest v1.22 branch HEAD of kubernetes on local s390x cluster
@@ -356,12 +359,6 @@ dashboards:
     - name: Periodic s390x conformance test on local cluster , v1.20
       test_group_name: s390x-conformance-v1.20
       description: Runs conformance tests by using kubetest against latest v1.20 branch HEAD of kubernetes on local s390x cluster
-    - name: Periodic s390x conformance test on local cluster , v1.19
-      test_group_name: s390x-conformance-v1.19
-      description: Runs conformance tests by using kubetest against latest v1.19 branch HEAD of kubernetes on local s390x cluster
-    - name: Periodic s390x conformance test on local cluster , v1.18
-      test_group_name: s390x-conformance-v1.18
-      description: Runs conformance tests by using kubetest against latest v1.18 branch HEAD of kubernetes on local s390x cluster
 
 # CEL Conformance Tests
 - name: google-cel
@@ -409,16 +406,14 @@ test_groups:
 #IBM s390x test results
 - name: s390x-conformance
   gcs_prefix: k8s-conform-s390x-k8s/logs/ci-k8s-conformance-s390x
+- name: s390x-conformance-v1.23
+  gcs_prefix: k8s-conform-s390x-k8s/logs/ci-k8s-conformance-s390x-v1.23
 - name: s390x-conformance-v1.22
   gcs_prefix: k8s-conform-s390x-k8s/logs/ci-k8s-conformance-s390x-v1.22
 - name: s390x-conformance-v1.21
   gcs_prefix: k8s-conform-s390x-k8s/logs/ci-k8s-conformance-s390x-v1.21
 - name: s390x-conformance-v1.20
   gcs_prefix: k8s-conform-s390x-k8s/logs/ci-k8s-conformance-s390x-v1.20
-- name: s390x-conformance-v1.19
-  gcs_prefix: k8s-conform-s390x-k8s/logs/ci-k8s-conformance-s390x-v1.19
-- name: s390x-conformance-v1.18
-  gcs_prefix: k8s-conform-s390x-k8s/logs/ci-k8s-conformance-s390x-v1.18
 
 # google-gce-compute-image-tools
 - name: ci-daisy-e2e


### PR DESCRIPTION
Added entry in testgrid for v1.23 conformance results of s390x and removed test results entries for v1.18 and v1.19