### PR TITLE
Do not add `needs-ok-to-test` if PR already has `ok-to-test`

### DIFF
--- a/prow/plugins/trigger/BUILD.bazel
+++ b/prow/plugins/trigger/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
         "//prow/labels:go_default_library",
         "//prow/pjutil:go_default_library",
         "//prow/plugins:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/api/equality:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",

--- a/prow/plugins/trigger/pull-request.go
+++ b/prow/plugins/trigger/pull-request.go
@@ -286,8 +286,17 @@ I understand the commands that are listed [here](https://go.k8s.io/bot-commands?
 %s
 </details>
 `, author, org, org, more, joinOrgURL, labels.OkToTest, encodedRepoFullName, plugins.AboutThisBotWithoutCommands)
-		if err := ghc.AddLabel(org, repo, pr.Number, labels.NeedsOkToTest); err != nil {
+
+		l, err := ghc.GetIssueLabels(org, repo, pr.Number)
+		if err != nil {
 			errors = append(errors, err)
+		} else if !github.HasLabel(labels.OkToTest, l) {
+			// It is possible for bots and other automations to automatically
+			// add the ok-to-test label. If that's the case, then we will not
+			// add the needs-ok-to-test-label any more.
+			if err := ghc.AddLabel(org, repo, pr.Number, labels.NeedsOkToTest); err != nil {
+				errors = append(errors, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Some automations, for example GitHub actions and dependabot can be
configured to automatically add labels to PRs. To increase CI and
testing feedback, we would now skip the `needs-ok-to-test` label if we
already provide the `ok-to-test` label on PR creation.

This avoids having double labels excluding themself, for example like there: 
https://github.com/kubernetes-sigs/downloadkubernetes/pull/180#issuecomment-1022054735