### PR TITLE
feat(config/prow-jobs): Add cluster-api periodic job config for min-k8s v1.19.2

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -22,6 +22,32 @@ periodics:
     testgrid-tab-name: capi-test-main
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
+- name: periodic-cluster-api-test-mink8s-main
+  interval: 1h
+  decorate: true
+  labels:
+    preset-service-account: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220221-c13e827224-1.23
+      command:
+      - "./scripts/ci-test.sh"
+      env:
+      - name: KUBEBUILDER_ENVTEST_KUBERNETES_VERSION
+        value: "1.19.2"
+      resources:
+        requests:
+          cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+    testgrid-tab-name: capi-test-mink8s-main
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-upgrade-v0-3-to-main
   interval: 1h
   decorate: true


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder26@gmail.com>

**What this PR does / why we need it:**
This PR adds a periodic job config which will run the 'main' github.com/kubernetes-sigs/cluster-api on the min supported k8s version (i.e. 1.19.2).

**Which issue(s) this PR fixes:**
 Fixes https://github.com/kubernetes-sigs/cluster-api/issues/5963