### PR TITLE
Clean up reviewers for sig node owners files

### DIFF
--- a/config/jobs/kubernetes/sig-node/OWNERS
+++ b/config/jobs/kubernetes/sig-node/OWNERS
@@ -8,6 +8,7 @@ reviewers:
   - sjenning
   - SergeyKanzhelev
 approvers:
+  - yujuhong
   - Random-Liu
   - dchen1107
   - derekwaynecarr
@@ -18,6 +19,5 @@ approvers:
   - SergeyKanzhelev
 emeritus_approvers:
   - dashpole
-  - yujuhong
 labels:
   - sig/node

--- a/config/jobs/kubernetes/sig-node/OWNERS
+++ b/config/jobs/kubernetes/sig-node/OWNERS
@@ -1,27 +1,23 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- alejandrox1
-- bart0sh
-- derekwaynecarr
-- ehashman
-- endocrimes
-- karan
-- MHBauer
-- vpickard
-- sjenning
-- SergeyKanzhelev
+  - bart0sh
+  - derekwaynecarr
+  - ehashman
+  - endocrimes
+  - sjenning
+  - SergeyKanzhelev
 approvers:
-- yujuhong
-- Random-Liu
-- dchen1107
-- derekwaynecarr
-- sjenning
-- mrunalp
-- klueska
-- ehashman
-- SergeyKanzhelev
+  - Random-Liu
+  - dchen1107
+  - derekwaynecarr
+  - sjenning
+  - mrunalp
+  - ehashman
+  - SergeyKanzhelev
 emeritus_approvers:
-- dashpole
+  - dashpole
+  - klueska
+  - yujuhong
 labels:
-- sig/node
+  - sig/node

--- a/config/jobs/kubernetes/sig-node/OWNERS
+++ b/config/jobs/kubernetes/sig-node/OWNERS
@@ -13,11 +13,11 @@ approvers:
   - derekwaynecarr
   - sjenning
   - mrunalp
+  - klueska
   - ehashman
   - SergeyKanzhelev
 emeritus_approvers:
   - dashpole
-  - klueska
   - yujuhong
 labels:
   - sig/node

--- a/config/testgrids/kubernetes/sig-node/OWNERS
+++ b/config/testgrids/kubernetes/sig-node/OWNERS
@@ -8,6 +8,7 @@ reviewers:
   - sjenning
   - SergeyKanzhelev
 approvers:
+  - yujuhong
   - Random-Liu
   - dchen1107
   - derekwaynecarr
@@ -18,6 +19,5 @@ approvers:
   - SergeyKanzhelev
 emeritus_approvers:
   - dashpole
-  - yujuhong
 labels:
   - sig/node

--- a/config/testgrids/kubernetes/sig-node/OWNERS
+++ b/config/testgrids/kubernetes/sig-node/OWNERS
@@ -1,27 +1,23 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- alejandrox1
-- bart0sh
-- derekwaynecarr
-- ehashman
-- endocrimes
-- karan
-- MHBauer
-- vpickard
-- sjenning
-- SergeyKanzhelev
+  - bart0sh
+  - derekwaynecarr
+  - ehashman
+  - endocrimes
+  - sjenning
+  - SergeyKanzhelev
 approvers:
-- yujuhong
-- Random-Liu
-- dchen1107
-- derekwaynecarr
-- sjenning
-- mrunalp
-- klueska
-- ehashman
-- SergeyKanzhelev
+  - Random-Liu
+  - dchen1107
+  - derekwaynecarr
+  - sjenning
+  - mrunalp
+  - ehashman
+  - SergeyKanzhelev
 emeritus_approvers:
-- dashpole
+  - dashpole
+  - klueska
+  - yujuhong
 labels:
-- sig/node
+  - sig/node

--- a/config/testgrids/kubernetes/sig-node/OWNERS
+++ b/config/testgrids/kubernetes/sig-node/OWNERS
@@ -13,11 +13,11 @@ approvers:
   - derekwaynecarr
   - sjenning
   - mrunalp
+  - klueska
   - ehashman
   - SergeyKanzhelev
 emeritus_approvers:
   - dashpole
-  - klueska
   - yujuhong
 labels:
   - sig/node


### PR DESCRIPTION
Cleaned up the SIG node reviewers list

/sig node

Run the following commands (first command is mostly out of interest):

```
cd config/jobs/kubernetes/sig-node/
../../../../../maintainers/maintainers prune --dryrun=false
../../../../../maintainers/maintainers prune --dryrun=false --repository-devstats=kubernetes/test-infra

cd config/testgrids/kubernetes/sig-node/
../../../../../maintainers/maintainers prune --dryrun=false 
../../../../../maintainers/maintainers prune --dryrun=false --repository-devstats=kubernetes/test-infra
```

Then restored klueska back as approver to match this file: https://github.com/kubernetes/kubernetes/blob/01da891398e3f05c39881897e69ab6489dfa73d4/test/e2e_node/OWNERS I think it is important to keep approvers across e2e folder in k/k and approvers in this repo.

One exception for ^^^ is tallclair. Perhaps we need to add tallclair to these OWNERS files to match approvers lists.

Also restored yujuhong to match the https://github.com/kubernetes/kubernetes/blob/master/OWNERS_ALIASES#L218. Only meant to clean up the reviewers list.


FYI: @alejandrox1 @karan @MHBauer @vpickard 

Commands output:

```
$ cd config/jobs/kubernetes/sig-node/
$ ../../../../../maintainers/maintainers prune --dryrun=false

    Running script : 01-14-2022 22:27:22
    Processed /usr/local/google/home/skanzhelev/go/src/k8s.io/test-infra/config/jobs/kubernetes/sig-node/OWNERS
    Found 0 unique aliases
    Found 15 unique users
    .....................


    >>>>> Contributions from kubernetes/kubernetes devstats repo and kubernetes/kubernetes github repo : 14
    >>>>> GitHub ID : Devstats contrib count : GitHub PR comment count
    ehashman : 2741 : 546 
    mrunalp : 310 : 330 
    SergeyKanzhelev : 1430 : 246 
    klueska : 325 : 58 
    derekwaynecarr : 208 : 101 
    endocrimes : 248 : 57 
    dchen1107 : 71 : 53 
    sjenning : 62 : 45 
    yujuhong : 26 : 20 
    bart0sh : 92 : 13 
    Random-Liu : 92 : 15 
    karan : 6 : 5 
    MHBauer : 8 : 4 
    vpickard : 5 : 2 


    >>>>> Missing Contributions in kubernetes/kubernetes (devstats == 0): 1
    alejandrox1


    >>>>> Low reviews/approvals in kubernetes/kubernetes (GH pr comments <= 10 && devstats <=20): 3
    MHBauer
    karan
    vpickard
    Fixing up /usr/local/google/home/skanzhelev/go/src/k8s.io/test-infra/config/jobs/kubernetes/sig-node/OWNERS


$ ../../../../../maintainers/maintainers prune --dryrun=false --repository-devstats=kubernetes/test-infra

    Running script : 01-14-2022 22:29:29
    Processed /usr/local/google/home/skanzhelev/go/src/k8s.io/test-infra/config/jobs/kubernetes/sig-node/OWNERS
    Found 0 unique aliases
    Found 11 unique users
    .........


    >>>>> Contributions from kubernetes/test-infra devstats repo and kubernetes/kubernetes github repo : 9
    >>>>> GitHub ID : Devstats contrib count : GitHub PR comment count
    ehashman : 183 : 546 
    SergeyKanzhelev : 144 : 246 
    endocrimes : 35 : 57 
    bart0sh : 19 : 13 
    mrunalp : 9 : 330 
    dchen1107 : 8 : 53 
    derekwaynecarr : 7 : 101 
    sjenning : 5 : 45 
    Random-Liu : 1 : 15 


    >>>>> Missing Contributions in kubernetes/test-infra (devstats == 0): 2
    klueska
    yujuhong


    >>>>> Low reviews/approvals in kubernetes/kubernetes (GH pr comments <= 10 && devstats <=20): 0
    Fixing up /usr/local/google/home/skanzhelev/go/src/k8s.io/test-infra/config/jobs/kubernetes/sig-node/OWNERS


$ cd config/testgrids/kubernetes/sig-node/
$ ../../../../../maintainers/maintainers prune --dryrun=false 

    Running script : 01-14-2022 22:30:47
    Processed /usr/local/google/home/skanzhelev/go/src/k8s.io/test-infra/config/testgrids/kubernetes/sig-node/OWNERS
    Found 0 unique aliases
    Found 15 unique users
    .....................


    >>>>> Contributions from kubernetes/kubernetes devstats repo and kubernetes/kubernetes github repo : 14
    >>>>> GitHub ID : Devstats contrib count : GitHub PR comment count
    ehashman : 2741 : 546 
    mrunalp : 310 : 330 
    SergeyKanzhelev : 1430 : 246 
    klueska : 325 : 58 
    derekwaynecarr : 208 : 101 
    endocrimes : 248 : 57 
    dchen1107 : 71 : 53 
    sjenning : 62 : 45 
    yujuhong : 26 : 20 
    bart0sh : 92 : 13 
    Random-Liu : 92 : 15 
    karan : 6 : 5 
    MHBauer : 8 : 4 
    vpickard : 5 : 2 


    >>>>> Missing Contributions in kubernetes/kubernetes (devstats == 0): 1
    alejandrox1


    >>>>> Low reviews/approvals in kubernetes/kubernetes (GH pr comments <= 10 && devstats <=20): 3
    MHBauer
    karan
    vpickard
    Fixing up /usr/local/google/home/skanzhelev/go/src/k8s.io/test-infra/config/testgrids/kubernetes/sig-node/OWNERS


$ ../../../../../maintainers/maintainers prune --dryrun=false --repository-devstats=kubernetes/test-infra

    Running script : 01-14-2022 22:32:18
    Processed /usr/local/google/home/skanzhelev/go/src/k8s.io/test-infra/config/testgrids/kubernetes/sig-node/OWNERS
    Found 0 unique aliases
    Found 11 unique users
    .............


    >>>>> Contributions from kubernetes/test-infra devstats repo and kubernetes/kubernetes github repo : 9
    >>>>> GitHub ID : Devstats contrib count : GitHub PR comment count
    ehashman : 183 : 546 
    SergeyKanzhelev : 144 : 246 
    endocrimes : 35 : 57 
    bart0sh : 19 : 13 
    mrunalp : 9 : 330 
    dchen1107 : 8 : 53 
    derekwaynecarr : 7 : 101 
    sjenning : 5 : 45 
    Random-Liu : 1 : 15 


    >>>>> Missing Contributions in kubernetes/test-infra (devstats == 0): 2
    klueska
    yujuhong


    >>>>> Low reviews/approvals in kubernetes/kubernetes (GH pr comments <= 10 && devstats <=20): 0
    Fixing up /usr/local/google/home/skanzhelev/go/src/k8s.io/test-infra/config/testgrids/kubernetes/sig-node/OWNERS
```