### PR TITLE
Fix typo in presubmit Prow job of kube-scheduler-simulator

### DIFF
--- a/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-master.yaml
@@ -36,7 +36,7 @@ presubmits:
         - /bin/bash
         - -c
         - >
-          cd /web
+          cd ./web &&
           npm ci &&
           npm install -g yarn &&
           yarn install --frozen-lockfile &&


### PR DESCRIPTION
This PR is part of changes under issue: https://github.com/kubernetes-sigs/kube-scheduler-simulator/issues/56

As part of this change, we are fixing a minor typo in one of the Prow configuration jobs of kube-scheduler-simulator.