### PR TITLE
add container-runtime-endpoint

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -91,7 +91,7 @@ periodics:
         --gcp-zone=us-west1-b
         --node-tests=true
         "--node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/image-config.yaml --extra-envs=${EXTRA_ENVS}"
-        '--node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"'
+        '--node-test-args=--kubelet-flags="--container-runtime=containerd --container-runtime-pid-file= --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock --cgroups-per-qos=true --cgroup-root=/"'
         '--test_args=--nodes=8 --focus=NodeProblemDetector'
         --timeout=60m
   annotations:

--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -91,7 +91,7 @@ periodics:
         --gcp-zone=us-west1-b
         --node-tests=true
         "--node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/image-config.yaml --extra-envs=${EXTRA_ENVS}"
-        '--node-test-args=--kubelet-flags="--container-runtime=containerd --container-runtime-pid-file= --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock --cgroups-per-qos=true --cgroup-root=/"'
+        '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
         '--test_args=--nodes=8 --focus=NodeProblemDetector'
         --timeout=60m
   annotations:


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind failing-test


#### What this PR does / why we need it:
As dockershim is getting deprecate, replace with the containerd.sock as the container-runtime-endpoint.

#### Which issue(s) this PR fixes:
Fixes #107067

#### Special notes for your reviewer:

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
