### PR TITLE
Add prow configs for cloud-provider-azure

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1043,6 +1043,8 @@ plugins:
     - milestonestatus
     - release-note
     - require-matching-label
+    - mergecommitblocker
+    - override
 
   kubernetes-sigs/gcp-compute-persistent-disk-csi-driver:
     plugins:
@@ -1238,6 +1240,12 @@ external_plugins:
     events:
       - issue_comment
       - pull_request
+  kubernetes-sigs/cloud-provider-azure:
+  - name: cherrypicker
+    events:
+    - issue_comment
+    - pull_request
+    endpoint: http://cherrypicker
   kubernetes-sigs/cluster-api:
   - name: cherrypicker
     events:


### PR DESCRIPTION
As part of this PR, we want to enable Prow based CI checks for kubernetes-sigs/cloud-provider-azure project.
