### PR TITLE
fix 1.20 test failure, should test against azure disk csi driver release-1.9 branch

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.20-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.20-windows-presubmits.yaml
@@ -128,7 +128,7 @@ presubmits:
     extra_refs:
     - org: kubernetes-sigs
       repo: azuredisk-csi-driver
-      base_ref: master
+      base_ref: release-1.9
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:


### PR DESCRIPTION
fix 1.20 test failure, should test against azure disk csi driver release-1.9 branch

https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/106067/pull-kubernetes-e2e-aks-engine-azure-disk-windows-dockershim-1-20/1481527740329889792

sigs.k8s.io/azuredisk-csi-driver/test/e2e
vendor/k8s.io/kubernetes/test/e2e/framework/testfiles/testfiles.go:28:2: cannot find package "." in:
	/home/prow/go/src/sigs.k8s.io/azuredisk-csi-driver/vendor/embed
FAIL	sigs.k8s.io/azuredisk-csi-driver/test/e2e [setup failed]