### PR TITLE
Use correct release branch for 1.23 Windows jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.23-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.23-windows.yaml
@@ -69,7 +69,7 @@ periodics:
   extra_refs:
   - org: kubernetes
     repo: kubernetes
-    base_ref: release-1.22
+    base_ref: release-1.23
     path_alias: k8s.io/kubernetes
   spec:
     containers:


### PR DESCRIPTION
The job was not running against the correct branch and when https://github.com/kubernetes/test-infra/pull/24718 went in it cannot find the flag which is 1.23+

from https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-aks-engine-azure-1-23-windows-containerd-serial-slow/1477798812234813440/build-log.txt:
```
2022/01/03 00:50:02 process.go:155: Step 'kubectl get nodes --no-headers' finished in 229.180371ms
2022/01/03 00:50:02 e2e.go:495: Cluster nodes:
3341k8s000              Ready   agent    11m   v1.22.6-rc.0.3+fba7198a2cc81c
3341k8s001              Ready   agent    11m   v1.22.6-rc.0.3+fba7198a2cc81c
3341k8s010              Ready   agent    11m   v1.22.6-rc.0.3+fba7198a2cc81c
k8s-master-33419732-0   Ready   master   12m   v1.22.6-rc.0.3+fba7198a2cc81c
2022/01/03 00:50:02 process.go:153: Running: kubectl --match-server-version=false version
2022/01/03 00:50:03 process.go:155: Step 'kubectl --match-server-version=false version' finished in 196.089635ms
2022/01/03 00:50:03 process.go:153: Running: ./hack/ginkgo-e2e.sh --node-os-distro=windows -prepull-images=true --ginkgo.focus=(\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-autoscaling\].\[Feature:HPA\]|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\]) --ginkgo.skip=\[LinuxOnly\]|device.plugin.for.Windows|\[sig-scheduling\].SchedulerPredicates.\[Serial\].validates.that.there.is.no.conflict.between.pods.with.same.hostPort --report-dir=/logs/artifacts --disable-log-dump=true
Conformance test: not doing test setup.
flag provided but not defined: -prepull-images
```

/sig windows 
/assign @claudiubelu @marosset 