### PR TITLE
kOps jobs: add workaround for serviceaccount issue on gce

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -433,7 +433,9 @@ def generate_grid():
                                        k8s_version=k8s_version,
                                        kops_version=kops_version,
                                        networking=networking,
-                                       container_runtime=container_runtime)
+                                       container_runtime=container_runtime,
+                                       extra_flags=["--gce-service-account=default"], # Workaround for test-infra#24747 # pylint: disable=line-too-long
+                                      )
                         )
 
     return filter(None, results)
@@ -1008,6 +1010,7 @@ def generate_presubmits_e2e():
             networking='cilium',
             tab_name='e2e-gce',
             always_run=False,
+            extra_flags=["--gce-service-account=default"], # Workaround for test-infra#24747
         ),
         presubmit_test(
             cloud='gce',
@@ -1017,6 +1020,7 @@ def generate_presubmits_e2e():
             networking='cilium',
             tab_name='e2e-gce-ci',
             always_run=False,
+            extra_flags=["--gce-service-account=default"], # Workaround for test-infra#24747
         ),
         presubmit_test(
             cloud='gce',
@@ -1028,6 +1032,7 @@ def generate_presubmits_e2e():
             tab_name='pull-kops-e2e-k8s-gce-calico-u2004-k22-containerd',
             always_run=False,
             feature_flags=['GoogleCloudBucketACL'],
+            extra_flags=["--gce-service-account=default"], # Workaround for test-infra#24747
         ),
         # A special test for AWS Cloud-Controller-Manager
         presubmit_test(

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -41394,7 +41394,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k23-ko23-containerd
 
-# {"cloud": "gce", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
+# {"cloud": "gce", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-gce-u2004-k22-docker
   cron: '38 23 * * *'
   labels:
@@ -41448,6 +41448,7 @@ periodics:
     test.kops.k8s.io/cloud: gce
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/extra_flags: --gce-service-account=default
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -41456,7 +41457,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-gce-u2004-k22-docker
 
-# {"cloud": "gce", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+# {"cloud": "gce", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-gce-calico-u2004-k22-docker
   cron: '28 4 * * *'
   labels:
@@ -41510,6 +41511,7 @@ periodics:
     test.kops.k8s.io/cloud: gce
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/extra_flags: --gce-service-account=default
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -41518,7 +41520,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-gce-calico-u2004-k22-docker
 
-# {"cloud": "gce", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+# {"cloud": "gce", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-gce-cilium-u2004-k22-docker
   cron: '6 6 * * *'
   labels:
@@ -41572,6 +41574,7 @@ periodics:
     test.kops.k8s.io/cloud: gce
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/extra_flags: --gce-service-account=default
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -41580,7 +41583,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-gce-cilium-u2004-k22-docker
 
-# {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
+# {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-gce-u2004-k22-containerd
   cron: '49 22 * * *'
   labels:
@@ -41634,6 +41637,7 @@ periodics:
     test.kops.k8s.io/cloud: gce
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/extra_flags: --gce-service-account=default
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -41642,7 +41646,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-gce-u2004-k22-containerd
 
-# {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+# {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-gce-calico-u2004-k22-containerd
   cron: '41 17 * * *'
   labels:
@@ -41696,6 +41700,7 @@ periodics:
     test.kops.k8s.io/cloud: gce
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/extra_flags: --gce-service-account=default
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -41704,7 +41709,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-gce-calico-u2004-k22-containerd
 
-# {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+# {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-gce-cilium-u2004-k22-containerd
   cron: '15 11 * * *'
   labels:
@@ -41758,6 +41763,7 @@ periodics:
     test.kops.k8s.io/cloud: gce
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/extra_flags: --gce-service-account=default
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''

--- a/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
@@ -471,7 +471,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-debian11
 
-# {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
+# {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
   - name: pull-kops-e2e-k8s-gce
     branches:
     - master
@@ -525,6 +525,7 @@ presubmits:
       test.kops.k8s.io/cloud: gce
       test.kops.k8s.io/container_runtime: containerd
       test.kops.k8s.io/distro: u2004
+      test.kops.k8s.io/extra_flags: --gce-service-account=default
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: cilium
@@ -532,7 +533,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-gce
 
-# {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "ci", "kops_channel": "alpha", "networking": "cilium"}
+# {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "ci", "kops_channel": "alpha", "networking": "cilium"}
   - name: pull-kops-e2e-k8s-gce-ci
     branches:
     - master
@@ -588,6 +589,7 @@ presubmits:
       test.kops.k8s.io/cloud: gce
       test.kops.k8s.io/container_runtime: containerd
       test.kops.k8s.io/distro: u2004
+      test.kops.k8s.io/extra_flags: --gce-service-account=default
       test.kops.k8s.io/k8s_version: ci
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: cilium
@@ -595,7 +597,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-gce-ci
 
-# {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "feature_flags": "GoogleCloudBucketACL", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
+# {"cloud": "gce", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--gce-service-account=default", "feature_flags": "GoogleCloudBucketACL", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-e2e-k8s-gce-calico-u2004-k22-containerd
     branches:
     - master
@@ -650,6 +652,7 @@ presubmits:
       test.kops.k8s.io/cloud: gce
       test.kops.k8s.io/container_runtime: containerd
       test.kops.k8s.io/distro: u2004
+      test.kops.k8s.io/extra_flags: --gce-service-account=default
       test.kops.k8s.io/feature_flags: GoogleCloudBucketACL
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha


### PR DESCRIPTION
Because we can't currently add project IAM bindings in our GCE test
accounts, we can't use custom serviceaccounts.  Use the default
serviceaccount instead.