### PR TITLE
upgrade pip before using pip

### DIFF
--- a/kettle/Dockerfile
+++ b/kettle/Dockerfile
@@ -30,7 +30,8 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --no-cache-dir requests google-cloud-pubsub==2.3.0 google-cloud-bigquery==2.11.0 influxdb ruamel.yaml==0.16
+RUN pip3 install --no-cache-dir --upgrade pip \
+    pip3 install --no-cache-dir requests google-cloud-pubsub==2.3.0 google-cloud-bigquery==2.11.0 influxdb ruamel.yaml==0.16
 
 RUN curl -fsSL https://downloads.python.org/pypy/pypy3.6-v7.3.1-linux64.tar.bz2 | tar xj -C opt  && \
     ln -s /opt/pypy*/bin/pypy3 /usr/bin


### PR DESCRIPTION
xref: https://github.com/kubernetes/test-infra/pull/24948#issuecomment-1018035026

pretty sure we're failing with `ModuleNotFoundError: No module named 'setuptools_rust'` because pip(3) is too old. we should keep pip up to date.