### PR TITLE
Add cluster api operator CI jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-operator/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+- JoelSpeed
+approvers:
+- JoelSpeed

--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-periodics-main.yaml
@@ -1,0 +1,21 @@
+periodics:
+- name: periodic-cluster-api-operator-test-main
+  interval: 24h
+  decorate: true
+  labels:
+    preset-service-account: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-operator
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-operator
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211217-ea95cec1d4-1.23
+      command:
+      - "./scripts/ci-test.sh"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
+    testgrid-tab-name: capi-operator-test-main
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "2"

--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-main.yaml
@@ -1,0 +1,98 @@
+presubmits:
+  kubernetes-sigs/cluster-api-operator:
+  - name: pull-cluster-api-operator-build-main
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-operator
+    always_run: true
+    labels:
+      preset-service-account: "true"
+    branches:
+    # The script this job runs is not in all branches.
+    - ^main$
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211217-ea95cec1d4-1.23
+        command:
+        - runner.sh
+        - ./scripts/ci-build.sh
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
+      testgrid-tab-name: capi-operator-pr-build-main
+  - name: pull-cluster-api-operator-make-main
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-operator
+    always_run: false
+    optional: true
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+    branches:
+    # The script this job runs is not in all branches.
+    - ^main$
+    spec:
+      containers:
+      - command:
+        - runner.sh
+        - ./scripts/ci-make.sh
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211217-ea95cec1d4-1.23
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
+      testgrid-tab-name: capi-operator-pr-make-main
+  - name: pull-cluster-api-operator-apidiff-main
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-operator
+    always_run: true
+    optional: true
+    labels:
+      preset-service-account: "true"
+    branches:
+    # The script this job runs is not in all branches.
+    - ^main$
+    spec:
+      containers:
+      - command:
+        - runner.sh
+        - ./scripts/ci-apidiff.sh
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211217-ea95cec1d4-1.23
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
+      testgrid-tab-name: capi-operator-pr-apidiff-main
+  - name: pull-cluster-api-operator-verify-main
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-operator
+    always_run: true
+    labels:
+      preset-service-account: "true"
+    branches:
+    # The script this job runs is not in all branches.
+    - ^main$
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211217-ea95cec1d4-1.23
+        command:
+        - "runner.sh"
+        - ./scripts/ci-verify.sh
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
+      testgrid-tab-name: capi-operator-pr-verify-main
+  - name: pull-cluster-api-operator-test-main
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-operator
+    always_run: true
+    labels:
+      preset-service-account: "true"
+    branches:
+    # The script this job runs is not in all branches.
+    - ^main$
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211217-ea95cec1d4-1.23
+        args:
+        - runner.sh
+        - ./scripts/ci-test.sh
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
+      testgrid-tab-name: capi-operator-pr-test-main

--- a/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
+++ b/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
@@ -16,6 +16,7 @@ dashboard_groups:
     - sig-cluster-lifecycle-cluster-api-provider-ibmcloud
     - sig-cluster-lifecycle-cluster-api-provider-openstack
     - sig-cluster-lifecycle-cluster-api-provider-nested
+    - sig-cluster-lifecycle-cluster-api-operator
     - sig-cluster-lifecycle-kops
     - sig-cluster-lifecycle-etcdadm
     - sig-cluster-lifecycle-image-pushes
@@ -46,6 +47,7 @@ dashboards:
 - name: sig-cluster-lifecycle-cluster-api-provider-vsphere
 - name: sig-cluster-lifecycle-cluster-api-provider-openstack
 - name: sig-cluster-lifecycle-cluster-api-provider-nested
+- name: sig-cluster-lifecycle-cluster-api-operator
 - name: sig-cluster-lifecycle-kops
 - name: sig-cluster-lifecycle-etcdadm
 - name: sig-cluster-lifecycle-image-pushes


### PR DESCRIPTION
Add basic cluster api operator CI jobs: build, test, verify, apidiff. They are inherited from the core cluster-api repository. 