### PR TITLE
Generate 1.23 prow config for the CSI repos

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
@@ -2,102 +2,6 @@
 
 presubmits:
   kubernetes-csi/csi-driver-host-path:
-  - name: pull-kubernetes-csi-csi-driver-host-path-1-20-on-kubernetes-1-20
-    always_run: true
-    optional: false
-    decorate: true
-    skip_report: false
-    skip_branches: []
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
-      testgrid-tab-name: 1-20-on-kubernetes-1-20
-      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.20 on Kubernetes 1.20
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.20.0"
-        - name: CSI_PROW_USE_BAZEL
-          value: "true"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.20"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.7.2"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v4.0.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 2000m
-  - name: pull-kubernetes-csi-csi-driver-host-path-1-20-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
-      testgrid-tab-name: 1-20-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.20 on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_USE_BAZEL
-          value: "false"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.7.2"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
   - name: pull-kubernetes-csi-csi-driver-host-path-1-21-on-kubernetes-1-21
     always_run: true
     optional: false
@@ -196,7 +100,7 @@ presubmits:
           cpu: 2000m
   - name: pull-kubernetes-csi-csi-driver-host-path-1-22-on-kubernetes-1-22
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: []
@@ -239,13 +143,9 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+        resources:
+          requests:
+            cpu: 2000m
   - name: pull-kubernetes-csi-csi-driver-host-path-1-22-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -294,55 +194,7 @@ presubmits:
           memory: "9000Mi"
           # during the tests more like 3-20m is used
           cpu: 2000m
-  - name: pull-kubernetes-csi-csi-driver-host-path-alpha-1-21-on-kubernetes-1-21
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    skip_branches: []
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
-      testgrid-tab-name: alpha-1-21-on-kubernetes-1-21
-      description: Kubernetes-CSI pull job in repo csi-driver-host-path for alpha tests, using deployment 1.21 on Kubernetes 1.21
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.21.0"
-        - name: CSI_PROW_USE_BAZEL
-          value: "false"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.21"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.7.2"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v4.0.0"
-        - name: CSI_PROW_TESTS
-          value: "serial-alpha parallel-alpha"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 2000m
-  - name: pull-kubernetes-csi-csi-driver-host-path-1-20-test-on-kubernetes-1-20
+  - name: pull-kubernetes-csi-csi-driver-host-path-1-23-on-kubernetes-1-23
     always_run: true
     optional: true
     decorate: true
@@ -354,8 +206,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-storage-csi-csi-driver-host-path
-      testgrid-tab-name: 1-20-test-on-kubernetes-1-20
-      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.20-test on Kubernetes 1.20
+      testgrid-tab-name: 1-23-on-kubernetes-1-23
+      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.23 on Kubernetes 1.23
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -371,13 +223,13 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.20.0"
+          value: "1.23.0"
         - name: CSI_PROW_USE_BAZEL
-          value: "true"
+          value: "false"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.20"
+          value: "1.23"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: "-test"
+          value: ""
         - name: CSI_PROW_DRIVER_VERSION
           value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
@@ -387,10 +239,14 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        resources:
-          requests:
-            cpu: 2000m
-  - name: pull-kubernetes-csi-csi-driver-host-path-1-20-test-on-kubernetes-master
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+  - name: pull-kubernetes-csi-csi-driver-host-path-1-23-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
@@ -405,8 +261,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-storage-csi-csi-driver-host-path
-      testgrid-tab-name: 1-20-test-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.20-test on Kubernetes master
+      testgrid-tab-name: 1-23-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.23 on Kubernetes master
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -423,7 +279,7 @@ presubmits:
         - name: CSI_PROW_DRIVER_VERSION
           value: "v1.7.2"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: "-test"
+          value: ""
         - name: CSI_SNAPSHOTTER_VERSION
           value: "master"
         - name: CSI_PROW_TESTS
@@ -438,6 +294,54 @@ presubmits:
           memory: "9000Mi"
           # during the tests more like 3-20m is used
           cpu: 2000m
+  - name: pull-kubernetes-csi-csi-driver-host-path-alpha-1-22-on-kubernetes-1-22
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: []
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
+      testgrid-tab-name: alpha-1-22-on-kubernetes-1-22
+      description: Kubernetes-CSI pull job in repo csi-driver-host-path for alpha tests, using deployment 1.22 on Kubernetes 1.22
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.22.0"
+        - name: CSI_PROW_USE_BAZEL
+          value: "false"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.22"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.7.2"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v4.0.0"
+        - name: CSI_PROW_TESTS
+          value: "serial-alpha parallel-alpha"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 2000m
   - name: pull-kubernetes-csi-csi-driver-host-path-1-21-test-on-kubernetes-1-21
     always_run: true
     optional: true
@@ -579,13 +483,9 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+        resources:
+          requests:
+            cpu: 2000m
   - name: pull-kubernetes-csi-csi-driver-host-path-1-22-test-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -634,8 +534,8 @@ presubmits:
           memory: "9000Mi"
           # during the tests more like 3-20m is used
           cpu: 2000m
-  - name: pull-kubernetes-csi-csi-driver-host-path-alpha-1-21-test-on-kubernetes-1-21
-    always_run: false
+  - name: pull-kubernetes-csi-csi-driver-host-path-1-23-test-on-kubernetes-1-23
+    always_run: true
     optional: true
     decorate: true
     skip_report: false
@@ -646,8 +546,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-storage-csi-csi-driver-host-path
-      testgrid-tab-name: alpha-1-21-test-on-kubernetes-1-21
-      description: Kubernetes-CSI pull job in repo csi-driver-host-path for alpha tests, using deployment 1.21-test on Kubernetes 1.21
+      testgrid-tab-name: 1-23-test-on-kubernetes-1-23
+      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.23-test on Kubernetes 1.23
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -663,11 +563,111 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.21.0"
+          value: "1.23.0"
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.21"
+          value: "1.23"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: "-test"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.7.2"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v4.0.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+  - name: pull-kubernetes-csi-csi-driver-host-path-1-23-test-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
+      testgrid-tab-name: 1-23-test-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.23-test on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_USE_BAZEL
+          value: "false"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.7.2"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: "-test"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+  - name: pull-kubernetes-csi-csi-driver-host-path-alpha-1-22-test-on-kubernetes-1-22
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: []
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
+      testgrid-tab-name: alpha-1-22-test-on-kubernetes-1-22
+      description: Kubernetes-CSI pull job in repo csi-driver-host-path for alpha tests, using deployment 1.22-test on Kubernetes 1.22
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.22.0"
+        - name: CSI_PROW_USE_BAZEL
+          value: "false"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.22"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: "-test"
         - name: CSI_PROW_DRIVER_VERSION
@@ -719,202 +719,6 @@ presubmits:
           cpu: 2000m
 
 periodics:
-- interval: 6h
-  name: ci-kubernetes-csi-1-20-on-kubernetes-1-20
-  decorate: true
-  extra_refs:
-  - org: kubernetes-csi
-    repo: csi-driver-host-path
-    base_ref: master
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "false"
-    preset-kind-volume-mounts: "true"
-  annotations:
-    testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: 1.20-on-1.20
-    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.20 on Kubernetes 1.20
-  spec:
-    containers:
-    # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
-      command:
-      - runner.sh
-      args:
-      - ./.prow.sh
-      env:
-      - name: CSI_PROW_KUBERNETES_VERSION
-        value: "release-1.20"
-      - name: CSI_PROW_USE_BAZEL
-        value: "true"
-      - name: CSI_SNAPSHOTTER_VERSION
-        value: "v4.0.0"
-      - name: CSI_PROW_BUILD_JOB
-        value: "false"
-      - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.20"
-      - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: ""
-      - name: CSI_PROW_TESTS
-        value: "sanity serial parallel"
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
-- interval: 6h
-  name: ci-kubernetes-csi-1-20-on-kubernetes-1-21
-  decorate: true
-  extra_refs:
-  - org: kubernetes-csi
-    repo: csi-driver-host-path
-    base_ref: master
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "false"
-    preset-kind-volume-mounts: "true"
-  annotations:
-    testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: 1.20-on-1.21
-    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.20 on Kubernetes 1.21
-  spec:
-    containers:
-    # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
-      command:
-      - runner.sh
-      args:
-      - ./.prow.sh
-      env:
-      - name: CSI_PROW_KUBERNETES_VERSION
-        value: "release-1.21"
-      - name: CSI_PROW_USE_BAZEL
-        value: "false"
-      - name: CSI_SNAPSHOTTER_VERSION
-        value: "v4.0.0"
-      - name: CSI_PROW_BUILD_JOB
-        value: "false"
-      - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.20"
-      - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: ""
-      - name: CSI_PROW_TESTS
-        value: "sanity serial parallel"
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
-- interval: 6h
-  name: ci-kubernetes-csi-1-20-on-kubernetes-1-22
-  decorate: true
-  extra_refs:
-  - org: kubernetes-csi
-    repo: csi-driver-host-path
-    base_ref: master
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "false"
-    preset-kind-volume-mounts: "true"
-  annotations:
-    testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: 1.20-on-1.22
-    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.20 on Kubernetes 1.22
-  spec:
-    containers:
-    # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
-      command:
-      - runner.sh
-      args:
-      - ./.prow.sh
-      env:
-      - name: CSI_PROW_KUBERNETES_VERSION
-        value: "release-1.22"
-      - name: CSI_PROW_USE_BAZEL
-        value: "false"
-      - name: CSI_SNAPSHOTTER_VERSION
-        value: "v4.0.0"
-      - name: CSI_PROW_BUILD_JOB
-        value: "false"
-      - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.20"
-      - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: ""
-      - name: CSI_PROW_TESTS
-        value: "sanity serial parallel"
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
-- interval: 6h
-  name: ci-kubernetes-csi-1-20-on-kubernetes-master
-  decorate: true
-  extra_refs:
-  - org: kubernetes-csi
-    repo: csi-driver-host-path
-    base_ref: master
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  annotations:
-    testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: 1.20-on-master
-    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.20 on Kubernetes master
-  spec:
-    containers:
-    # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
-      command:
-      - runner.sh
-      args:
-      - ./.prow.sh
-      env:
-      - name: CSI_PROW_KUBERNETES_VERSION
-        value: "latest"
-      - name: CSI_PROW_USE_BAZEL
-        value: "false"
-      - name: CSI_SNAPSHOTTER_VERSION
-        value: "master"
-      - name: CSI_PROW_BUILD_JOB
-        value: "false"
-      - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.20"
-      - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: ""
-      - name: CSI_PROW_TESTS
-        value: "sanity serial parallel"
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-        resources:
-          requests:
-            cpu: 2000m
 - interval: 6h
   name: ci-kubernetes-csi-1-21-on-kubernetes-1-21
   decorate: true
@@ -993,6 +797,56 @@ periodics:
       env:
       - name: CSI_PROW_KUBERNETES_VERSION
         value: "release-1.22"
+      - name: CSI_PROW_USE_BAZEL
+        value: "false"
+      - name: CSI_SNAPSHOTTER_VERSION
+        value: "v4.0.0"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-1.21"
+      - name: CSI_PROW_DEPLOYMENT_SUFFIX
+        value: ""
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+- interval: 6h
+  name: ci-kubernetes-csi-1-21-on-kubernetes-1-23
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "false"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi-ci
+    testgrid-tab-name: 1.21-on-1.23
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.21 on Kubernetes 1.23
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "release-1.23"
       - name: CSI_PROW_USE_BAZEL
         value: "false"
       - name: CSI_SNAPSHOTTER_VERSION
@@ -1112,6 +966,56 @@ periodics:
           # during the tests more like 3-20m is used
           cpu: 2000m
 - interval: 6h
+  name: ci-kubernetes-csi-1-22-on-kubernetes-1-23
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "false"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi-ci
+    testgrid-tab-name: 1.22-on-1.23
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.22 on Kubernetes 1.23
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "release-1.23"
+      - name: CSI_PROW_USE_BAZEL
+        value: "false"
+      - name: CSI_SNAPSHOTTER_VERSION
+        value: "v4.0.0"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-1.22"
+      - name: CSI_PROW_DEPLOYMENT_SUFFIX
+        value: ""
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+- interval: 6h
   name: ci-kubernetes-csi-1-22-on-kubernetes-master
   decorate: true
   extra_refs:
@@ -1158,7 +1062,7 @@ periodics:
           requests:
             cpu: 2000m
 - interval: 6h
-  name: ci-kubernetes-csi-1-20-test-on-kubernetes-1-20
+  name: ci-kubernetes-csi-1-23-on-kubernetes-1-23
   decorate: true
   extra_refs:
   - org: kubernetes-csi
@@ -1171,9 +1075,9 @@ periodics:
     preset-kind-volume-mounts: "true"
   annotations:
     testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: 1.20-test-on-1.20
+    testgrid-tab-name: 1.23-on-1.23
     testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.20-test on Kubernetes 1.20
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.23 on Kubernetes 1.23
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
@@ -1184,17 +1088,17 @@ periodics:
       - ./.prow.sh
       env:
       - name: CSI_PROW_KUBERNETES_VERSION
-        value: "release-1.20"
+        value: "release-1.23"
       - name: CSI_PROW_USE_BAZEL
-        value: "true"
+        value: "false"
       - name: CSI_SNAPSHOTTER_VERSION
         value: "v4.0.0"
       - name: CSI_PROW_BUILD_JOB
         value: "false"
       - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.20"
+        value: "kubernetes-1.23"
       - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: "-test"
+        value: ""
       - name: CSI_PROW_TESTS
         value: "sanity serial parallel"
       # docker-in-docker needs privileged mode
@@ -1208,107 +1112,7 @@ periodics:
           # during the tests more like 3-20m is used
           cpu: 2000m
 - interval: 6h
-  name: ci-kubernetes-csi-1-20-test-on-kubernetes-1-21
-  decorate: true
-  extra_refs:
-  - org: kubernetes-csi
-    repo: csi-driver-host-path
-    base_ref: master
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "false"
-    preset-kind-volume-mounts: "true"
-  annotations:
-    testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: 1.20-test-on-1.21
-    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.20-test on Kubernetes 1.21
-  spec:
-    containers:
-    # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
-      command:
-      - runner.sh
-      args:
-      - ./.prow.sh
-      env:
-      - name: CSI_PROW_KUBERNETES_VERSION
-        value: "release-1.21"
-      - name: CSI_PROW_USE_BAZEL
-        value: "false"
-      - name: CSI_SNAPSHOTTER_VERSION
-        value: "v4.0.0"
-      - name: CSI_PROW_BUILD_JOB
-        value: "false"
-      - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.20"
-      - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: "-test"
-      - name: CSI_PROW_TESTS
-        value: "sanity serial parallel"
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
-- interval: 6h
-  name: ci-kubernetes-csi-1-20-test-on-kubernetes-1-22
-  decorate: true
-  extra_refs:
-  - org: kubernetes-csi
-    repo: csi-driver-host-path
-    base_ref: master
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "false"
-    preset-kind-volume-mounts: "true"
-  annotations:
-    testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: 1.20-test-on-1.22
-    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.20-test on Kubernetes 1.22
-  spec:
-    containers:
-    # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
-      command:
-      - runner.sh
-      args:
-      - ./.prow.sh
-      env:
-      - name: CSI_PROW_KUBERNETES_VERSION
-        value: "release-1.22"
-      - name: CSI_PROW_USE_BAZEL
-        value: "false"
-      - name: CSI_SNAPSHOTTER_VERSION
-        value: "v4.0.0"
-      - name: CSI_PROW_BUILD_JOB
-        value: "false"
-      - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.20"
-      - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: "-test"
-      - name: CSI_PROW_TESTS
-        value: "sanity serial parallel"
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
-- interval: 6h
-  name: ci-kubernetes-csi-1-20-test-on-kubernetes-master
+  name: ci-kubernetes-csi-1-23-on-kubernetes-master
   decorate: true
   extra_refs:
   - org: kubernetes-csi
@@ -1321,9 +1125,9 @@ periodics:
     preset-kind-volume-mounts: "true"
   annotations:
     testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: 1.20-test-on-master
+    testgrid-tab-name: 1.23-on-master
     testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.20-test on Kubernetes master
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.23 on Kubernetes master
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
@@ -1342,9 +1146,9 @@ periodics:
       - name: CSI_PROW_BUILD_JOB
         value: "false"
       - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.20"
+        value: "kubernetes-1.23"
       - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: "-test"
+        value: ""
       - name: CSI_PROW_TESTS
         value: "sanity serial parallel"
       # docker-in-docker needs privileged mode
@@ -1431,6 +1235,56 @@ periodics:
       env:
       - name: CSI_PROW_KUBERNETES_VERSION
         value: "release-1.22"
+      - name: CSI_PROW_USE_BAZEL
+        value: "false"
+      - name: CSI_SNAPSHOTTER_VERSION
+        value: "v4.0.0"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-1.21"
+      - name: CSI_PROW_DEPLOYMENT_SUFFIX
+        value: "-test"
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+- interval: 6h
+  name: ci-kubernetes-csi-1-21-test-on-kubernetes-1-23
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "false"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi-ci
+    testgrid-tab-name: 1.21-test-on-1.23
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.21-test on Kubernetes 1.23
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "release-1.23"
       - name: CSI_PROW_USE_BAZEL
         value: "false"
       - name: CSI_SNAPSHOTTER_VERSION
@@ -1550,6 +1404,56 @@ periodics:
           # during the tests more like 3-20m is used
           cpu: 2000m
 - interval: 6h
+  name: ci-kubernetes-csi-1-22-test-on-kubernetes-1-23
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "false"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi-ci
+    testgrid-tab-name: 1.22-test-on-1.23
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.22-test on Kubernetes 1.23
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "release-1.23"
+      - name: CSI_PROW_USE_BAZEL
+        value: "false"
+      - name: CSI_SNAPSHOTTER_VERSION
+        value: "v4.0.0"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-1.22"
+      - name: CSI_PROW_DEPLOYMENT_SUFFIX
+        value: "-test"
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+- interval: 6h
   name: ci-kubernetes-csi-1-22-test-on-kubernetes-master
   decorate: true
   extra_refs:
@@ -1596,7 +1500,57 @@ periodics:
           requests:
             cpu: 2000m
 - interval: 6h
-  name: ci-kubernetes-csi-canary-on-kubernetes-1-20
+  name: ci-kubernetes-csi-1-23-test-on-kubernetes-1-23
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "false"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi-ci
+    testgrid-tab-name: 1.23-test-on-1.23
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.23-test on Kubernetes 1.23
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "release-1.23"
+      - name: CSI_PROW_USE_BAZEL
+        value: "false"
+      - name: CSI_SNAPSHOTTER_VERSION
+        value: "v4.0.0"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-1.23"
+      - name: CSI_PROW_DEPLOYMENT_SUFFIX
+        value: "-test"
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+- interval: 6h
+  name: ci-kubernetes-csi-1-23-test-on-kubernetes-master
   decorate: true
   extra_refs:
   - org: kubernetes-csi
@@ -1609,9 +1563,9 @@ periodics:
     preset-kind-volume-mounts: "true"
   annotations:
     testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: canary-on-1.20
+    testgrid-tab-name: 1.23-test-on-master
     testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment canary on Kubernetes 1.20
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.23-test on Kubernetes master
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
@@ -1622,23 +1576,17 @@ periodics:
       - ./.prow.sh
       env:
       - name: CSI_PROW_KUBERNETES_VERSION
-        value: "1.20.0"
+        value: "latest"
       - name: CSI_PROW_USE_BAZEL
-        value: "true"
-      - name: CSI_PROW_BUILD_JOB
         value: "false"
-      # Replace images....
-      - name: CSI_PROW_HOSTPATH_CANARY
-        value: "canary"
-      - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: ""
       - name: CSI_SNAPSHOTTER_VERSION
         value: "master"
-      # ... but the RBAC rules only when testing on master.
-      # The other jobs test against the unmodified deployment for
-      # that Kubernetes version, i.e. with the original RBAC rules.
-      - name: UPDATE_RBAC_RULES
+      - name: CSI_PROW_BUILD_JOB
         value: "false"
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-1.23"
+      - name: CSI_PROW_DEPLOYMENT_SUFFIX
+        value: "-test"
       - name: CSI_PROW_TESTS
         value: "sanity serial parallel"
       # docker-in-docker needs privileged mode
@@ -1727,6 +1675,58 @@ periodics:
       env:
       - name: CSI_PROW_KUBERNETES_VERSION
         value: "1.22.0"
+      - name: CSI_PROW_USE_BAZEL
+        value: "false"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      # Replace images....
+      - name: CSI_PROW_HOSTPATH_CANARY
+        value: "canary"
+      - name: CSI_PROW_DEPLOYMENT_SUFFIX
+        value: ""
+      - name: CSI_SNAPSHOTTER_VERSION
+        value: "master"
+      # ... but the RBAC rules only when testing on master.
+      # The other jobs test against the unmodified deployment for
+      # that Kubernetes version, i.e. with the original RBAC rules.
+      - name: UPDATE_RBAC_RULES
+        value: "false"
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+        resources:
+          requests:
+            cpu: 2000m
+- interval: 6h
+  name: ci-kubernetes-csi-canary-on-kubernetes-1-23
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi-ci
+    testgrid-tab-name: canary-on-1.23
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment canary on Kubernetes 1.23
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "1.23.0"
       - name: CSI_PROW_USE_BAZEL
         value: "false"
       - name: CSI_PROW_BUILD_JOB
@@ -1856,58 +1856,6 @@ periodics:
           requests:
             cpu: 2000m
 - interval: 6h
-  name: ci-kubernetes-csi-canary-test-on-kubernetes-1-20
-  decorate: true
-  extra_refs:
-  - org: kubernetes-csi
-    repo: csi-driver-host-path
-    base_ref: master
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  annotations:
-    testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: canary-test-on-1.20
-    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment canary-test on Kubernetes 1.20
-  spec:
-    containers:
-    # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
-      command:
-      - runner.sh
-      args:
-      - ./.prow.sh
-      env:
-      - name: CSI_PROW_KUBERNETES_VERSION
-        value: "1.20.0"
-      - name: CSI_PROW_USE_BAZEL
-        value: "true"
-      - name: CSI_PROW_BUILD_JOB
-        value: "false"
-      # Replace images....
-      - name: CSI_PROW_HOSTPATH_CANARY
-        value: "canary"
-      - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: "-test"
-      - name: CSI_SNAPSHOTTER_VERSION
-        value: "master"
-      # ... but the RBAC rules only when testing on master.
-      # The other jobs test against the unmodified deployment for
-      # that Kubernetes version, i.e. with the original RBAC rules.
-      - name: UPDATE_RBAC_RULES
-        value: "false"
-      - name: CSI_PROW_TESTS
-        value: "sanity serial parallel"
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-        resources:
-          requests:
-            cpu: 2000m
-- interval: 6h
   name: ci-kubernetes-csi-canary-test-on-kubernetes-1-21
   decorate: true
   extra_refs:
@@ -1987,6 +1935,58 @@ periodics:
       env:
       - name: CSI_PROW_KUBERNETES_VERSION
         value: "1.22.0"
+      - name: CSI_PROW_USE_BAZEL
+        value: "false"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      # Replace images....
+      - name: CSI_PROW_HOSTPATH_CANARY
+        value: "canary"
+      - name: CSI_PROW_DEPLOYMENT_SUFFIX
+        value: "-test"
+      - name: CSI_SNAPSHOTTER_VERSION
+        value: "master"
+      # ... but the RBAC rules only when testing on master.
+      # The other jobs test against the unmodified deployment for
+      # that Kubernetes version, i.e. with the original RBAC rules.
+      - name: UPDATE_RBAC_RULES
+        value: "false"
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+        resources:
+          requests:
+            cpu: 2000m
+- interval: 6h
+  name: ci-kubernetes-csi-canary-test-on-kubernetes-1-23
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi-ci
+    testgrid-tab-name: canary-test-on-1.23
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment canary-test on Kubernetes 1.23
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "1.23.0"
       - name: CSI_PROW_USE_BAZEL
         value: "false"
       - name: CSI_PROW_BUILD_JOB

--- a/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
@@ -50,7 +50,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-storage-csi-other
       testgrid-tab-name: pull-csi-release-tools-in-csi-test
-      description: Kubernetes-CSI pull job in repo csi-release-tools for csi-test, using deployment 1.21 on Kubernetes 1.21
+      description: Kubernetes-CSI pull job in repo csi-release-tools for csi-test, using deployment 1.22 on Kubernetes 1.22
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -61,11 +61,11 @@ presubmits:
         - ./pull-test.sh # provided by csi-release-tools
         env:
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.21.0"
+          value: "1.22.0"
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.21"
+          value: "1.22"
         - name: CSI_PROW_DRIVER_VERSION
           value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
@@ -98,7 +98,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-storage-csi-other
       testgrid-tab-name: pull-csi-release-tools-in-external-provisioner
-      description: Kubernetes-CSI pull job in repo csi-release-tools for external-provisioner, using deployment 1.21 on Kubernetes 1.21
+      description: Kubernetes-CSI pull job in repo csi-release-tools for external-provisioner, using deployment 1.22 on Kubernetes 1.22
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -109,11 +109,11 @@ presubmits:
         - ./pull-test.sh # provided by csi-release-tools
         env:
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.21.0"
+          value: "1.22.0"
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.21"
+          value: "1.22"
         - name: CSI_PROW_DRIVER_VERSION
           value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
@@ -146,7 +146,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-storage-csi-other
       testgrid-tab-name: pull-csi-release-tools-in-external-snapshotter
-      description: Kubernetes-CSI pull job in repo csi-release-tools for external-snapshotter, using deployment 1.21 on Kubernetes 1.21
+      description: Kubernetes-CSI pull job in repo csi-release-tools for external-snapshotter, using deployment 1.22 on Kubernetes 1.22
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -157,11 +157,11 @@ presubmits:
         - ./pull-test.sh # provided by csi-release-tools
         env:
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.21.0"
+          value: "1.22.0"
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.21"
+          value: "1.22"
         - name: CSI_PROW_DRIVER_VERSION
           value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION
@@ -194,7 +194,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-storage-csi-other
       testgrid-tab-name: pull-csi-release-tools-in-csi-driver-host-path
-      description: Kubernetes-CSI pull job in repo csi-release-tools for csi-driver-host-path, using deployment 1.21 on Kubernetes 1.21
+      description: Kubernetes-CSI pull job in repo csi-release-tools for csi-driver-host-path, using deployment 1.22 on Kubernetes 1.22
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -205,11 +205,11 @@ presubmits:
         - ./pull-test.sh # provided by csi-release-tools
         env:
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.21.0"
+          value: "1.22.0"
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.21"
+          value: "1.22"
         - name: CSI_PROW_DRIVER_VERSION
           value: "v1.7.2"
         - name: CSI_SNAPSHOTTER_VERSION

--- a/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
+++ b/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
@@ -2,102 +2,6 @@
 
 presubmits:
   kubernetes-csi/external-attacher:
-  - name: pull-kubernetes-csi-external-attacher-1-20-on-kubernetes-1-20
-    always_run: true
-    optional: false
-    decorate: true
-    skip_report: false
-    skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|v0.1.0)$"]
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-attacher
-      testgrid-tab-name: 1-20-on-kubernetes-1-20
-      description: Kubernetes-CSI pull job in repo external-attacher for non-alpha tests, using deployment 1.20 on Kubernetes 1.20
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.20.0"
-        - name: CSI_PROW_USE_BAZEL
-          value: "true"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.20"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.7.2"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v4.0.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 2000m
-  - name: pull-kubernetes-csi-external-attacher-1-20-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-attacher
-      testgrid-tab-name: 1-20-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo external-attacher for non-alpha tests, using deployment 1.20 on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_USE_BAZEL
-          value: "false"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.7.2"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
   - name: pull-kubernetes-csi-external-attacher-1-21-on-kubernetes-1-21
     always_run: true
     optional: false
@@ -196,7 +100,7 @@ presubmits:
           cpu: 2000m
   - name: pull-kubernetes-csi-external-attacher-1-22-on-kubernetes-1-22
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|v0.1.0)$"]
@@ -239,13 +143,9 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+        resources:
+          requests:
+            cpu: 2000m
   - name: pull-kubernetes-csi-external-attacher-1-22-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -294,8 +194,8 @@ presubmits:
           memory: "9000Mi"
           # during the tests more like 3-20m is used
           cpu: 2000m
-  - name: pull-kubernetes-csi-external-attacher-alpha-1-21-on-kubernetes-1-21
-    always_run: false
+  - name: pull-kubernetes-csi-external-attacher-1-23-on-kubernetes-1-23
+    always_run: true
     optional: true
     decorate: true
     skip_report: false
@@ -306,8 +206,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-storage-csi-external-attacher
-      testgrid-tab-name: alpha-1-21-on-kubernetes-1-21
-      description: Kubernetes-CSI pull job in repo external-attacher for alpha tests, using deployment 1.21 on Kubernetes 1.21
+      testgrid-tab-name: 1-23-on-kubernetes-1-23
+      description: Kubernetes-CSI pull job in repo external-attacher for non-alpha tests, using deployment 1.23 on Kubernetes 1.23
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -323,11 +223,111 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.21.0"
+          value: "1.23.0"
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.21"
+          value: "1.23"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.7.2"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v4.0.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+  - name: pull-kubernetes-csi-external-attacher-1-23-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-attacher
+      testgrid-tab-name: 1-23-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo external-attacher for non-alpha tests, using deployment 1.23 on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_USE_BAZEL
+          value: "false"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.7.2"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+  - name: pull-kubernetes-csi-external-attacher-alpha-1-22-on-kubernetes-1-22
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|v0.1.0)$"]
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-attacher
+      testgrid-tab-name: alpha-1-22-on-kubernetes-1-22
+      description: Kubernetes-CSI pull job in repo external-attacher for alpha tests, using deployment 1.22 on Kubernetes 1.22
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.22.0"
+        - name: CSI_PROW_USE_BAZEL
+          value: "false"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.22"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
@@ -2,102 +2,6 @@
 
 presubmits:
   kubernetes-csi/external-provisioner:
-  - name: pull-kubernetes-csi-external-provisioner-1-20-on-kubernetes-1-20
-    always_run: true
-    optional: false
-    decorate: true
-    skip_report: false
-    skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|v0.1.0)$"]
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-provisioner
-      testgrid-tab-name: 1-20-on-kubernetes-1-20
-      description: Kubernetes-CSI pull job in repo external-provisioner for non-alpha tests, using deployment 1.20 on Kubernetes 1.20
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.20.0"
-        - name: CSI_PROW_USE_BAZEL
-          value: "true"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.20"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.7.2"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v4.0.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 2000m
-  - name: pull-kubernetes-csi-external-provisioner-1-20-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-provisioner
-      testgrid-tab-name: 1-20-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo external-provisioner for non-alpha tests, using deployment 1.20 on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_USE_BAZEL
-          value: "false"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.7.2"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
   - name: pull-kubernetes-csi-external-provisioner-1-21-on-kubernetes-1-21
     always_run: true
     optional: false
@@ -196,7 +100,7 @@ presubmits:
           cpu: 2000m
   - name: pull-kubernetes-csi-external-provisioner-1-22-on-kubernetes-1-22
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|v0.1.0)$"]
@@ -239,13 +143,9 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+        resources:
+          requests:
+            cpu: 2000m
   - name: pull-kubernetes-csi-external-provisioner-1-22-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -294,8 +194,8 @@ presubmits:
           memory: "9000Mi"
           # during the tests more like 3-20m is used
           cpu: 2000m
-  - name: pull-kubernetes-csi-external-provisioner-alpha-1-21-on-kubernetes-1-21
-    always_run: false
+  - name: pull-kubernetes-csi-external-provisioner-1-23-on-kubernetes-1-23
+    always_run: true
     optional: true
     decorate: true
     skip_report: false
@@ -306,8 +206,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-storage-csi-external-provisioner
-      testgrid-tab-name: alpha-1-21-on-kubernetes-1-21
-      description: Kubernetes-CSI pull job in repo external-provisioner for alpha tests, using deployment 1.21 on Kubernetes 1.21
+      testgrid-tab-name: 1-23-on-kubernetes-1-23
+      description: Kubernetes-CSI pull job in repo external-provisioner for non-alpha tests, using deployment 1.23 on Kubernetes 1.23
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -323,11 +223,111 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.21.0"
+          value: "1.23.0"
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.21"
+          value: "1.23"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.7.2"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v4.0.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+  - name: pull-kubernetes-csi-external-provisioner-1-23-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-provisioner
+      testgrid-tab-name: 1-23-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo external-provisioner for non-alpha tests, using deployment 1.23 on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_USE_BAZEL
+          value: "false"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.7.2"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+  - name: pull-kubernetes-csi-external-provisioner-alpha-1-22-on-kubernetes-1-22
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|v0.1.0)$"]
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-provisioner
+      testgrid-tab-name: alpha-1-22-on-kubernetes-1-22
+      description: Kubernetes-CSI pull job in repo external-provisioner for alpha tests, using deployment 1.22 on Kubernetes 1.22
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.22.0"
+        - name: CSI_PROW_USE_BAZEL
+          value: "false"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.22"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION

--- a/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
+++ b/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
@@ -2,102 +2,6 @@
 
 presubmits:
   kubernetes-csi/external-resizer:
-  - name: pull-kubernetes-csi-external-resizer-1-20-on-kubernetes-1-20
-    always_run: true
-    optional: false
-    decorate: true
-    skip_report: false
-    skip_branches: []
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-resizer
-      testgrid-tab-name: 1-20-on-kubernetes-1-20
-      description: Kubernetes-CSI pull job in repo external-resizer for non-alpha tests, using deployment 1.20 on Kubernetes 1.20
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.20.0"
-        - name: CSI_PROW_USE_BAZEL
-          value: "true"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.20"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.7.2"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v4.0.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 2000m
-  - name: pull-kubernetes-csi-external-resizer-1-20-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-resizer
-      testgrid-tab-name: 1-20-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo external-resizer for non-alpha tests, using deployment 1.20 on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_USE_BAZEL
-          value: "false"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.7.2"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
   - name: pull-kubernetes-csi-external-resizer-1-21-on-kubernetes-1-21
     always_run: true
     optional: false
@@ -196,7 +100,7 @@ presubmits:
           cpu: 2000m
   - name: pull-kubernetes-csi-external-resizer-1-22-on-kubernetes-1-22
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: []
@@ -239,13 +143,9 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+        resources:
+          requests:
+            cpu: 2000m
   - name: pull-kubernetes-csi-external-resizer-1-22-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -294,8 +194,8 @@ presubmits:
           memory: "9000Mi"
           # during the tests more like 3-20m is used
           cpu: 2000m
-  - name: pull-kubernetes-csi-external-resizer-alpha-1-21-on-kubernetes-1-21
-    always_run: false
+  - name: pull-kubernetes-csi-external-resizer-1-23-on-kubernetes-1-23
+    always_run: true
     optional: true
     decorate: true
     skip_report: false
@@ -306,8 +206,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-storage-csi-external-resizer
-      testgrid-tab-name: alpha-1-21-on-kubernetes-1-21
-      description: Kubernetes-CSI pull job in repo external-resizer for alpha tests, using deployment 1.21 on Kubernetes 1.21
+      testgrid-tab-name: 1-23-on-kubernetes-1-23
+      description: Kubernetes-CSI pull job in repo external-resizer for non-alpha tests, using deployment 1.23 on Kubernetes 1.23
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -323,11 +223,111 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.21.0"
+          value: "1.23.0"
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.21"
+          value: "1.23"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.7.2"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v4.0.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+  - name: pull-kubernetes-csi-external-resizer-1-23-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-resizer
+      testgrid-tab-name: 1-23-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo external-resizer for non-alpha tests, using deployment 1.23 on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_USE_BAZEL
+          value: "false"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.7.2"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+  - name: pull-kubernetes-csi-external-resizer-alpha-1-22-on-kubernetes-1-22
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: []
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-resizer
+      testgrid-tab-name: alpha-1-22-on-kubernetes-1-22
+      description: Kubernetes-CSI pull job in repo external-resizer for alpha tests, using deployment 1.22 on Kubernetes 1.22
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.22.0"
+        - name: CSI_PROW_USE_BAZEL
+          value: "false"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.22"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION

--- a/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
+++ b/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
@@ -2,102 +2,6 @@
 
 presubmits:
   kubernetes-csi/external-snapshotter:
-  - name: pull-kubernetes-csi-external-snapshotter-1-20-on-kubernetes-1-20
-    always_run: true
-    optional: false
-    decorate: true
-    skip_report: false
-    skip_branches: ["^(k8s_1.12.0-beta.1|release-0.4|release-1.0)$"]
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-snapshotter
-      testgrid-tab-name: 1-20-on-kubernetes-1-20
-      description: Kubernetes-CSI pull job in repo external-snapshotter for non-alpha tests, using deployment 1.20 on Kubernetes 1.20
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.20.0"
-        - name: CSI_PROW_USE_BAZEL
-          value: "true"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.20"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.7.2"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v4.0.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 2000m
-  - name: pull-kubernetes-csi-external-snapshotter-1-20-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-snapshotter
-      testgrid-tab-name: 1-20-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo external-snapshotter for non-alpha tests, using deployment 1.20 on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_USE_BAZEL
-          value: "false"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.7.2"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
   - name: pull-kubernetes-csi-external-snapshotter-1-21-on-kubernetes-1-21
     always_run: true
     optional: false
@@ -196,7 +100,7 @@ presubmits:
           cpu: 2000m
   - name: pull-kubernetes-csi-external-snapshotter-1-22-on-kubernetes-1-22
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: ["^(k8s_1.12.0-beta.1|release-0.4|release-1.0)$"]
@@ -239,13 +143,9 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+        resources:
+          requests:
+            cpu: 2000m
   - name: pull-kubernetes-csi-external-snapshotter-1-22-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -294,8 +194,8 @@ presubmits:
           memory: "9000Mi"
           # during the tests more like 3-20m is used
           cpu: 2000m
-  - name: pull-kubernetes-csi-external-snapshotter-alpha-1-21-on-kubernetes-1-21
-    always_run: false
+  - name: pull-kubernetes-csi-external-snapshotter-1-23-on-kubernetes-1-23
+    always_run: true
     optional: true
     decorate: true
     skip_report: false
@@ -306,8 +206,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-storage-csi-external-snapshotter
-      testgrid-tab-name: alpha-1-21-on-kubernetes-1-21
-      description: Kubernetes-CSI pull job in repo external-snapshotter for alpha tests, using deployment 1.21 on Kubernetes 1.21
+      testgrid-tab-name: 1-23-on-kubernetes-1-23
+      description: Kubernetes-CSI pull job in repo external-snapshotter for non-alpha tests, using deployment 1.23 on Kubernetes 1.23
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -323,11 +223,111 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.21.0"
+          value: "1.23.0"
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.21"
+          value: "1.23"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.7.2"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v4.0.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+  - name: pull-kubernetes-csi-external-snapshotter-1-23-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-snapshotter
+      testgrid-tab-name: 1-23-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo external-snapshotter for non-alpha tests, using deployment 1.23 on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_USE_BAZEL
+          value: "false"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.7.2"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+  - name: pull-kubernetes-csi-external-snapshotter-alpha-1-22-on-kubernetes-1-22
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: ["^(k8s_1.12.0-beta.1|release-0.4|release-1.0)$"]
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-snapshotter
+      testgrid-tab-name: alpha-1-22-on-kubernetes-1-22
+      description: Kubernetes-CSI pull job in repo external-snapshotter for alpha tests, using deployment 1.22 on Kubernetes 1.22
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.22.0"
+        - name: CSI_PROW_USE_BAZEL
+          value: "false"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.22"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -24,23 +24,23 @@ base="$(dirname $0)"
 # irrelevant because the prow.sh script will pick a suitable KinD
 # image or build from source.
 k8s_versions="
-1.20
 1.21
 1.22
+1.23
 "
 
 # All the deployment versions we're testing.
 deployment_versions="
-1.20
 1.21
 1.22
+1.23
 "
 
 # The experimental version for which jobs are optional.
-experimental_k8s_version="1.22"
+experimental_k8s_version="1.23"
 
 # The latest stable Kubernetes version for testing alpha jobs
-latest_stable_k8s_version="1.21" # TODO: bump to 1.22 after testing a pull job
+latest_stable_k8s_version="1.22" # TODO: bump to 1.23 after testing a pull job
 
 # Tag of the hostpath driver we should use for sidecar pull jobs
 hostpath_driver_version="v1.7.2"

--- a/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
+++ b/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
@@ -2,102 +2,6 @@
 
 presubmits:
   kubernetes-csi/livenessprobe:
-  - name: pull-kubernetes-csi-livenessprobe-1-20-on-kubernetes-1-20
-    always_run: true
-    optional: false
-    decorate: true
-    skip_report: false
-    skip_branches: ["^(release-0.4|release-1.0)$"]
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-livenessprobe
-      testgrid-tab-name: 1-20-on-kubernetes-1-20
-      description: Kubernetes-CSI pull job in repo livenessprobe for non-alpha tests, using deployment 1.20 on Kubernetes 1.20
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.20.0"
-        - name: CSI_PROW_USE_BAZEL
-          value: "true"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.20"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.7.2"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v4.0.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 2000m
-  - name: pull-kubernetes-csi-livenessprobe-1-20-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-livenessprobe
-      testgrid-tab-name: 1-20-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo livenessprobe for non-alpha tests, using deployment 1.20 on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_USE_BAZEL
-          value: "false"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.7.2"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
   - name: pull-kubernetes-csi-livenessprobe-1-21-on-kubernetes-1-21
     always_run: true
     optional: false
@@ -196,7 +100,7 @@ presubmits:
           cpu: 2000m
   - name: pull-kubernetes-csi-livenessprobe-1-22-on-kubernetes-1-22
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: ["^(release-0.4|release-1.0)$"]
@@ -239,13 +143,9 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+        resources:
+          requests:
+            cpu: 2000m
   - name: pull-kubernetes-csi-livenessprobe-1-22-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -294,8 +194,8 @@ presubmits:
           memory: "9000Mi"
           # during the tests more like 3-20m is used
           cpu: 2000m
-  - name: pull-kubernetes-csi-livenessprobe-alpha-1-21-on-kubernetes-1-21
-    always_run: false
+  - name: pull-kubernetes-csi-livenessprobe-1-23-on-kubernetes-1-23
+    always_run: true
     optional: true
     decorate: true
     skip_report: false
@@ -306,8 +206,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-storage-csi-livenessprobe
-      testgrid-tab-name: alpha-1-21-on-kubernetes-1-21
-      description: Kubernetes-CSI pull job in repo livenessprobe for alpha tests, using deployment 1.21 on Kubernetes 1.21
+      testgrid-tab-name: 1-23-on-kubernetes-1-23
+      description: Kubernetes-CSI pull job in repo livenessprobe for non-alpha tests, using deployment 1.23 on Kubernetes 1.23
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -323,11 +223,111 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.21.0"
+          value: "1.23.0"
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.21"
+          value: "1.23"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.7.2"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v4.0.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+  - name: pull-kubernetes-csi-livenessprobe-1-23-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-livenessprobe
+      testgrid-tab-name: 1-23-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo livenessprobe for non-alpha tests, using deployment 1.23 on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_USE_BAZEL
+          value: "false"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.7.2"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+  - name: pull-kubernetes-csi-livenessprobe-alpha-1-22-on-kubernetes-1-22
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: ["^(release-0.4|release-1.0)$"]
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-livenessprobe
+      testgrid-tab-name: alpha-1-22-on-kubernetes-1-22
+      description: Kubernetes-CSI pull job in repo livenessprobe for alpha tests, using deployment 1.22 on Kubernetes 1.22
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.22.0"
+        - name: CSI_PROW_USE_BAZEL
+          value: "false"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.22"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION

--- a/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
+++ b/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
@@ -2,102 +2,6 @@
 
 presubmits:
   kubernetes-csi/node-driver-registrar:
-  - name: pull-kubernetes-csi-node-driver-registrar-1-20-on-kubernetes-1-20
-    always_run: true
-    optional: false
-    decorate: true
-    skip_report: false
-    skip_branches: ["^(release-1.0)$"]
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-node-driver-registrar
-      testgrid-tab-name: 1-20-on-kubernetes-1-20
-      description: Kubernetes-CSI pull job in repo node-driver-registrar for non-alpha tests, using deployment 1.20 on Kubernetes 1.20
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.20.0"
-        - name: CSI_PROW_USE_BAZEL
-          value: "true"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.20"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.7.2"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v4.0.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 2000m
-  - name: pull-kubernetes-csi-node-driver-registrar-1-20-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-node-driver-registrar
-      testgrid-tab-name: 1-20-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo node-driver-registrar for non-alpha tests, using deployment 1.20 on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_USE_BAZEL
-          value: "false"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.7.2"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
   - name: pull-kubernetes-csi-node-driver-registrar-1-21-on-kubernetes-1-21
     always_run: true
     optional: false
@@ -196,7 +100,7 @@ presubmits:
           cpu: 2000m
   - name: pull-kubernetes-csi-node-driver-registrar-1-22-on-kubernetes-1-22
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: ["^(release-1.0)$"]
@@ -239,13 +143,9 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-      resources:
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+        resources:
+          requests:
+            cpu: 2000m
   - name: pull-kubernetes-csi-node-driver-registrar-1-22-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
@@ -294,8 +194,8 @@ presubmits:
           memory: "9000Mi"
           # during the tests more like 3-20m is used
           cpu: 2000m
-  - name: pull-kubernetes-csi-node-driver-registrar-alpha-1-21-on-kubernetes-1-21
-    always_run: false
+  - name: pull-kubernetes-csi-node-driver-registrar-1-23-on-kubernetes-1-23
+    always_run: true
     optional: true
     decorate: true
     skip_report: false
@@ -306,8 +206,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-storage-csi-node-driver-registrar
-      testgrid-tab-name: alpha-1-21-on-kubernetes-1-21
-      description: Kubernetes-CSI pull job in repo node-driver-registrar for alpha tests, using deployment 1.21 on Kubernetes 1.21
+      testgrid-tab-name: 1-23-on-kubernetes-1-23
+      description: Kubernetes-CSI pull job in repo node-driver-registrar for non-alpha tests, using deployment 1.23 on Kubernetes 1.23
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -323,11 +223,111 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.21.0"
+          value: "1.23.0"
         - name: CSI_PROW_USE_BAZEL
           value: "false"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.21"
+          value: "1.23"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.7.2"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v4.0.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+  - name: pull-kubernetes-csi-node-driver-registrar-1-23-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-node-driver-registrar
+      testgrid-tab-name: 1-23-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo node-driver-registrar for non-alpha tests, using deployment 1.23 on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_USE_BAZEL
+          value: "false"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.7.2"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+  - name: pull-kubernetes-csi-node-driver-registrar-alpha-1-22-on-kubernetes-1-22
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: ["^(release-1.0)$"]
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-node-driver-registrar
+      testgrid-tab-name: alpha-1-22-on-kubernetes-1-22
+      description: Kubernetes-CSI pull job in repo node-driver-registrar for alpha tests, using deployment 1.22 on Kubernetes 1.22
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211103-c5cdf1865f-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://k8s-testgrid.appspot.com/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.22.0"
+        - name: CSI_PROW_USE_BAZEL
+          value: "false"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.22"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION


### PR DESCRIPTION
Steps:

- updated gen-jobs.sh following the first step in kubernetes-csi/csi-releasetools@master/SIDECAR_RELEASE_PROCESS.md#adding-support-for-a-new-kubernetes-release
- run the gen-jobs.sh script

/cc @pohly @xing-yang @jingxu97 