### PR TITLE
use correct set of images for windows 1.20 presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/generate-presubmits.sh
+++ b/config/jobs/kubernetes-sigs/sig-windows/generate-presubmits.sh
@@ -44,11 +44,13 @@ for release in "$@"; do
   branch_name="release-${release}"
   dockershim_api_model="https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_release_staging.json"
   containerd_api_model="https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_master.json"
+  repolist_label="preset-windows-repo-list-master: \"true\""
 
   case ${release} in
     1.20)
       dockershim_api_model="https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_release_1_20.json"
       containerd_api_model="https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_containerd_1_20.json"
+      repolist_label="preset-windows-repo-list: \"true\""
       ;;
     1.21)
       dockershim_api_model="https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_release_1_21.json"
@@ -84,7 +86,7 @@ presubmits:
       preset-service-account: "true"
       preset-azure-cred: "true"
       preset-azure-windows: "true"
-      preset-windows-repo-list-master: "true"
+      ${repolist_label}
       preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
       preset-windows-private-registry-cred: "true"
@@ -136,7 +138,7 @@ $(generate_presubmit_annotations ${branch_name} pull-kubernetes-e2e-aks-engine-w
       preset-service-account: "true"
       preset-azure-cred: "true"
       preset-azure-windows: "true"
-      preset-windows-repo-list-master: "true"
+      ${repolist_label}
       preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
       preset-windows-private-registry-cred: "true"

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.20-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.20-windows-presubmits.yaml
@@ -68,7 +68,7 @@ presubmits:
       preset-service-account: "true"
       preset-azure-cred: "true"
       preset-azure-windows: "true"
-      preset-windows-repo-list-master: "true"
+      preset-windows-repo-list: "true"
       preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
       preset-windows-private-registry-cred: "true"


### PR DESCRIPTION
The 1.20 presubmit for containerd is failing: https://testgrid.k8s.io/sig-windows-presubmit#pull-kubernetes-e2e-aks-engine-windows-containerd-1.20

should be using different repolist: https://github.com/kubernetes-sigs/windows-testing/tree/master/images#image-repository-list

The images are failing to pull:

```
concurrent-1642097940-btmdk
Jan 13 18:23:06.475: INFO: At 2022-01-13 18:19:06 +0000 UTC - event for concurrent-1642097820-lqnqr: {kubelet 2641k8s000} Failed: Error: ImagePullBackOff
Jan 13 18:23:06.475: INFO: At 2022-01-13 18:19:06 +0000 UTC - event for concurrent-1642097880-rfjnv: {kubelet 2641k8s000} Failed: Error: ImagePullBackOff
Jan 13 18:23:06.475: INFO: At 2022-01-13 18:19:08 +0000 UTC - event for concurrent-1642097940-btmdk: {kubelet 2641k8s001} Pulling: Pulling image "docker.io/library/busybox:1.29"
Jan 13 18:23:06.475: INFO: At 2022-01-13 18:19:11 +0000 UTC - event for concurrent-1642097940-btmdk: {kubelet 2641k8s001} Failed: Error: ImagePullBackOff
Jan 13 18:23:06.475: INFO: At 2022-01-13 18:19:11 +0000 UTC - event for concurrent-1642097940-btmdk: {kubelet 2641k8s001} Failed: Failed to pull image "docker.io/library/busybox:1.29": rpc error: code = NotFound desc = failed to pull and unpack image "docker.io/library/busybox:1.29": no match for platform in manifest: not found
Jan 13 18:23:06.475: INFO: At 2022-01-13 18:20:05 +0000 UTC - even
```