### PR TITLE
cluster-api: ensure we're upgrading to corresponding upstream CoreDNS version

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
@@ -205,7 +205,7 @@ periodics:
         - name: ETCD_VERSION_UPGRADE_TO
           value: "3.5.1-0"
         - name: COREDNS_VERSION_UPGRADE_TO
-          value: "v1.8.4"
+          value: "v1.8.6"
         - name: GINKGO_FOCUS
           value: "\\[K8s-Upgrade\\]"
       # we need privileged mode in order to do docker in docker
@@ -249,7 +249,7 @@ periodics:
       - name: ETCD_VERSION_UPGRADE_TO
         value: "3.5.1-0"
       - name: COREDNS_VERSION_UPGRADE_TO
-        value: "v1.8.4"
+        value: "v1.8.6"
       - name: GINKGO_FOCUS
         value: "\\[K8s-Upgrade\\]"
       # we need privileged mode in order to do docker in docker

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-4-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-4-upgrades.yaml
@@ -205,7 +205,7 @@ periodics:
         - name: ETCD_VERSION_UPGRADE_TO
           value: "3.5.1-0"
         - name: COREDNS_VERSION_UPGRADE_TO
-          value: "v1.8.4"
+          value: "v1.8.6"
         - name: GINKGO_FOCUS
           value: "\\[K8s-Upgrade\\]"
       # we need privileged mode in order to do docker in docker
@@ -249,7 +249,7 @@ periodics:
       - name: ETCD_VERSION_UPGRADE_TO
         value: "3.5.1-0"
       - name: COREDNS_VERSION_UPGRADE_TO
-        value: "v1.8.4"
+        value: "v1.8.6"
       - name: GINKGO_FOCUS
         value: "\\[K8s-Upgrade\\]"
       # we need privileged mode in order to do docker in docker

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-0-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-0-upgrades.yaml
@@ -205,7 +205,7 @@ periodics:
         - name: ETCD_VERSION_UPGRADE_TO
           value: "3.5.1-0"
         - name: COREDNS_VERSION_UPGRADE_TO
-          value: "v1.8.4"
+          value: "v1.8.6"
         - name: GINKGO_FOCUS
           value: "\\[K8s-Upgrade\\]"
       # we need privileged mode in order to do docker in docker
@@ -249,7 +249,7 @@ periodics:
       - name: ETCD_VERSION_UPGRADE_TO
         value: "3.5.1-0"
       - name: COREDNS_VERSION_UPGRADE_TO
-        value: "v1.8.4"
+        value: "v1.8.6"
       - name: GINKGO_FOCUS
         value: "\\[K8s-Upgrade\\]"
       # we need privileged mode in order to do docker in docker

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -286,7 +286,7 @@ presubmits:
           - name: ETCD_VERSION_UPGRADE_TO
             value: "3.5.1-0"
           - name: COREDNS_VERSION_UPGRADE_TO
-            value: "v1.8.4"
+            value: "v1.8.6"
           - name: GINKGO_FOCUS
             value: "\\[K8s-Upgrade\\]"
         # we need privileged mode in order to do docker in docker

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-0-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-0-4.yaml
@@ -265,7 +265,7 @@ presubmits:
           - name: ETCD_VERSION_UPGRADE_TO
             value: "3.5.1-0"
           - name: COREDNS_VERSION_UPGRADE_TO
-            value: "v1.8.4"
+            value: "v1.8.6"
           - name: GINKGO_FOCUS
             value: "\\[K8s-Upgrade\\]"
         # we need privileged mode in order to do docker in docker

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-0.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-0.yaml
@@ -259,7 +259,7 @@ presubmits:
           - name: ETCD_VERSION_UPGRADE_TO
             value: "3.5.1-0"
           - name: COREDNS_VERSION_UPGRADE_TO
-            value: "v1.8.4"
+            value: "v1.8.6"
           - name: GINKGO_FOCUS
             value: "\\[K8s-Upgrade\\]"
         # we need privileged mode in order to do docker in docker


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/5849

(more details in https://github.com/kubernetes-sigs/cluster-api/issues/5849#issuecomment-1005695342)

Signed-off-by: Stefan Büringer buringerst@vmware.com