### PR TITLE
tests: (*testing.common).Errorf: replace %w with %v

### DIFF
--- a/prow/gerrit/adapter/adapter_test.go
+++ b/prow/gerrit/adapter/adapter_test.go
@@ -1281,7 +1281,7 @@ func TestDeckLinkForPR(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := deckLinkForPR(tc.deckURL, tc.refs, tc.changeStatus)
 			if err != nil {
-				t.Errorf("unexpected error generating Deck link: %w", err)
+				t.Errorf("unexpected error generating Deck link: %v", err)
 			}
 			if result != tc.expected {
 				t.Errorf("expected deck link %s, but got %s", tc.expected, result)

--- a/prow/metrics/http_test.go
+++ b/prow/metrics/http_test.go
@@ -231,7 +231,7 @@ func TestHandleWithMetricsCustomTimer(t *testing.T) {
 			rr := httptest.NewRecorder()
 			req, err := http.NewRequest("GET", "http://example.com", nil)
 			if err != nil {
-				t.Errorf("error while creating dummy request: %w", err)
+				t.Errorf("error while creating dummy request: %v", err)
 			}
 			handler.ServeHTTP(rr, req)
 			if err := testutil.CollectAndCompare(httpResponseSize, strings.NewReader(tc.expectedResponseSizeOut)); err != nil {


### PR DESCRIPTION
This avoids the errors

     gerrit/adapter/adapter_test.go:1284:5: (*testing.common).Errorf does not support error-wrapping directive %w
     metrics/http_test.go:234:5: (*testing.common).Errorf does not support error-wrapping directive %w

which otherwise make these tests fails when running

     go test -race -cover k8s.io/test-infra/prow/gerrit/adapter

and

     go test -race -cover k8s.io/test-infra/prow/metrics

respectively.

See https://stackoverflow.com/a/70505666/437583.