### PR TITLE
Add a new optional CI job to trigger make update

### DIFF
--- a/config/jobs/kubernetes/sig-testing/update.yaml
+++ b/config/jobs/kubernetes/sig-testing/update.yaml
@@ -1,0 +1,51 @@
+presubmits:
+  kubernetes/kubernetes:
+  - name: pull-kubernetes-update
+    cluster: k8s-infra-prow-build
+    always_run: false
+    skip_report: false
+    decorate: true
+    skip_branches:
+    - release-\d+.\d+ # per-release job
+    annotations:
+      fork-per-release: "true"
+      testgrid-num-failures-to-alert: '10'
+      testgrid-alert-stale-results-hours: '24'
+      testgrid-create-test-group: 'true'
+      testgrid-dashboards: sig-testing-misc
+    path_alias: k8s.io/kubernetes
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220121-354980456e-master
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - ./hack/jenkins/update-dockerized.sh
+        env:
+        - name: EXCLUDE_TYPECHECK
+          value: "y"
+        # this is now covered by the optional pull-kubernetes-files-remake that runs when Makefile.generated_files / make-rules changes
+        - name: EXCLUDE_FILES_REMAKE
+          value: "y"
+        - name: EXCLUDE_GODEP
+          value: "y"
+        - name: KUBE_VERIFY_GIT_BRANCH
+          value: master
+        - name: REPO_DIR
+          value: /workspace/k8s.io/kubernetes
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          # Consider reducing memory limits after govet memory usage issue is
+          # addressed in https://github.com/kubernetes/kubernetes/issues/93822
+          limits:
+            cpu: 7
+            memory: 12Gi
+          requests:
+            cpu: 7
+            memory: 12Gi


### PR DESCRIPTION
Related to
- https://github.com/kubernetes/kubernetes/pull/107728
- https://github.com/kubernetes/kubernetes/issues/107726

Trying to make it easier for new folks in the community to be productive.

This is a copy-paste of `pull-kubernetes-verify` with one additional annotation (`testgrid-dashboards: sig-testing-misc`)

Signed-off-by: Davanum Srinivas <davanum@gmail.com>