### PR TITLE
Upgrade to Kubernetes 1.23.3 in CI for cluster-api project

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -93,7 +93,7 @@ periodics:
       - name: INIT_WITH_PROVIDERS_CONTRACT
         value: v1beta1
       - name: INIT_WITH_KUBERNETES_VERSION
-        value: v1.23.0
+        value: v1.23.3
 
       # we need privileged mode in order to do docker in docker
       securityContext:

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-1.yaml
@@ -93,7 +93,7 @@ periodics:
       - name: INIT_WITH_PROVIDERS_CONTRACT
         value: v1beta1
       - name: INIT_WITH_KUBERNETES_VERSION
-        value: v1.23.0
+        value: v1.23.3
 
       # we need privileged mode in order to do docker in docker
       securityContext:


### PR DESCRIPTION
Upgrade to Kubernetes 1.23.3 in Quickstart and CI for cluster-api project
Fix: https://github.com/kubernetes-sigs/cluster-api/issues/5995
