### PR TITLE
label_sync: disable retries on 404 responses

### DIFF
--- a/label_sync/main.go
+++ b/label_sync/main.go
@@ -705,6 +705,7 @@ type client interface {
 	FindIssues(query, order string, ascending bool) ([]github.Issue, error)
 	GetRepos(org string, isUser bool) ([]github.Repo, error)
 	GetRepoLabels(string, string) ([]github.Label, error)
+	SetMax404Retries(int)
 }
 
 func newClient(tokenPath string, tokens, tokenBurst int, dryRun bool, graphqlEndpoint string, hosts ...string) (client, error) {
@@ -779,6 +780,8 @@ func main() {
 		if err != nil {
 			logrus.WithError(err).Fatal("failed to create client")
 		}
+
+		githubClient.SetMax404Retries(0)
 
 		// there are three ways to configure which repos to sync:
 		//  - a list of org/repo values


### PR DESCRIPTION
There are no point to retry for requests with 404 (e.g. `repo does not exists`.) to save some tokens.

The situation described in github `client.go` ( https://github.com/kubernetes/test-infra/blob/1256a81e66d64ace1cf50520e82510a3316319d6/prow/github/client.go#L1038 ) seems not quite apply here since we are dealing with repos.

