### PR TITLE
Remove typecheck for dockerless build tag

### DIFF
--- a/config/jobs/kubernetes/sig-testing/typecheck.yaml
+++ b/config/jobs/kubernetes/sig-testing/typecheck.yaml
@@ -32,4 +32,4 @@ presubmits:
         env:
         # Space separated list of the checks to run
         - name: WHAT
-          value: typecheck typecheck-providerless typecheck-dockerless
+          value: typecheck typecheck-providerless


### PR DESCRIPTION
As part of the removal of dockershim, we should also the `dockerless` build tag.

xRef: https://github.com/kubernetes/kubernetes/pull/107119