### PR TITLE
Additional CSI Proxy working directory setup for LVP

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner.yaml
+++ b/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner.yaml
@@ -99,6 +99,11 @@ presubmits:
         # this is done so that the e2e test runs faster
         - name: WINDOWS_NODE_OS_DISTRIBUTION
           value: "win2019"
+        # in the e2e tests the flag --working-dir set on CSI Proxy allows
+        # setting the locations where CSI Proxy is supposed to run
+        # the test location is defined in /test/e2e/e2e_test.go
+        - name: CSI_PROXY_FLAGS
+          value: "--working-dir C:\\tmp"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
`/tmp` is defined in https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/blob/master/test/e2e/e2e_test.go#L55, the discovery directories created during the e2e are under `/tmp/<random_test_case>`

CSI_PROXY_FLAGS was added in https://github.com/kubernetes/kubernetes/pull/107806

/cc @jingxu97 
/assign @msau42 