### PR TITLE
Switch cgroupv2 COS jobs to cos-dev image family

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -1131,9 +1131,8 @@ periodics:
       - --gcp-nodes=4
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=30
-      # Using cos-93-lts to pick up 5.10 kernel.
-      # See https://github.com/kubernetes/kubernetes/issues/103759
-      - --image-family=cos-93-lts
+      # Using cos-dev to pick up cgroupv2 enabled by default as of cos-dev-97-16778-0-0.
+      - --image-family=cos-dev
       - --image-project=cos-cloud
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8

--- a/jobs/e2e_node/containerd/containerd-master/cgroupv2/image-config-cgroupv2-serial.yaml
+++ b/jobs/e2e_node/containerd/containerd-master/cgroupv2/image-config-cgroupv2-serial.yaml
@@ -1,6 +1,7 @@
 images:
   cos-stable:
-    image_family: cos-93-lts
+    # Using cos-dev to pick up cgroupv2 enabled by default as of cos-dev-97-16778-0-0.
+    image_family: cos-dev
     project: cos-cloud
     machine: n1-standard-2 # These tests need a lot of memory
     metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-master/cgroupv2/env-cgroupv2,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/containerd/containerd-master/cgroupv2/image-config-cgroupv2.yaml
+++ b/jobs/e2e_node/containerd/containerd-master/cgroupv2/image-config-cgroupv2.yaml
@@ -1,5 +1,6 @@
 images:
   cos-stable:
-    image_family: cos-93-lts # deprecated after October 2023 (https://cloud.google.com/container-optimized-os/docs/release-notes)
+    # Using cos-dev to pick up cgroupv2 enabled by default as of cos-dev-97-16778-0-0.
+    image_family: cos-dev
     project: cos-cloud
     metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-master/cgroupv2/env-cgroupv2,gci-update-strategy=update_disabled"


### PR DESCRIPTION
Switch to use cos-dev image family to start testing against
cos-dev-97-16778-0-0. cos-dev-97-16778-0-0 is first COS release that
enables cgroupv2 by default.

![image](https://user-images.githubusercontent.com/486583/148470266-898016d2-7ba0-4e12-be54-bd4d1365fd3b.png)


Signed-off-by: David Porter <porterdavid@google.com>