### PR TITLE
Add Gerrit adapter metrics for query and processing results.

### DIFF
--- a/prow/cmd/gerrit/BUILD.bazel
+++ b/prow/cmd/gerrit/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//prow/gerrit/client:go_default_library",
         "//prow/interrupts:go_default_library",
         "//prow/logrusutil:go_default_library",
+        "//prow/metrics:go_default_library",
         "//prow/pjutil/pprof:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],

--- a/prow/cmd/gerrit/main.go
+++ b/prow/cmd/gerrit/main.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/metrics"
 	"k8s.io/test-infra/prow/pjutil/pprof"
 
 	"k8s.io/test-infra/pkg/flagutil"
@@ -113,6 +114,9 @@ func main() {
 		logrus.WithError(err).Fatal("Error starting config agent.")
 	}
 	cfg := ca.Config
+
+	// Expose Prometheus metrics
+	metrics.ExposeMetrics("gerrit", cfg().PushGateway, o.instrumentationOptions.MetricsPort)
 
 	prowJobClient, err := o.kubernetes.ProwJobClient(cfg().ProwJobNamespace, o.dryRun)
 	if err != nil {

--- a/prow/gerrit/adapter/BUILD.bazel
+++ b/prow/gerrit/adapter/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//prow/io:go_default_library",
         "//prow/pjutil:go_default_library",
         "@com_github_andygrunwald_go_gerrit//:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",

--- a/prow/gerrit/client/BUILD.bazel
+++ b/prow/gerrit/client/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_andygrunwald_go_gerrit//:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/util/errors:go_default_library",
     ],

--- a/prow/gerrit/client/client.go
+++ b/prow/gerrit/client/client.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	gerrit "github.com/andygrunwald/go-gerrit"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -59,7 +60,27 @@ const (
 	ReadyForReviewMessageFixed = "Set Ready For Review"
 	// This message will be sent if users press the `SEND AND START REVIEW` button.
 	ReadyForReviewMessageCustomizable = "This change is ready for review."
+
+	ResultError   = "ERROR"
+	ResultSuccess = "SUCCESS"
 )
+
+var clientMetrics = struct {
+	queryResults *prometheus.CounterVec
+}{
+	queryResults: prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "gerrit_query_results",
+		Help: "Count of Gerrit API queries by instance, repo, and result.",
+	}, []string{
+		"instance",
+		"repo",
+		"result",
+	}),
+}
+
+func init() {
+	prometheus.MustRegister(clientMetrics.queryResults)
+}
 
 // ProjectsFlag is the flag type for gerrit projects when initializing a gerrit client
 type ProjectsFlag map[string][]string
@@ -407,6 +428,7 @@ func (h *gerritInstanceHandler) queryAllChanges(lastState map[string]time.Time, 
 		}
 		changes, err := h.queryChangesForProject(log, project, lastUpdate, rateLimit)
 		if err != nil {
+			clientMetrics.queryResults.WithLabelValues(h.instance, project, ResultError).Inc()
 			// don't halt on error from one project, log & continue
 			log.WithError(err).WithFields(logrus.Fields{
 				"lastUpdate": lastUpdate,
@@ -414,6 +436,7 @@ func (h *gerritInstanceHandler) queryAllChanges(lastState map[string]time.Time, 
 			}).Error("Failed to query changes")
 			continue
 		}
+		clientMetrics.queryResults.WithLabelValues(h.instance, project, ResultSuccess).Inc()
 		result = append(result, changes...)
 	}
 


### PR DESCRIPTION
These will let us write alerts based for high gerrit adapter error rates. Including counters for success results lets us normalize against load.
/assign @chaodaiG 