### PR TITLE
Make windows capz job more frequent

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -186,7 +186,7 @@ presubmits:
       description: Run Azure File e2e test with Azure File in-tree volume plugin in a Windows cluster with containerd runtime
 periodics:
 - name: ci-kubernetes-e2e-capz-master-containerd-windows
-  interval: 12h
+  interval: 3h
   decorate: true
   decoration_config:
     timeout: 4h


### PR DESCRIPTION
With https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1932 merged we have better logging and some of the flakiness should be resolved. 

Would like to run this as frequently as our release informing job https://testgrid.k8s.io/sig-windows-signal#aks-engine-windows-containerd-master to help spot more flakes with the eventual goal of replacing the job with this one.

/sig windows
/assign @marosset 