### PR TITLE
Add support for gerrit InRepoConfig with fallback

### DIFF
--- a/prow/gerrit/adapter/BUILD.bazel
+++ b/prow/gerrit/adapter/BUILD.bazel
@@ -40,6 +40,8 @@ go_test(
         "//prow/config:go_default_library",
         "//prow/crier/reporters/gerrit:go_default_library",
         "//prow/gerrit/client:go_default_library",
+        "//prow/git/localgit:go_default_library",
+        "//prow/git/v2:go_default_library",
         "//prow/io:go_default_library",
         "//prow/kube:go_default_library",
         "@com_github_andygrunwald_go_gerrit//:go_default_library",

--- a/prow/gerrit/adapter/BUILD.bazel
+++ b/prow/gerrit/adapter/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//prow/config:go_default_library",
         "//prow/crier/reporters/gerrit:go_default_library",
         "//prow/gerrit/client:go_default_library",
+        "//prow/git/v2:go_default_library",
         "//prow/io:go_default_library",
         "//prow/pjutil:go_default_library",
         "@com_github_andygrunwald_go_gerrit//:go_default_library",

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/test-infra/prow/config"
 	reporter "k8s.io/test-infra/prow/crier/reporters/gerrit"
 	"k8s.io/test-infra/prow/gerrit/client"
+	"k8s.io/test-infra/prow/git/v2"
 	"k8s.io/test-infra/prow/io"
 	"k8s.io/test-infra/prow/pjutil"
 )
@@ -60,6 +61,7 @@ type Controller struct {
 	tracker            LastSyncTracker
 	projectsOptOutHelp map[string]sets.String
 	lock               sync.RWMutex
+	cookieFilePath     string
 }
 
 type LastSyncTracker interface {
@@ -97,6 +99,7 @@ func NewController(ctx context.Context, prowJobClient prowv1.ProwJobInterface, o
 		gc:                 gerritClient,
 		tracker:            lastSyncTracker,
 		projectsOptOutHelp: projectsOptOutHelpMap,
+		cookieFilePath:     cookiefilePath,
 	}
 
 	// applyGlobalConfig reads gerrit configurations from global gerrit config,
@@ -310,11 +313,30 @@ func (c *Controller) processChange(logger logrus.FieldLogger, instance string, c
 
 	changedFiles := listChangedFiles(change)
 
+	//Attempt to Get InRepoConfig
+	opts := git.ClientFactoryOpts{
+		CloneURI:       cloneURI.String(),
+		Host:           cloneURI.Host,
+		CookieFilePath: c.cookieFilePath,
+	}
+	gc, err := git.NewClientFactory(opts.Apply)
+	if err != nil {
+		//TODO(mpherman): Return Error once we know this usually works
+		logger.Warn("Failed to create Gerrit Client for InRepoConfig")
+	}
+
 	switch change.Status {
 	case client.Merged:
-		// TODO: Do we want to add support for dynamic postsubmits?
-		postsubmits := c.config().PostsubmitsStatic[cloneURI.String()]
-		postsubmits = append(postsubmits, c.config().PostsubmitsStatic[cloneURI.Host+"/"+cloneURI.Path]...)
+		postsubmits := []config.Postsubmit{}
+		if gc != nil {
+			postsubmits, err = c.config().GetPostsubmits(gc, cloneURI.Host+"/"+cloneURI.Path, func() (string, error) { return baseSHA, nil })
+			if err != nil {
+				//TODO(mpherman): Return Error once we know this usually works
+				logger.Warn("Failed to get InRepoConfig for Postsubmits")
+				postsubmits = append(postsubmits, c.config().PostsubmitsStatic[cloneURI.Host+"/"+cloneURI.Path]...)
+			}
+		}
+		postsubmits = append(postsubmits, c.config().PostsubmitsStatic[cloneURI.String()]...)
 		for _, postsubmit := range postsubmits {
 			if shouldRun, err := postsubmit.ShouldRun(change.Branch, changedFiles); err != nil {
 				return fmt.Errorf("failed to determine if postsubmit %q should run: %w", postsubmit.Name, err)
@@ -326,9 +348,16 @@ func (c *Controller) processChange(logger logrus.FieldLogger, instance string, c
 			}
 		}
 	case client.New:
-		// TODO: Do we want to add support for dynamic presubmits?
-		presubmits := c.config().PresubmitsStatic[cloneURI.String()]
-		presubmits = append(presubmits, c.config().PresubmitsStatic[cloneURI.Host+"/"+cloneURI.Path]...)
+		presubmits := []config.Presubmit{}
+		if gc != nil {
+			presubmits, err = c.config().GetPresubmits(gc, cloneURI.Host+"/"+cloneURI.Path, func() (string, error) { return baseSHA, nil })
+			if err != nil {
+				//TODO(mpherman): Return Error once we know this usually works
+				logger.Warn("Failed to get InRepoConfig for Presubmits")
+				presubmits = append(presubmits, c.config().PresubmitsStatic[cloneURI.Host+"/"+cloneURI.Path]...)
+			}
+		}
+		presubmits = append(presubmits, c.config().PresubmitsStatic[cloneURI.String()]...)
 
 		account, err := c.gc.Account(instance)
 		if err != nil {


### PR DESCRIPTION
PR enables InRepoConfig for Gerrit. If Getting InRepoConfig fails, this will log a warning and fall back to just getting static presubmits. Doing this as we do not have robust gerrit integration tests yet, and I do not want to break Gerrit component.
/assign @chaodaiG @cjwagner 
/hold