### PR TITLE
fix broken coredns upgrade in tests for Cluster API 0.4 and 1.0

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-4-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-4-upgrades.yaml
@@ -205,7 +205,8 @@ periodics:
         - name: ETCD_VERSION_UPGRADE_TO
           value: "3.5.1-0"
         - name: COREDNS_VERSION_UPGRADE_TO
-          value: "v1.8.6"
+          # CAPI 0.4 only supports up to CoreDNS version 1.8.4.
+          value: "v1.8.4"
         - name: GINKGO_FOCUS
           value: "\\[K8s-Upgrade\\]"
       # we need privileged mode in order to do docker in docker

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-0-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-0-upgrades.yaml
@@ -205,7 +205,8 @@ periodics:
         - name: ETCD_VERSION_UPGRADE_TO
           value: "3.5.1-0"
         - name: COREDNS_VERSION_UPGRADE_TO
-          value: "v1.8.6"
+          # CAPI 1.0 only supports up to CoreDNS version 1.8.5.
+          value: "v1.8.5"
         - name: GINKGO_FOCUS
           value: "\\[K8s-Upgrade\\]"
       # we need privileged mode in order to do docker in docker


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

This change fixes failing upgrade tests in older version of Cluster API due to lack of support for newer versions of CoreDNS in the CoreDNS migration library.

c/f https://github.com/kubernetes-sigs/cluster-api/issues/5952