### PR TITLE
cla: Switch over to EasyCLA

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -667,19 +667,27 @@ tide:
     orgs:
       kubernetes:
         optional-contexts:
-        - "EasyCLA" # NOTE(cblecker): This is temporary until we fully roll out EasyCLA
+        # NOTE(MadhavJivrajani): This is temporary and left in for an additional release cycle after full EasyCLA rollout
+        # to ensure things get merged in.
+        - "cla/linuxfoundation"
         repos:
           dashboard:
             from-branch-protection: true
       kubernetes-client:
         optional-contexts:
-        - "EasyCLA" # NOTE(mrbobbytables): This is temporary until we fully roll out EasyCLA
+        # NOTE(MadhavJivrajani): This is temporary and left in for an additional release cycle after full EasyCLA rollout
+        # to ensure things get merged in.
+        - "cla/linuxfoundation"
       kubernetes-csi:
         optional-contexts:
-        - "EasyCLA" # NOTE(mrbobbytables): This is temporary until we fully roll out EasyCLA
+        # NOTE(MadhavJivrajani): This is temporary and left in for an additional release cycle after full EasyCLA rollout
+        # to ensure things get merged in.
+        - "cla/linuxfoundation"
       kubernetes-sigs:
         optional-contexts:
-        - "EasyCLA" # NOTE(mrbobbytables): This is temporary until we fully roll out EasyCLA
+        # NOTE(MadhavJivrajani): This is temporary and left in for an additional release cycle after full EasyCLA rollout
+        # to ensure things get merged in.
+        - "cla/linuxfoundation"
   batch_size_limit:
     "kubernetes/kubernetes": 15
   priority:

--- a/prow/plugins/cla/cla.go
+++ b/prow/plugins/cla/cla.go
@@ -32,29 +32,9 @@ import (
 )
 
 const (
-	pluginName             = "cla"
-	claContextName         = "cla/linuxfoundation"
-	cncfclaNotFoundMessage = `Thanks for your pull request. Before we can look at your pull request, you'll need to sign a Contributor License Agreement (CLA).
-
-:memo: **Please follow instructions at <https://git.k8s.io/community/CLA.md#the-contributor-license-agreement> to sign the CLA.**
-
-It may take a couple minutes for the CLA signature to be fully registered; after that, please reply here with a new comment and we'll verify.  Thanks.
-
----
-
-- If you've already signed a CLA, it's possible we don't have your GitHub username or you're using a different email address.  Check your existing CLA data and verify that your [email is set on your git commits](https://help.github.com/articles/setting-your-email-in-git/).
-- If you signed the CLA as a corporation, please sign in with your organization's credentials at <https://identity.linuxfoundation.org/projects/cncf> to be authorized.
-- If you have done the above and are still having issues with the CLA being reported as unsigned, please log a ticket with the Linux Foundation Helpdesk: <https://support.linuxfoundation.org/>
-- Should you encounter any issues with the Linux Foundation Helpdesk, send a message to the backup e-mail support address at: login-issues@jira.linuxfoundation.org
-
-<!-- need_sender_cla -->
-
-<details>
-
-%s
-</details>
-	`
-	maxRetries = 5
+	pluginName     = "cla"
+	claContextName = "EasyCLA"
+	maxRetries     = 5
 )
 
 var (
@@ -83,7 +63,6 @@ func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhel
 }
 
 type gitHubClient interface {
-	CreateComment(owner, repo string, number int, comment string) error
 	AddLabel(owner, repo string, number int, label string) error
 	RemoveLabel(owner, repo string, number int, label string) error
 	GetPullRequest(owner, repo string, number int) (*github.PullRequest, error)
@@ -181,9 +160,6 @@ func handle(gc gitHubClient, log *logrus.Entry, se github.StatusEvent) error {
 			if err := gc.RemoveLabel(org, repo, number, labels.ClaYes); err != nil {
 				l.WithError(err).Warningf("Could not remove %s label.", labels.ClaYes)
 			}
-		}
-		if err := gc.CreateComment(org, repo, number, fmt.Sprintf(cncfclaNotFoundMessage, plugins.AboutThisBot)); err != nil {
-			l.WithError(err).Warning("Could not create CLA not found comment.")
 		}
 		if err := gc.AddLabel(org, repo, number, labels.ClaNo); err != nil {
 			l.WithError(err).Warningf("Could not add %s label.", labels.ClaNo)

--- a/prow/plugins/cla/cla_test.go
+++ b/prow/plugins/cla/cla_test.go
@@ -48,16 +48,16 @@ func TestCLALabels(t *testing.T) {
 			removedLabels: nil,
 		},
 		{
-			name:          "cla/linuxfoundation status pending has no effect",
-			context:       "cla/linuxfoundation",
+			name:          "EasyCLA status pending has no effect",
+			context:       "EasyCLA",
 			state:         "pending",
 			addedLabels:   nil,
 			removedLabels: nil,
 		},
 		{
-			name: "cla/linuxfoundation status success does not add/remove labels " +
+			name: "EasyCLA status success does not add/remove labels " +
 				"when not the head commit in a PR",
-			context:   "cla/linuxfoundation",
+			context:   "EasyCLA",
 			state:     "success",
 			statusSHA: "a",
 			issues: []github.Issue{
@@ -70,9 +70,9 @@ func TestCLALabels(t *testing.T) {
 			removedLabels: nil,
 		},
 		{
-			name: "cla/linuxfoundation status failure does not add/remove labels " +
+			name: "EasyCLA status failure does not add/remove labels " +
 				"when not the head commit in a PR",
-			context:   "cla/linuxfoundation",
+			context:   "EasyCLA",
 			state:     "failure",
 			statusSHA: "a",
 			issues: []github.Issue{
@@ -85,8 +85,8 @@ func TestCLALabels(t *testing.T) {
 			removedLabels: nil,
 		},
 		{
-			name:      "cla/linuxfoundation status on head commit of PR adds the cla-yes label when its state is \"success\"",
-			context:   "cla/linuxfoundation",
+			name:      "EasyCLA status on head commit of PR adds the cla-yes label when its state is \"success\"",
+			context:   "EasyCLA",
 			state:     "success",
 			statusSHA: "a",
 			issues: []github.Issue{
@@ -99,8 +99,8 @@ func TestCLALabels(t *testing.T) {
 			removedLabels: nil,
 		},
 		{
-			name:      "cla/linuxfoundation status on head commit of PR does nothing when pending",
-			context:   "cla/linuxfoundation",
+			name:      "EasyCLA status on head commit of PR does nothing when pending",
+			context:   "EasyCLA",
 			state:     "pending",
 			statusSHA: "a",
 			issues: []github.Issue{
@@ -113,8 +113,8 @@ func TestCLALabels(t *testing.T) {
 			removedLabels: nil,
 		},
 		{
-			name:      "cla/linuxfoundation status success removes \"cncf-cla: no\" label",
-			context:   "cla/linuxfoundation",
+			name:      "EasyCLA status success removes \"cncf-cla: no\" label",
+			context:   "EasyCLA",
 			state:     "success",
 			statusSHA: "a",
 			issues: []github.Issue{
@@ -127,8 +127,8 @@ func TestCLALabels(t *testing.T) {
 			removedLabels: []string{fmt.Sprintf("/#3:%s", labels.ClaNo)},
 		},
 		{
-			name:      "cla/linuxfoundation status failure removes \"cncf-cla: yes\" label",
-			context:   "cla/linuxfoundation",
+			name:      "EasyCLA status failure removes \"cncf-cla: yes\" label",
+			context:   "EasyCLA",
 			state:     "failure",
 			statusSHA: "a",
 			issues: []github.Issue{
@@ -195,7 +195,7 @@ func TestCheckCLA(t *testing.T) {
 		removedLabel string
 	}{
 		{
-			name:       "ignore non cla/linuxfoundation context",
+			name:       "ignore non EasyCLA context",
 			context:    "random/context",
 			state:      "success",
 			issueState: "open",
@@ -208,7 +208,7 @@ func TestCheckCLA(t *testing.T) {
 		},
 		{
 			name:       "ignore non open PRs",
-			context:    "cla/linuxfoundation",
+			context:    "EasyCLA",
 			state:      "success",
 			issueState: "closed",
 			SHA:        "sha",
@@ -220,7 +220,7 @@ func TestCheckCLA(t *testing.T) {
 		},
 		{
 			name:       "ignore non /check-cla comments",
-			context:    "cla/linuxfoundation",
+			context:    "EasyCLA",
 			state:      "success",
 			issueState: "open",
 			SHA:        "sha",
@@ -232,7 +232,7 @@ func TestCheckCLA(t *testing.T) {
 		},
 		{
 			name:       "do nothing on when status state is \"pending\"",
-			context:    "cla/linuxfoundation",
+			context:    "EasyCLA",
 			state:      "pending",
 			issueState: "open",
 			SHA:        "sha",
@@ -243,8 +243,8 @@ func TestCheckCLA(t *testing.T) {
 			},
 		},
 		{
-			name:       "cla/linuxfoundation status adds the cla-yes label when its state is \"success\"",
-			context:    "cla/linuxfoundation",
+			name:       "EasyCLA status adds the cla-yes label when its state is \"success\"",
+			context:    "EasyCLA",
 			state:      "success",
 			issueState: "open",
 			SHA:        "sha",
@@ -257,8 +257,8 @@ func TestCheckCLA(t *testing.T) {
 			addedLabel: fmt.Sprintf("/#3:%s", labels.ClaYes),
 		},
 		{
-			name:       "cla/linuxfoundation status adds the cla-yes label and removes cla-no label when its state is \"success\"",
-			context:    "cla/linuxfoundation",
+			name:       "EasyCLA status adds the cla-yes label and removes cla-no label when its state is \"success\"",
+			context:    "EasyCLA",
 			state:      "success",
 			issueState: "open",
 			SHA:        "sha",
@@ -273,8 +273,8 @@ func TestCheckCLA(t *testing.T) {
 			removedLabel: fmt.Sprintf("/#3:%s", labels.ClaNo),
 		},
 		{
-			name:       "cla/linuxfoundation status adds the cla-no label when its state is \"failure\"",
-			context:    "cla/linuxfoundation",
+			name:       "EasyCLA status adds the cla-no label when its state is \"failure\"",
+			context:    "EasyCLA",
 			state:      "failure",
 			issueState: "open",
 			SHA:        "sha",
@@ -287,8 +287,8 @@ func TestCheckCLA(t *testing.T) {
 			addedLabel: fmt.Sprintf("/#3:%s", labels.ClaNo),
 		},
 		{
-			name:       "cla/linuxfoundation status adds the cla-no label and removes cla-yes label when its state is \"failure\"",
-			context:    "cla/linuxfoundation",
+			name:       "EasyCLA status adds the cla-no label and removes cla-yes label when its state is \"failure\"",
+			context:    "EasyCLA",
 			state:      "failure",
 			issueState: "open",
 			SHA:        "sha",
@@ -303,8 +303,8 @@ func TestCheckCLA(t *testing.T) {
 			removedLabel: fmt.Sprintf("/#3:%s", labels.ClaYes),
 		},
 		{
-			name:       "cla/linuxfoundation status retains the cla-yes label and removes cla-no label when its state is \"success\"",
-			context:    "cla/linuxfoundation",
+			name:       "EasyCLA status retains the cla-yes label and removes cla-no label when its state is \"success\"",
+			context:    "EasyCLA",
 			state:      "success",
 			issueState: "open",
 			SHA:        "sha",
@@ -319,8 +319,8 @@ func TestCheckCLA(t *testing.T) {
 			removedLabel: fmt.Sprintf("/#3:%s", labels.ClaNo),
 		},
 		{
-			name:       "cla/linuxfoundation status retains the cla-no label and removes cla-yes label when its state is \"failure\"",
-			context:    "cla/linuxfoundation",
+			name:       "EasyCLA status retains the cla-no label and removes cla-yes label when its state is \"failure\"",
+			context:    "EasyCLA",
 			state:      "failure",
 			issueState: "open",
 			SHA:        "sha",


### PR DESCRIPTION
This makes the required changes needed to support EasyCLA
after it has been fully migrated:

* Change the context checked from cla/linuxfoundation to EasyCLA
* Update tests to reflect the changed context
* Remove bot comment in case the CLA is not signed and default
  to the EasyCLA bot's message.
* Change prow config to not treat EasyCLA as an optional context
  anymore. Add cla/linuxfoundation as the optional context and
  leave it there for an additional release cycle after EasyCLA
  is fully rolled out.

/area github-management
/sig contributor-experience
/assign @mrbobbytables @cblecker @nikhita 
/hold