### PR TITLE
Overrides value of server URL for CAPV prow jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -3,10 +3,7 @@ presets:
     preset-cluster-api-provider-vsphere-e2e-config: "true"
   env:
   - name: GOVC_URL
-    valueFrom:
-      secretKeyRef:
-        name: clusterapi-provider-vsphere-ci-prow
-        key: vsphere-server
+    value: 10.2.224.4
   - name: GOVC_USERNAME
     valueFrom:
       secretKeyRef:


### PR DESCRIPTION
This patch overrides the server URL used in the CI E2E tests for CAPV with a private IP address. Since the IP address requires a special VPN connection, plaintext works as well.
Eventually, this will get replaced by the way of an ExternalSecret.

