### PR TITLE
Allow App Auth related Post Requests in Dry Run

### DIFF
--- a/prow/github/app_auth_roundtripper_test.go
+++ b/prow/github/app_auth_roundtripper_test.go
@@ -61,67 +61,6 @@ func (frt *fakeRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) 
 func TestAppsAuth(t *testing.T) {
 
 	const appID = "13"
-	testCasesDryRun := []struct {
-		name                string
-		githubBaseURL       string
-		cachedAppSlug       *string
-		cachedInstallations map[string]AppInstallation
-		cachedTokens        map[int64]*AppInstallationToken
-		doRequest           func(Client) error
-		responses           map[string]*http.Response
-		verifyRequests      func([]*http.Request) error
-	}{
-		{
-			name:          "App installation auth success, installations and token is requsted, No Writes executed",
-			cachedAppSlug: utilpointer.StringPtr("ci-app"),
-			doRequest: func(c Client) error {
-				_, err := c.GetOrg("org")
-				if err != nil {
-					return err
-				}
-				_, err = c.CreateRepo("org", false, RepoCreateRequest{RepoRequest: RepoRequest{Name: utilpointer.StringPtr("test-repo")}})
-				return err
-			},
-			responses: map[string]*http.Response{
-				"/app/installations":                 {StatusCode: 200, Body: serializeOrDie([]AppInstallation{{ID: 1, Account: User{Login: "org"}}})},
-				"/app/installations/1/access_tokens": {StatusCode: 201, Body: serializeOrDie(AppInstallationToken{Token: "the-token"})},
-				"/orgs/org":                          {StatusCode: 200, Body: serializeOrDie(Organization{})},
-			},
-			verifyRequests: func(r []*http.Request) error {
-				if n := len(r); n != 3 {
-					return fmt.Errorf("expected exactly three request, got %d", n)
-				}
-				if r[0].URL.Path != "/app/installations" {
-					return fmt.Errorf("expected first request to have path '/app/installations' but had %q", r[0].URL.Path)
-				}
-				if val := r[0].Header.Get("Authorization"); !strings.HasPrefix(val, "Bearer ") {
-					return fmt.Errorf("expected the Authorization header %q to start with 'Bearer '", val)
-				}
-				if val := r[0].Header.Get("X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER"); val != "ci-app" {
-					return fmt.Errorf("expected X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER header %q to have value ci-app", val)
-				}
-
-				if r[1].URL.Path != "/app/installations/1/access_tokens" {
-					return fmt.Errorf("expected second request to request a token, but had path %s", r[0].URL.Path)
-				}
-				if val := r[1].Header.Get("Authorization"); !strings.HasPrefix(val, "Bearer ") {
-					return fmt.Errorf("expected the Authorization header %q to start with 'Bearer '", val)
-				}
-				if val := r[1].Header.Get("X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER"); val != "ci-app" {
-					return fmt.Errorf("expected X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER header %q to have value ci-app", val)
-				}
-
-				expectedGHCacheHeaderValue := "ci-app - org"
-				if val := r[2].Header.Get("Authorization"); val != "Bearer the-token" {
-					return fmt.Errorf("expected the Authorization header %q to be 'Bearer the-token'", val)
-				}
-				if val := r[2].Header.Get("X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER"); val != expectedGHCacheHeaderValue {
-					return fmt.Errorf("expected X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER header %q to be %q", val, expectedGHCacheHeaderValue)
-				}
-				return nil
-			},
-		},
-	}
 	testCases := []struct {
 		name                string
 		githubBaseURL       string
@@ -131,6 +70,7 @@ func TestAppsAuth(t *testing.T) {
 		doRequest           func(Client) error
 		responses           map[string]*http.Response
 		verifyRequests      func([]*http.Request) error
+		useDryRun           bool
 	}{
 		{
 			name: "App auth success",
@@ -433,6 +373,57 @@ func TestAppsAuth(t *testing.T) {
 				return nil
 			},
 		},
+		{
+			name:          "App installation auth success, installations and token is requsted, No Writes executed",
+			useDryRun:     true,
+			cachedAppSlug: utilpointer.StringPtr("ci-app"),
+			doRequest: func(c Client) error {
+				_, err := c.GetOrg("org")
+				if err != nil {
+					return err
+				}
+				_, err = c.CreateRepo("org", false, RepoCreateRequest{RepoRequest: RepoRequest{Name: utilpointer.StringPtr("test-repo")}})
+				return err
+			},
+			responses: map[string]*http.Response{
+				"/app/installations":                 {StatusCode: 200, Body: serializeOrDie([]AppInstallation{{ID: 1, Account: User{Login: "org"}}})},
+				"/app/installations/1/access_tokens": {StatusCode: 201, Body: serializeOrDie(AppInstallationToken{Token: "the-token"})},
+				"/orgs/org":                          {StatusCode: 200, Body: serializeOrDie(Organization{})},
+			},
+			verifyRequests: func(r []*http.Request) error {
+				if n := len(r); n != 3 {
+					return fmt.Errorf("expected exactly three request, got %d", n)
+				}
+				if r[0].URL.Path != "/app/installations" {
+					return fmt.Errorf("expected first request to have path '/app/installations' but had %q", r[0].URL.Path)
+				}
+				if val := r[0].Header.Get("Authorization"); !strings.HasPrefix(val, "Bearer ") {
+					return fmt.Errorf("expected the Authorization header %q to start with 'Bearer '", val)
+				}
+				if val := r[0].Header.Get("X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER"); val != "ci-app" {
+					return fmt.Errorf("expected X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER header %q to have value ci-app", val)
+				}
+
+				if r[1].URL.Path != "/app/installations/1/access_tokens" {
+					return fmt.Errorf("expected second request to request a token, but had path %s", r[0].URL.Path)
+				}
+				if val := r[1].Header.Get("Authorization"); !strings.HasPrefix(val, "Bearer ") {
+					return fmt.Errorf("expected the Authorization header %q to start with 'Bearer '", val)
+				}
+				if val := r[1].Header.Get("X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER"); val != "ci-app" {
+					return fmt.Errorf("expected X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER header %q to have value ci-app", val)
+				}
+
+				expectedGHCacheHeaderValue := "ci-app - org"
+				if val := r[2].Header.Get("Authorization"); val != "Bearer the-token" {
+					return fmt.Errorf("expected the Authorization header %q to be 'Bearer the-token'", val)
+				}
+				if val := r[2].Header.Get("X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER"); val != expectedGHCacheHeaderValue {
+					return fmt.Errorf("expected X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER header %q to be %q", val, expectedGHCacheHeaderValue)
+				}
+				return nil
+			},
+		},
 	}
 
 	// Generate it only once. Can not be smaller, otherwise the JWT signature generation
@@ -441,8 +432,10 @@ func TestAppsAuth(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to generate RSA key: %v", err)
 	}
-	for _, tc := range testCasesDryRun {
+
+	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+
 			if tc.githubBaseURL == "" {
 				tc.githubBaseURL = "https://api.github.com"
 			}
@@ -452,54 +445,9 @@ func TestAppsAuth(t *testing.T) {
 				AppPrivateKey:   func() *rsa.PrivateKey { return rsaKey },
 				GraphqlEndpoint: "",
 				Bases:           []string{tc.githubBaseURL},
-				DryRun:          true,
+				DryRun:          tc.useDryRun,
 			}.Default())
 
-			if err != nil {
-				t.Fatalf("failed to construct client: %v", err)
-			}
-
-			if _, ok := ghClient.(*client); !ok {
-				t.Fatal("ghclient is not a *client")
-			}
-			if _, ok := ghClient.(*client).client.(*http.Client); !ok {
-				t.Fatal("the ghclients client is not a *http.Client")
-			}
-			if _, ok := ghClient.(*client).client.(*http.Client).Transport.(*appsRoundTripper); !ok {
-				t.Fatal("the ghclients didn't get configured to use the appsRoundTripper")
-			}
-
-			roundTripper := &fakeRoundTripper{
-				responses: tc.responses,
-			}
-
-			appsRoundTripper := ghClient.(*client).client.(*http.Client).Transport.(*appsRoundTripper)
-			appsRoundTripper.upstream = roundTripper
-			if tc.cachedAppSlug != nil {
-				appsRoundTripper.appSlug = *tc.cachedAppSlug
-			}
-			if tc.cachedInstallations != nil {
-				appsRoundTripper.installations = tc.cachedInstallations
-			}
-			if tc.cachedTokens != nil {
-				appsRoundTripper.tokens = tc.cachedTokens
-			}
-
-			if err := tc.doRequest(ghClient); err != nil {
-				t.Fatalf("Failed to do request: %v", err)
-			}
-
-			if err := tc.verifyRequests(roundTripper.requests); err != nil {
-				t.Errorf("Request verification failed: %v", err)
-			}
-		})
-	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			if tc.githubBaseURL == "" {
-				tc.githubBaseURL = "https://api.github.com"
-			}
-			_, _, ghClient, err := NewAppsAuthClientWithFields(logrus.Fields{}, func(b []byte) []byte { return b }, appID, func() *rsa.PrivateKey { return rsaKey }, "", tc.githubBaseURL)
 			if err != nil {
 				t.Fatalf("failed to construct client: %v", err)
 			}

--- a/prow/github/app_auth_roundtripper_test.go
+++ b/prow/github/app_auth_roundtripper_test.go
@@ -61,6 +61,67 @@ func (frt *fakeRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) 
 func TestAppsAuth(t *testing.T) {
 
 	const appID = "13"
+	testCasesDryRun := []struct {
+		name                string
+		githubBaseURL       string
+		cachedAppSlug       *string
+		cachedInstallations map[string]AppInstallation
+		cachedTokens        map[int64]*AppInstallationToken
+		doRequest           func(Client) error
+		responses           map[string]*http.Response
+		verifyRequests      func([]*http.Request) error
+	}{
+		{
+			name:          "App installation auth success, installations and token is requsted, No Writes executed",
+			cachedAppSlug: utilpointer.StringPtr("ci-app"),
+			doRequest: func(c Client) error {
+				_, err := c.GetOrg("org")
+				if err != nil {
+					return err
+				}
+				_, err = c.CreateRepo("org", false, RepoCreateRequest{RepoRequest: RepoRequest{Name: utilpointer.StringPtr("test-repo")}})
+				return err
+			},
+			responses: map[string]*http.Response{
+				"/app/installations":                 {StatusCode: 200, Body: serializeOrDie([]AppInstallation{{ID: 1, Account: User{Login: "org"}}})},
+				"/app/installations/1/access_tokens": {StatusCode: 201, Body: serializeOrDie(AppInstallationToken{Token: "the-token"})},
+				"/orgs/org":                          {StatusCode: 200, Body: serializeOrDie(Organization{})},
+			},
+			verifyRequests: func(r []*http.Request) error {
+				if n := len(r); n != 3 {
+					return fmt.Errorf("expected exactly three request, got %d", n)
+				}
+				if r[0].URL.Path != "/app/installations" {
+					return fmt.Errorf("expected first request to have path '/app/installations' but had %q", r[0].URL.Path)
+				}
+				if val := r[0].Header.Get("Authorization"); !strings.HasPrefix(val, "Bearer ") {
+					return fmt.Errorf("expected the Authorization header %q to start with 'Bearer '", val)
+				}
+				if val := r[0].Header.Get("X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER"); val != "ci-app" {
+					return fmt.Errorf("expected X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER header %q to have value ci-app", val)
+				}
+
+				if r[1].URL.Path != "/app/installations/1/access_tokens" {
+					return fmt.Errorf("expected second request to request a token, but had path %s", r[0].URL.Path)
+				}
+				if val := r[1].Header.Get("Authorization"); !strings.HasPrefix(val, "Bearer ") {
+					return fmt.Errorf("expected the Authorization header %q to start with 'Bearer '", val)
+				}
+				if val := r[1].Header.Get("X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER"); val != "ci-app" {
+					return fmt.Errorf("expected X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER header %q to have value ci-app", val)
+				}
+
+				expectedGHCacheHeaderValue := "ci-app - org"
+				if val := r[2].Header.Get("Authorization"); val != "Bearer the-token" {
+					return fmt.Errorf("expected the Authorization header %q to be 'Bearer the-token'", val)
+				}
+				if val := r[2].Header.Get("X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER"); val != expectedGHCacheHeaderValue {
+					return fmt.Errorf("expected X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER header %q to be %q", val, expectedGHCacheHeaderValue)
+				}
+				return nil
+			},
+		},
+	}
 	testCases := []struct {
 		name                string
 		githubBaseURL       string
@@ -380,7 +441,59 @@ func TestAppsAuth(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to generate RSA key: %v", err)
 	}
+	for _, tc := range testCasesDryRun {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.githubBaseURL == "" {
+				tc.githubBaseURL = "https://api.github.com"
+			}
+			_, _, ghClient, err := NewClientFromOptions(logrus.Fields{}, ClientOptions{
+				Censor:          func(b []byte) []byte { return b },
+				AppID:           appID,
+				AppPrivateKey:   func() *rsa.PrivateKey { return rsaKey },
+				GraphqlEndpoint: "",
+				Bases:           []string{tc.githubBaseURL},
+				DryRun:          true,
+			}.Default())
 
+			if err != nil {
+				t.Fatalf("failed to construct client: %v", err)
+			}
+
+			if _, ok := ghClient.(*client); !ok {
+				t.Fatal("ghclient is not a *client")
+			}
+			if _, ok := ghClient.(*client).client.(*http.Client); !ok {
+				t.Fatal("the ghclients client is not a *http.Client")
+			}
+			if _, ok := ghClient.(*client).client.(*http.Client).Transport.(*appsRoundTripper); !ok {
+				t.Fatal("the ghclients didn't get configured to use the appsRoundTripper")
+			}
+
+			roundTripper := &fakeRoundTripper{
+				responses: tc.responses,
+			}
+
+			appsRoundTripper := ghClient.(*client).client.(*http.Client).Transport.(*appsRoundTripper)
+			appsRoundTripper.upstream = roundTripper
+			if tc.cachedAppSlug != nil {
+				appsRoundTripper.appSlug = *tc.cachedAppSlug
+			}
+			if tc.cachedInstallations != nil {
+				appsRoundTripper.installations = tc.cachedInstallations
+			}
+			if tc.cachedTokens != nil {
+				appsRoundTripper.tokens = tc.cachedTokens
+			}
+
+			if err := tc.doRequest(ghClient); err != nil {
+				t.Fatalf("Failed to do request: %v", err)
+			}
+
+			if err := tc.verifyRequests(roundTripper.requests); err != nil {
+				t.Errorf("Request verification failed: %v", err)
+			}
+		})
+	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.githubBaseURL == "" {

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -1008,7 +1008,7 @@ func (c *client) requestRaw(r *request) (int, []byte, error) {
 }
 
 func (c *client) requestRawWithContext(ctx context.Context, r *request) (int, []byte, error) {
-	if c.fake || c.dry && (r.method != http.MethodGet || !allowedDryRunPostPaths.MatchString(r.path)) {
+	if c.fake || c.dry && (r.method != http.MethodGet || !allowedDryRunPostPaths.MatchString(r.path) )) {
 		return r.exitCodes[0], nil, nil
 	}
 	resp, err := c.requestRetryWithContext(ctx, r.method, r.path, r.accept, r.org, r.requestBody)

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -47,6 +47,7 @@ import (
 	"k8s.io/test-infra/prow/version"
 )
 
+// When using AppToken Auth some POSTS that do not lead to a changed state need to be whitelisted to allow creating diffs.
 var allowedDryRunPostPaths = regexp.MustCompile(`(?m)/app/installations/\d+/access_tokens`)
 
 type timeClient interface {

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -1008,7 +1008,7 @@ func (c *client) requestRaw(r *request) (int, []byte, error) {
 }
 
 func (c *client) requestRawWithContext(ctx context.Context, r *request) (int, []byte, error) {
-	if c.fake || c.dry && (r.method != http.MethodGet || !allowedDryRunPostPaths.MatchString(r.path) )) {
+	if c.fake || c.dry && (r.method != http.MethodGet || !allowedDryRunPostPaths.MatchString(r.path)) {
 		return r.exitCodes[0], nil, nil
 	}
 	resp, err := c.requestRetryWithContext(ctx, r.method, r.path, r.accept, r.org, r.requestBody)

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -1008,7 +1008,7 @@ func (c *client) requestRaw(r *request) (int, []byte, error) {
 }
 
 func (c *client) requestRawWithContext(ctx context.Context, r *request) (int, []byte, error) {
-	if c.fake || c.dry && (r.method != http.MethodGet || !allowedDryRunPostPaths.MatchString(r.path) )) {
+	if c.fake || c.dry && (r.method != http.MethodGet && (!allowedDryRunPostPaths.MatchString(r.path) && r.method == http.MethodPost)) {
 		return r.exitCodes[0], nil, nil
 	}
 	resp, err := c.requestRetryWithContext(ctx, r.method, r.path, r.accept, r.org, r.requestBody)


### PR DESCRIPTION
When in dry run mode allow obtaining an app access token
to be able to perform authenticated get requests.

We we're trying to run a dry run// confirm=false with app auth and were not getting to the "skipping changes..." log lines that would've helped us evaluating which changes would be done. 

It would error out early within the check we removed here: 
https://github.com/kubernetes/test-infra/compare/master...nouseforaname:feature/dry-run-authenticated-get-requests-app-auth?expand=1#diff-43bdff30b56d33fef7db34c315dd186dab4fa8295ef72f8796fdf33984e959aeL4652-L4654

instead we added a regex check here:
https://github.com/kubernetes/test-infra/compare/master...nouseforaname:feature/dry-run-authenticated-get-requests-app-auth?expand=1#diff-43bdff30b56d33fef7db34c315dd186dab4fa8295ef72f8796fdf33984e959aeR991

to make sure that we only post to the token endpoint.
CC @rkoster