### PR TITLE
kube-scheduler-simulator: update frontend-presubmit config

### DIFF
--- a/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-master.yaml
@@ -38,7 +38,6 @@ presubmits:
         - -c
         - >
           cd ./web &&
-          npm ci &&
           npm install -g yarn &&
           yarn install --frozen-lockfile &&
           yarn run lint


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-sigs/kube-scheduler-simulator/issues/56

As part of this change, we are removing `npm ci` command from the `presubmits-frontend-lint` job configuration.