### PR TITLE
Crier: collects prometheus metrics for times spent reporting

### DIFF
--- a/prow/crier/BUILD.bazel
+++ b/prow/crier/BUILD.bazel
@@ -2,11 +2,15 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["controller.go"],
+    srcs = [
+        "controller.go",
+        "metrics.go",
+    ],
     importpath = "k8s.io/test-infra/prow/crier",
     visibility = ["//visibility:public"],
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/types:go_default_library",
@@ -50,6 +54,7 @@ go_test(
         "//prow/apis/prowjobs/v1:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_apimachinery//pkg/types:go_default_library",
         "@io_k8s_sigs_controller_runtime//:go_default_library",

--- a/prow/crier/controller_test.go
+++ b/prow/crier/controller_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
@@ -119,6 +120,24 @@ func TestReconcile(t *testing.T) {
 				},
 				Status: prowv1.ProwJobStatus{
 					State: prowv1.TriggeredState,
+				},
+			},
+			enablementChecker: func(org, repo string) bool { return org == "org" && repo == "repo" },
+			shouldReport:      true,
+			expectReport:      true,
+			expectPatch:       true,
+		},
+		{
+			name: "reports/patches job whose org/repo in extra refs enabled, completed",
+			job: &prowv1.ProwJob{
+				Spec: prowv1.ProwJobSpec{
+					Job:       "foo",
+					Report:    true,
+					ExtraRefs: []prowv1.Refs{{Org: "org", Repo: "repo"}},
+				},
+				Status: prowv1.ProwJobStatus{
+					State:          prowv1.SuccessState,
+					CompletionTime: &v1.Time{Time: time.Now()},
 				},
 			},
 			enablementChecker: func(org, repo string) bool { return org == "org" && repo == "repo" },

--- a/prow/crier/metrics.go
+++ b/prow/crier/metrics.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package crier reports finished prowjob status to git providers.
+package crier
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// Prometheus Metrics
+var (
+	crierMetrics = struct {
+		latency *prometheus.HistogramVec
+	}{
+		latency: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "crier_report_latency",
+			Help:    "Histogram of time spent reporting, calculated by the time difference between job completion and end of reporting.",
+			Buckets: []float64{1, 10, 20, 30, 60, 120, 300, 600, 1800, 3600},
+		}, []string{
+			"reporter",
+		}),
+	}
+)
+
+func init() {
+	prometheus.MustRegister(crierMetrics.latency)
+}


### PR DESCRIPTION
And by the way fixing a minor issue:
- When a reporter reports on behalf of other jobs, it's also responsible for updating previous reported states on the other jobs, the current behavior is quit right away when one of them failed, this is probably not the best thing to do as when this job was reconciled again it'll pick up from where it's left at and there is a higher chance of error the next time around. Update the logic to continue updating the rest of the jobs and return with error. Note that this is only applicable to gerrit reporter at the moment