### PR TITLE
Remove duplicate key in gateway-api/OWNERS

### DIFF
--- a/config/jobs/kubernetes-sigs/gateway-api/OWNERS
+++ b/config/jobs/kubernetes-sigs/gateway-api/OWNERS
@@ -3,8 +3,7 @@
 reviewers:
 - bowei
 - thockin
+- aojea
 approvers:
 - bowei
 - thockin
-reviewers:
-- aojea


### PR DESCRIPTION
Should have only one key for `reviewers` so merge the 2 lists into one.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>