### PR TITLE
bugzilla: improve identifierNotForPull error

### DIFF
--- a/prow/bugzilla/client.go
+++ b/prow/bugzilla/client.go
@@ -968,11 +968,11 @@ func IdentifierForPull(org, repo string, num int) string {
 
 func PullFromIdentifier(identifier string) (org, repo string, num int, err error) {
 	parts := strings.Split(identifier, "/")
+	if len(parts) >= 3 && parts[2] != "pull" {
+		return "", "", 0, &identifierNotForPull{identifier: identifier}
+	}
 	if len(parts) != 4 && !(len(parts) == 5 && (parts[4] == "" || parts[4] == "files")) && !(len(parts) == 6 && (parts[4] == "files" && parts[5] == "")) {
 		return "", "", 0, fmt.Errorf("invalid pull identifier with %d parts: %q", len(parts), identifier)
-	}
-	if parts[2] != "pull" {
-		return "", "", 0, &identifierNotForPull{identifier: identifier}
 	}
 	number, err := strconv.Atoi(parts[3])
 	if err != nil {


### PR DESCRIPTION
The `release-controller` is encountering an error for an invalid pull
identifier for a github link that is not a pull. This PR imporves
identification for non-pull github links to prevent that.