### PR TITLE
capz: fix AKS regex so that jobs run appropriately

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -135,7 +135,7 @@ presubmits:
     always_run: false
     optional: true
     decorate: true
-    run_if_changed: '^((exp)/|main\.go|go\.mod|go\.sum|managed.*\.go|Dockerfile|Makefile)'
+    run_if_changed: '^((exp)\/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)|managed.*\.go|aks'
     max_concurrency: 5
     labels:
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1alpha4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1alpha4.yaml
@@ -135,7 +135,7 @@ presubmits:
     always_run: false
     optional: true
     decorate: true
-    run_if_changed: '^((exp)/|main\.go|go\.mod|go\.sum|managed.*\.go|Dockerfile|Makefile)'
+    run_if_changed: '^((exp)\/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)|managed.*\.go|aks'
     max_concurrency: 5
     labels:
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -173,7 +173,7 @@ presubmits:
     always_run: false
     optional: true
     decorate: true
-    run_if_changed: '^((exp)/|main\.go|go\.mod|go\.sum|managed.*\.go|Dockerfile|Makefile)'
+    run_if_changed: '^((exp)\/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)|managed.*\.go|aks'
     max_concurrency: 5
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
PR #24621 introduced a "managed.go" regex match so that such-named files would trigger AKS runs. That match needs to not be in a group that includes a `^` (beginning of line) requirement. This PR fixes that, and adds an additional "aks" match to handle cluster template files such-named.