### PR TITLE
tide: Add some debugging logs

### DIFF
--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -264,6 +264,7 @@ func (sc *statusController) expectedStatus(log *logrus.Entry, queryMap *config.Q
 	if reason, err := sc.mergeChecker.isAllowed(pr); err != nil {
 		return "", "", fmt.Errorf("error checking if merge is allowed: %w", err)
 	} else if reason != "" {
+		log.WithField("reason", reason).Debug("The PR is not mergeable")
 		return github.StatusError, fmt.Sprintf(statusNotInPool, " "+reason), nil
 	}
 

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -691,6 +691,13 @@ func (m *mergeChecker) repoMethods(orgRepo config.OrgRepo) (map[github.PullReque
 		if err != nil {
 			return nil, err
 		}
+		logrus.WithFields(logrus.Fields{
+			"org":              orgRepo.Org,
+			"repo":             orgRepo.Repo,
+			"AllowMergeCommit": fullRepo.AllowMergeCommit,
+			"AllowSquashMerge": fullRepo.AllowSquashMerge,
+			"AllowRebaseMerge": fullRepo.AllowRebaseMerge,
+		}).Debug("GetRepo returns these values for repo methods")
 		repoMethods = map[github.PullRequestMergeType]bool{
 			github.MergeMerge:  fullRepo.AllowMergeCommit,
 			github.MergeSquash: fullRepo.AllowSquashMerge,


### PR DESCRIPTION
Tide status in the PR [1] shows "Not mergeable. Merge type "merge" disallowed by repo settings".
However, the following cmd shows it is allowed.

```bash
$ oc exec -n ci ${TIDE_POD} -- wget -O- -q --header "Authorization: Token $TOKEN" --header "Accept: application/vnd.github.v3+json" http://ghproxy/repos/red-hat-storage/kubernetes-csi-addons | jq .allow_merge_commit
true
```

The added logs will help us to compare the value from the github API calls and the one from the cache.

[1]. https://github.com/red-hat-storage/kubernetes-csi-addons/pull/7

/cc @petr-muller @alvaroaleman 