### PR TITLE
add main branch for presubmit jobs and update some generate scripts

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-e2e-test-images.sh
+++ b/config/jobs/image-pushing/k8s-staging-e2e-test-images.sh
@@ -82,7 +82,9 @@ for image in "${IMAGES[@]}"; do
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/${image//\//\\/}\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:

--- a/config/jobs/image-pushing/k8s-staging-e2e-test-images.yaml
+++ b/config/jobs/image-pushing/k8s-staging-e2e-test-images.yaml
@@ -21,7 +21,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/agnhost\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -61,7 +63,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/apparmor-loader\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -101,7 +105,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/busybox\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -141,7 +147,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/cuda-vector-add\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -181,7 +189,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/cuda-vector-add-old\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -221,7 +231,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/echoserver\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -261,7 +273,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/glusterdynamic-provisioner\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -301,7 +315,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/httpd\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -341,7 +357,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/httpd-new\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -381,7 +399,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/ipc-utils\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -421,7 +441,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/jessie-dnsutils\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -461,7 +483,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/kitten\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -501,7 +525,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/metadata-concealment\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -541,7 +567,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/nautilus\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -581,7 +609,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/nginx\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -621,7 +651,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/nginx-new\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -661,7 +693,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/node-perf\/tf-wide-deep\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -701,7 +735,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/node-perf\/npb-ep\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -741,7 +777,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/node-perf\/npb-is\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -781,7 +819,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/nonewprivs\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -821,7 +861,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/nonroot\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -861,7 +903,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/perl\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -901,7 +945,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/pets\/redis-installer\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -941,7 +987,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/pets\/peer-finder\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -981,7 +1029,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/pets\/zookeeper-installer\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -1021,7 +1071,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/redis\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -1061,7 +1113,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/regression-issue-74839\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -1101,7 +1155,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/resource-consumer\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -1141,7 +1197,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/sample-apiserver\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -1181,7 +1239,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/sample-device-plugin\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -1221,7 +1281,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/volume\/iscsi\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -1261,7 +1323,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/volume\/rbd\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -1301,7 +1365,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/volume\/nfs\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -1341,7 +1407,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/volume\/gluster\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -1381,7 +1449,9 @@ postsubmits:
       # we only need to run if the test images have been changed.
       run_if_changed: '^test\/images\/windows-servercore-cache\/'
       branches:
+        # TODO(releng): Remove once repo default branch has been renamed
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:

--- a/config/jobs/kubernetes-sigs/sig-windows/generate-presubmits.sh
+++ b/config/jobs/kubernetes-sigs/sig-windows/generate-presubmits.sh
@@ -41,6 +41,7 @@ for release in "$@"; do
   output="${dir}/release-${release}-windows-presubmits.yaml"
   orchestrator_release="${release}"
   branch="release-${release}"
+  branch_name="release-${release}"
   dockershim_api_model="https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_release_staging.json"
   containerd_api_model="https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_master.json"
 
@@ -60,7 +61,8 @@ for release in "$@"; do
       containerd_api_model="https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_1_23.json"
       ;;
     *)
-      branch="master"
+      branch=$(echo -e 'master # TODO(releng): Remove once repo default branch has been renamed\n    - main')
+      branch_name=master
       orchestrator_release="1.23"
       ;;
   esac
@@ -119,7 +121,7 @@ presubmits:
         - --ginkgo-parallel=4
         securityContext:
           privileged: true
-$(generate_presubmit_annotations ${branch} pull-kubernetes-e2e-aks-engine-windows-dockershim-${release})
+$(generate_presubmit_annotations ${branch_name} pull-kubernetes-e2e-aks-engine-windows-dockershim-${release})
   - name: pull-kubernetes-e2e-aks-engine-windows-containerd-${release//./-}
     always_run: false
     optional: true
@@ -171,7 +173,7 @@ $(generate_presubmit_annotations ${branch} pull-kubernetes-e2e-aks-engine-window
         - --ginkgo-parallel=4
         securityContext:
           privileged: true
-$(generate_presubmit_annotations ${branch} pull-kubernetes-e2e-aks-engine-windows-containerd-${release})
+$(generate_presubmit_annotations ${branch_name} pull-kubernetes-e2e-aks-engine-windows-containerd-${release})
   - name: pull-kubernetes-e2e-aks-engine-azure-disk-windows-dockershim-${release//./-}
     decorate: true
     decoration_config:
@@ -230,7 +232,7 @@ $(generate_presubmit_annotations ${branch} pull-kubernetes-e2e-aks-engine-window
           value: kubernetes.io/azure-disk # In-tree Azure disk storage class
         - name: TEST_WINDOWS
           value: "true"
-$(generate_presubmit_annotations ${branch} pull-kubernetes-e2e-aks-engine-azure-disk-windows-dockershim-${release})
+$(generate_presubmit_annotations ${branch_name} pull-kubernetes-e2e-aks-engine-azure-disk-windows-dockershim-${release})
   - name: pull-kubernetes-e2e-aks-engine-azure-file-windows-dockershim-${release//./-}
     decorate: true
     decoration_config:
@@ -289,6 +291,6 @@ $(generate_presubmit_annotations ${branch} pull-kubernetes-e2e-aks-engine-azure-
           value: kubernetes.io/azure-file # In-tree Azure file storage class
         - name: TEST_WINDOWS
           value: "true"
-$(generate_presubmit_annotations ${branch} pull-kubernetes-e2e-aks-engine-azure-file-windows-dockershim-${release})
+$(generate_presubmit_annotations ${branch_name} pull-kubernetes-e2e-aks-engine-azure-file-windows-dockershim-${release})
 EOF
 done

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -8,7 +8,9 @@ presubmits:
       timeout: 3h
     path_alias: k8s.io/kubernetes
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     labels:
       preset-service-account: "true"
       preset-azure-cred: "true"
@@ -64,7 +66,9 @@ presubmits:
     optional: true
     path_alias: k8s.io/kubernetes
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     labels:
       preset-service-account: "true"
       preset-azure-cred: "true"
@@ -125,7 +129,9 @@ presubmits:
     optional: true
     path_alias: k8s.io/kubernetes
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     labels:
       preset-service-account: "true"
       preset-azure-cred: "true"

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/generate.sh
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/generate.sh
@@ -47,9 +47,11 @@ for release in "$@"; do
   kubernetes_version="latest"
 
   if [[ "${release}" == "master" ]]; then
-    branch="master"
+    branch=$(echo -e 'master # TODO(releng): Remove once repo default branch has been renamed\n      - main')
+    branch_name="master"
   else
     branch="release-${release}"
+    branch_name="release-${release}"
     kubernetes_version+="-${release}"
   fi
 
@@ -105,7 +107,7 @@ presubmits:
             requests:
               cpu: 1
               memory: "4Gi"
-$(generate_presubmit_annotations ${branch} pull-kubernetes-e2e-capz-azure-disk)
+$(generate_presubmit_annotations ${branch_name} pull-kubernetes-e2e-capz-azure-disk)
   - name: pull-kubernetes-e2e-capz-azure-disk-vmss
     decorate: true
     always_run: false
@@ -152,7 +154,7 @@ $(generate_presubmit_annotations ${branch} pull-kubernetes-e2e-capz-azure-disk)
             requests:
               cpu: 1
               memory: "4Gi"
-$(generate_presubmit_annotations ${branch} pull-kubernetes-e2e-capz-azure-disk-vmss)
+$(generate_presubmit_annotations ${branch_name} pull-kubernetes-e2e-capz-azure-disk-vmss)
   - name: pull-kubernetes-e2e-capz-azure-file
     decorate: true
     always_run: false
@@ -198,7 +200,7 @@ $(generate_presubmit_annotations ${branch} pull-kubernetes-e2e-capz-azure-disk-v
             requests:
               cpu: 1
               memory: "4Gi"
-$(generate_presubmit_annotations ${branch} pull-kubernetes-e2e-capz-azure-file)
+$(generate_presubmit_annotations ${branch_name} pull-kubernetes-e2e-capz-azure-file)
   - name: pull-kubernetes-e2e-capz-azure-file-vmss
     decorate: true
     always_run: false
@@ -246,7 +248,7 @@ $(generate_presubmit_annotations ${branch} pull-kubernetes-e2e-capz-azure-file)
             requests:
               cpu: 1
               memory: "4Gi"
-$(generate_presubmit_annotations ${branch} pull-kubernetes-e2e-capz-azure-file-vmss)
+$(generate_presubmit_annotations ${branch_name} pull-kubernetes-e2e-capz-azure-file-vmss)
   - name: pull-kubernetes-e2e-capz-conformance
     decorate: true
     always_run: false
@@ -283,7 +285,7 @@ $(generate_presubmit_annotations ${branch} pull-kubernetes-e2e-capz-azure-file-v
           value: /home/prow/go/src/sigs.k8s.io/cluster-api-provider-azure/test/e2e/data/kubetest/conformance-fast.yaml
         - name: CONFORMANCE_NODES
           value: "25"
-$(generate_presubmit_annotations ${branch} pull-kubernetes-e2e-capz-conformance)
+$(generate_presubmit_annotations ${branch_name} pull-kubernetes-e2e-capz-conformance)
   - name: pull-kubernetes-e2e-capz-ha-control-plane
     decorate: true
     decoration_config:
@@ -323,7 +325,7 @@ $(generate_presubmit_annotations ${branch} pull-kubernetes-e2e-capz-conformance)
           value: "1"
         - name: CONFORMANCE_CONTROL_PLANE_MACHINE_COUNT
           value: "3"
-$(generate_presubmit_annotations ${branch} pull-kubernetes-e2e-capz-ha-control-plane)
+$(generate_presubmit_annotations ${branch_name} pull-kubernetes-e2e-capz-ha-control-plane)
 periodics:
 - interval: 3h
   name: capz-conformance-${release/./-}
@@ -384,7 +386,7 @@ periodics:
     path_alias: sigs.k8s.io/azurefile-csi-driver
   - org: kubernetes
     repo: kubernetes
-    base_ref: ${branch}
+    base_ref: ${branch_name}
     path_alias: k8s.io/kubernetes
   spec:
     containers:
@@ -436,7 +438,7 @@ periodics:
     path_alias: sigs.k8s.io/azurefile-csi-driver
   - org: kubernetes
     repo: kubernetes
-    base_ref: ${branch}
+    base_ref: ${branch_name}
     path_alias: k8s.io/kubernetes
   spec:
     containers:
@@ -490,7 +492,7 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   - org: kubernetes
     repo: kubernetes
-    base_ref: ${branch}
+    base_ref: ${branch_name}
     path_alias: k8s.io/kubernetes
   spec:
     containers:
@@ -541,7 +543,7 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   - org: kubernetes
     repo: kubernetes
-    base_ref: ${branch}
+    base_ref: ${branch_name}
     path_alias: k8s.io/kubernetes
   spec:
     containers:

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
@@ -8,7 +8,8 @@ presubmits:
     run_if_changed: 'azure.*\.go'
     path_alias: k8s.io/kubernetes
     branches:
-      - master
+      - master # TODO(releng): Remove once repo default branch has been renamed
+      - main
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -57,7 +58,8 @@ presubmits:
     run_if_changed: 'azure.*\.go'
     path_alias: k8s.io/kubernetes
     branches:
-      - master
+      - master # TODO(releng): Remove once repo default branch has been renamed
+      - main
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -108,7 +110,8 @@ presubmits:
     run_if_changed: 'azure.*\.go'
     path_alias: k8s.io/kubernetes
     branches:
-      - master
+      - master # TODO(releng): Remove once repo default branch has been renamed
+      - main
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -158,7 +161,8 @@ presubmits:
     run_if_changed: 'azure.*\.go'
     path_alias: k8s.io/kubernetes
     branches:
-      - master
+      - master # TODO(releng): Remove once repo default branch has been renamed
+      - main
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -210,7 +214,8 @@ presubmits:
     run_if_changed: 'azure.*\.go'
     path_alias: k8s.io/kubernetes
     branches:
-      - master
+      - master # TODO(releng): Remove once repo default branch has been renamed
+      - main
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -252,7 +257,8 @@ presubmits:
     optional: true
     path_alias: k8s.io/kubernetes
     branches:
-      - master
+      - master # TODO(releng): Remove once repo default branch has been renamed
+      - main
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -108,7 +108,9 @@ presubmits:
     # if at all it is run and fails, don't block the PR
     optional: true
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     decorate: true
     decoration_config:
       timeout: 80m # hard cap, based on original pre-kubetest2 job but moved to a prow-level timeout
@@ -378,7 +380,9 @@ presubmits:
     optional: true
     run_if_changed: '^.*feature.*\.go'
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"

--- a/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml
@@ -386,7 +386,9 @@ presubmits:
     optional: true
     path_alias: k8s.io/kubernetes
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     labels:
       preset-service-account: "true"
       preset-azure-cred: "true"
@@ -439,7 +441,9 @@ presubmits:
     optional: true
     path_alias: k8s.io/kubernetes
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     labels:
       preset-service-account: "true"
       preset-azure-cred: "true"

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -5,7 +5,9 @@ presubmits:
 
   - name: pull-kubernetes-e2e-gci-gce-ingress
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     always_run: false
     run_if_changed: '^(test/e2e/network/|pkg/apis/networking)'
     optional: true
@@ -72,7 +74,9 @@ presubmits:
 
   - name: pull-kubernetes-e2e-ubuntu-gce-network-policies
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     always_run: false
     run_if_changed: '^(test/e2e/network/|pkg/apis/networking)'
     optional: true
@@ -140,7 +144,9 @@ presubmits:
 
   - name: pull-kubernetes-e2e-gci-gce-ipvs
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     always_run: false
     run_if_changed: '^(test/e2e/network/|pkg/apis/networking|pkg/.*/ipvs/)'
     optional: true

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -3,7 +3,9 @@ presubmits:
   - name: pull-kubernetes-node-e2e
     cluster: k8s-infra-prow-build
     branches:
-      - master
+    # TODO(releng): Remove once repo default branch has been renamed
+    - master
+    - main
     annotations:
       testgrid-create-test-group: "true"
     always_run: false
@@ -92,7 +94,9 @@ presubmits:
     # if it is run and fails, don't block the PR
     optional: true
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     decorate: true
     path_alias: k8s.io/kubernetes
     extra_refs:
@@ -224,7 +228,9 @@ presubmits:
     always_run: false
     optional: true
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     decorate: true
     path_alias: k8s.io/kubernetes
     extra_refs:
@@ -270,7 +276,9 @@ presubmits:
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config.yaml
   - name: pull-kubernetes-node-e2e-containerd-features
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     always_run: false
     optional: true
     max_concurrency: 12
@@ -317,7 +325,9 @@ presubmits:
     # if at all it is run and fails, don't block the PR
     optional: true
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     decorate: true
     path_alias: k8s.io/kubernetes
     extra_refs:
@@ -370,7 +380,9 @@ presubmits:
   - name: pull-kubernetes-node-e2e-alpha
     cluster: k8s-infra-prow-build
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     annotations:
       testgrid-create-test-group: "true"
     always_run: false
@@ -414,7 +426,9 @@ presubmits:
     # if at all it is run and fails, don't block the PR
     optional: true
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     decorate: true
     path_alias: k8s.io/kubernetes
     extra_refs:
@@ -622,7 +636,9 @@ presubmits:
     # if at all it is run and fails, don't block the PR
     optional: true
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     decorate: true
     path_alias: k8s.io/kubernetes
     extra_refs:
@@ -714,7 +730,9 @@ presubmits:
     # if at all it is run and fails, don't block the PR
     optional: true
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     decorate: true
     path_alias: k8s.io/kubernetes
     extra_refs:
@@ -798,7 +816,9 @@ presubmits:
     # if at all it is run and fails, don't block the PR
     optional: true
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     decorate: true
     path_alias: k8s.io/kubernetes
     extra_refs:
@@ -882,7 +902,9 @@ presubmits:
     # if at all it is run and fails, don't block the PR
     optional: true
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     decorate: true
     path_alias: k8s.io/kubernetes
     extra_refs:
@@ -971,7 +993,9 @@ presubmits:
     # if at all it is run and fails, don't block the PR
     optional: true
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     decorate: true
     path_alias: k8s.io/kubernetes
     extra_refs:
@@ -1103,7 +1127,9 @@ presubmits:
     # if at all it is run and fails, don't block the PR
     optional: true
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     decorate: true
     path_alias: k8s.io/kubernetes
     extra_refs:
@@ -1281,7 +1307,9 @@ presubmits:
     # if at all it is run and fails, don't block the PR
     optional: true
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     decorate: true
     path_alias: k8s.io/kubernetes
     extra_refs:

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -79,7 +79,9 @@ presubmits:
     always_run: false
     max_concurrency: 1
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     decorate: true
     path_alias: k8s.io/kubernetes
     decoration_config:
@@ -205,7 +207,9 @@ presubmits:
     always_run: false
     max_concurrency: 1
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     decorate: true
     path_alias: k8s.io/kubernetes
     decoration_config:
@@ -359,7 +363,9 @@ presubmits:
     always_run: false
     max_concurrency: 1
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     decorate: true
     path_alias: k8s.io/kubernetes
     decoration_config:

--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -14,7 +14,9 @@ presubmits:
     # test/e2e/testing-manifests/storage-csi
     run_if_changed: '^(pkg\/controller\/volume|pkg\/kubelet\/volumemanager|pkg\/volume|pkg\/util\/mount|test\/e2e\/storage|test\/e2e\/testing-manifests\/storage-csi)'
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
@@ -63,7 +65,9 @@ presubmits:
     # test/e2e/testing-manifests/storage-csi
     run_if_changed: '^(pkg\/controller\/volume|pkg\/kubelet\/volumemanager|pkg\/volume|pkg\/util\/mount|test\/e2e\/storage|test\/e2e\/testing-manifests\/storage-csi)'
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
@@ -111,7 +115,9 @@ presubmits:
     # test/e2e/testing-manifests/storage-csi
     run_if_changed: '^(pkg\/controller\/volume|pkg\/kubelet\/volumemanager|pkg\/volume|pkg\/util\/mount|test\/e2e\/storage|test\/e2e\/testing-manifests\/storage-csi)'
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
@@ -150,7 +156,9 @@ presubmits:
     optional: true
     run_if_changed: '(pkg\/volume\/iscsi)'
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
@@ -193,7 +201,9 @@ presubmits:
     optional: true
     run_if_changed: '(pkg\/volume\/iscsi)'
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
@@ -234,7 +244,9 @@ presubmits:
     always_run: false
     optional: true
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"

--- a/config/jobs/kubernetes/sig-testing/local-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/local-e2e.yaml
@@ -2,7 +2,9 @@ presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-local-e2e
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     always_run: false
     skip_report: false
     max_concurrency: 8

--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -541,7 +541,9 @@ presubmits:
     always_run: false
     optional: true
     branches:
+    # TODO(releng): Remove once repo default branch has been renamed
     - master
+    - main
     spec:
       containers:
       - command:


### PR DESCRIPTION
As part of the work that we are doing for this KEP https://github.com/kubernetes/enhancements/pull/3053

- added the future new branch name `main` in the job configs for the presubmits
- updated some scripts that generate the jobs


/assign @justaugustus @saschagrunert @puerco @dims @BenTheElder 
cc @kubernetes/release-engineering 