### PR TITLE
Do not use irsa for networking grid

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -411,7 +411,7 @@ def generate_grid():
                                        k8s_version=k8s_version,
                                        kops_version=kops_version,
                                        networking=networking,
-                                       irsa=k8s_version >= '1.22',
+                                       irsa=False,
                                        container_runtime=container_runtime)
                         )
 

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -254,7 +254,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-amzn2-k22-docker
   cron: '14 8 * * 0'
   labels:
@@ -283,7 +283,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -309,7 +309,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -318,7 +317,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
 - name: e2e-kops-grid-amzn2-k22-ko22-docker
   cron: '52 15 * * 4'
   labels:
@@ -347,7 +346,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -373,7 +372,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -382,7 +380,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-amzn2-k22-ko23-docker
   cron: '26 17 * * 1'
   labels:
@@ -411,7 +409,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -437,7 +435,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -446,7 +443,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-amzn2-k23-docker
   cron: '4 6 * * 6'
   labels:
@@ -475,7 +472,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -501,7 +498,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -510,7 +506,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-amzn2-k23-ko23-docker
   cron: '47 20 * * 4'
   labels:
@@ -539,7 +535,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -565,7 +561,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -763,7 +758,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
 - name: e2e-kops-grid-deb9-k22-ko22-docker
   cron: '10 19 * * 1'
   labels:
@@ -792,7 +787,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -818,7 +813,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -827,7 +821,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-deb9-k22-ko23-docker
   cron: '4 5 * * 3'
   labels:
@@ -856,7 +850,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -882,7 +876,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -891,7 +884,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-deb9-k23-ko23-docker
   cron: '21 16 * * 2'
   labels:
@@ -920,7 +913,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -946,7 +939,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -1207,7 +1199,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-deb10-k22-docker
   cron: '10 0 * * 4'
   labels:
@@ -1236,7 +1228,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -1262,7 +1254,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -1271,7 +1262,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
 - name: e2e-kops-grid-deb10-k22-ko22-docker
   cron: '47 0 * * 5'
   labels:
@@ -1300,7 +1291,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -1326,7 +1317,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -1335,7 +1325,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-deb10-k22-ko23-docker
   cron: '21 22 * * 4'
   labels:
@@ -1364,7 +1354,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -1390,7 +1380,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -1399,7 +1388,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-deb10-k23-docker
   cron: '24 6 * * 2'
   labels:
@@ -1428,7 +1417,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -1454,7 +1443,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -1463,7 +1451,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-deb10-k23-ko23-docker
   cron: '48 11 * * 2'
   labels:
@@ -1492,7 +1480,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -1518,7 +1506,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -1791,7 +1778,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-flatcar-k22-docker
   cron: '54 4 * * 2'
   labels:
@@ -1820,7 +1807,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
@@ -1849,7 +1836,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -1858,7 +1844,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
 - name: e2e-kops-grid-flatcar-k22-ko22-docker
   cron: '39 23 * * 4'
   labels:
@@ -1887,7 +1873,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
@@ -1916,7 +1902,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -1925,7 +1910,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-flatcar-k22-ko23-docker
   cron: '41 9 * * 2'
   labels:
@@ -1954,7 +1939,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
@@ -1983,7 +1968,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -1992,7 +1976,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-flatcar-k23-docker
   cron: '0 2 * * 5'
   labels:
@@ -2021,7 +2005,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
@@ -2050,7 +2034,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -2059,7 +2042,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-flatcar-k23-ko23-docker
   cron: '36 12 * * 2'
   labels:
@@ -2088,7 +2071,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
@@ -2117,7 +2100,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -2315,7 +2297,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel7-k22-ko22-docker
   cron: '19 12 * * 5'
   labels:
@@ -2344,7 +2326,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -2370,7 +2352,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -2379,7 +2360,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel7-k22-ko23-docker
   cron: '41 2 * * 0'
   labels:
@@ -2408,7 +2389,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -2434,7 +2415,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -2443,7 +2423,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel7-k23-ko23-docker
   cron: '20 7 * * 5'
   labels:
@@ -2472,7 +2452,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -2498,7 +2478,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -2759,7 +2738,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-rhel8-k22-docker
   cron: '17 7 * * 2'
   labels:
@@ -2788,7 +2767,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -2814,7 +2793,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -2823,7 +2801,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel8-k22-ko22-docker
   cron: '6 17 * * 3'
   labels:
@@ -2852,7 +2830,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -2878,7 +2856,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -2887,7 +2864,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel8-k22-ko23-docker
   cron: '0 15 * * 2'
   labels:
@@ -2916,7 +2893,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -2942,7 +2919,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -2951,7 +2927,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-rhel8-k23-docker
   cron: '31 9 * * 2'
   labels:
@@ -2980,7 +2956,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -3006,7 +2982,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -3015,7 +2990,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel8-k23-ko23-docker
   cron: '45 18 * * 5'
   labels:
@@ -3044,7 +3019,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -3070,7 +3045,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -3268,7 +3242,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
 - name: e2e-kops-grid-u1804-k22-ko22-docker
   cron: '23 8 * * 6'
   labels:
@@ -3297,7 +3271,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -3323,7 +3297,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -3332,7 +3305,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-u1804-k22-ko23-docker
   cron: '9 14 * * 6'
   labels:
@@ -3361,7 +3334,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -3387,7 +3360,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -3396,7 +3368,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-u1804-k23-ko23-docker
   cron: '32 19 * * 1'
   labels:
@@ -3425,7 +3397,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -3451,7 +3423,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -3712,7 +3683,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-u2004-k22-docker
   cron: '15 21 * * *'
   labels:
@@ -3741,7 +3712,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -3767,7 +3738,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -3776,7 +3746,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
 - name: e2e-kops-grid-u2004-k22-ko22-docker
   cron: '0 7 * * *'
   labels:
@@ -3805,7 +3775,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -3831,7 +3801,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -3840,7 +3809,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-u2004-k22-ko23-docker
   cron: '34 9 * * *'
   labels:
@@ -3869,7 +3838,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -3895,7 +3864,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -3904,7 +3872,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-u2004-k23-docker
   cron: '29 3 * * *'
   labels:
@@ -3933,7 +3901,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -3959,7 +3927,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -3968,7 +3935,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-u2004-k23-ko23-docker
   cron: '23 4 * * *'
   labels:
@@ -3997,7 +3964,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kubenet --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kubenet --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -4023,7 +3990,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -4284,7 +4250,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k22-docker
   cron: '4 0 * * 5'
   labels:
@@ -4313,7 +4279,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -4339,7 +4305,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -4348,7 +4313,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k22-ko22-docker
   cron: '50 13 * * 5'
   labels:
@@ -4377,7 +4342,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -4403,7 +4368,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -4412,7 +4376,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k22-ko23-docker
   cron: '20 19 * * 2'
   labels:
@@ -4441,7 +4405,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -4467,7 +4431,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -4476,7 +4439,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k23-docker
   cron: '2 22 * * 6'
   labels:
@@ -4505,7 +4468,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -4531,7 +4494,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -4540,7 +4502,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k23-ko23-docker
   cron: '9 6 * * 2'
   labels:
@@ -4569,7 +4531,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -4595,7 +4557,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -4793,7 +4754,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-k22-ko22-docker
   cron: '42 22 * * 2'
   labels:
@@ -4822,7 +4783,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -4848,7 +4809,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -4857,7 +4817,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-k22-ko23-docker
   cron: '32 16 * * 4'
   labels:
@@ -4886,7 +4846,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -4912,7 +4872,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -4921,7 +4880,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-k23-ko23-docker
   cron: '53 21 * * 1'
   labels:
@@ -4950,7 +4909,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -4976,7 +4935,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -5237,7 +5195,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k22-docker
   cron: '24 8 * * 5'
   labels:
@@ -5266,7 +5224,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -5292,7 +5250,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -5301,7 +5258,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k22-ko22-docker
   cron: '13 18 * * 4'
   labels:
@@ -5330,7 +5287,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -5356,7 +5313,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -5365,7 +5321,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k22-ko23-docker
   cron: '19 20 * * 1'
   labels:
@@ -5394,7 +5350,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -5420,7 +5376,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -5429,7 +5384,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k23-docker
   cron: '22 6 * * 3'
   labels:
@@ -5458,7 +5413,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -5484,7 +5439,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -5493,7 +5447,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k23-ko23-docker
   cron: '22 9 * * 2'
   labels:
@@ -5522,7 +5476,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -5548,7 +5502,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -5821,7 +5774,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k22-docker
   cron: '16 18 * * 6'
   labels:
@@ -5850,7 +5803,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
@@ -5879,7 +5832,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -5888,7 +5840,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k22-ko22-docker
   cron: '57 21 * * 3'
   labels:
@@ -5917,7 +5869,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
@@ -5946,7 +5898,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -5955,7 +5906,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k22-ko23-docker
   cron: '27 3 * * 4'
   labels:
@@ -5984,7 +5935,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
@@ -6013,7 +5964,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -6022,7 +5972,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k23-docker
   cron: '6 4 * * 1'
   labels:
@@ -6051,7 +6001,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
@@ -6080,7 +6030,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -6089,7 +6038,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k23-ko23-docker
   cron: '54 6 * * 5'
   labels:
@@ -6118,7 +6067,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=calico --container-runtime=docker" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
@@ -6147,7 +6096,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -6345,7 +6293,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-k22-ko22-docker
   cron: '37 22 * * 2'
   labels:
@@ -6374,7 +6322,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -6400,7 +6348,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -6409,7 +6356,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-k22-ko23-docker
   cron: '55 8 * * 1'
   labels:
@@ -6438,7 +6385,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -6464,7 +6411,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -6473,7 +6419,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-k23-ko23-docker
   cron: '42 21 * * 0'
   labels:
@@ -6502,7 +6448,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -6528,7 +6474,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -6789,7 +6734,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k22-docker
   cron: '7 23 * * 6'
   labels:
@@ -6818,7 +6763,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -6844,7 +6789,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -6853,7 +6797,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k22-ko22-docker
   cron: '24 3 * * 2'
   labels:
@@ -6882,7 +6826,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -6908,7 +6852,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -6917,7 +6860,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k22-ko23-docker
   cron: '50 5 * * 3'
   labels:
@@ -6946,7 +6889,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -6972,7 +6915,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -6981,7 +6923,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k23-docker
   cron: '41 9 * * 2'
   labels:
@@ -7010,7 +6952,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -7036,7 +6978,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -7045,7 +6986,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k23-ko23-docker
   cron: '3 16 * * 2'
   labels:
@@ -7074,7 +7015,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -7100,7 +7041,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -7298,7 +7238,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-k22-ko22-docker
   cron: '9 2 * * 6'
   labels:
@@ -7327,7 +7267,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -7353,7 +7293,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -7362,7 +7301,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-k22-ko23-docker
   cron: '47 20 * * 1'
   labels:
@@ -7391,7 +7330,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -7417,7 +7356,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -7426,7 +7364,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-k23-ko23-docker
   cron: '46 1 * * 2'
   labels:
@@ -7455,7 +7393,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -7481,7 +7419,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -7742,7 +7679,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k22-docker
   cron: '1 21 * * *'
   labels:
@@ -7771,7 +7708,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -7797,7 +7734,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -7806,7 +7742,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k22-ko22-docker
   cron: '54 21 * * *'
   labels:
@@ -7835,7 +7771,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -7861,7 +7797,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -7870,7 +7805,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k22-ko23-docker
   cron: '44 3 * * *'
   labels:
@@ -7899,7 +7834,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -7925,7 +7860,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -7934,7 +7868,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k23-docker
   cron: '39 11 * * *'
   labels:
@@ -7963,7 +7897,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -7989,7 +7923,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -7998,7 +7931,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k23-ko23-docker
   cron: '53 14 * * *'
   labels:
@@ -8027,7 +7960,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=calico --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=calico --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -8053,7 +7986,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -8314,7 +8246,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k22-docker
   cron: '26 18 * * 6'
   labels:
@@ -8343,7 +8275,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -8369,7 +8301,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -8378,7 +8309,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k22-ko22-docker
   cron: '12 11 * * 1'
   labels:
@@ -8407,7 +8338,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -8433,7 +8364,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -8442,7 +8372,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k22-ko23-docker
   cron: '42 5 * * 5'
   labels:
@@ -8471,7 +8401,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -8497,7 +8427,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -8506,7 +8435,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k23-docker
   cron: '36 4 * * 5'
   labels:
@@ -8535,7 +8464,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -8561,7 +8490,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -8570,7 +8498,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k23-ko23-docker
   cron: '35 16 * * 0'
   labels:
@@ -8599,7 +8527,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -8625,7 +8553,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -8886,7 +8813,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k22-docker
   cron: '14 18 * * 6'
   labels:
@@ -8915,7 +8842,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -8941,7 +8868,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -8950,7 +8876,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k22-ko22-docker
   cron: '59 12 * * 3'
   labels:
@@ -8979,7 +8905,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -9005,7 +8931,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -9014,7 +8939,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k22-ko23-docker
   cron: '49 18 * * 3'
   labels:
@@ -9043,7 +8968,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -9069,7 +8994,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -9078,7 +9002,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k23-docker
   cron: '56 4 * * 4'
   labels:
@@ -9107,7 +9031,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -9133,7 +9057,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -9142,7 +9065,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k23-ko23-docker
   cron: '4 15 * * 6'
   labels:
@@ -9171,7 +9094,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -9197,7 +9120,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -9458,7 +9380,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k22-docker
   cron: '41 13 * * 4'
   labels:
@@ -9487,7 +9409,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -9513,7 +9435,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -9522,7 +9443,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k22-ko22-docker
   cron: '46 21 * * 1'
   labels:
@@ -9551,7 +9472,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -9577,7 +9498,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -9586,7 +9506,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k22-ko23-docker
   cron: '36 19 * * 6'
   labels:
@@ -9615,7 +9535,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -9641,7 +9561,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -9650,7 +9569,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k23-docker
   cron: '39 11 * * 5'
   labels:
@@ -9679,7 +9598,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -9705,7 +9624,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -9714,7 +9632,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k23-ko23-docker
   cron: '21 22 * * 6'
   labels:
@@ -9743,7 +9661,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -9769,7 +9687,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -10030,7 +9947,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k22-docker
   cron: '35 15 * * *'
   labels:
@@ -10059,7 +9976,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -10085,7 +10002,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -10094,7 +10010,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k22-ko22-docker
   cron: '24 3 * * *'
   labels:
@@ -10123,7 +10039,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -10149,7 +10065,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -10158,7 +10073,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k22-ko23-docker
   cron: '6 21 * * *'
   labels:
@@ -10187,7 +10102,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -10213,7 +10128,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -10222,7 +10136,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k23-docker
   cron: '53 9 * * *'
   labels:
@@ -10251,7 +10165,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -10277,7 +10191,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -10286,7 +10199,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k23-ko23-docker
   cron: '27 8 * * *'
   labels:
@@ -10315,7 +10228,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -10341,7 +10254,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -10602,7 +10514,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-amzn2-k22-docker
   cron: '36 15 * * 5'
   labels:
@@ -10631,7 +10543,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -10657,7 +10569,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -10666,7 +10577,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-amzn2-k22-ko22-docker
   cron: '28 18 * * 2'
   labels:
@@ -10695,7 +10606,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -10721,7 +10632,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -10730,7 +10640,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-amzn2-k22-ko23-docker
   cron: '46 4 * * 3'
   labels:
@@ -10759,7 +10669,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -10785,7 +10695,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -10794,7 +10703,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-amzn2-k23-docker
   cron: '26 9 * * 5'
   labels:
@@ -10823,7 +10732,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -10849,7 +10758,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -10858,7 +10766,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-amzn2-k23-ko23-docker
   cron: '43 17 * * 0'
   labels:
@@ -10887,7 +10795,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -10913,7 +10821,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -11174,7 +11081,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb10-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-deb10-k22-docker
   cron: '16 15 * * 2'
   labels:
@@ -11203,7 +11110,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium-etcd --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -11229,7 +11136,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -11238,7 +11144,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb10-k22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-deb10-k22-ko22-docker
   cron: '47 5 * * 6'
   labels:
@@ -11267,7 +11173,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium-etcd --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -11293,7 +11199,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -11302,7 +11207,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb10-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-deb10-k22-ko23-docker
   cron: '53 11 * * 1'
   labels:
@@ -11331,7 +11236,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium-etcd --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -11357,7 +11262,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -11366,7 +11270,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb10-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-deb10-k23-docker
   cron: '6 17 * * 1'
   labels:
@@ -11395,7 +11299,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium-etcd --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -11421,7 +11325,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -11430,7 +11333,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb10-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-deb10-k23-ko23-docker
   cron: '4 6 * * 3'
   labels:
@@ -11459,7 +11362,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium-etcd --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -11485,7 +11388,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -11746,7 +11648,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-rhel8-k22-docker
   cron: '39 16 * * 3'
   labels:
@@ -11775,7 +11677,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -11801,7 +11703,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -11810,7 +11711,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-rhel8-k22-ko22-docker
   cron: '34 4 * * 0'
   labels:
@@ -11839,7 +11740,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -11865,7 +11766,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -11874,7 +11774,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-rhel8-k22-ko23-docker
   cron: '56 10 * * 3'
   labels:
@@ -11903,7 +11803,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -11929,7 +11829,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -11938,7 +11837,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-rhel8-k23-docker
   cron: '17 22 * * 1'
   labels:
@@ -11967,7 +11866,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -11993,7 +11892,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -12002,7 +11900,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-rhel8-k23-ko23-docker
   cron: '25 7 * * 3'
   labels:
@@ -12031,7 +11929,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -12057,7 +11955,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -12318,7 +12215,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-u2004-k22-docker
   cron: '17 10 * * *'
   labels:
@@ -12347,7 +12244,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium-etcd --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -12373,7 +12270,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -12382,7 +12278,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-u2004-k22-ko22-docker
   cron: '28 18 * * *'
   labels:
@@ -12411,7 +12307,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium-etcd --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -12437,7 +12333,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -12446,7 +12341,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-u2004-k22-ko23-docker
   cron: '18 4 * * *'
   labels:
@@ -12475,7 +12370,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium-etcd --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -12501,7 +12396,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -12510,7 +12404,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-u2004-k23-docker
   cron: '31 4 * * *'
   labels:
@@ -12539,7 +12433,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium-etcd --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -12565,7 +12459,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -12574,7 +12467,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-u2004-k23-ko23-docker
   cron: '3 17 * * *'
   labels:
@@ -12603,7 +12496,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium-etcd --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium-etcd --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -12629,7 +12522,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -12890,7 +12782,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k22-docker
   cron: '5 14 * * 0'
   labels:
@@ -12919,7 +12811,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -12945,7 +12837,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -12954,7 +12845,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k22-ko22-docker
   cron: '46 21 * * 0'
   labels:
@@ -12983,7 +12874,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -13009,7 +12900,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -13018,7 +12908,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k22-ko23-docker
   cron: '0 11 * * 1'
   labels:
@@ -13047,7 +12937,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -13073,7 +12963,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -13082,7 +12971,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k23-docker
   cron: '39 8 * * 6'
   labels:
@@ -13111,7 +13000,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -13137,7 +13026,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -13146,7 +13034,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k23-ko23-docker
   cron: '5 6 * * 0'
   labels:
@@ -13175,7 +13063,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -13201,7 +13089,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -13399,7 +13286,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-k22-ko22-docker
   cron: '46 5 * * 3'
   labels:
@@ -13428,7 +13315,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -13454,7 +13341,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -13463,7 +13349,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-k22-ko23-docker
   cron: '56 11 * * 0'
   labels:
@@ -13492,7 +13378,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -13518,7 +13404,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -13527,7 +13412,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-k23-ko23-docker
   cron: '21 22 * * 4'
   labels:
@@ -13556,7 +13441,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -13582,7 +13467,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -13843,7 +13727,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k22-docker
   cron: '41 14 * * 6'
   labels:
@@ -13872,7 +13756,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -13898,7 +13782,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -13907,7 +13790,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k22-ko22-docker
   cron: '41 18 * * 1'
   labels:
@@ -13936,7 +13819,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -13962,7 +13845,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -13971,7 +13853,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k22-ko23-docker
   cron: '35 20 * * 3'
   labels:
@@ -14000,7 +13882,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -14026,7 +13908,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -14035,7 +13916,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k23-docker
   cron: '19 8 * * 6'
   labels:
@@ -14064,7 +13945,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -14090,7 +13971,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -14099,7 +13979,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k23-ko23-docker
   cron: '26 17 * * 3'
   labels:
@@ -14128,7 +14008,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -14154,7 +14034,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -14427,7 +14306,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k22-docker
   cron: '42 19 * * 5'
   labels:
@@ -14456,7 +14335,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
@@ -14485,7 +14364,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -14494,7 +14372,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k22-ko22-docker
   cron: '2 2 * * 0'
   labels:
@@ -14523,7 +14401,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
@@ -14552,7 +14430,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -14561,7 +14438,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k22-ko23-docker
   cron: '52 20 * * 4'
   labels:
@@ -14590,7 +14467,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
@@ -14619,7 +14496,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -14628,7 +14504,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k23-docker
   cron: '48 13 * * 0'
   labels:
@@ -14657,7 +14533,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
@@ -14686,7 +14562,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -14695,7 +14570,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k23-ko23-docker
   cron: '53 1 * * 0'
   labels:
@@ -14724,7 +14599,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=flannel --container-runtime=docker" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
@@ -14753,7 +14628,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -14951,7 +14825,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-k22-ko22-docker
   cron: '21 14 * * 1'
   labels:
@@ -14980,7 +14854,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -15006,7 +14880,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -15015,7 +14888,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-k22-ko23-docker
   cron: '55 8 * * 1'
   labels:
@@ -15044,7 +14917,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -15070,7 +14943,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -15079,7 +14951,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-k23-ko23-docker
   cron: '58 21 * * 3'
   labels:
@@ -15108,7 +14980,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -15134,7 +15006,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -15395,7 +15266,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k22-docker
   cron: '54 17 * * 2'
   labels:
@@ -15424,7 +15295,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -15450,7 +15321,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -15459,7 +15329,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k22-ko22-docker
   cron: '8 3 * * 2'
   labels:
@@ -15488,7 +15358,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -15514,7 +15384,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -15523,7 +15392,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k22-ko23-docker
   cron: '18 21 * * 0'
   labels:
@@ -15552,7 +15421,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -15578,7 +15447,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -15587,7 +15455,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k23-docker
   cron: '48 7 * * 1'
   labels:
@@ -15616,7 +15484,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -15642,7 +15510,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -15651,7 +15518,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k23-ko23-docker
   cron: '19 16 * * 5'
   labels:
@@ -15680,7 +15547,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -15706,7 +15573,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -15904,7 +15770,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-k22-ko22-docker
   cron: '45 2 * * 4'
   labels:
@@ -15933,7 +15799,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -15959,7 +15825,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -15968,7 +15833,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-k22-ko23-docker
   cron: '15 20 * * 1'
   labels:
@@ -15997,7 +15862,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -16023,7 +15888,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -16032,7 +15896,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-k23-ko23-docker
   cron: '54 1 * * 3'
   labels:
@@ -16061,7 +15925,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -16087,7 +15951,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -16348,7 +16211,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k22-docker
   cron: '24 11 * * *'
   labels:
@@ -16377,7 +16240,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -16403,7 +16266,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -16412,7 +16274,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k22-ko22-docker
   cron: '6 21 * * *'
   labels:
@@ -16441,7 +16303,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -16467,7 +16329,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -16476,7 +16337,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k22-ko23-docker
   cron: '16 11 * * *'
   labels:
@@ -16505,7 +16366,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -16531,7 +16392,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -16540,7 +16400,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k23-docker
   cron: '14 13 * * *'
   labels:
@@ -16569,7 +16429,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -16595,7 +16455,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -16604,7 +16463,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k23-ko23-docker
   cron: '49 22 * * *'
   labels:
@@ -16633,7 +16492,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=flannel --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=flannel --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -16659,7 +16518,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -16920,7 +16778,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k22-docker
   cron: '52 16 * * 4'
   labels:
@@ -16949,7 +16807,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -16975,7 +16833,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -16984,7 +16841,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k22-ko22-docker
   cron: '0 15 * * 4'
   labels:
@@ -17013,7 +16870,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -17039,7 +16896,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -17048,7 +16904,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k22-ko23-docker
   cron: '54 9 * * 3'
   labels:
@@ -17077,7 +16933,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -17103,7 +16959,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -17112,7 +16967,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k23-docker
   cron: '30 22 * * 1'
   labels:
@@ -17141,7 +16996,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -17167,7 +17022,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -17176,7 +17030,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k23-ko23-docker
   cron: '35 4 * * 4'
   labels:
@@ -17205,7 +17059,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -17231,7 +17085,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -17429,7 +17282,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-k22-ko22-docker
   cron: '57 21 * * 6'
   labels:
@@ -17458,7 +17311,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -17484,7 +17337,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -17493,7 +17345,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-k22-ko23-docker
   cron: '39 19 * * 4'
   labels:
@@ -17522,7 +17374,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -17548,7 +17400,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -17557,7 +17408,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-k23-ko23-docker
   cron: '42 6 * * 4'
   labels:
@@ -17586,7 +17437,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -17612,7 +17463,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb9
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -17873,7 +17723,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k22-docker
   cron: '4 0 * * 5'
   labels:
@@ -17902,7 +17752,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -17928,7 +17778,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -17937,7 +17786,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k22-ko22-docker
   cron: '47 16 * * 5'
   labels:
@@ -17966,7 +17815,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -17992,7 +17841,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -18001,7 +17849,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k22-ko23-docker
   cron: '45 6 * * 4'
   labels:
@@ -18030,7 +17878,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -18056,7 +17904,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -18065,7 +17912,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k23-docker
   cron: '22 14 * * 0'
   labels:
@@ -18094,7 +17941,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -18120,7 +17967,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -18129,7 +17975,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k23-ko23-docker
   cron: '40 3 * * 4'
   labels:
@@ -18158,7 +18004,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -18184,7 +18030,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -18457,7 +18302,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k22-docker
   cron: '39 9 * * 2'
   labels:
@@ -18486,7 +18331,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
@@ -18515,7 +18360,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -18524,7 +18368,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k22-ko22-docker
   cron: '7 7 * * 6'
   labels:
@@ -18553,7 +18397,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
@@ -18582,7 +18426,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -18591,7 +18434,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k22-ko23-docker
   cron: '21 17 * * 2'
   labels:
@@ -18620,7 +18463,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
@@ -18649,7 +18492,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -18658,7 +18500,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k23-docker
   cron: '49 23 * * 4'
   labels:
@@ -18687,7 +18529,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
@@ -18716,7 +18558,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -18725,7 +18566,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k23-ko23-docker
   cron: '52 20 * * 0'
   labels:
@@ -18754,7 +18595,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
@@ -18783,7 +18624,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -18981,7 +18821,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-k22-ko22-docker
   cron: '35 4 * * 3'
   labels:
@@ -19010,7 +18850,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -19036,7 +18876,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -19045,7 +18884,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-k22-ko23-docker
   cron: '45 2 * * 4'
   labels:
@@ -19074,7 +18913,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -19100,7 +18939,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -19109,7 +18947,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-k23-ko23-docker
   cron: '24 23 * * 2'
   labels:
@@ -19138,7 +18976,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -19164,7 +19002,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel7
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -19425,7 +19262,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k22-docker
   cron: '59 7 * * 3'
   labels:
@@ -19454,7 +19291,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -19480,7 +19317,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -19489,7 +19325,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k22-ko22-docker
   cron: '30 9 * * 2'
   labels:
@@ -19518,7 +19354,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -19544,7 +19380,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -19553,7 +19388,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k22-ko23-docker
   cron: '56 23 * * 0'
   labels:
@@ -19582,7 +19417,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -19608,7 +19443,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -19617,7 +19451,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k23-docker
   cron: '17 17 * * 3'
   labels:
@@ -19646,7 +19480,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -19672,7 +19506,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -19681,7 +19514,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k23-ko23-docker
   cron: '53 18 * * 3'
   labels:
@@ -19710,7 +19543,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -19736,7 +19569,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -19934,7 +19766,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-k22-ko22-docker
   cron: '7 16 * * 6'
   labels:
@@ -19963,7 +19795,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -19989,7 +19821,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -19998,7 +19829,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-k22-ko23-docker
   cron: '21 22 * * 6'
   labels:
@@ -20027,7 +19858,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -20053,7 +19884,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -20062,7 +19892,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-k23-ko23-docker
   cron: '24 3 * * 3'
   labels:
@@ -20091,7 +19921,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -20117,7 +19947,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u1804
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -20378,7 +20207,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k21-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k22-docker
   cron: '29 21 * * *'
   labels:
@@ -20407,7 +20236,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -20433,7 +20262,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -20442,7 +20270,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k22-ko22-docker
   cron: '24 7 * * *'
   labels:
@@ -20471,7 +20299,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -20497,7 +20325,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -20506,7 +20333,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k22-ko22-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k22-ko23-docker
   cron: '30 1 * * *'
   labels:
@@ -20535,7 +20362,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -20561,7 +20388,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -20570,7 +20396,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k22-ko23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k23-docker
   cron: '47 3 * * *'
   labels:
@@ -20599,7 +20425,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -20625,7 +20451,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -20634,7 +20459,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k23-docker
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k23-ko23-docker
   cron: '43 12 * * *'
   labels:
@@ -20663,7 +20488,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kopeio --container-runtime=docker --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kopeio --container-runtime=docker" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -20689,7 +20514,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -20950,7 +20774,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-amzn2-k22-containerd
   cron: '8 1 * * 1'
   labels:
@@ -20979,7 +20803,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -21005,7 +20829,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -21014,7 +20837,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
 - name: e2e-kops-grid-amzn2-k22-ko22-containerd
   cron: '20 2 * * 0'
   labels:
@@ -21043,7 +20866,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -21069,7 +20892,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -21078,7 +20900,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-amzn2-k22-ko23-containerd
   cron: '39 13 * * 6'
   labels:
@@ -21107,7 +20929,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -21133,7 +20955,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -21142,7 +20963,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-amzn2-k23-containerd
   cron: '47 14 * * 0'
   labels:
@@ -21171,7 +20992,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -21197,7 +21018,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -21206,7 +21026,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-amzn2-k23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-amzn2-k23-ko23-containerd
   cron: '32 6 * * 1'
   labels:
@@ -21235,7 +21055,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -21261,7 +21081,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -21459,7 +21278,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
 - name: e2e-kops-grid-deb9-k22-ko22-containerd
   cron: '26 21 * * 3'
   labels:
@@ -21488,7 +21307,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -21514,7 +21333,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -21523,7 +21341,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-deb9-k22-ko23-containerd
   cron: '53 18 * * 6'
   labels:
@@ -21552,7 +21370,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -21578,7 +21396,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -21587,7 +21404,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb9-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-deb9-k23-ko23-containerd
   cron: '26 9 * * 4'
   labels:
@@ -21616,7 +21433,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -21642,7 +21459,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -21903,7 +21719,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-deb10-k22-containerd
   cron: '33 8 * * 2'
   labels:
@@ -21932,7 +21748,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -21958,7 +21774,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -21967,7 +21782,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
 - name: e2e-kops-grid-deb10-k22-ko22-containerd
   cron: '10 0 * * 3'
   labels:
@@ -21996,7 +21811,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -22022,7 +21837,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -22031,7 +21845,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-deb10-k22-ko23-containerd
   cron: '29 7 * * 1'
   labels:
@@ -22060,7 +21874,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -22086,7 +21900,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -22095,7 +21908,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-deb10-k23-containerd
   cron: '26 7 * * 0'
   labels:
@@ -22124,7 +21937,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -22150,7 +21963,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -22159,7 +21971,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-deb10-k23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-deb10-k23-ko23-containerd
   cron: '30 4 * * 6'
   labels:
@@ -22188,7 +22000,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -22214,7 +22026,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -22487,7 +22298,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-flatcar-k22-containerd
   cron: '13 18 * * 6'
   labels:
@@ -22516,7 +22327,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
@@ -22545,7 +22356,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -22554,7 +22364,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
 - name: e2e-kops-grid-flatcar-k22-ko22-containerd
   cron: '21 21 * * 0'
   labels:
@@ -22583,7 +22393,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
@@ -22612,7 +22422,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -22621,7 +22430,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-flatcar-k22-ko23-containerd
   cron: '42 18 * * 1'
   labels:
@@ -22650,7 +22459,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
@@ -22679,7 +22488,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -22688,7 +22496,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-flatcar-k23-containerd
   cron: '26 13 * * 6'
   labels:
@@ -22717,7 +22525,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
@@ -22746,7 +22554,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -22755,7 +22562,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flatcar-k23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-flatcar-k23-ko23-containerd
   cron: '1 9 * * 1'
   labels:
@@ -22784,7 +22591,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
@@ -22813,7 +22620,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -23011,7 +22817,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel7-k22-ko22-containerd
   cron: '56 22 * * 6'
   labels:
@@ -23040,7 +22846,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -23066,7 +22872,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -23075,7 +22880,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel7-k22-ko23-containerd
   cron: '39 17 * * 4'
   labels:
@@ -23104,7 +22909,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -23130,7 +22935,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -23139,7 +22943,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel7-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel7-k23-ko23-containerd
   cron: '8 10 * * 3'
   labels:
@@ -23168,7 +22972,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -23194,7 +22998,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -23455,7 +23258,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-rhel8-k22-containerd
   cron: '2 7 * * 4'
   labels:
@@ -23484,7 +23287,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -23510,7 +23313,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -23519,7 +23321,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel8-k22-ko22-containerd
   cron: '10 16 * * 4'
   labels:
@@ -23548,7 +23350,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -23574,7 +23376,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -23583,7 +23384,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel8-k22-ko23-containerd
   cron: '13 23 * * 4'
   labels:
@@ -23612,7 +23413,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -23638,7 +23439,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -23647,7 +23447,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-rhel8-k23-containerd
   cron: '21 0 * * 5'
   labels:
@@ -23676,7 +23476,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -23702,7 +23502,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -23711,7 +23510,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-rhel8-k23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-rhel8-k23-ko23-containerd
   cron: '30 20 * * 3'
   labels:
@@ -23740,7 +23539,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -23766,7 +23565,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -23964,7 +23762,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
 - name: e2e-kops-grid-u1804-k22-ko22-containerd
   cron: '5 23 * * 2'
   labels:
@@ -23993,7 +23791,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -24019,7 +23817,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -24028,7 +23825,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-u1804-k22-ko23-containerd
   cron: '10 16 * * 3'
   labels:
@@ -24057,7 +23854,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -24083,7 +23880,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -24092,7 +23888,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u1804-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-u1804-k23-ko23-containerd
   cron: '13 11 * * 4'
   labels:
@@ -24121,7 +23917,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -24147,7 +23943,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -24408,7 +24203,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-u2004-k22-containerd
   cron: '4 5 * * *'
   labels:
@@ -24437,7 +24232,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -24463,7 +24258,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -24472,7 +24266,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kubenet"}
 - name: e2e-kops-grid-u2004-k22-ko22-containerd
   cron: '47 1 * * *'
   labels:
@@ -24501,7 +24295,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -24527,7 +24321,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -24536,7 +24329,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-u2004-k22-ko23-containerd
   cron: '4 6 * * *'
   labels:
@@ -24565,7 +24358,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -24591,7 +24384,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -24600,7 +24392,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-u2004-k23-containerd
   cron: '19 2 * * *'
   labels:
@@ -24629,7 +24421,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -24655,7 +24447,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -24664,7 +24455,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-u2004-k23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kubenet"}
 - name: e2e-kops-grid-u2004-k23-ko23-containerd
   cron: '23 13 * * *'
   labels:
@@ -24693,7 +24484,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kubenet --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kubenet --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -24719,7 +24510,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -24980,7 +24770,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k22-containerd
   cron: '44 4 * * 2'
   labels:
@@ -25009,7 +24799,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -25035,7 +24825,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -25044,7 +24833,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k22-ko22-containerd
   cron: '45 23 * * 6'
   labels:
@@ -25073,7 +24862,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -25099,7 +24888,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -25108,7 +24896,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k22-ko23-containerd
   cron: '30 8 * * 6'
   labels:
@@ -25137,7 +24925,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -25163,7 +24951,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -25172,7 +24959,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k23-containerd
   cron: '23 19 * * 0'
   labels:
@@ -25201,7 +24988,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -25227,7 +25014,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -25236,7 +25022,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-amzn2-k23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k23-ko23-containerd
   cron: '1 3 * * 4'
   labels:
@@ -25265,7 +25051,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -25291,7 +25077,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -25489,7 +25274,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-k22-ko22-containerd
   cron: '36 0 * * 0'
   labels:
@@ -25518,7 +25303,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -25544,7 +25329,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -25553,7 +25337,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-k22-ko23-containerd
   cron: '51 23 * * 4'
   labels:
@@ -25582,7 +25366,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -25608,7 +25392,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -25617,7 +25400,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb9-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-k23-ko23-containerd
   cron: '12 4 * * 0'
   labels:
@@ -25646,7 +25429,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -25672,7 +25455,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -25933,7 +25715,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k22-containerd
   cron: '17 13 * * 1'
   labels:
@@ -25962,7 +25744,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -25988,7 +25770,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -25997,7 +25778,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k22-ko22-containerd
   cron: '11 5 * * 1'
   labels:
@@ -26026,7 +25807,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -26052,7 +25833,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -26061,7 +25841,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k22-ko23-containerd
   cron: '28 2 * * 5'
   labels:
@@ -26090,7 +25870,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -26116,7 +25896,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -26125,7 +25904,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k23-containerd
   cron: '22 2 * * 1'
   labels:
@@ -26154,7 +25933,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -26180,7 +25959,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -26189,7 +25967,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb10-k23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k23-ko23-containerd
   cron: '35 9 * * 5'
   labels:
@@ -26218,7 +25996,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -26244,7 +26022,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -26517,7 +26294,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k22-containerd
   cron: '14 13 * * 6'
   labels:
@@ -26546,7 +26323,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
@@ -26575,7 +26352,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -26584,7 +26360,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k22-ko22-containerd
   cron: '30 23 * * 6'
   labels:
@@ -26613,7 +26389,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
@@ -26642,7 +26418,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -26651,7 +26426,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k22-ko23-containerd
   cron: '57 8 * * 6'
   labels:
@@ -26680,7 +26455,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
@@ -26709,7 +26484,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -26718,7 +26492,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k23-containerd
   cron: '57 18 * * 1'
   labels:
@@ -26747,7 +26521,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
@@ -26776,7 +26550,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -26785,7 +26558,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k23-ko23-containerd
   cron: '26 19 * * 3'
   labels:
@@ -26814,7 +26587,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=calico --container-runtime=containerd" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
@@ -26843,7 +26616,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -27041,7 +26813,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-k22-ko22-containerd
   cron: '33 11 * * 3'
   labels:
@@ -27070,7 +26842,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -27096,7 +26868,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -27105,7 +26876,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-k22-ko23-containerd
   cron: '10 12 * * 1'
   labels:
@@ -27134,7 +26905,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -27160,7 +26931,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -27169,7 +26939,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel7-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-k23-ko23-containerd
   cron: '57 7 * * 4'
   labels:
@@ -27198,7 +26968,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -27224,7 +26994,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -27485,7 +27254,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k22-containerd
   cron: '38 18 * * 1'
   labels:
@@ -27514,7 +27283,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -27540,7 +27309,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -27549,7 +27317,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k22-ko22-containerd
   cron: '59 13 * * 3'
   labels:
@@ -27578,7 +27346,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -27604,7 +27372,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -27613,7 +27380,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k22-ko23-containerd
   cron: '16 10 * * 5'
   labels:
@@ -27642,7 +27409,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -27668,7 +27435,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -27677,7 +27443,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k23-containerd
   cron: '53 21 * * 0'
   labels:
@@ -27706,7 +27472,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -27732,7 +27498,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -27741,7 +27506,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k23-ko23-containerd
   cron: '7 17 * * 0'
   labels:
@@ -27770,7 +27535,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -27796,7 +27561,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -27994,7 +27758,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-k22-ko22-containerd
   cron: '48 18 * * 6'
   labels:
@@ -28023,7 +27787,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -28049,7 +27813,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -28058,7 +27821,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-k22-ko23-containerd
   cron: '23 13 * * 4'
   labels:
@@ -28087,7 +27850,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -28113,7 +27876,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -28122,7 +27884,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u1804-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-k23-ko23-containerd
   cron: '8 22 * * 2'
   labels:
@@ -28151,7 +27913,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -28177,7 +27939,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -28438,7 +28199,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k22-containerd
   cron: '28 16 * * *'
   labels:
@@ -28467,7 +28228,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -28493,7 +28254,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -28502,7 +28262,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k22-ko22-containerd
   cron: '58 4 * * *'
   labels:
@@ -28531,7 +28291,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -28557,7 +28317,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -28566,7 +28325,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k22-ko23-containerd
   cron: '25 3 * * *'
   labels:
@@ -28595,7 +28354,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -28621,7 +28380,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -28630,7 +28388,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k23-containerd
   cron: '3 23 * * *'
   labels:
@@ -28659,7 +28417,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -28685,7 +28443,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -28694,7 +28451,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k23-ko23-containerd
   cron: '14 8 * * *'
   labels:
@@ -28723,7 +28480,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=calico --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=calico --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -28749,7 +28506,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -29010,7 +28766,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k22-containerd
   cron: '6 22 * * 6'
   labels:
@@ -29039,7 +28795,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -29065,7 +28821,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -29074,7 +28829,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k22-ko22-containerd
   cron: '13 11 * * 4'
   labels:
@@ -29103,7 +28858,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -29129,7 +28884,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -29138,7 +28892,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k22-ko23-containerd
   cron: '6 12 * * 2'
   labels:
@@ -29167,7 +28921,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -29193,7 +28947,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -29202,7 +28955,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k23-containerd
   cron: '29 17 * * 3'
   labels:
@@ -29231,7 +28984,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -29257,7 +29010,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -29266,7 +29018,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-amzn2-k23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k23-ko23-containerd
   cron: '1 23 * * 0'
   labels:
@@ -29295,7 +29047,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -29321,7 +29073,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -29582,7 +29333,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k22-containerd
   cron: '31 7 * * 1'
   labels:
@@ -29611,7 +29362,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -29637,7 +29388,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -29646,7 +29396,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k22-ko22-containerd
   cron: '47 17 * * 6'
   labels:
@@ -29675,7 +29425,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -29701,7 +29451,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -29710,7 +29459,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k22-ko23-containerd
   cron: '32 22 * * 2'
   labels:
@@ -29739,7 +29488,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -29765,7 +29514,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -29774,7 +29522,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k23-containerd
   cron: '56 0 * * 6'
   labels:
@@ -29803,7 +29551,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -29829,7 +29577,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -29838,7 +29585,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb10-k23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k23-ko23-containerd
   cron: '43 21 * * 6'
   labels:
@@ -29867,7 +29614,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -29893,7 +29640,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -30154,7 +29900,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k22-containerd
   cron: '12 0 * * 4'
   labels:
@@ -30183,7 +29929,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -30209,7 +29955,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -30218,7 +29963,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k22-ko22-containerd
   cron: '43 9 * * 1'
   labels:
@@ -30247,7 +29992,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -30273,7 +30018,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -30282,7 +30026,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k22-ko23-containerd
   cron: '8 22 * * 6'
   labels:
@@ -30311,7 +30055,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -30337,7 +30081,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -30346,7 +30089,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k23-containerd
   cron: '51 15 * * 1'
   labels:
@@ -30375,7 +30118,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -30401,7 +30144,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -30410,7 +30152,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k23-ko23-containerd
   cron: '31 5 * * 0'
   labels:
@@ -30439,7 +30181,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -30465,7 +30207,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -30726,7 +30467,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k22-containerd
   cron: '2 10 * * *'
   labels:
@@ -30755,7 +30496,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -30781,7 +30522,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -30790,7 +30530,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k22-ko22-containerd
   cron: '22 16 * * *'
   labels:
@@ -30819,7 +30559,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -30845,7 +30585,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -30854,7 +30593,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k22-ko23-containerd
   cron: '25 23 * * *'
   labels:
@@ -30883,7 +30622,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -30909,7 +30648,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -30918,7 +30656,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k23-containerd
   cron: '17 21 * * *'
   labels:
@@ -30947,7 +30685,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -30973,7 +30711,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -30982,7 +30719,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k23-ko23-containerd
   cron: '2 20 * * *'
   labels:
@@ -31011,7 +30748,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -31037,7 +30774,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -31298,7 +31034,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-amzn2-k22-containerd
   cron: '4 10 * * 5'
   labels:
@@ -31327,7 +31063,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -31353,7 +31089,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -31362,7 +31097,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-amzn2-k22-ko22-containerd
   cron: '9 19 * * 4'
   labels:
@@ -31391,7 +31126,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -31417,7 +31152,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -31426,7 +31160,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-amzn2-k22-ko23-containerd
   cron: '58 20 * * 0'
   labels:
@@ -31455,7 +31189,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -31481,7 +31215,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -31490,7 +31223,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-amzn2-k23-containerd
   cron: '3 21 * * 4'
   labels:
@@ -31519,7 +31252,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -31545,7 +31278,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -31554,7 +31286,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-amzn2-k23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-amzn2-k23-ko23-containerd
   cron: '17 23 * * 1'
   labels:
@@ -31583,7 +31315,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -31609,7 +31341,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -31870,7 +31601,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb10-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-deb10-k22-containerd
   cron: '17 3 * * 6'
   labels:
@@ -31899,7 +31630,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium-etcd --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -31925,7 +31656,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -31934,7 +31664,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb10-k22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-deb10-k22-ko22-containerd
   cron: '31 17 * * 4'
   labels:
@@ -31963,7 +31693,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium-etcd --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -31989,7 +31719,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -31998,7 +31727,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb10-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-deb10-k22-ko23-containerd
   cron: '44 14 * * 0'
   labels:
@@ -32027,7 +31756,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium-etcd --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -32053,7 +31782,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -32062,7 +31790,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb10-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-deb10-k23-containerd
   cron: '54 12 * * 4'
   labels:
@@ -32091,7 +31819,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium-etcd --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -32117,7 +31845,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -32126,7 +31853,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb10-k23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-deb10-k23-ko23-containerd
   cron: '47 5 * * 3'
   labels:
@@ -32155,7 +31882,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium-etcd --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -32181,7 +31908,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -32442,7 +32168,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-rhel8-k22-containerd
   cron: '58 20 * * 6'
   labels:
@@ -32471,7 +32197,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -32497,7 +32223,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -32506,7 +32231,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-rhel8-k22-ko22-containerd
   cron: '19 17 * * 4'
   labels:
@@ -32535,7 +32260,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -32561,7 +32286,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -32570,7 +32294,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-rhel8-k22-ko23-containerd
   cron: '24 6 * * 4'
   labels:
@@ -32599,7 +32323,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -32625,7 +32349,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -32634,7 +32357,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-rhel8-k23-containerd
   cron: '41 11 * * 6'
   labels:
@@ -32663,7 +32386,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -32689,7 +32412,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -32698,7 +32420,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-rhel8-k23-ko23-containerd
   cron: '51 21 * * 0'
   labels:
@@ -32727,7 +32449,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -32753,7 +32475,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -33014,7 +32735,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-u2004-k22-containerd
   cron: '0 22 * * *'
   labels:
@@ -33043,7 +32764,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium-etcd --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -33069,7 +32790,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -33078,7 +32798,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-u2004-k22-ko22-containerd
   cron: '34 8 * * *'
   labels:
@@ -33107,7 +32827,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium-etcd --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -33133,7 +32853,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -33142,7 +32861,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-u2004-k22-ko23-containerd
   cron: '13 7 * * *'
   labels:
@@ -33171,7 +32890,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium-etcd --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -33197,7 +32916,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -33206,7 +32924,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-u2004-k23-containerd
   cron: '15 9 * * *'
   labels:
@@ -33235,7 +32953,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium-etcd --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -33261,7 +32979,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -33270,7 +32987,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-u2004-k23-ko23-containerd
   cron: '14 20 * * *'
   labels:
@@ -33299,7 +33016,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium-etcd --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=cilium-etcd --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -33325,7 +33042,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -33586,7 +33302,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k22-containerd
   cron: '12 15 * * 0'
   labels:
@@ -33615,7 +33331,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -33641,7 +33357,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -33650,7 +33365,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k22-ko22-containerd
   cron: '10 4 * * 6'
   labels:
@@ -33679,7 +33394,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -33705,7 +33420,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -33714,7 +33428,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k22-ko23-containerd
   cron: '13 19 * * 4'
   labels:
@@ -33743,7 +33457,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -33769,7 +33483,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -33778,7 +33491,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k23-containerd
   cron: '11 16 * * 0'
   labels:
@@ -33807,7 +33520,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -33833,7 +33546,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -33842,7 +33554,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-amzn2-k23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k23-ko23-containerd
   cron: '22 8 * * 5'
   labels:
@@ -33871,7 +33583,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -33897,7 +33609,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -34095,7 +33806,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-k22-ko22-containerd
   cron: '20 14 * * 4'
   labels:
@@ -34124,7 +33835,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -34150,7 +33861,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -34159,7 +33869,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-k22-ko23-containerd
   cron: '31 1 * * 1'
   labels:
@@ -34188,7 +33898,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -34214,7 +33924,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -34223,7 +33932,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb9-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-k23-ko23-containerd
   cron: '56 2 * * 4'
   labels:
@@ -34252,7 +33961,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -34278,7 +33987,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -34539,7 +34247,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k22-containerd
   cron: '33 22 * * 2'
   labels:
@@ -34568,7 +34276,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -34594,7 +34302,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -34603,7 +34310,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k22-ko22-containerd
   cron: '16 6 * * 2'
   labels:
@@ -34632,7 +34339,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -34658,7 +34365,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -34667,7 +34373,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k22-ko23-containerd
   cron: '43 17 * * 6'
   labels:
@@ -34696,7 +34402,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -34722,7 +34428,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -34731,7 +34436,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k23-containerd
   cron: '14 1 * * 5'
   labels:
@@ -34760,7 +34465,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -34786,7 +34491,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -34795,7 +34499,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-deb10-k23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k23-ko23-containerd
   cron: '36 10 * * 2'
   labels:
@@ -34824,7 +34528,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -34850,7 +34554,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -35123,7 +34826,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k22-containerd
   cron: '5 13 * * 0'
   labels:
@@ -35152,7 +34855,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
@@ -35181,7 +34884,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -35190,7 +34892,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k22-ko22-containerd
   cron: '28 21 * * 5'
   labels:
@@ -35219,7 +34921,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
@@ -35248,7 +34950,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -35257,7 +34958,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k22-ko23-containerd
   cron: '43 2 * * 0'
   labels:
@@ -35286,7 +34987,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
@@ -35315,7 +35016,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -35324,7 +35024,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k23-containerd
   cron: '46 18 * * 3'
   labels:
@@ -35353,7 +35053,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
@@ -35382,7 +35082,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -35391,7 +35090,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-flatcar-k23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k23-ko23-containerd
   cron: '48 9 * * 3'
   labels:
@@ -35420,7 +35119,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
@@ -35449,7 +35148,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -35647,7 +35345,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-k22-ko22-containerd
   cron: '38 8 * * 4'
   labels:
@@ -35676,7 +35374,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -35702,7 +35400,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -35711,7 +35408,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-k22-ko23-containerd
   cron: '37 23 * * 1'
   labels:
@@ -35740,7 +35437,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -35766,7 +35463,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -35775,7 +35471,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel7-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-k23-ko23-containerd
   cron: '34 12 * * 6'
   labels:
@@ -35804,7 +35500,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -35830,7 +35526,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -36091,7 +35786,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k22-containerd
   cron: '18 17 * * 1'
   labels:
@@ -36120,7 +35815,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -36146,7 +35841,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -36155,7 +35849,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k22-ko22-containerd
   cron: '4 14 * * 0'
   labels:
@@ -36184,7 +35878,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -36210,7 +35904,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -36219,7 +35912,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k22-ko23-containerd
   cron: '3 17 * * 4'
   labels:
@@ -36248,7 +35941,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -36274,7 +35967,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -36283,7 +35975,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k23-containerd
   cron: '33 14 * * 2'
   labels:
@@ -36312,7 +36004,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -36338,7 +36030,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -36347,7 +36038,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-rhel8-k23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k23-ko23-containerd
   cron: '32 10 * * 1'
   labels:
@@ -36376,7 +36067,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -36402,7 +36093,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -36600,7 +36290,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-k22-ko22-containerd
   cron: '31 9 * * 1'
   labels:
@@ -36629,7 +36319,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -36655,7 +36345,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -36664,7 +36353,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-k22-ko23-containerd
   cron: '40 6 * * 2'
   labels:
@@ -36693,7 +36382,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -36719,7 +36408,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -36728,7 +36416,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u1804-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-k23-ko23-containerd
   cron: '7 21 * * 3'
   labels:
@@ -36757,7 +36445,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -36783,7 +36471,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -37044,7 +36731,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k22-containerd
   cron: '12 3 * * *'
   labels:
@@ -37073,7 +36760,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -37099,7 +36786,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -37108,7 +36794,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k22-ko22-containerd
   cron: '25 23 * * *'
   labels:
@@ -37137,7 +36823,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -37163,7 +36849,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -37172,7 +36857,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k22-ko23-containerd
   cron: '6 0 * * *'
   labels:
@@ -37201,7 +36886,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -37227,7 +36912,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -37236,7 +36920,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k23-containerd
   cron: '55 12 * * *'
   labels:
@@ -37265,7 +36949,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -37291,7 +36975,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -37300,7 +36983,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-flannel-u2004-k23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k23-ko23-containerd
   cron: '1 19 * * *'
   labels:
@@ -37329,7 +37012,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=flannel --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=flannel --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -37355,7 +37038,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -37616,7 +37298,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k22-containerd
   cron: '47 15 * * 1'
   labels:
@@ -37645,7 +37327,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -37671,7 +37353,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -37680,7 +37361,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k22-ko22-containerd
   cron: '53 23 * * 3'
   labels:
@@ -37709,7 +37390,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -37735,7 +37416,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -37744,7 +37424,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k22-ko23-containerd
   cron: '46 8 * * 3'
   labels:
@@ -37773,7 +37453,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -37799,7 +37479,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -37808,7 +37487,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k23-containerd
   cron: '44 16 * * 6'
   labels:
@@ -37837,7 +37516,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -37863,7 +37542,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -37872,7 +37550,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-amzn2-k23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k23-ko23-containerd
   cron: '41 11 * * 5'
   labels:
@@ -37901,7 +37579,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211223.0-x86_64-gp2' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -37927,7 +37605,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: amzn2
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -38125,7 +37802,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-k22-ko22-containerd
   cron: '59 11 * * 1'
   labels:
@@ -38154,7 +37831,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -38180,7 +37857,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -38189,7 +37865,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-k22-ko23-containerd
   cron: '48 20 * * 2'
   labels:
@@ -38218,7 +37894,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -38244,7 +37920,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -38253,7 +37928,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb9-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-k23-ko23-containerd
   cron: '31 23 * * 4'
   labels:
@@ -38282,7 +37957,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='379101102735/debian-stretch-hvm-x86_64-gp2-2021-12-30-21724' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -38308,7 +37983,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb9
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -38569,7 +38243,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k22-containerd
   cron: '50 14 * * 1'
   labels:
@@ -38598,7 +38272,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -38624,7 +38298,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -38633,7 +38306,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k22-ko22-containerd
   cron: '3 5 * * 3'
   labels:
@@ -38662,7 +38335,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -38688,7 +38361,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -38697,7 +38369,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k22-ko23-containerd
   cron: '20 10 * * 4'
   labels:
@@ -38726,7 +38398,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -38752,7 +38424,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -38761,7 +38432,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k23-containerd
   cron: '29 1 * * 4'
   labels:
@@ -38790,7 +38461,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -38816,7 +38487,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -38825,7 +38495,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb10-k23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k23-ko23-containerd
   cron: '31 1 * * 5'
   labels:
@@ -38854,7 +38524,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='136693071363/debian-10-amd64-20211011-792' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -38880,7 +38550,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: deb10
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -39153,7 +38822,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k22-containerd
   cron: '4 11 * * 4'
   labels:
@@ -39182,7 +38851,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
@@ -39211,7 +38880,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -39220,7 +38888,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k22-ko22-containerd
   cron: '46 7 * * 1'
   labels:
@@ -39249,7 +38917,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
@@ -39278,7 +38946,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -39287,7 +38954,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k22-ko23-containerd
   cron: '21 8 * * 5'
   labels:
@@ -39316,7 +38983,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
@@ -39345,7 +39012,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -39354,7 +39020,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k23-containerd
   cron: '15 20 * * 4'
   labels:
@@ -39383,7 +39049,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
@@ -39412,7 +39078,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -39421,7 +39086,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-flatcar-k23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k23-ko23-containerd
   cron: '50 11 * * 4'
   labels:
@@ -39450,7 +39115,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='075585003325/Flatcar-stable-3033.2.0-hvm' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --control-plane-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --node-instance-group-overrides="spec.instanceMetadata.httpTokens=optional" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
@@ -39479,7 +39144,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -39677,7 +39341,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-k22-ko22-containerd
   cron: '49 19 * * 1'
   labels:
@@ -39706,7 +39370,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -39732,7 +39396,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -39741,7 +39404,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-k22-ko23-containerd
   cron: '58 4 * * 5'
   labels:
@@ -39770,7 +39433,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -39796,7 +39459,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -39805,7 +39467,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel7-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-k23-ko23-containerd
   cron: '45 7 * * 5'
   labels:
@@ -39834,7 +39496,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -39860,7 +39522,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel7
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -40121,7 +39782,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k22-containerd
   cron: '1 9 * * 0'
   labels:
@@ -40150,7 +39811,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -40176,7 +39837,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -40185,7 +39845,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k22-ko22-containerd
   cron: '43 5 * * 1'
   labels:
@@ -40214,7 +39874,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -40240,7 +39900,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -40249,7 +39908,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k22-ko23-containerd
   cron: '0 10 * * 4'
   labels:
@@ -40278,7 +39937,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -40304,7 +39963,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -40313,7 +39971,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k23-containerd
   cron: '6 22 * * 4'
   labels:
@@ -40342,7 +40000,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -40368,7 +40026,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -40377,7 +40034,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k23-ko23-containerd
   cron: '23 1 * * 1'
   labels:
@@ -40406,7 +40063,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='309956199498/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -40432,7 +40089,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -40630,7 +40286,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-k22-ko22-containerd
   cron: '0 2 * * 5'
   labels:
@@ -40659,7 +40315,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -40685,7 +40341,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -40694,7 +40349,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-k22-ko23-containerd
   cron: '55 21 * * 6'
   labels:
@@ -40723,7 +40378,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -40749,7 +40404,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -40758,7 +40412,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u1804-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-k23-ko23-containerd
   cron: '32 14 * * 4'
   labels:
@@ -40787,7 +40441,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20220104' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -40813,7 +40467,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u1804
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -41074,7 +40727,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k21-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k22-containerd
   cron: '55 19 * * *'
   labels:
@@ -41103,7 +40756,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -41129,7 +40782,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -41138,7 +40790,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.22", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k22-ko22-containerd
   cron: '22 12 * * *'
   labels:
@@ -41167,7 +40819,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.22/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -41193,7 +40845,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.22'
@@ -41202,7 +40853,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k22-ko22-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.22", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k22-ko23-containerd
   cron: '53 11 * * *'
   labels:
@@ -41231,7 +40882,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.22.txt \
           --test=kops \
@@ -41257,7 +40908,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.22'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'
@@ -41266,7 +40916,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k22-ko23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k23-containerd
   cron: '4 20 * * *'
   labels:
@@ -41295,7 +40945,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -41321,7 +40971,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
@@ -41330,7 +40979,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k23-containerd
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.23", "kops_channel": "alpha", "kops_version": "1.23", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k23-ko23-containerd
   cron: '58 8 * * *'
   labels:
@@ -41359,7 +41008,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kopeio --container-runtime=containerd --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220110' --channel=alpha --networking=kopeio --container-runtime=containerd" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/markers/release-1.23/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt \
           --test=kops \
@@ -41385,7 +41034,6 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: '1.23'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: '1.23'


### PR DESCRIPTION
AWS has a hard max-limit of 100 OIDC providers per account, and we are hitting this limit all the time.
Removing IRSA from the networking grid as there is nothing unique, irsa-related in those tests.

/cc @hakman @johngmyers @rifelpet 