### PR TITLE
Make the PD CSI Windows CI --repo flag the same as Linux

### DIFF
--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-windows.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-windows.yaml
@@ -19,7 +19,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220120-50581feb62-master
       args:
-      - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+      - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver"
       - "--root=/go/src"
       - "--upload=gs://kubernetes-jenkins/logs"
       - "--clean"
@@ -65,7 +65,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220120-50581feb62-master
       args:
-      - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+      - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver"
       - "--root=/go/src"
       - "--upload=gs://kubernetes-jenkins/logs"
       - "--clean"
@@ -111,7 +111,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220120-50581feb62-master
       args:
-      - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+      - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver"
       - "--root=/go/src"
       - "--upload=gs://kubernetes-jenkins/logs"
       - "--clean"
@@ -159,7 +159,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220120-50581feb62-master
       args:
-      - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+      - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver"
       - "--root=/go/src"
       - "--upload=gs://kubernetes-jenkins/logs"
       - "--clean"
@@ -205,7 +205,7 @@ presubmits:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220120-50581feb62-master
         args:
-        - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver"
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/logs"
         - "--clean"
@@ -248,7 +248,7 @@ presubmits:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220120-50581feb62-master
         args:
-        - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver"
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/logs"
         - "--clean"


### PR DESCRIPTION
I saw that the jobs failed and this field is different in CI in both Linux and Windows, attempting to change it to be like Linux.
/cc @jingxu97 