### PR TITLE
Add new metrics to prow plugins lgtm and approve

### DIFF
--- a/prow/plugins/approve/approve.go
+++ b/prow/plugins/approve/approve.go
@@ -148,14 +148,20 @@ func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) 
 }
 
 func handleGenericCommentEvent(pc plugins.Agent, ce github.GenericCommentEvent) error {
-	return handleGenericComment(
-		pc.Logger,
-		pc.GitHubClient,
-		pc.OwnersClient,
-		pc.Config.GitHubOptions,
-		pc.PluginConfig,
-		&ce,
+	return pc.GatherHandlerMetrics(func() error {
+		return handleGenericComment(
+			pc.Logger,
+			pc.GitHubClient,
+			pc.OwnersClient,
+			pc.Config.GitHubOptions,
+			pc.PluginConfig,
+			&ce,
+		)
+	},
+		PluginName,
+		"handleGenericComment",
 	)
+
 }
 
 func handleGenericComment(log *logrus.Entry, ghc githubClient, oc ownersClient, githubConfig config.GitHubOptions, config *plugins.Configuration, ce *github.GenericCommentEvent) error {
@@ -213,13 +219,18 @@ func handleGenericComment(log *logrus.Entry, ghc githubClient, oc ownersClient, 
 // handleReviewEvent should only handle reviews that have no approval command.
 // Reviews with approval commands will be handled by handleGenericCommentEvent.
 func handleReviewEvent(pc plugins.Agent, re github.ReviewEvent) error {
-	return handleReview(
-		pc.Logger,
-		pc.GitHubClient,
-		pc.OwnersClient,
-		pc.Config.GitHubOptions,
-		pc.PluginConfig,
-		&re,
+	return pc.GatherHandlerMetrics(func() error {
+		return handleReview(
+			pc.Logger,
+			pc.GitHubClient,
+			pc.OwnersClient,
+			pc.Config.GitHubOptions,
+			pc.PluginConfig,
+			&re,
+		)
+	},
+		PluginName,
+		"handleReview",
 	)
 }
 
@@ -282,14 +293,20 @@ func handleReview(log *logrus.Entry, ghc githubClient, oc ownersClient, githubCo
 }
 
 func handlePullRequestEvent(pc plugins.Agent, pre github.PullRequestEvent) error {
-	return handlePullRequest(
-		pc.Logger,
-		pc.GitHubClient,
-		pc.OwnersClient,
-		pc.Config.GitHubOptions,
-		pc.PluginConfig,
-		&pre,
+	return pc.GatherHandlerMetrics(func() error {
+		return handlePullRequest(
+			pc.Logger,
+			pc.GitHubClient,
+			pc.OwnersClient,
+			pc.Config.GitHubOptions,
+			pc.PluginConfig,
+			&pre,
+		)
+	},
+		PluginName,
+		"handlePullRequest",
 	)
+
 }
 
 func handlePullRequest(log *logrus.Entry, ghc githubClient, oc ownersClient, githubConfig config.GitHubOptions, config *plugins.Configuration, pre *github.PullRequestEvent) error {

--- a/prow/plugins/lgtm/lgtm.go
+++ b/prow/plugins/lgtm/lgtm.go
@@ -151,15 +151,22 @@ func handleGenericCommentEvent(pc plugins.Agent, e github.GenericCommentEvent) e
 	if err != nil {
 		return err
 	}
-	return handleGenericComment(pc.GitHubClient, pc.PluginConfig, pc.OwnersClient, pc.Logger, cp, e)
+
+	return pc.GatherHandlerMetrics(func() error {
+		return handleGenericComment(pc.GitHubClient, pc.PluginConfig, pc.OwnersClient, pc.Logger, cp, e)
+	},
+		PluginName,
+		"handleGenericComment",
+	)
+
 }
 
 func handlePullRequestEvent(pc plugins.Agent, pre github.PullRequestEvent) error {
-	return handlePullRequest(
-		pc.Logger,
-		pc.GitHubClient,
-		pc.PluginConfig,
-		&pre,
+	return pc.GatherHandlerMetrics(func() error {
+		return handlePullRequest(pc.Logger, pc.GitHubClient, pc.PluginConfig, &pre)
+	},
+		PluginName,
+		"handlePullRequest",
 	)
 }
 
@@ -173,7 +180,12 @@ func handlePullRequestReviewEvent(pc plugins.Agent, e github.ReviewEvent) error 
 	if err != nil {
 		return err
 	}
-	return handlePullRequestReview(pc.GitHubClient, pc.PluginConfig, pc.OwnersClient, pc.Logger, cp, e)
+	return pc.GatherHandlerMetrics(func() error {
+		return handlePullRequestReview(pc.GitHubClient, pc.PluginConfig, pc.OwnersClient, pc.Logger, cp, e)
+	},
+		PluginName,
+		"handlePullRequestReview",
+	)
 }
 
 func handleGenericComment(gc githubClient, config *plugins.Configuration, ownersClient repoowners.Interface, log *logrus.Entry, cp commentPruner, e github.GenericCommentEvent) error {


### PR DESCRIPTION
This commit adds durations, successes, and failures metrics to measure transactions
in plugins: lgtm, approve. Some transactions take an exceptionally long time in
our installation. This change could confirm our findings and enable the possibility
to act acordingly.

Signed-off-by: Jakub Guzik <jguzik@redhat.com>