### PR TITLE
Add preserveUnknowFields: false in prowjob schema CRD

### DIFF
--- a/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
@@ -8,6 +8,7 @@ metadata:
   creationTimestamp: null
   name: prowjobs.prow.k8s.io
 spec:
+  preserveUnknownFields: false
   group: prow.k8s.io
   names:
     kind: ProwJob

--- a/hack/make-rules/update/codegen.sh
+++ b/hack/make-rules/update/codegen.sh
@@ -205,6 +205,7 @@ gen-prowjob-crd(){
   if [[ -z ${HOME:-} ]]; then export HOME=$PWD; fi
   $controller_gen crd:preserveUnknownFields=false,crdVersions=v1 paths=./prow/apis/prowjobs/v1 output:stdout \
     | $SED '/^$/d' \
+    | $SED '/^spec:.*/a  \  preserveUnknownFields: false' \
     | $SED '/^  annotations.*/a  \    api-approved.kubernetes.io: https://github.com/kubernetes/test-infra/pull/8669' \
     | $SED '/^          status:/r'<(cat<<EOF
             anyOf:


### PR DESCRIPTION
When applying schema'ed prowjob CRD the first time with force-conflicts=true, preserveUnknownFields is inhereted from old prowjob CRD, with the value of false, which doesn't work with k8s v1.22, and we had to manually modify this line before running kubectl apply. Explicitly setting the value here to avoid the hassle of downstream prowjob CRDs differ from upstream.

For ref: https://github.com/GoogleCloudPlatform/oss-test-infra/blob/master/prow/oss/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml

/cc @cjwagner @alvaroaleman 