### PR TITLE
Crier gerrit reporter: log contains the job to be reported

### DIFF
--- a/prow/crier/reporters/gerrit/reporter.go
+++ b/prow/crier/reporters/gerrit/reporter.go
@@ -252,6 +252,7 @@ func (c *Client) ShouldReport(ctx context.Context, log *logrus.Entry, pj *v1.Pro
 
 // Report will send the current prowjob status as a gerrit review
 func (c *Client) Report(ctx context.Context, logger *logrus.Entry, pj *v1.ProwJob) ([]*v1.ProwJob, *reconcile.Result, error) {
+	logger = logger.WithFields(logrus.Fields{"job": pj.Spec.Job, "id": pj.Name})
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
@@ -358,7 +359,7 @@ func (c *Client) Report(ctx context.Context, logger *logrus.Entry, pj *v1.ProwJo
 func jobNames(jobs []*v1.ProwJob) []string {
 	names := make([]string, len(jobs))
 	for i, job := range jobs {
-		names[i] = job.Name
+		names[i] = job.Spec.Job
 	}
 	return names
 }


### PR DESCRIPTION
It's not always easy to identify the context of the log without job name or id. Include these in the log so that it's easier to debug

/cc @cjwagner @mpherman2 @listx 