### PR TITLE
Update release-1.21-windows-presubmits.yaml

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.21-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.21-windows-presubmits.yaml
@@ -129,11 +129,11 @@ presubmits:
     extra_refs:
     - org: kubernetes-sigs
       repo: azuredisk-csi-driver
-      base_ref: master
+      base_ref: release-1.9
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211217-ea95cec1d4-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211217-ea95cec1d4-1.21
         command:
         - runner.sh
         - kubetest

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.22-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.22-windows-presubmits.yaml
@@ -129,11 +129,11 @@ presubmits:
     extra_refs:
     - org: kubernetes-sigs
       repo: azuredisk-csi-driver
-      base_ref: master
+      base_ref: release-1.9
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211217-ea95cec1d4-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211217-ea95cec1d4-1.22
         command:
         - runner.sh
         - kubetest


### PR DESCRIPTION
this PR reverts changes:
 - https://github.com/kubernetes/test-infra/pull/24861
 - https://github.com/kubernetes/test-infra/pull/24862

And test against azure disk csi driver release-1.9 test suites.