### PR TITLE
Add support for Cached InRepoConfig for Gerrit with fallback

### DIFF
--- a/prow/cmd/gerrit/main.go
+++ b/prow/cmd/gerrit/main.go
@@ -51,6 +51,7 @@ type options struct {
 	kubernetes             prowflagutil.KubernetesOptions
 	storage                prowflagutil.StorageClientOptions
 	instrumentationOptions prowflagutil.InstrumentationOptions
+	inRepoConfigCacheSize  int
 }
 
 func (o *options) validate() error {
@@ -92,6 +93,7 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	fs.StringVar(&o.lastSyncFallback, "last-sync-fallback", "", "The /local/path, gs://path/to/object or s3://path/to/object to sync the latest timestamp")
 	fs.BoolVar(&o.dryRun, "dry-run", false, "Run in dry-run mode, performing no modifying actions.")
 	fs.StringVar(&o.tokenPathOverride, "token-path", "", "Force the use of the token in this path, use with gcloud auth print-access-token")
+	fs.IntVar(&o.inRepoConfigCacheSize, "in-repo-config-cache-size", 1000, "Cache size for ProwYAMLs read from in-repo configs.")
 	for _, group := range []flagutil.OptionGroup{&o.kubernetes, &o.storage, &o.instrumentationOptions, &o.config} {
 		group.AddFlags(fs)
 	}
@@ -129,7 +131,7 @@ func main() {
 		logrus.WithError(err).Fatal("Error creating opener")
 	}
 
-	c := adapter.NewController(ctx, prowJobClient, op, cfg, o.projects, o.projectsOptOutHelp, o.cookiefilePath, o.tokenPathOverride, o.lastSyncFallback)
+	c := adapter.NewController(ctx, prowJobClient, op, ca, o.projects, o.projectsOptOutHelp, o.cookiefilePath, o.tokenPathOverride, o.lastSyncFallback, o.inRepoConfigCacheSize)
 
 	logrus.Infof("Starting gerrit fetcher")
 

--- a/prow/cmd/gerrit/main.go
+++ b/prow/cmd/gerrit/main.go
@@ -93,7 +93,7 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	fs.StringVar(&o.lastSyncFallback, "last-sync-fallback", "", "The /local/path, gs://path/to/object or s3://path/to/object to sync the latest timestamp")
 	fs.BoolVar(&o.dryRun, "dry-run", false, "Run in dry-run mode, performing no modifying actions.")
 	fs.StringVar(&o.tokenPathOverride, "token-path", "", "Force the use of the token in this path, use with gcloud auth print-access-token")
-	fs.IntVar(&o.inRepoConfigCacheSize, "in-repo-config-cache-size", 1000, "Cache size for ProwYAMLs read from in-repo configs.")
+	fs.IntVar(&o.inRepoConfigCacheSize, "in-repo-config-cache-size", 100, "Cache size for ProwYAMLs read from in-repo configs. Each host receives its own cache.")
 	for _, group := range []flagutil.OptionGroup{&o.kubernetes, &o.storage, &o.instrumentationOptions, &o.config} {
 		group.AddFlags(fs)
 	}

--- a/prow/cmd/gerrit/main_test.go
+++ b/prow/cmd/gerrit/main_test.go
@@ -96,7 +96,7 @@ func TestFlags(t *testing.T) {
 				},
 				dryRun:                 false,
 				instrumentationOptions: flagutil.DefaultInstrumentationOptions(),
-				inRepoConfigCacheSize:  1000,
+				inRepoConfigCacheSize:  100,
 			}
 			expected.projects.Set("foo=bar,baz")
 			expected.projectsOptOutHelp.Set("foo=bar")

--- a/prow/cmd/gerrit/main_test.go
+++ b/prow/cmd/gerrit/main_test.go
@@ -96,6 +96,7 @@ func TestFlags(t *testing.T) {
 				},
 				dryRun:                 false,
 				instrumentationOptions: flagutil.DefaultInstrumentationOptions(),
+				inRepoConfigCacheSize:  1000,
 			}
 			expected.projects.Set("foo=bar,baz")
 			expected.projectsOptOutHelp.Set("foo=bar")

--- a/prow/gerrit/adapter/BUILD.bazel
+++ b/prow/gerrit/adapter/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
         "@com_github_andygrunwald_go_gerrit//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go_storage//:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/equality:go_default_library",
         "@io_k8s_apimachinery//pkg/util/diff:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",

--- a/prow/gerrit/adapter/BUILD.bazel
+++ b/prow/gerrit/adapter/BUILD.bazel
@@ -41,6 +41,8 @@ go_test(
         "//prow/config:go_default_library",
         "//prow/crier/reporters/gerrit:go_default_library",
         "//prow/gerrit/client:go_default_library",
+        "//prow/git/localgit:go_default_library",
+        "//prow/git/v2:go_default_library",
         "//prow/io:go_default_library",
         "//prow/kube:go_default_library",
         "@com_github_andygrunwald_go_gerrit//:go_default_library",

--- a/prow/gerrit/adapter/BUILD.bazel
+++ b/prow/gerrit/adapter/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//prow/config:go_default_library",
         "//prow/crier/reporters/gerrit:go_default_library",
         "//prow/gerrit/client:go_default_library",
+        "//prow/git/v2:go_default_library",
         "//prow/io:go_default_library",
         "//prow/pjutil:go_default_library",
         "@com_github_andygrunwald_go_gerrit//:go_default_library",

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -184,8 +184,26 @@ func (c *Controller) Sync() error {
 				"repo":     change.Project,
 				"revision": change.CurrentRevision,
 			})
+
+			cloneURI, err := makeCloneURI(instance, change.Project)
+			if err != nil {
+				return fmt.Errorf("makeCloneURI: %w", err)
+			}
+
+			//Attempt to Get InRepoConfig
+			opts := git.ClientFactoryOpts{
+				CloneURI:       cloneURI.String(),
+				Host:           cloneURI.Host,
+				CookieFilePath: c.cookieFilePath,
+			}
+			gc, err := git.NewClientFactory(opts.Apply)
+			if err != nil {
+				//TODO(mpherman): Return Error once we know this usually works
+				log.Warn("Failed to create Gerrit Client for InRepoConfig")
+			}
+
 			result := client.ResultSuccess
-			if err := c.processChange(log, instance, change); err != nil {
+			if err := c.processChange(log, instance, change, cloneURI, gc); err != nil {
 				result = client.ResultError
 				log.WithError(err).Errorf("Failed to process change")
 			}
@@ -301,13 +319,7 @@ func failedJobs(account int, revision int, messages ...gerrit.ChangeMessageInfo)
 }
 
 // processChange creates new presubmit/postsubmit prowjobs base off the gerrit changes
-func (c *Controller) processChange(logger logrus.FieldLogger, instance string, change client.ChangeInfo) error {
-
-	cloneURI, err := makeCloneURI(instance, change.Project)
-	if err != nil {
-		return fmt.Errorf("makeCloneURI: %w", err)
-	}
-
+func (c *Controller) processChange(logger logrus.FieldLogger, instance string, change client.ChangeInfo, cloneURI *url.URL, gc git.ClientFactory) error {
 	baseSHA, err := c.gc.GetBranchRevision(instance, change.Project, change.Branch)
 	if err != nil {
 		return fmt.Errorf("GetBranchRevision: %w", err)
@@ -333,18 +345,6 @@ func (c *Controller) processChange(logger logrus.FieldLogger, instance string, c
 
 	changedFiles := listChangedFiles(change)
 
-	//Attempt to Get InRepoConfig
-	opts := git.ClientFactoryOpts{
-		CloneURI:       cloneURI.String(),
-		Host:           cloneURI.Host,
-		CookieFilePath: c.cookieFilePath,
-	}
-	gc, err := git.NewClientFactory(opts.Apply)
-	if err != nil {
-		//TODO(mpherman): Return Error once we know this usually works
-		logger.Warn("Failed to create Gerrit Client for InRepoConfig")
-	}
-
 	switch change.Status {
 	case client.Merged:
 		postsubmits := []config.Postsubmit{}
@@ -355,6 +355,8 @@ func (c *Controller) processChange(logger logrus.FieldLogger, instance string, c
 				logger.Warn("Failed to get InRepoConfig for Postsubmits")
 				postsubmits = append(postsubmits, c.config().PostsubmitsStatic[cloneURI.Host+"/"+cloneURI.Path]...)
 			}
+		} else {
+			postsubmits = append(postsubmits, c.config().PostsubmitsStatic[cloneURI.Host+"/"+cloneURI.Path]...)
 		}
 		postsubmits = append(postsubmits, c.config().PostsubmitsStatic[cloneURI.String()]...)
 		for _, postsubmit := range postsubmits {
@@ -376,6 +378,8 @@ func (c *Controller) processChange(logger logrus.FieldLogger, instance string, c
 				logger.Warn("Failed to get InRepoConfig for Presubmits")
 				presubmits = append(presubmits, c.config().PresubmitsStatic[cloneURI.Host+"/"+cloneURI.Path]...)
 			}
+		} else {
+			presubmits = append(presubmits, c.config().PresubmitsStatic[cloneURI.Host+"/"+cloneURI.Path]...)
 		}
 		presubmits = append(presubmits, c.config().PresubmitsStatic[cloneURI.String()]...)
 


### PR DESCRIPTION
Enable InRepoConfig for Gerrit component. This will attempt to do inrepoconfig, but if it fails will just log a warning and continue without InRepoConfig 

/assign @chaodaiG @cjwagner 