### PR TITLE
Makefile change also triggers prow deploy job

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -113,7 +113,7 @@ postsubmits:
         - images/git/
   - name: post-test-infra-deploy-prow
     cluster: test-infra-trusted
-    run_if_changed: 'config/prow/cluster/'
+    run_if_changed: '^(config/prow/cluster/|config/prow/Makefile$|Makefile.base.mk$)'
     decorate: true
     branches:
     - ^master$


### PR DESCRIPTION
Now that prow is deployed using make rules, updating in the make files should also trigger prow deployment job

/cc @cjwagner 