### PR TITLE
Gerrit reporter: sort results also consider error state

### DIFF
--- a/prow/crier/reporters/gerrit/reporter.go
+++ b/prow/crier/reporters/gerrit/reporter.go
@@ -408,17 +408,17 @@ func GenerateReport(pjs []*v1.ProwJob, commentSizeLimit int) JobReport {
 
 	// Sort first so that failed jobs always on top
 	sort.Slice(report.Jobs, func(i, j int) bool {
-		if report.Jobs[i].State == v1.FailureState {
-			return true
-		}
-		if report.Jobs[j].State == v1.FailureState {
-			return false
-		}
-		if report.Jobs[i].State == v1.AbortedState {
-			return true
-		}
-		if report.Jobs[j].State == v1.AbortedState {
-			return false
+		for _, state := range []v1.ProwJobState{
+			v1.FailureState,
+			v1.ErrorState,
+			v1.AbortedState,
+		} {
+			if report.Jobs[i].State == state {
+				return true
+			}
+			if report.Jobs[j].State == state {
+				return false
+			}
 		}
 		// We don't care the orders of the following states, so keep original order
 		return true

--- a/prow/crier/reporters/gerrit/reporter_test.go
+++ b/prow/crier/reporters/gerrit/reporter_test.go
@@ -1549,9 +1549,11 @@ func TestGenerateReport(t *testing.T) {
 			jobs: []*v1.ProwJob{
 				job("this", "url", v1.SuccessState),
 				job("that", "hey", v1.FailureState),
+				job("left", "foo", v1.AbortedState),
+				job("right", "bar", v1.ErrorState),
 			},
-			wantHeader:  "Prow Status: 1 out of 2 pjs passed! Comment '/retest' to rerun all failed tests\n",
-			wantMessage: "❌ that FAILURE - hey\n\n✔️ this SUCCESS - url\n\n",
+			wantHeader:  "Prow Status: 1 out of 4 pjs passed! Comment '/retest' to rerun all failed tests\n",
+			wantMessage: "❌ that FAILURE - hey\n\n🚫 right ERROR - bar\n\n🚫 left ABORTED - foo\n\n✔️ this SUCCESS - url\n\n",
 		},
 		{
 			name: "exceed limit",


### PR DESCRIPTION
It makes more sense to display jobs failed with error state over succeeded instead of mixed in