### PR TITLE
build kubetest binary with current go version instead of kubernetes g…

### DIFF
--- a/images/kubekins-e2e/cloudbuild.yaml
+++ b/images/kubekins-e2e/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
-  - name: golang:$_GO_VERSION
+  - name: golang:latest
     args:
     - go
     - build


### PR DESCRIPTION
…o version

we could pin this, but ideally stable go should continue to work. we have seen issues the other direction where outdated go is missing standard library additions, but go1 compatibility should mean upgrading go to do a simple binary build is safe ™️ 

pinning the kubetest build to the kubernetes go version introduces skew, if it is going to be pinned it should be pinned to the version of go used in test-infra, not kubernetes

fixes #24970 