### PR TITLE
Use containerd in Ubuntu swap job

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -1195,3 +1195,38 @@ periodics:
     testgrid-tab-name: node-kubelet-containerd-hugepages
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "Executes hugepages e2e tests"
+
+- name: ci-kubernetes-node-swap-ubuntu
+  interval: 4h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211217-ea95cec1d4-master
+        args:
+          - --repo=k8s.io/kubernetes=master
+          - --timeout=240
+          - --root=/go/src
+          - --scenario=kubernetes_e2e
+          - --
+          - --deployment=node
+          - --gcp-project-type=node-e2e-project
+          - --gcp-zone=us-west1-b
+          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/swap/image-config-swap.yaml
+          - '--node-test-args=--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --feature-gates=NodeSwap=true --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --fail-swap-on=false --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+          - --node-tests=true
+          - --provider=gce
+          - --test_args=--nodes=8 --focus="\[NodeConformance\]|\[NodeFeature:.+\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
+          - --timeout=180m
+        env:
+          - name: GOPATH
+            value: /go
+        resources:
+          requests:
+            memory: "6Gi"
+  annotations:
+    testgrid-dashboards: sig-node-kubelet
+    testgrid-tab-name: kubelet-gce-e2e-swap-ubuntu
+    testgrid-alert-email: ehashman@redhat.com, mkmir@google.com
+    description: Executes E2E suite with swap enabled on Ubuntu

--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -78,42 +78,6 @@ periodics:
     testgrid-alert-email: skclark@redhat.com
     description: "Uses kubetest to run serial node-e2e tests (+Serial, -Flaky|Benchmark|Node*Feature)"
 
-# TODO: migrate swap+docker special config tests to containerd
-#- name: ci-kubernetes-node-swap-ubuntu
-#  interval: 4h
-#  labels:
-#    preset-service-account: "true"
-#    preset-k8s-ssh: "true"
-#  spec:
-#    containers:
-#      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211217-ea95cec1d4-master
-#        args:
-#          - --repo=k8s.io/kubernetes=master
-#          - --timeout=240
-#          - --root=/go/src
-#          - --scenario=kubernetes_e2e
-#          - --
-#          - --deployment=node
-#          - --gcp-project-type=node-e2e-project
-#          - --gcp-zone=us-west1-b
-#          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/swap/image-config-swap.yaml
-#          - --node-test-args=--feature-gates=NodeSwap=true --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --fail-swap-on=false"
-#          - --node-tests=true
-#          - --provider=gce
-#          - --test_args=--nodes=8 --focus="\[NodeConformance\]|\[NodeFeature:.+\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
-#          - --timeout=180m
-#        env:
-#          - name: GOPATH
-#            value: /go
-#        resources:
-#            requests:
-#              memory: "6Gi"
-#  annotations:
-#    testgrid-dashboards: sig-node-kubelet
-#    testgrid-tab-name: kubelet-gce-e2e-swap-ubuntu
-#    testgrid-alert-email: ehashman@redhat.com, ikema@google.com
-#    description: Executes E2E suite with swap enabled on Ubuntu
-
 - name: ci-kubernetes-node-swap-fedora
   interval: 4h
   labels:

--- a/jobs/e2e_node/swap/image-config-swap.yaml
+++ b/jobs/e2e_node/swap/image-config-swap.yaml
@@ -5,5 +5,5 @@ images:
   ubuntu:
     image: ubuntu-gke-2004-1-20-v20210401 # docker 19.03.8 / containerd 1.4.3
     project: ubuntu-os-gke-cloud
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/swap/ubuntu-swap-1G-allocation.yaml"
+    metadata: "user-data</workspace/test-infra/jobs/e2e_node/swap/ubuntu-swap-1G-allocation.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"
     machine: n1-standard-2

--- a/jobs/e2e_node/swap/ubuntu-swap-1G-allocation.yaml
+++ b/jobs/e2e_node/swap/ubuntu-swap-1G-allocation.yaml
@@ -1,6 +1,16 @@
 #cloud-config
 
 runcmd:
+  - mount /tmp /tmp -o remount,exec,suid
+  - mkdir -p /home/containerd
+  - mount --bind /home/containerd /home/containerd
+  - mount -o remount,exec /home/containerd
+  - mkdir -p /etc/containerd
+  - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /home/containerd/cni.template http://metadata.google.internal/computeMetadata/v1/instance/attributes/cni-template'
+  - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /etc/containerd/config.toml http://metadata.google.internal/computeMetadata/v1/instance/attributes/containerd-config'
+  - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /home/containerd/cni.tgz https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz'
+  - tar xzf /home/containerd/cni.tgz -C /home/containerd --overwrite
+  - systemctl restart containerd
   - 'echo current swappiness: $(sysctl vm.swappiness)'
   - 'echo create swap file'
   - 'fallocate -l 1G /swapfile || true'


### PR DESCRIPTION
Migrate swap Ubuntu job to containerd. For this, I modified the following:
- Moved the job to the more proper `containerd.yaml`.
- Configured the job to use containerd as container runtime.
- Included required config files in the image metadata (and retrieve them using the same approach as in #24673).
- Add myself as an owner for the job.

/sig node
/kind cleanup
/area jobs
/priority important-soon