### PR TITLE
Runs integration-test on default branch runs only

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -177,6 +177,8 @@ presubmits:
     run_if_changed: '^((api|cmd|config|contrib|controllers|pkg|test)/|Makefile)'
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    branches:
+    - ^master$
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220119-cac87ea594-1.21


### PR DESCRIPTION
This change edits the `integration-test` job to run only for PRs against the default branch.