### PR TITLE
Prow uses prowjob CRD with schema

### DIFF
--- a/config/prow/Makefile
+++ b/config/prow/Makefile
@@ -32,7 +32,7 @@ update-plugins: get-cluster-credentials
 	kubectl create configmap plugins --from-file=plugins.yaml=plugins.yaml --dry-run -o yaml | kubectl replace configmap plugins -f -
 
 deploy-prow: get-cluster-credentials
-	kubectl apply -f ./cluster/prowjob-crd/legacy/prowjob-schemaless_customresourcedefinition.yaml
+	kubectl apply --server-side=true -f ./config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
 	kubectl apply -f ./cluster/
 
 deploy-build: get-build-cluster-credentials


### PR DESCRIPTION
Schemaless prowjob CRD doesn't work with k8s v1.22 out of the box. Switching over to CRD with schema in preparation for the upcoming cluster upgrade

/hold
Will need run `kubectl apply --server-side=true --force-conflicts=true -f ./config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml` manually before merging this PR

/cc @cjwagner @alvaroaleman 