### PR TITLE
Ensure windows nodes provision for pull-cluster-api-provider-azure-ci-entrypoint jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -556,6 +556,9 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        env:
+          - name: TEST_WINDOWS
+            value: "true"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-ci-entrypoint-main

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -333,6 +333,9 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        env:
+          - name: TEST_WINDOWS
+            value: "true"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-ci-entrypoint-v1beta1


### PR DESCRIPTION

Signed-off-by: Mark Rossetti <marosset@microsoft.com>

Setting TEST_WINDOWS will provision 2 Windows nodes in the workload cluster

https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/7979a9705adabde2085801b04f87ad00e8888e1e/scripts/ci-entrypoint.sh#L104-L107