### PR TITLE
OWNERS: Update aliases with latest release managers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -226,14 +226,19 @@ aliases:
     - cpanato # SIG Technical Lead / RelEng subproject owner / Release Manager
     - jeremyrickard # SIG Technical Lead / RelEng subproject owner
     - justaugustus # SIG Chair / RelEng subproject owner / Release Manager
+    - palnabarun # Release Manager
     - puerco # SIG Technical Lead / RelEng subproject owner / Release Manager
     - saschagrunert # SIG Chair / RelEng subproject owner / Release Manager
+    - Verolop # Release Manager
+    - xmudrii # Release Manager
   release-engineering-reviewers:
     - cpanato # SIG Technical Lead / RelEng subproject owner / Release Manager
     - jeremyrickard # SIG Technical Lead / RelEng subproject owner
     - justaugustus # SIG Chair / RelEng subproject owner / Release Manager
+    - palnabarun # Release Manager
     - puerco # SIG Technical Lead / RelEng subproject owner / Release Manager
     - saschagrunert # SIG Chair / RelEng subproject owner / Release Manager
+    - Verolop # Release Manager
     - xmudrii # Release Manager
 
   # copied from git.k8s.io/enhancements/OWNERS_ALIASES
@@ -322,6 +327,7 @@ aliases:
     - dims
     - justaugustus
     - nikhita
+    - palnabarun
     - puerco
     - saschagrunert
     - sttts


### PR DESCRIPTION
- Add palnabarun to release-engineering-approvers,
  release-engineering-reviewers, publishing-bot-reviewers
- Add Verolop to release-engineering-approvers,
  release-engineering-reviewers
- Add xmudrii to release-engineering-approvers

Ref: https://github.com/kubernetes/sig-release/issues/1713 https://github.com/kubernetes/sig-release/issues/1789

Signed-off-by: Nabarun Pal <pal.nabarun95@gmail.com>
