### PR TITLE
Moving Docker-based SIG Node performance tests to CRI-O

### DIFF
--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -288,3 +288,34 @@ periodics:
     testgrid-tab-name: ci-crio-cgroupv1-node-e2e-hugepages
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "Executes hugepages e2e tests"
+- name: ci-crio-cgroupv1-node-e2e-performance
+ interval: 12h
+ labels:
+   preset-service-account: "true"
+   preset-k8s-ssh: "true"
+ spec:
+   containers:
+     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211217-ea95cec1d4-master
+       args:
+         - --repo=k8s.io/kubernetes=master
+         - --timeout=90
+         - --root=/go/src
+         - --scenario=kubernetes_e2e
+         - --
+         - --deployment=node
+         - --gcp-project-type=node-e2e-project
+         - --gcp-zone=us-west1-b
+         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/perf-image-config.yaml
+         - '--node-test-args=--feature-gates=LocalStorageCapacityIsolation=true --container-runtime=remote --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service --non-masquerade-cidr=0.0.0.0/0" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
+         - --node-tests=true
+         - --provider=gce
+         - --test_args=--nodes=1
+         - --timeout=60m
+       env:
+         - name: GOPATH
+           value: /go
+ annotations:
+   testgrid-dashboards: sig-node-cri-o
+    testgrid-tab-name: ci-crio-cgroupv1-node-e2e-performance
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    description: "Executes performance e2e tests"

--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -113,34 +113,3 @@ periodics:
     testgrid-tab-name: kubelet-gce-e2e-swap-fedora
     testgrid-alert-email: ehashman@redhat.com, ikema@google.com
     description: Executes E2E suite with swap enabled on Fedora
-
-# TODO: migrate performance special config tests to containerd/cri-o
-#- name: ci-kubernetes-node-kubelet-performance-test
-#  interval: 12h
-#  labels:
-#    preset-service-account: "true"
-#    preset-k8s-ssh: "true"
-#  spec:
-#    containers:
-#      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-master
-#        args:
-#          - --repo=k8s.io/kubernetes=master
-#          - --timeout=90
-#          - --root=/go/src
-#          - --scenario=kubernetes_e2e
-#          - --
-#          - --deployment=node
-#          - --gcp-project-type=node-e2e-project
-#          - --gcp-zone=us-west1-b
-#          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/perf-image-config.yaml
-#          - --node-test-args= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/" --server-start-timeout=420s
-#          - --node-tests=true
-#          - --provider=gce
-#          - --test_args=--nodes=1
-#          - --timeout=60m
-#        env:
-#          - name: GOPATH
-#            value: /go
-#  annotations:
-#    testgrid-dashboards: sig-node-kubelet
-#    testgrid-tab-name: node-performance-test


### PR DESCRIPTION
Signed-off-by: Naman Lakhwani <namanlakhwani@gmail.com>

fixes: https://github.com/kubernetes/test-infra/issues/24619

This PR aims to migrate Docker-based SIG Node performance tests to CRI-O on fedora

cc: @SergeyKanzhelev @ehashman