### PR TITLE
Crier gerrit reporter: truncate when there are too many jobs

### DIFF
--- a/prow/gerrit/adapter/adapter_test.go
+++ b/prow/gerrit/adapter/adapter_test.go
@@ -234,7 +234,7 @@ func TestFailedJobs(t *testing.T) {
 			pj.Status.URL = "whatever"
 			pjs = append(pjs, &pj)
 		}
-		return reporter.GenerateReport(pjs).String()
+		return reporter.GenerateReport(pjs, 0).String()
 	}
 
 	cases := []struct {


### PR DESCRIPTION
Gerrit by default limits to 5000 chars per comment, this could be reached when there are many prow jobs reporting.