### PR TITLE
Dump more node info in log-dump.sh

### DIFF
--- a/logexporter/cluster/log-dump.sh
+++ b/logexporter/cluster/log-dump.sh
@@ -809,6 +809,23 @@ function dump_nodes_with_logexporter() {
   fi
 }
 
+# Writes node information that's available through the gcloud and kubectl API
+# surfaces to a nodes/ subdirectory of $report_dir.
+function dump_node_info() {
+  nodes_dir="${report_dir}/nodes"
+  mkdir -p "${nodes_dir}"
+
+  detect-node-names
+  if [[ -n "${NODE_NAMES:-}" ]]; then
+    printf "%s\n" "${NODE_NAMES[@]}" > "${nodes_dir}/node_names.txt"
+  fi
+  if [[ -n "${WINDOWS_NODE_NAMES:-}" ]]; then
+    printf "%s\n" "${WINDOWS_NODE_NAMES[@]}" > "${nodes_dir}/windows_node_names.txt"
+  fi
+
+  kubectl get nodes -o yaml > "${nodes_dir}/kubectl_get_nodes.yaml" || true
+}
+
 function detect_node_failures() {
   if ! [[ "${gcloud_supported_providers}" =~ ${KUBERNETES_PROVIDER} ]]; then
     return
@@ -882,6 +899,7 @@ function main() {
   fi
 
   dump_logs
+  dump_node_info
 
   if [[ "${DUMP_TO_GCS_ONLY:-}" == "true" ]] && [[ -n "${gcs_artifacts_dir}" ]]; then
     if [[ "$(ls -A ${report_dir})" ]]; then


### PR DESCRIPTION
Causes log-dump to capture some node information even when not fetching full logs from every node. The information includes all node names and the nodes' kubernetes status.

For GCE/GKE we run some scalability tests that bring up a cluster with hundreds of nodes. Sometimes just a handful of those nodes fail to start, but the log-dump output that we get right now doesn't indicate which nodes failed because we don't gather logs individually for every single node. The summary nodes information that this PR adds should help for troubleshooting this sort of issue.

Depends on https://github.com/kubernetes/test-infra/pull/24759.