### PR TITLE
Crier gerrit reporter: worker can be more than 1

### DIFF
--- a/prow/cmd/crier/main.go
+++ b/prow/cmd/crier/main.go
@@ -245,7 +245,7 @@ func main() {
 	}
 
 	if o.gerritWorkers > 0 {
-		gerritReporter, err := gerritreporter.NewReporter(cfg, o.cookiefilePath, o.gerritProjects, mgr.GetCache())
+		gerritReporter, err := gerritreporter.NewReporter(cfg, o.cookiefilePath, o.gerritProjects, mgr.GetClient())
 		if err != nil {
 			logrus.WithError(err).Fatal("Error starting gerrit reporter")
 		}

--- a/prow/cmd/crier/main.go
+++ b/prow/cmd/crier/main.go
@@ -78,14 +78,6 @@ type options struct {
 }
 
 func (o *options) validate() error {
-
-	// TODO(krzyzacy): gerrit && github report are actually stateful..
-	// Need a better design to re-enable parallel reporting
-	if o.gerritWorkers > 1 {
-		logrus.Warn("gerrit reporter only supports one worker")
-		o.gerritWorkers = 1
-	}
-
 	if o.gerritWorkers+o.pubsubWorkers+o.githubWorkers+o.slackWorkers+o.gcsWorkers+o.k8sGCSWorkers+o.blobStorageWorkers+o.k8sBlobStorageWorkers <= 0 {
 		return errors.New("crier need to have at least one report worker to start")
 	}

--- a/prow/cmd/crier/main_test.go
+++ b/prow/cmd/crier/main_test.go
@@ -51,10 +51,10 @@ func TestOptions(t *testing.T) {
 		},
 		//Gerrit Reporter
 		{
-			name: "gerrit only support one worker",
+			name: "gerrit supports multiple workers",
 			args: []string{"--gerrit-workers=99", "--gerrit-projects=foo=bar", "--cookiefile=foobar", "--config-path=foo"},
 			expected: &options{
-				gerritWorkers:  1,
+				gerritWorkers:  99,
 				cookiefilePath: "foobar",
 				gerritProjects: map[string][]string{
 					"foo": {"bar"},
@@ -74,7 +74,7 @@ func TestOptions(t *testing.T) {
 			name: "gerrit missing --cookiefile",
 			args: []string{"--gerrit-workers=5", "--gerrit-projects=foo=bar", "--config-path=foo"},
 			expected: &options{
-				gerritWorkers: 1,
+				gerritWorkers: 5,
 				gerritProjects: map[string][]string{
 					"foo": {"bar"},
 				},

--- a/prow/crier/BUILD.bazel
+++ b/prow/crier/BUILD.bazel
@@ -35,6 +35,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//prow/crier/reporters/criercommonlib:all-srcs",
         "//prow/crier/reporters/gcs:all-srcs",
         "//prow/crier/reporters/gerrit:all-srcs",
         "//prow/crier/reporters/github:all-srcs",

--- a/prow/crier/BUILD.bazel
+++ b/prow/crier/BUILD.bazel
@@ -10,12 +10,10 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
+        "//prow/crier/reporters/criercommonlib:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
-        "@io_k8s_apimachinery//pkg/types:go_default_library",
-        "@io_k8s_apimachinery//pkg/util/wait:go_default_library",
-        "@io_k8s_client_go//util/retry:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/builder:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/controller:go_default_library",

--- a/prow/crier/controller.go
+++ b/prow/crier/controller.go
@@ -24,9 +24,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -34,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/crier/reporters/criercommonlib"
 )
 
 type ReportClient interface {
@@ -77,66 +75,6 @@ func New(
 		return fmt.Errorf("failed to construct controller: %w", err)
 	}
 
-	return nil
-}
-
-func (r *reconciler) updateReportState(ctx context.Context, pj *prowv1.ProwJob, log *logrus.Entry, reportedState prowv1.ProwJobState) error {
-	// update pj report status
-	newpj := pj.DeepCopy()
-	// we set omitempty on PrevReportStates, so here we need to init it if is nil
-	if newpj.Status.PrevReportStates == nil {
-		newpj.Status.PrevReportStates = map[string]prowv1.ProwJobState{}
-	}
-	newpj.Status.PrevReportStates[r.reporter.GetName()] = reportedState
-
-	if err := r.pjclientset.Patch(ctx, newpj, ctrlruntimeclient.MergeFrom(pj)); err != nil {
-		return fmt.Errorf("failed to patch: %w", err)
-	}
-
-	// Block until the update is in the lister to make sure that events from another controller
-	// that also does reporting dont trigger another report because our lister doesn't yet contain
-	// the updated Status
-	name := types.NamespacedName{Namespace: pj.Namespace, Name: pj.Name}
-	if err := wait.Poll(100*time.Millisecond, 10*time.Second, func() (bool, error) {
-		if err := r.pjclientset.Get(ctx, name, pj); err != nil {
-			return false, err
-		}
-		if pj.Status.PrevReportStates != nil &&
-			pj.Status.PrevReportStates[r.reporter.GetName()] == reportedState {
-			return true, nil
-		}
-		return false, nil
-	}); err != nil {
-		return fmt.Errorf("failed to wait for updated report status to be in lister: %w", err)
-	}
-	return nil
-}
-
-func (r *reconciler) updateReportStateWithRetries(ctx context.Context, pj *prowv1.ProwJob, log *logrus.Entry) error {
-	reportState := pj.Status.State
-	log = log.WithFields(logrus.Fields{
-		"prowjob":   pj.Name,
-		"jobName":   pj.Spec.Job,
-		"jobStatus": reportState,
-	})
-	// We have to retry here, if we return we lose the information that we already reported this job.
-	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		// Get it first, this is very cheap
-		name := types.NamespacedName{Namespace: pj.Namespace, Name: pj.Name}
-		if err := r.pjclientset.Get(ctx, name, pj); err != nil {
-			return err
-		}
-		// Must not wrap until we have kube 1.19, otherwise the RetryOnConflict won't recognize conflicts
-		// correctly
-		return r.updateReportState(ctx, pj, log, reportState)
-	}); err != nil {
-		// Very subpar, we will report again. But even if we didn't do that now, we would do so
-		// latest when crier gets restarted. In an ideal world, all reporters are idempotent and
-		// reporting has no cost.
-		return fmt.Errorf("failed to update report state on prowjob: %w", err)
-	}
-
-	log.Info("Successfully updated report state on prowjob")
 	return nil
 }
 
@@ -207,7 +145,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *logrus.Entry, req recon
 	log.WithField("job-count", len(pjs)).Info("Reported job(s), now will update pj(s).")
 	var lastErr error
 	for _, pjob := range pjs {
-		if err := r.updateReportStateWithRetries(ctx, pjob, log); err != nil {
+		if err := criercommonlib.UpdateReportStateWithRetries(ctx, pjob, log, r.pjclientset, r.reporter.GetName()); err != nil {
 			log.WithError(err).Error("Failed to update report state on prowjob")
 			// The error above is alreay logged, so it would be duplicated
 			// effort to combine all errors to return, only capture the last

--- a/prow/crier/reporters/criercommonlib/BUILD.bazel
+++ b/prow/crier/reporters/criercommonlib/BUILD.bazel
@@ -1,12 +1,20 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["shardedlock.go"],
+    srcs = [
+        "shardedlock.go",
+        "updatereportstatus.go",
+    ],
     importpath = "k8s.io/test-infra/prow/crier/reporters/criercommonlib",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/apis/prowjobs/v1:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_apimachinery//pkg/types:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/wait:go_default_library",
+        "@io_k8s_client_go//util/retry:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
         "@org_golang_x_sync//semaphore:go_default_library",
     ],
 )
@@ -23,4 +31,12 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["shardedlock_test.go"],
+    embed = [":go_default_library"],
+    tags = ["manual"],
+    deps = ["@org_golang_x_sync//semaphore:go_default_library"],
 )

--- a/prow/crier/reporters/criercommonlib/BUILD.bazel
+++ b/prow/crier/reporters/criercommonlib/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["shardedlock.go"],
+    importpath = "k8s.io/test-infra/prow/crier/reporters/criercommonlib",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@org_golang_x_sync//semaphore:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/crier/reporters/criercommonlib/shardedlock.go
+++ b/prow/crier/reporters/criercommonlib/shardedlock.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package criercommonlib contains shared lib used by reporters
+package criercommonlib
+
+import (
+	"context"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/semaphore"
+)
+
+// SimplePull contains info for identifying a shard
+type SimplePull struct {
+	org, repo string
+	number    int
+}
+
+// NewSimplePull creates SimplePull
+func NewSimplePull(org, repo string, number int) *SimplePull {
+	return &SimplePull{org: org, repo: repo, number: number}
+}
+
+// ShardedLock contains sharding information based on PRs
+type ShardedLock struct {
+	mapLock *semaphore.Weighted
+	locks   map[SimplePull]*semaphore.Weighted
+}
+
+// NewShardedLock creates ShardedLock
+func NewShardedLock(mapLock *semaphore.Weighted, locks map[SimplePull]*semaphore.Weighted) *ShardedLock {
+	return &ShardedLock{mapLock: mapLock, locks: locks}
+}
+
+// GetLock aquires the lock for a PR
+func (s *ShardedLock) GetLock(ctx context.Context, key SimplePull) (*semaphore.Weighted, error) {
+	if err := s.mapLock.Acquire(ctx, 1); err != nil {
+		return nil, err
+	}
+	defer s.mapLock.Release(1)
+	if _, exists := s.locks[key]; !exists {
+		s.locks[key] = semaphore.NewWeighted(1)
+	}
+	return s.locks[key], nil
+}
+
+// Cleanup deletes all locks by acquiring first
+// the mapLock and then each individual lock before
+// deleting it. The individual lock must be acquired
+// because otherwise it may be held, we delete it from
+// the map, it gets recreated and acquired and two
+// routines report in parallel for the same job.
+// Note that while this function is running, no new
+// presubmit reporting can happen, as we hold the mapLock.
+func (s *ShardedLock) Cleanup() {
+	ctx := context.Background()
+	s.mapLock.Acquire(ctx, 1)
+	defer s.mapLock.Release(1)
+
+	for key, lock := range s.locks {
+		lock.Acquire(ctx, 1)
+		delete(s.locks, key)
+		lock.Release(1)
+	}
+}
+
+// RunCleanup asynchronously runs the cleanup once per hour.
+func (s *ShardedLock) RunCleanup() {
+	go func() {
+		for range time.Tick(time.Hour) {
+			logrus.Debug("Starting to clean up presubmit locks")
+			startTime := time.Now()
+			s.Cleanup()
+			logrus.WithField("duration", time.Since(startTime).String()).Debug("Finished cleaning up presubmit locks")
+		}
+	}()
+}

--- a/prow/crier/reporters/criercommonlib/shardedlock_test.go
+++ b/prow/crier/reporters/criercommonlib/shardedlock_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package criercommonlib contains shared lib used by reporters
+package criercommonlib
+
+import (
+	"testing"
+
+	"golang.org/x/sync/semaphore"
+)
+
+func TestShardedLockCleanup(t *testing.T) {
+	t.Parallel()
+	sl := &ShardedLock{mapLock: semaphore.NewWeighted(1), locks: map[SimplePull]*semaphore.Weighted{}}
+	key := SimplePull{"org", "repo", 1}
+	sl.locks[key] = semaphore.NewWeighted(1)
+	sl.Cleanup()
+	if _, exists := sl.locks[key]; exists {
+		t.Error("lock didn't get cleaned up")
+	}
+
+}

--- a/prow/crier/reporters/criercommonlib/updatereportstatus.go
+++ b/prow/crier/reporters/criercommonlib/updatereportstatus.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package criercommonlib contains shared lib used by reporters
+package criercommonlib
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+)
+
+func updateReportState(ctx context.Context, pj *prowv1.ProwJob, log *logrus.Entry, reportedState prowv1.ProwJobState, pjclientset ctrlruntimeclient.Client, reporterName string) error {
+	// update pj report status
+	newpj := pj.DeepCopy()
+	// we set omitempty on PrevReportStates, so here we need to init it if is nil
+	if newpj.Status.PrevReportStates == nil {
+		newpj.Status.PrevReportStates = map[string]prowv1.ProwJobState{}
+	}
+	newpj.Status.PrevReportStates[reporterName] = reportedState
+
+	if err := pjclientset.Patch(ctx, newpj, ctrlruntimeclient.MergeFrom(pj)); err != nil {
+		return fmt.Errorf("failed to patch: %w", err)
+	}
+
+	// Block until the update is in the lister to make sure that events from another controller
+	// that also does reporting dont trigger another report because our lister doesn't yet contain
+	// the updated Status
+	name := types.NamespacedName{Namespace: pj.Namespace, Name: pj.Name}
+	if err := wait.Poll(100*time.Millisecond, 10*time.Second, func() (bool, error) {
+		if err := pjclientset.Get(ctx, name, pj); err != nil {
+			return false, err
+		}
+		if pj.Status.PrevReportStates != nil &&
+			pj.Status.PrevReportStates[reporterName] == reportedState {
+			return true, nil
+		}
+		return false, nil
+	}); err != nil {
+		return fmt.Errorf("failed to wait for updated report status to be in lister: %w", err)
+	}
+	return nil
+}
+
+func UpdateReportStateWithRetries(ctx context.Context, pj *prowv1.ProwJob, log *logrus.Entry, pjclientset ctrlruntimeclient.Client, reporterName string) error {
+	reportState := pj.Status.State
+	log = log.WithFields(logrus.Fields{
+		"prowjob":   pj.Name,
+		"jobName":   pj.Spec.Job,
+		"jobStatus": reportState,
+	})
+	// We have to retry here, if we return we lose the information that we already reported this job.
+	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		// Get it first, this is very cheap
+		name := types.NamespacedName{Namespace: pj.Namespace, Name: pj.Name}
+		if err := pjclientset.Get(ctx, name, pj); err != nil {
+			return err
+		}
+		// Must not wrap until we have kube 1.19, otherwise the RetryOnConflict won't recognize conflicts
+		// correctly
+		return updateReportState(ctx, pj, log, reportState, pjclientset, reporterName)
+	}); err != nil {
+		// Very subpar, we will report again. But even if we didn't do that now, we would do so
+		// latest when crier gets restarted. In an ideal world, all reporters are idempotent and
+		// reporting has no cost.
+		return fmt.Errorf("failed to update report state on prowjob: %w", err)
+	}
+
+	log.Info("Successfully updated report state on prowjob")
+	return nil
+}

--- a/prow/crier/reporters/gerrit/BUILD.bazel
+++ b/prow/crier/reporters/gerrit/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/reconcile:go_default_library",
-        "@org_golang_x_sync//semaphore:go_default_library",
     ],
 )
 
@@ -41,6 +40,7 @@ go_test(
     tags = ["manual"],
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
+        "//prow/crier/reporters/criercommonlib:go_default_library",
         "//prow/gerrit/client:go_default_library",
         "//prow/kube:go_default_library",
         "@com_github_andygrunwald_go_gerrit//:go_default_library",
@@ -50,5 +50,6 @@ go_test(
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_apimachinery//pkg/util/diff:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client/fake:go_default_library",
+        "@org_golang_x_sync//errgroup:go_default_library",
     ],
 )

--- a/prow/crier/reporters/gerrit/BUILD.bazel
+++ b/prow/crier/reporters/gerrit/BUILD.bazel
@@ -8,12 +8,15 @@ go_library(
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
+        "//prow/crier/reporters/criercommonlib:go_default_library",
         "//prow/gerrit/client:go_default_library",
         "//prow/kube:go_default_library",
         "@com_github_andygrunwald_go_gerrit//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/reconcile:go_default_library",
+        "@org_golang_x_sync//semaphore:go_default_library",
     ],
 )
 

--- a/prow/crier/reporters/gerrit/reporter_test.go
+++ b/prow/crier/reporters/gerrit/reporter_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/andygrunwald/go-gerrit"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/semaphore"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -35,6 +36,7 @@ import (
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	v1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/crier/reporters/criercommonlib"
 	"k8s.io/test-infra/prow/gerrit/client"
 	"k8s.io/test-infra/prow/kube"
 )
@@ -205,6 +207,11 @@ func TestReport(t *testing.T) {
 				Spec: v1.ProwJobSpec{
 					Refs: &v1.Refs{
 						Repo: "foo",
+						Pulls: []v1.Pull{
+							{
+								Number: 0,
+							},
+						},
 					},
 					Job:    "ci-foo",
 					Report: true,
@@ -236,6 +243,11 @@ func TestReport(t *testing.T) {
 				Spec: v1.ProwJobSpec{
 					Refs: &v1.Refs{
 						Repo: "foo",
+						Pulls: []v1.Pull{
+							{
+								Number: 0,
+							},
+						},
 					},
 					Job:    "ci-foo",
 					Report: false,
@@ -263,6 +275,11 @@ func TestReport(t *testing.T) {
 				Spec: v1.ProwJobSpec{
 					Refs: &v1.Refs{
 						Repo: "foo",
+						Pulls: []v1.Pull{
+							{
+								Number: 0,
+							},
+						},
 					},
 					Job:    "ci-foo",
 					Report: true,
@@ -293,6 +310,11 @@ func TestReport(t *testing.T) {
 				Spec: v1.ProwJobSpec{
 					Refs: &v1.Refs{
 						Repo: "foo",
+						Pulls: []v1.Pull{
+							{
+								Number: 0,
+							},
+						},
 					},
 					Job:    "ci-foo",
 					Report: true,
@@ -323,6 +345,11 @@ func TestReport(t *testing.T) {
 				Spec: v1.ProwJobSpec{
 					Refs: &v1.Refs{
 						Repo: "foo",
+						Pulls: []v1.Pull{
+							{
+								Number: 0,
+							},
+						},
 					},
 					Job:    "ci-foo",
 					Report: true,
@@ -351,6 +378,11 @@ func TestReport(t *testing.T) {
 				Spec: v1.ProwJobSpec{
 					Refs: &v1.Refs{
 						Repo: "foo",
+						Pulls: []v1.Pull{
+							{
+								Number: 0,
+							},
+						},
 					},
 					Job:    "ci-foo",
 					Report: true,
@@ -383,6 +415,11 @@ func TestReport(t *testing.T) {
 					Type: v1.PresubmitJob,
 					Refs: &v1.Refs{
 						Repo: "foo",
+						Pulls: []v1.Pull{
+							{
+								Number: 0,
+							},
+						},
 					},
 					Job:    "ci-foo",
 					Report: true,
@@ -414,6 +451,11 @@ func TestReport(t *testing.T) {
 				Spec: v1.ProwJobSpec{
 					Refs: &v1.Refs{
 						Repo: "foo/bar",
+						Pulls: []v1.Pull{
+							{
+								Number: 0,
+							},
+						},
 					},
 					Job:    "ci-foo-bar",
 					Report: true,
@@ -446,6 +488,11 @@ func TestReport(t *testing.T) {
 				Spec: v1.ProwJobSpec{
 					Refs: &v1.Refs{
 						Repo: "foo",
+						Pulls: []v1.Pull{
+							{
+								Number: 0,
+							},
+						},
 					},
 					Job:    "ci-foo",
 					Report: true,
@@ -471,6 +518,11 @@ func TestReport(t *testing.T) {
 					Spec: v1.ProwJobSpec{
 						Refs: &v1.Refs{
 							Repo: "bar",
+							Pulls: []v1.Pull{
+								{
+									Number: 0,
+								},
+							},
 						},
 						Job:    "ci-bar",
 						Report: true,
@@ -504,6 +556,11 @@ func TestReport(t *testing.T) {
 				Spec: v1.ProwJobSpec{
 					Refs: &v1.Refs{
 						Repo: "foo",
+						Pulls: []v1.Pull{
+							{
+								Number: 0,
+							},
+						},
 					},
 					Job:    "ci-foo",
 					Report: true,
@@ -529,6 +586,11 @@ func TestReport(t *testing.T) {
 					Spec: v1.ProwJobSpec{
 						Refs: &v1.Refs{
 							Repo: "bar",
+							Pulls: []v1.Pull{
+								{
+									Number: 0,
+								},
+							},
 						},
 						Job:    "ci-bar",
 						Report: true,
@@ -557,6 +619,11 @@ func TestReport(t *testing.T) {
 				Spec: v1.ProwJobSpec{
 					Refs: &v1.Refs{
 						Repo: "foo",
+						Pulls: []v1.Pull{
+							{
+								Number: 0,
+							},
+						},
 					},
 					Job:    "ci-foo",
 					Report: true,
@@ -582,6 +649,11 @@ func TestReport(t *testing.T) {
 					Spec: v1.ProwJobSpec{
 						Refs: &v1.Refs{
 							Repo: "bar",
+							Pulls: []v1.Pull{
+								{
+									Number: 0,
+								},
+							},
 						},
 						Job:    "ci-bar",
 						Report: true,
@@ -615,6 +687,11 @@ func TestReport(t *testing.T) {
 					Type: v1.PostsubmitJob,
 					Refs: &v1.Refs{
 						Repo: "foo",
+						Pulls: []v1.Pull{
+							{
+								Number: 0,
+							},
+						},
 					},
 					Job:    "ci-foo",
 					Report: true,
@@ -646,6 +723,11 @@ func TestReport(t *testing.T) {
 					Type: v1.PresubmitJob,
 					Refs: &v1.Refs{
 						Repo: "foo",
+						Pulls: []v1.Pull{
+							{
+								Number: 0,
+							},
+						},
 					},
 					Job:    "ci-foo",
 					Report: true,
@@ -672,6 +754,11 @@ func TestReport(t *testing.T) {
 						Type: v1.PresubmitJob,
 						Refs: &v1.Refs{
 							Repo: "bar",
+							Pulls: []v1.Pull{
+								{
+									Number: 0,
+								},
+							},
 						},
 						Job:    "ci-bar",
 						Report: true,
@@ -705,6 +792,11 @@ func TestReport(t *testing.T) {
 				Spec: v1.ProwJobSpec{
 					Refs: &v1.Refs{
 						Repo: "foo",
+						Pulls: []v1.Pull{
+							{
+								Number: 0,
+							},
+						},
 					},
 					Job:    "ci-foo",
 					Report: true,
@@ -730,6 +822,11 @@ func TestReport(t *testing.T) {
 					Spec: v1.ProwJobSpec{
 						Refs: &v1.Refs{
 							Repo: "bar",
+							Pulls: []v1.Pull{
+								{
+									Number: 0,
+								},
+							},
 						},
 						Job:    "ci-bar",
 						Report: true,
@@ -763,6 +860,11 @@ func TestReport(t *testing.T) {
 				Spec: v1.ProwJobSpec{
 					Refs: &v1.Refs{
 						Repo: "foo",
+						Pulls: []v1.Pull{
+							{
+								Number: 0,
+							},
+						},
 					},
 					Job:    "ci-foo",
 					Type:   v1.PresubmitJob,
@@ -789,6 +891,11 @@ func TestReport(t *testing.T) {
 					Spec: v1.ProwJobSpec{
 						Refs: &v1.Refs{
 							Repo: "bar",
+							Pulls: []v1.Pull{
+								{
+									Number: 0,
+								},
+							},
 						},
 						Job:    "ci-bar",
 						Type:   v1.PresubmitJob,
@@ -822,6 +929,11 @@ func TestReport(t *testing.T) {
 				Spec: v1.ProwJobSpec{
 					Refs: &v1.Refs{
 						Repo: "foo",
+						Pulls: []v1.Pull{
+							{
+								Number: 0,
+							},
+						},
 					},
 					Job:    "ci-foo",
 					Report: true,
@@ -847,6 +959,11 @@ func TestReport(t *testing.T) {
 					Spec: v1.ProwJobSpec{
 						Refs: &v1.Refs{
 							Repo: "bar",
+							Pulls: []v1.Pull{
+								{
+									Number: 0,
+								},
+							},
 						},
 						Job:    "ci-bar",
 						Report: true,
@@ -879,6 +996,11 @@ func TestReport(t *testing.T) {
 				Spec: v1.ProwJobSpec{
 					Refs: &v1.Refs{
 						Repo: "foo",
+						Pulls: []v1.Pull{
+							{
+								Number: 0,
+							},
+						},
 					},
 					Job:    "ci-foo",
 					Report: true,
@@ -904,6 +1026,11 @@ func TestReport(t *testing.T) {
 					Spec: v1.ProwJobSpec{
 						Refs: &v1.Refs{
 							Repo: "bar",
+							Pulls: []v1.Pull{
+								{
+									Number: 0,
+								},
+							},
 						},
 						Job:    "ci-bar",
 						Report: true,
@@ -939,6 +1066,11 @@ func TestReport(t *testing.T) {
 				Spec: v1.ProwJobSpec{
 					Refs: &v1.Refs{
 						Repo: "foo",
+						Pulls: []v1.Pull{
+							{
+								Number: 0,
+							},
+						},
 					},
 					Job:    "ci-foo",
 					Report: true,
@@ -970,6 +1102,11 @@ func TestReport(t *testing.T) {
 					Spec: v1.ProwJobSpec{
 						Refs: &v1.Refs{
 							Repo: "foo",
+							Pulls: []v1.Pull{
+								{
+									Number: 0,
+								},
+							},
 						},
 						Job:    "ci-foo",
 						Report: true,
@@ -1002,6 +1139,11 @@ func TestReport(t *testing.T) {
 				Spec: v1.ProwJobSpec{
 					Refs: &v1.Refs{
 						Repo: "foo",
+						Pulls: []v1.Pull{
+							{
+								Number: 0,
+							},
+						},
 					},
 					Job:    "ci-foo",
 					Report: true,
@@ -1027,6 +1169,11 @@ func TestReport(t *testing.T) {
 					Spec: v1.ProwJobSpec{
 						Refs: &v1.Refs{
 							Repo: "bar",
+							Pulls: []v1.Pull{
+								{
+									Number: 0,
+								},
+							},
 						},
 						Job:    "ci-bar",
 						Report: true,
@@ -1063,6 +1210,11 @@ func TestReport(t *testing.T) {
 					Type: v1.PresubmitJob,
 					Refs: &v1.Refs{
 						Repo: "foo",
+						Pulls: []v1.Pull{
+							{
+								Number: 0,
+							},
+						},
 					},
 					Job:    "ci-foo",
 					Report: true,
@@ -1094,6 +1246,11 @@ func TestReport(t *testing.T) {
 					Spec: v1.ProwJobSpec{
 						Refs: &v1.Refs{
 							Repo: "bar",
+							Pulls: []v1.Pull{
+								{
+									Number: 0,
+								},
+							},
 						},
 						Job:    "ci-bar",
 						Type:   v1.PresubmitJob,
@@ -1125,6 +1282,11 @@ func TestReport(t *testing.T) {
 					Spec: v1.ProwJobSpec{
 						Refs: &v1.Refs{
 							Repo: "foo",
+							Pulls: []v1.Pull{
+								{
+									Number: 0,
+								},
+							},
 						},
 						Job:    "ci-foo",
 						Type:   v1.PresubmitJob,
@@ -1166,6 +1328,11 @@ func TestReport(t *testing.T) {
 					Type: v1.PresubmitJob,
 					Refs: &v1.Refs{
 						Repo: "foo",
+						Pulls: []v1.Pull{
+							{
+								Number: 0,
+							},
+						},
 					},
 					Job:    "ci-foo",
 					Report: true,
@@ -1201,6 +1368,11 @@ func TestReport(t *testing.T) {
 					Spec: v1.ProwJobSpec{
 						Refs: &v1.Refs{
 							Repo: "bar",
+							Pulls: []v1.Pull{
+								{
+									Number: 0,
+								},
+							},
 						},
 						Job:    "ci-bar",
 						Type:   v1.PresubmitJob,
@@ -1236,6 +1408,11 @@ func TestReport(t *testing.T) {
 					Spec: v1.ProwJobSpec{
 						Refs: &v1.Refs{
 							Repo: "foo",
+							Pulls: []v1.Pull{
+								{
+									Number: 0,
+								},
+							},
 						},
 						Job:    "ci-foo",
 						Type:   v1.PresubmitJob,
@@ -1268,6 +1445,11 @@ func TestReport(t *testing.T) {
 					Spec: v1.ProwJobSpec{
 						Refs: &v1.Refs{
 							Repo: "foo",
+							Pulls: []v1.Pull{
+								{
+									Number: 0,
+								},
+							},
 						},
 						Job:    "ci-foo",
 						Type:   v1.PresubmitJob,
@@ -1306,6 +1488,11 @@ func TestReport(t *testing.T) {
 					Type: v1.PresubmitJob,
 					Refs: &v1.Refs{
 						Repo: "foo",
+						Pulls: []v1.Pull{
+							{
+								Number: 0,
+							},
+						},
 					},
 					Job:    "ci-foo",
 					Report: true,
@@ -1341,6 +1528,11 @@ func TestReport(t *testing.T) {
 					Spec: v1.ProwJobSpec{
 						Refs: &v1.Refs{
 							Repo: "bar",
+							Pulls: []v1.Pull{
+								{
+									Number: 0,
+								},
+							},
 						},
 						Job:    "ci-bar",
 						Type:   v1.PresubmitJob,
@@ -1376,6 +1568,11 @@ func TestReport(t *testing.T) {
 					Spec: v1.ProwJobSpec{
 						Refs: &v1.Refs{
 							Repo: "foo",
+							Pulls: []v1.Pull{
+								{
+									Number: 0,
+								},
+							},
 						},
 						Job:    "ci-foo",
 						Type:   v1.PresubmitJob,
@@ -1408,6 +1605,11 @@ func TestReport(t *testing.T) {
 					Spec: v1.ProwJobSpec{
 						Refs: &v1.Refs{
 							Repo: "foo",
+							Pulls: []v1.Pull{
+								{
+									Number: 0,
+								},
+							},
 						},
 						Job:    "ci-foo",
 						Type:   v1.PresubmitJob,
@@ -1439,6 +1641,11 @@ func TestReport(t *testing.T) {
 					Type: v1.PresubmitJob,
 					Refs: &v1.Refs{
 						Repo: "foo",
+						Pulls: []v1.Pull{
+							{
+								Number: 0,
+							},
+						},
 					},
 					Job:    "ci-foo",
 					Report: true,
@@ -1470,6 +1677,11 @@ func TestReport(t *testing.T) {
 				Spec: v1.ProwJobSpec{
 					Refs: &v1.Refs{
 						Repo: "foo",
+						Pulls: []v1.Pull{
+							{
+								Number: 0,
+							},
+						},
 					},
 					Job:    "ci-foo",
 					Report: true,
@@ -1491,7 +1703,12 @@ func TestReport(t *testing.T) {
 				allpj = append(allpj, pj)
 			}
 
-			reporter := &Client{gc: fgc, lister: fakectrlruntimeclient.NewFakeClient(allpj...)}
+			reporter := &Client{
+				gc:     fgc,
+				lister: fakectrlruntimeclient.NewFakeClient(allpj...),
+				prLocks: criercommonlib.NewShardedLock(semaphore.NewWeighted(1),
+					map[criercommonlib.SimplePull]*semaphore.Weighted{}),
+			}
 
 			shouldReport := reporter.ShouldReport(context.Background(), logrus.NewEntry(logrus.StandardLogger()), tc.pj)
 			if shouldReport != tc.expectReport {

--- a/prow/crier/reporters/github/BUILD.bazel
+++ b/prow/crier/reporters/github/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
+        "//prow/crier/reporters/criercommonlib:go_default_library",
         "//prow/gerrit/client:go_default_library",
         "//prow/github/report:go_default_library",
         "//prow/kube:go_default_library",

--- a/prow/crier/reporters/github/BUILD.bazel
+++ b/prow/crier/reporters/github/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/reconcile:go_default_library",
-        "@org_golang_x_sync//semaphore:go_default_library",
     ],
 )
 
@@ -50,6 +49,5 @@ go_test(
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client/fake:go_default_library",
-        "@org_golang_x_sync//semaphore:go_default_library",
     ],
 )

--- a/prow/crier/reporters/github/reporter.go
+++ b/prow/crier/reporters/github/reporter.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sync/semaphore"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -58,10 +57,8 @@ func NewReporter(gc report.GitHubClient, cfg config.Getter, reportAgent v1.ProwJ
 		gc:          gc,
 		config:      cfg,
 		reportAgent: reportAgent,
-		prLocks: criercommonlib.NewShardedLock(
-			semaphore.NewWeighted(1),
-			map[criercommonlib.SimplePull]*semaphore.Weighted{}),
-		lister: lister,
+		prLocks:     criercommonlib.NewShardedLock(),
+		lister:      lister,
 	}
 	c.prLocks.RunCleanup()
 	return c

--- a/prow/crier/reporters/github/reporter_test.go
+++ b/prow/crier/reporters/github/reporter_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sync/semaphore"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -169,18 +168,6 @@ func TestPresumitReportingLocks(t *testing.T) {
 	}()
 
 	wg.Wait()
-}
-
-func TestShardedLockCleanup(t *testing.T) {
-	t.Parallel()
-	sl := &shardedLock{mapLock: semaphore.NewWeighted(1), locks: map[simplePull]*semaphore.Weighted{}}
-	key := simplePull{"org", "repo", 1}
-	sl.locks[key] = semaphore.NewWeighted(1)
-	sl.cleanup()
-	if _, exists := sl.locks[key]; exists {
-		t.Error("lock didn't get cleaned up")
-	}
-
 }
 
 func TestReport(t *testing.T) {


### PR DESCRIPTION
Initially gerrit worker is restricted to be only 1, due to the fact that gerrit worker could potentially do duplicated work if they don't understand each other. This resulted in gerrit reporter to work single-threaded, which is a performance bottleneck when there are lots of workloads to be reported.

Similar problem had happened on github reporter too, that multiple jobs trying to access the same github comment. This problem was solved by introducing a ShardedLock. This PR refactors ShardedLock so that it can be used by both gerrit and github reporter.