### PR TITLE
kube-scheduler-simulator: update always_run to true

### DIFF
--- a/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-master.yaml
@@ -9,7 +9,7 @@ presubmits:
     path_alias: sigs.k8s.io/kube-scheduler-simulator
     branches:
     - ^master$
-    always_run: false
+    always_run: true
     spec:
       containers:
       - image: golang:1.17
@@ -29,7 +29,7 @@ presubmits:
     path_alias: sigs.k8s.io/kube-scheduler-simulator
     branches:
     - ^master$
-    always_run: false
+    always_run: true
     spec:
       containers:
       - image: node:16

--- a/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-test-backend.yaml
+++ b/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-test-backend.yaml
@@ -9,7 +9,7 @@ presubmits:
     path_alias: sigs.k8s.io/kube-scheduler-simulator
     branches:
     - ^master$
-    always_run: false
+    always_run: true
     spec:
       containers:
       - image: golang:1.17


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-sigs/kube-scheduler-simulator/issues/56

As part of this change, we are updating the `always_run` field in config to `True`.