### PR TITLE
releng: update kubekins/krte to Go 1.17.6 and Go 1.16.13

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.17.5
+    GO_VERSION: 1.17.6
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
@@ -22,25 +22,25 @@ variants:
     KIND_VERSION: 0.10.0
   master:
     CONFIG: master
-    GO_VERSION: 1.17.5
+    GO_VERSION: 1.17.6
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.23':
     CONFIG: '1.23'
-    GO_VERSION: 1.17.5
+    GO_VERSION: 1.17.6
     K8S_RELEASE: stable-1.23
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.22':
     CONFIG: '1.22'
-    GO_VERSION: 1.16.12
+    GO_VERSION: 1.16.13
     K8S_RELEASE: stable-1.22
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.21':
     CONFIG: '1.21'
-    GO_VERSION: 1.16.12
+    GO_VERSION: 1.16.13
     K8S_RELEASE: stable-1.21
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
Part of https://github.com/kubernetes/release/issues/2379

Ready to merge after k/k Go update PRs merge: https://github.com/kubernetes/kubernetes/pull/107612 (master), https://github.com/kubernetes/kubernetes/pull/107613 (release-1.23), https://github.com/kubernetes/kubernetes/pull/107614 (release-1.22), https://github.com/kubernetes/kubernetes/pull/107615 (release-1.21)

/assign @cpanato @saschagrunert @justaugustus @puerco @xmudrii @Verolop @BenTheElder
cc: @kubernetes/release-engineering