### PR TITLE
Make the GCP Zone and env var in the csi proxy integration config

### DIFF
--- a/config/jobs/kubernetes-csi/csi-proxy/csi-proxy-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-proxy/csi-proxy-config.yaml
@@ -57,7 +57,7 @@ presubmits:
         - --check-leaked-resources
         - --cluster=
         - --extract=ci/latest
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=$GCP_ZONE
         - --provider=gce
         - --gcp-nodes=1
         - --test=false
@@ -78,5 +78,7 @@ presubmits:
           value: "1"
         - name: NUM_NODES
           value: "1"
+        - name: GCP_ZONE
+          value: "us-west1-b"
         securityContext:
             privileged: true


### PR DESCRIPTION
The CSI Proxy integration shell script needs it to configure the gcloud SDK

/cc @jingxu97 
/assign @msau42 