### PR TITLE
Bump Go version for cli-utils build

### DIFF
--- a/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
+++ b/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
@@ -9,7 +9,7 @@ presubmits:
     - ^release-.*$
     spec:
       containers:
-      - image: golang:1.16.4
+      - image: golang:1.17.6
         command:
         - make
         args:


### PR DESCRIPTION
Trying to bump dependencies to Kube 1.23.1 (https://github.com/kubernetes-sigs/cli-utils/pull/497) and ran into a build failure (https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cli-utils/497/cli-utils-presubmit-master/1472089142102855680).

/assign @mortent 