### PR TITLE
Make Sub include a "https://" prefix when looking up presubmit/postsubmit jobs for gerrit.

### DIFF
--- a/prow/pubsub/subscriber/BUILD.bazel
+++ b/prow/pubsub/subscriber/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
+        "//prow/gerrit/client:go_default_library",
         "//prow/pjutil:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
@@ -33,6 +34,7 @@ go_test(
         "//prow/client/clientset/versioned/fake:go_default_library",
         "//prow/config:go_default_library",
         "//prow/crier/reporters/pubsub:go_default_library",
+        "//prow/gerrit/client:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go_pubsub//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",


### PR DESCRIPTION
Currently users wishing to trigger presubmit or postsubmit jobs for gerrit via pubsub must incorrectly prepend `https://` to the `refs.org` field in order for Sub to be able to find the job's config. This allows the job to be triggered, but the incorrect `refs.org` value causes problems elsewhere (e.g. links on Prow's front end).

This PR updates Sub to prepend the `https://` during the config lookup if the job is associated with a gerrit revision.

/assign @chaodaiG
/cc @alvaroaleman 