### PR TITLE
Configurable timeout initializing deck

### DIFF
--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -803,6 +803,9 @@ func Test_gatherOptions(t *testing.T) {
 	}{
 		{
 			name: "minimal flags work",
+			expected: func(o *options) {
+				o.timeoutListingProwJobs = 30
+			},
 		},
 		{
 			name: "explicitly set --config-path",
@@ -811,6 +814,7 @@ func Test_gatherOptions(t *testing.T) {
 			},
 			expected: func(o *options) {
 				o.config.ConfigPath = "/random/value"
+				o.timeoutListingProwJobs = 30
 			},
 		},
 		{


### PR DESCRIPTION
Deck has a hardcoded timeout of 30s for establishing cachsync, which might not be enough when there are lots of prowjobs, and it would crash deck. Make it configurable on prow instances that are very heavily loaded