### PR TITLE
Add IgnoreDrafts option to blunderbuss plugin

### DIFF
--- a/prow/plugins/blunderbuss/blunderbuss.go
+++ b/prow/plugins/blunderbuss/blunderbuss.go
@@ -144,10 +144,13 @@ func handlePullRequestEvent(pc plugins.Agent, pre github.PullRequestEvent) error
 }
 
 func handlePullRequest(ghc githubClient, roc repoownersClient, log *logrus.Entry, config plugins.Blunderbuss, action github.PullRequestEventAction, pr *github.PullRequest, repo *github.Repo) error {
-	if action != github.PullRequestActionOpened || assign.CCRegexp.MatchString(pr.Body) {
+	if !(action == github.PullRequestActionOpened || action == github.PullRequestActionReadyForReview) || assign.CCRegexp.MatchString(pr.Body) {
 		return nil
 	}
-
+	if pr.Draft && config.IgnoreDrafts {
+		// ignore Draft PR when IgnoreDrafts is true
+		return nil
+	}
 	return handle(
 		ghc,
 		roc,

--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -160,6 +160,9 @@ type Blunderbuss struct {
 	// additional token per successful reviewer (and potentially more depending on
 	// how many busy reviewers it had to pass over).
 	UseStatusAvailability bool `json:"use_status_availability,omitempty"`
+	// IgnoreDrafts instructs the plugin to ignore assigning reviewers
+	// to the PR that is in Draft state. Default it's false.
+	IgnoreDrafts bool `json:"ignore_drafts,omitempty"`
 }
 
 // Owners contains configuration related to handling OWNERS files.


### PR DESCRIPTION
Right now blunderbuss plugin assigns people to the PRs even when they are in Draft. This PR adds functionality to ignore requesting reviews when PR is Draft and assign reviews when PR changes status to ready for review.

This option works will work only when `ignore_drafts` is `true`. This option should not change the workflow of the plugin when not set. The change works only on PR events, so comments will operate with the plugin as usual.

The functionality is required because in [kyma-project org](https://github.com/kyma-project/test-infra/issues/4798) we do not want opened Draft PRs to be requested for review to avoid unnecessary notifications from GitHub.