### PR TITLE
Add petr-muller to Prow approvers

### DIFF
--- a/prow/OWNERS
+++ b/prow/OWNERS
@@ -5,6 +5,7 @@ approvers:
   - cblecker
   - cjwagner
   - fejta
+  - petr-muller
   - stevekuznetsov
 emeritus_approvers:
   - spxtr # 2018-09-17


### PR DESCRIPTION
After talking to Alvaro I'm applying to be a Prow approver.

I am a Prow reviewer for 17 months now and [reviewed ~250 PRs](https://github.com/kubernetes/test-infra/pulls?q=is%3Apr+is%3Aopen+reviewed-by%3A%40me+-author%3Aopenshift-bot) over time. I have authored a [reasonable amount of PRs](https://github.com/kubernetes/test-infra/pulls?q=is%3Apr+author%3Apetr-muller+is%3Aclosed) too. I know Prow well and I am leading a team that operates one of the large Prow deployments out there (the OpenShift one).

Tagging all current approvers:
/cc @alvaroaleman @cblecker @cjwagner @fejta @stevekuznetsov 
