### PR TITLE
capz: skip in-tree tests instead of out-of-tree tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -57,7 +57,7 @@ presubmits:
           - name: GINKGO_FOCUS
             value: "Workload cluster creation"
           - name: GINKGO_SKIP
-            value: "Creating a GPU-enabled cluster|.*Windows.*dockershim.*|.*AKS.*|Creating a cluster that uses the external cloud provider"
+            value: "Creating a GPU-enabled cluster|.*Windows.*dockershim.*|.*AKS.*|Creating a cluster that uses the in-tree cloud provider"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -57,7 +57,7 @@ presubmits:
           - name: GINKGO_FOCUS
             value: "Workload cluster creation"
           - name: GINKGO_SKIP
-            value: "Creating a GPU-enabled cluster|.*Windows.*dockershim.*|.*AKS.*|Creating a cluster that uses the external cloud provider"
+            value: "Creating a GPU-enabled cluster|.*Windows.*dockershim.*|.*AKS.*|in-tree cloud provider|external cloud provider"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
The following PR updates its set of E2E test definitions so that out-of-tree (aka "external") cloud-provider-azure configurations are the default, and demotes in-tree cloud-provider to an optional test config:

https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1994

In response to the above change, we need to update the capz test-infra specs to invert their skip logic. Instead of skipping "external" cloud-provider-azure scenarios, we not want to skip "in-tree" cloud-provider azure scenarios. This PR does that.

This PR should merge only after capz PR 1994 merges.