### PR TITLE
sig-node: change ssh user for pull-kubernetes-node-kubelet-serial-crio-cgroupv1

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -763,7 +763,7 @@ presubmits:
         - --scenario=kubernetes_e2e
         - -- # end bootstrap args, scenario args below
         - --deployment=node
-        - --env=KUBE_SSH_USER=core
+        - --env=KUBE_SSH_USER=prow
         - --gcp-zone=us-west1-b
         - '--node-test-args=--feature-gates=LocalStorageCapacityIsolation=true --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service --non-masquerade-cidr=0.0.0.0/0" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
         - --node-tests=true


### PR DESCRIPTION
Related:
  - https://github.com/kubernetes/test-infra/issues/24798

Change the SSH user to match the one associated to the SSH keys added to
the community infrastructure.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>