### PR TITLE
CSI Proxy presubmit integration tests

### DIFF
--- a/config/jobs/kubernetes-csi/csi-proxy/csi-proxy-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-proxy/csi-proxy-config.yaml
@@ -32,3 +32,51 @@ presubmits:
         resources:
           requests:
             cpu: 2000m
+  - name: pull-kubernetes-csi-csi-proxy-integration
+    always_run: false
+    decorate: true
+    labels:
+      preset-k8s-ssh: "true"
+      preset-service-account: "true"
+      preset-common-gce-windows: "true"
+      preset-e2e-gce-windows-containerd: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-other
+      testgrid-tab-name: pull-kubernetes-csi-csi-proxy-integration
+      description: kubernetes-csi/csi-proxy integration tests
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211217-ea95cec1d4-master
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        args:
+        - --check-leaked-resources
+        - --cluster=
+        - --extract=ci/latest
+        - --gcp-zone=us-west1-b
+        - --provider=gce
+        - --gcp-nodes=1
+        - --test=false
+        - --test-cmd=$GOPATH/src/github.com/kubernetes-csi/csi-proxy/scripts/run-integration.sh
+        - --timeout=60m
+        env:
+        - name: NODE_SIZE
+          value: "n2-standard-2"
+        # added in https://github.com/kubernetes/kubernetes/pull/105999
+        - name: WINDOWS_ENABLE_HYPERV
+          value: "true"
+        - name: WINDOWS_NODE_OS_DISTRIBUTION
+          value: "win2019"
+        - name: PREPULL_YAML
+          value: "prepull-head.yaml"
+        # these two values replace the preset-e2e-gce-windows values
+        - name: NUM_WINDOWS_NODES
+          value: "1"
+        - name: NUM_NODES
+          value: "1"
+        securityContext:
+            privileged: true


### PR DESCRIPTION
Run the CSI Proxy integration tests with a Prow job, after this is stable I'll run it with `always_run: true`.

/cc @jingxu97 @ddebroy 
/sig storage