### PR TITLE
Make image-builder OVA CI enforcing

### DIFF
--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-ova-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-ova-presubmits.yaml
@@ -5,9 +5,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-kind-volume-mounts: "true"
         preset-cluster-api-provider-vsphere-e2e-config: "true"
-        preset-cloud-provider-vsphere-e2e-config: "true"
       decorate: true
-      optional: true
       decoration_config:
         timeout: 1h
       run_if_changed: 'images/capi/(Makefile|ansible\.cfg)|images/capi/ansible/.*|images/capi/scripts/ci-ova\.sh|images/capi/packer/(config|goss|ova)/.*|images/capi/hack/ensure-(ansible|packer|goss).*'


### PR DESCRIPTION
Switch OVA CI to no longer be optional when triggered.

Remove unnecessary preset, as it is no longer used by CI script in repo.

/assign @CecileRobertMichon 

With the merge of https://github.com/kubernetes-sigs/image-builder/pull/789, OVA CI is working and stable again, so I'd like to make it as no longer optional. As part of that fix, the CI script no longer uses any files or env vars from `preset-cloud-provider-vsphere-e2e-config`, so there is no need to include in the spec.

@kkeshavamurthy you may be interested in this one.

One more thing, @CecileRobertMichon, I think it would be good for me to create a PR that updates the OWNERS file for this section, akin to what you did for image-builder. Would you be okay with that? Not everyone could be added since they are `kubernetes-sigs` members and not `kubernetes`, but for those that can, I think it would make sense.