### PR TITLE
crier: gerrit: fix wording for `/test all`

### DIFF
--- a/prow/crier/reporters/gerrit/reporter.go
+++ b/prow/crier/reporters/gerrit/reporter.go
@@ -577,7 +577,7 @@ func GenerateReport(pjs []*v1.ProwJob, commentSizeLimit int) JobReport {
 	// This shouldn't happen unless there are too many prow jobs(e.g. > 300) and
 	// each job name is super long(e.g. > 50)
 	if remainingSize < 0 {
-		report.Header = fullHeader(report.Header, " Comment '/test all' to rerun all failed tests")
+		report.Header = fullHeader(report.Header, " Comment '/test all' to rerun all tests")
 		report.Message = errorMessageLine("Prow failed to report all jobs, are there excessive amount of prow jobs?")
 		return report
 	}

--- a/prow/crier/reporters/gerrit/reporter_test.go
+++ b/prow/crier/reporters/gerrit/reporter_test.go
@@ -2147,7 +2147,7 @@ func TestGenerateReport(t *testing.T) {
 				job("some", "other", v1.SuccessState),
 			},
 			commentSizeLimit: 81 + 55,
-			wantHeader:       "Prow Status: 2 out of 3 pjs passed! Comment '/test all' to rerun all failed tests\n",
+			wantHeader:       "Prow Status: 2 out of 3 pjs passed! Comment '/test all' to rerun all tests\n",
 			wantMessage:      "[NOTE FROM PROW: Prow failed to report all jobs, are there excessive amount of prow jobs?]",
 		},
 	}


### PR DESCRIPTION
According to docs, `/test all` runs all tests, not just the failed ones.

See https://github.com/kubernetes/test-infra/blob/05c84566e96e2a6edfeea915d32b27ff81c43786/prow/plugins/trigger/trigger.go#L122.