### PR TITLE
Inrepoconfig: cached client fetches with --prune

### DIFF
--- a/prow/config/inrepoconfig.go
+++ b/prow/config/inrepoconfig.go
@@ -282,8 +282,13 @@ func (c *InRepoConfigGitCache) ClientFor(org, repo string) (git.RepoClient, erro
 					return nil, nil
 				}
 			}
-			// Don't unlock the client unless we get an error or the consumer indicates they are done by Clean()ing.
-			if err := client.Fetch(); err != nil {
+			// Don't unlock the client unless we get an error or the consumer
+			// indicates they are done by Clean()ing.
+			// This fetch operation is repeated executed in the clone repo,
+			// which fails if there is a commit being deleted from remote. This
+			// is a corner case, but when it happens it would be really
+			// annoying, adding `--prune` tag here for mitigation.
+			if err := client.Fetch("--prune"); err != nil {
 				client.Unlock()
 				return nil, err
 			}

--- a/prow/config/inrepoconfig_test.go
+++ b/prow/config/inrepoconfig_test.go
@@ -660,7 +660,7 @@ type fetchOnlyNoCleanRepoClient struct {
 	git.RepoClient // This will be nil during testing, we override the functions that are allowed to be used.
 }
 
-func (rc *fetchOnlyNoCleanRepoClient) Fetch() error {
+func (rc *fetchOnlyNoCleanRepoClient) Fetch(arg ...string) error {
 	return nil
 }
 

--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -589,12 +589,13 @@ func (r *Repo) ShowRef(commitlike string) (string, error) {
 }
 
 // Fetch fetches from remote
-func (r *Repo) Fetch() error {
+func (r *Repo) Fetch(arg ...string) error {
+	arg = append([]string{"fetch"}, arg...)
 	if err := r.refreshRepoAuth(); err != nil {
 		return err
 	}
 	r.logger.Infof("Fetching from remote.")
-	out, err := r.gitCommand("fetch").CombinedOutput()
+	out, err := r.gitCommand(arg...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to fetch: %v.\nOutput: %s", err, string(out))
 	}

--- a/prow/git/v2/adapter.go
+++ b/prow/git/v2/adapter.go
@@ -90,8 +90,8 @@ func (a *repoClientAdapter) MirrorClone() error {
 	return errors.New("no MirrorClone implementation exists in the v1 repo client")
 }
 
-func (a *repoClientAdapter) Fetch() error {
-	return a.Repo.Fetch()
+func (a *repoClientAdapter) Fetch(arg ...string) error {
+	return a.Repo.Fetch(arg...)
 }
 
 func (a *repoClientAdapter) FetchFromRemote(resolver RemoteResolver, branch string) error {

--- a/prow/git/v2/interactor.go
+++ b/prow/git/v2/interactor.go
@@ -54,8 +54,8 @@ type Interactor interface {
 	MergeAndCheckout(baseSHA string, mergeStrategy string, headSHAs ...string) error
 	// Am calls `git am`
 	Am(path string) error
-	// Fetch calls `git fetch`
-	Fetch() error
+	// Fetch calls `git fetch arg...`
+	Fetch(arg ...string) error
 	// FetchRef fetches the refspec
 	FetchRef(refspec string) error
 	// FetchFromRemote fetches the branch of the given remote
@@ -301,13 +301,14 @@ func (i *interactor) RemoteUpdate() error {
 }
 
 // Fetch fetches all updates from the remote.
-func (i *interactor) Fetch() error {
+func (i *interactor) Fetch(arg ...string) error {
 	remote, err := i.remote()
 	if err != nil {
 		return fmt.Errorf("could not resolve remote for fetching: %w", err)
 	}
+	arg = append([]string{"fetch", remote}, arg...)
 	i.logger.Infof("Fetching from %s", remote)
-	if out, err := i.executor.Run("fetch", remote); err != nil {
+	if out, err := i.executor.Run(arg...); err != nil {
 		return fmt.Errorf("error fetching: %w %v", err, string(out))
 	}
 	return nil

--- a/prow/git/v2/interactor_test.go
+++ b/prow/git/v2/interactor_test.go
@@ -1089,6 +1089,7 @@ func TestInteractor_Fetch(t *testing.T) {
 		name          string
 		remote        RemoteResolver
 		responses     map[string]execResponse
+		extraArgs     []string
 		expectedCalls [][]string
 		expectedErr   bool
 	}{
@@ -1104,6 +1105,22 @@ func TestInteractor_Fetch(t *testing.T) {
 			},
 			expectedCalls: [][]string{
 				{"fetch", "someone.com"},
+			},
+			expectedErr: false,
+		},
+		{
+			name: "with arg",
+			remote: func() (string, error) {
+				return "someone.com", nil
+			},
+			responses: map[string]execResponse{
+				"fetch someone.com --prune": {
+					out: []byte(`ok`),
+				},
+			},
+			extraArgs: []string{"--prune"},
+			expectedCalls: [][]string{
+				{"fetch", "someone.com", "--prune"},
 			},
 			expectedErr: false,
 		},
@@ -1144,7 +1161,7 @@ func TestInteractor_Fetch(t *testing.T) {
 				remote:   testCase.remote,
 				logger:   logrus.WithField("test", testCase.name),
 			}
-			actualErr := i.Fetch()
+			actualErr := i.Fetch(testCase.extraArgs...)
 			if testCase.expectedErr && actualErr == nil {
 				t.Errorf("%s: expected an error but got none", testCase.name)
 			}


### PR DESCRIPTION
This fetch operation is repeated executed in the clone which fails if there is a commit being deleted from remote. is a corner case, but when it happens it would be really annoying, adding  tag here for mitigation