### PR TITLE
Lower frequency of Windows release jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.22-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.22-windows.yaml
@@ -11,7 +11,7 @@ periodics:
     org: kubernetes
     path_alias: k8s.io/kubernetes
     repo: kubernetes
-  interval: 12h
+  interval: 24h
   labels:
     preset-azure-cred: "true"
     preset-azure-windows: "true"

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.23-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.23-windows.yaml
@@ -11,7 +11,7 @@ periodics:
     org: kubernetes
     path_alias: k8s.io/kubernetes
     repo: kubernetes
-  interval: 3h
+  interval: 24h
   labels:
     preset-azure-cred: "true"
     preset-azure-windows: "true"


### PR DESCRIPTION
We typically run the release jobs daily, since the number of commits going in is much lower.

/sig windows
/assign @marosset 