### PR TITLE
Add SIG Release k/k fast-forward job

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -164,3 +164,34 @@ periodics:
     testgrid-alert-email: release-managers+alerts@kubernetes.io
     testgrid-dashboards: sig-release-releng-informing
     testgrid-tab-name: build-packages-rpms
+
+- interval: 6h
+  name: ci-fast-forward
+  cluster: k8s-infra-prow-build
+  decorate: true
+  spec:
+    serviceAccountName: gcb-builder
+    containers:
+    - image: gcr.io/k8s-staging-releng/k8s-ci-builder:latest-default
+      imagePullPolicy: Always
+      command:
+      - wrapper.sh
+      - /krel
+      - fast-forward
+      - --non-interactive
+      - --submit
+      resources:
+        requests:
+          cpu: 4
+          memory: "8Gi"
+        limits:
+          cpu: 4
+          memory: "8Gi"
+  rerun_auth_config:
+    github_team_slugs:
+      - org: kubernetes
+        slug: release-managers
+  annotations:
+    testgrid-alert-email: release-managers+alerts@kubernetes.io
+    testgrid-dashboards: sig-release-releng-informing
+    testgrid-tab-name: git-repo-kubernetes-fast-forward


### PR DESCRIPTION
Requires https://github.com/kubernetes/release/pull/2391 to be merged before.

This job runs in nomock mode, so it does not modification to k/k at all.