### PR TITLE
Define list of trusted users that can run tests

### DIFF
--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -429,6 +429,9 @@ type AssignOnLabel struct {
 type Trigger struct {
 	// Repos is either of the form org/repos or just org.
 	Repos []string `json:"repos,omitempty"`
+	// TrustedUsers is the explicit list of GitHub users whose PRs will be automatically
+	// considered as trusted. By default, trigger will ignore this list.
+	TrustedUsers []string `json:"trusted_users,omitempty"`
 	// TrustedOrg is the org whose members' PRs will be automatically built for
 	// PRs to the above repos. The default is the PR's org.
 	//

--- a/prow/plugins/trigger/generic-comment.go
+++ b/prow/plugins/trigger/generic-comment.go
@@ -76,7 +76,7 @@ func handleGenericComment(c Client, trigger plugins.Trigger, gc github.GenericCo
 	}
 
 	// Skip untrusted users comments.
-	trustedResponse, err := TrustedUser(c.GitHubClient, trigger.OnlyOrgMembers, trigger.TrustedOrg, commentAuthor, org, repo)
+	trustedResponse, err := TrustedUser(c.GitHubClient, trigger.OnlyOrgMembers, trigger.TrustedUsers, trigger.TrustedOrg, commentAuthor, org, repo)
 	if err != nil {
 		return fmt.Errorf("error checking trust of %s: %w", commentAuthor, err)
 	}

--- a/prow/plugins/trigger/pull-request.go
+++ b/prow/plugins/trigger/pull-request.go
@@ -72,7 +72,7 @@ func handlePR(c Client, trigger plugins.Trigger, pr github.PullRequestEvent) err
 		// When a PR is opened, if the author is in the org then build it.
 		// Otherwise, ask for "/ok-to-test". There's no need to look for previous
 		// "/ok-to-test" comments since the PR was just opened!
-		trustedResponse, err := TrustedUser(c.GitHubClient, trigger.OnlyOrgMembers, trigger.TrustedOrg, author, org, repo)
+		trustedResponse, err := TrustedUser(c.GitHubClient, trigger.OnlyOrgMembers, trigger.TrustedUsers, trigger.TrustedOrg, author, org, repo)
 		member := trustedResponse.IsTrusted
 		if err != nil {
 			return fmt.Errorf("could not check membership: %s", err)
@@ -313,7 +313,7 @@ func draftMsg(ghc githubClient, pr github.PullRequest) error {
 // If already known, GitHub labels should be provided to save tokens. Otherwise, it fetches them.
 func TrustedPullRequest(tprc trustedPullRequestClient, trigger plugins.Trigger, author, org, repo string, num int, l []github.Label) ([]github.Label, bool, error) {
 	// First check if the author is a member of the org.
-	if trustedResponse, err := TrustedUser(tprc, trigger.OnlyOrgMembers, trigger.TrustedOrg, author, org, repo); err != nil {
+	if trustedResponse, err := TrustedUser(tprc, trigger.OnlyOrgMembers, trigger.TrustedUsers, trigger.TrustedOrg, author, org, repo); err != nil {
 		return l, false, fmt.Errorf("error checking %s for trust: %w", author, err)
 	} else if trustedResponse.IsTrusted {
 		return l, true, nil

--- a/prow/plugins/trigger/trigger.go
+++ b/prow/plugins/trigger/trigger.go
@@ -222,7 +222,7 @@ type TrustedUserResponse struct {
 
 // TrustedUser returns true if user is trusted in repo.
 // Trusted users are either repo collaborators, org members or trusted org members.
-func TrustedUser(ghc trustedUserClient, onlyOrgMembers bool, trustedOrg, user, org, repo string) (TrustedUserResponse, error) {
+func TrustedUser(ghc trustedUserClient, onlyOrgMembers bool, trustedUsers []string, trustedOrg, user, org, repo string) (TrustedUserResponse, error) {
 	errorResponse := TrustedUserResponse{IsTrusted: false}
 	okResponse := TrustedUserResponse{IsTrusted: true}
 
@@ -250,6 +250,14 @@ func TrustedUser(ghc trustedUserClient, onlyOrgMembers bool, trustedOrg, user, o
 		if ok, err := ghc.IsCollaborator(org, repo, user); err != nil {
 			return errorResponse, fmt.Errorf("error in IsCollaborator: %w", err)
 		} else if ok {
+			return okResponse, nil
+		}
+	}
+
+	// Determine if user is on trusted_users list.
+	// This allows specific users, or GitHub automations that cannot be added as collaborators.
+	for _, trustedUser := range trustedUsers {
+		if user == trustedUser {
 			return okResponse, nil
 		}
 	}

--- a/prow/plugins/trigger/trigger_test.go
+++ b/prow/plugins/trigger/trigger_test.go
@@ -266,6 +266,7 @@ func TestTrustedUser(t *testing.T) {
 		name string
 
 		onlyOrgMembers bool
+		trustedUsers   []string
 		trustedOrg     string
 
 		user string
@@ -356,6 +357,18 @@ func TestTrustedUser(t *testing.T) {
 			user:            "k8s-ci-robot[bot]",
 			expectedTrusted: true,
 		},
+		{
+			name:            "user is in trusted users list",
+			user:            "trusted-user",
+			trustedUsers:    []string{"trusted-user"},
+			expectedTrusted: true,
+		},
+		{
+			name:            "app is in trusted users list",
+			user:            "github-app[bot]",
+			trustedUsers:    []string{"github-app[bot]"},
+			expectedTrusted: true,
+		},
 	}
 
 	for _, tc := range testcases {
@@ -366,7 +379,7 @@ func TestTrustedUser(t *testing.T) {
 			}
 			fc.Collaborators = []string{"test-collaborator"}
 
-			trustedResponse, err := TrustedUser(fc, tc.onlyOrgMembers, tc.trustedOrg, tc.user, tc.org, tc.repo)
+			trustedResponse, err := TrustedUser(fc, tc.onlyOrgMembers, tc.trustedUsers, tc.trustedOrg, tc.user, tc.org, tc.repo)
 			if err != nil {
 				t.Errorf("For case %s, didn't expect error from TrustedUser: %v", tc.name, err)
 			}


### PR DESCRIPTION
Looking at the code of the Prow I have noticed that it's not possible to flag specific users as trusted when they open a PR. The flagging pull requests can only be defined by `ok-to-test` flag, which can only be added by member of the organisation. 
With that it's not possible to implement some external repository integrations that raise PRs to have the tests run automatically.

This PR implements list of trusted users that are allowed to run tests in their PR. 
This gives the ability to trust external GitHub automations which use bot users, like dependabot, to have automated Jobs execution.