### PR TITLE
update oci-proxy shellcheck presubmit to use shellcheck installer

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/oci-proxy/sig-k8s-infra-oci-proxy-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/oci-proxy/sig-k8s-infra-oci-proxy-presubmits.yaml
@@ -18,11 +18,11 @@ presubmits:
     optional: true
     spec:
       containers:
-      # NOTE: We will have to keep this up to date with the repo ...
-      - image: koalaman/shellcheck:v0.8.0
+      - image: golang
         command:
-        - make
-        - shellcheck
+        - bash
+        - -c
+        - hack/tools/ci-install-shellcheck.sh && make shellcheck
   - name: pull-oci-proxy-test
     decorate: true
     always_run: true


### PR DESCRIPTION
depends on https://github.com/kubernetes-sigs/oci-proxy/pull/11

the official shellcheck images lack bash, make etc. (even the alpine version), this is probably a better approach. should unblock making these jobs blocking