### PR TITLE
Added test case for preparing test environment and getting deployer

### DIFF
--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -352,12 +352,17 @@ func complete(o *options) error {
 	if o.logexporterGCSPath != "" {
 		o.testArgs += fmt.Sprintf(" --logexporter-gcs-path=%s", o.logexporterGCSPath)
 	}
-	if err := prepare(o); err != nil {
+	if err := control.XMLWrap(&suite, "Prepare", func() error { return prepare(o) }); err != nil {
 		return fmt.Errorf("failed to prepare test environment: %w", err)
 	}
 	// Get the deployer before we acquire k8s so any additional flag
 	// verifications happen early.
-	deploy, err := getDeployer(o)
+	var deploy deployer
+	err := control.XMLWrap(&suite, "GetDeployer", func () error {
+		d, err := getDeployer(o)
+		deploy = d
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("error creating deployer: %w", err)
 	}


### PR DESCRIPTION
Methods `prepare` and `getDeployer`can potentially fail. In that case only `Overall` row would be present and failed in test grid.

In tests where `num_failures_to_alert` is greater then 1 `Overall` row can potentially create unwanted alerts, so it could be sometimes ignored. Ignoring this row causes failures in places that are not wrapped in separate test cases to be ignored.

I've wrapped calls to `prepare` and `getDeployer` in their separate test cases because those functions seem to have the highest probability to fail.