### PR TITLE
Makefile: remove deprecated `test` target

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-all: build test
+all: build
 
 
 # ALPINE_VERSION is the version of the alpine image
@@ -54,10 +54,7 @@ get-build-cluster-credentials:
 build:
 	go install ./cmd/...
 
-test:
-	go test -race -cover $$(go list ./... | grep -v "\/vendor\/")
-
-.PHONY: build test get-cluster-credentials
+.PHONY: build get-cluster-credentials
 
 alpine-image:
 	docker build -t "$(REGISTRY)/$(PROJECT)/alpine:$(ALPINE_VERSION)" $(DOCKER_LABELS) cmd/images/alpine

--- a/prow/Makefile
+++ b/prow/Makefile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-all: build
-
+all:
+	# NOP
 
 # ALPINE_VERSION is the version of the alpine image
 ALPINE_VERSION           ?= 0.1
@@ -51,10 +51,7 @@ get-cluster-credentials:
 get-build-cluster-credentials:
 	gcloud container clusters get-credentials "$(CLUSTER)" --project="$(BUILD_PROJECT)" --zone="$(ZONE)"
 
-build:
-	go install ./cmd/...
-
-.PHONY: build get-cluster-credentials
+.PHONY: get-cluster-credentials
 
 alpine-image:
 	docker build -t "$(REGISTRY)/$(PROJECT)/alpine:$(ALPINE_VERSION)" $(DOCKER_LABELS) cmd/images/alpine


### PR DESCRIPTION
This target should not be used. Instead, users should be using the
`test` target in the Makefile under the root folder, which has many
enhancements baked into it (such as using the top level `.go-version`
file to set the go version).