### PR TITLE
fix: containerd was installed under /home/containerd/usr/local/bin/containerd

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -1160,7 +1160,7 @@ periodics:
       - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/containerd-master/cgroupv2/image-config-cgroupv2-serial.yaml
       - --deployment=node
       - --gcp-zone=us-west1-b
-      - '--node-test-args=--feature-gates=LocalStorageCapacityIsolation=true --container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+      - '--node-test-args=--feature-gates=LocalStorageCapacityIsolation=true --container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
       - --node-tests=true
       - --provider=gce
       - --test_args=--nodes=1 --focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]|\[NodeFeature:DevicePluginProbe\]"


### PR DESCRIPTION
```--container-runtime-process-name=/bin/containerd```
will fit with bot `/usr/bin/containerd` and `/home/containerd/usr/local/bin/containerd`

Fixes https://github.com/kubernetes/kubernetes/issues/107062

According to https://github.com/kubernetes/kubernetes/issues/107062#issuecomment-1009446893.
