### PR TITLE
SIG-CLI: enable testing for krm-functions-registry repo

### DIFF
--- a/config/jobs/kubernetes-sigs/krm-functions-registry/OWNERS
+++ b/config/jobs/kubernetes-sigs/krm-functions-registry/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+- jeremyrickard
+- KnVerey
+- mengqiy
+approvers:
+- jeremyrickard
+- KnVerey
+- mengqiy

--- a/config/jobs/kubernetes-sigs/krm-functions-registry/krm-functions-registry-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/krm-functions-registry/krm-functions-registry-presubmits-master.yaml
@@ -1,0 +1,21 @@
+presubmits:
+  kubernetes-sigs/krm-functions-registry:
+  - name: pull-krm-functions-registry-test-master
+    decorate: true
+    always_run: true
+    path_alias: sigs.k8s.io/krm-functions-registry
+    branches:
+    # The script this job runs is not in all branches.
+    - ^master$
+    spec:
+      containers:
+      - image: golang:1.17
+        command:
+        - ./test.sh
+        resources:
+          requests:
+            cpu: "4000m"
+    annotations:
+      testgrid-dashboards: sig-cli-misc
+      testgrid-tab-name: krm-functions-registry-presubmit-master
+      description: krm-functions-registry presubmit tests on master branch


### PR DESCRIPTION
Enable testing for https://github.com/kubernetes-sigs/krm-functions-registry.
Added OWNERS file that is the same as https://github.com/kubernetes-sigs/krm-functions-registry/blob/main/OWNERS