### PR TITLE
[CPO] Let config jobs run on all branches

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-openstack/cloud-provider-openstack-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/cloud-provider-openstack-config.yaml
@@ -2,8 +2,8 @@ presubmits:
   kubernetes/cloud-provider-openstack:
   - name: pull-cloud-provider-openstack-check
     always_run: true
-    branches:
-    - master
+    skip_branches:
+    - gh-pages
     labels:
       preset-service-account: "true"
     spec:
@@ -20,8 +20,8 @@ presubmits:
 
   - name: pull-cloud-provider-openstack-test
     always_run: true
-    branches:
-    - master
+    skip_branches:
+    - gh-pages
     labels:
       preset-service-account: "true"
     spec:


### PR DESCRIPTION
Currently the basic make test/check are run only on master.
As these are basic build jobs and no breakage/changes should be there across branches , so this PR is to run them on all branches