### PR TITLE
Update cloud-provider-vsphere-config to run staticcheck when go.mod is updated.

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
@@ -122,7 +122,7 @@ presubmits:
 
   - name: pull-cloud-provider-vsphere-verify-staticcheck
     always_run: false
-    run_if_changed: '\.go$|hack/check-staticcheck\.sh'
+    run_if_changed: '\.go$|hack/check-staticcheck\.sh$|go.mod'
     decorate: true
     path_alias: k8s.io/cloud-provider-vsphere
     spec:


### PR DESCRIPTION
Trigger `pull-cloud-provider-vsphere-verify-staticcheck` whenever a go module file is changed.