### PR TITLE
prow/plugins: enable cherrypicker for nfd

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1266,3 +1266,15 @@ external_plugins:
     - issue_comment
     - pull_request
     endpoint: http://cherrypicker
+  kubernetes-sigs/node-feature-discovery:
+  - name: cherrypicker
+    events:
+    - issue_comment
+    - pull_request
+    endpoint: http://cherrypicker
+  kubernetes-sigs/node-feature-discovery-operator:
+  - name: cherrypicker
+    events:
+    - issue_comment
+    - pull_request
+    endpoint: http://cherrypicker


### PR DESCRIPTION
Enable cherrypicker plugin for kubernetes-sigs/node-feature-discovery
and kubernetes-sigs/node-feature-discovery-operator projects.