### PR TITLE
cluster-api: increase alert failure limit across capi test files

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
@@ -42,7 +42,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi-e2e-main-1-18-1-19
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-19-1-20-main
   interval: 24h
@@ -86,7 +86,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi-e2e-main-1-19-1-20
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-20-1-21-main
   interval: 24h
@@ -130,7 +130,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi-e2e-main-1-20-1-21
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-21-1-22-main
   interval: 24h
@@ -174,7 +174,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi-e2e-main-1-21-1-22
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-22-1-23-main
   interval: 24h
@@ -218,7 +218,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi-e2e-main-1-22-1-23
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-23-latest-main
   interval: 24h
@@ -262,4 +262,4 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi-e2e-main-1-23-latest
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -21,7 +21,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi-test-main
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-upgrade-v0-3-to-main
   interval: 1h
   decorate: true
@@ -63,7 +63,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi-e2e-upgrade-v0-3-to-main
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-upgrade-v1-0-to-main
   interval: 1h
   decorate: true
@@ -105,7 +105,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi-e2e-upgrade-v1-0-to-main
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-main
   interval: 1h
   decorate: true
@@ -140,7 +140,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi-e2e-main
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-mink8s-main
   interval: 1h
   decorate: true
@@ -179,7 +179,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi-e2e-mink8s-main
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-verify-book-links-main
   interval: 6h
   decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-3.yaml
@@ -21,7 +21,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.3
     testgrid-tab-name: capi-test-release-0-3
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-release-0-3
   interval: 4h
   decorate: true
@@ -49,7 +49,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.3
     testgrid-tab-name: capi-e2e-release-0-3
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-verify-book-links-release-0-3
   interval: 24h
   decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-4-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-4-upgrades.yaml
@@ -42,7 +42,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.4
     testgrid-tab-name: capi-e2e-release-0-4-1-18-1-19
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-19-1-20-release-0-4
   interval: 24h
@@ -86,7 +86,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.4
     testgrid-tab-name: capi-e2e-release-0-4-1-19-1-20
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-20-1-21-release-0-4
   interval: 24h
@@ -130,7 +130,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.4
     testgrid-tab-name: capi-e2e-release-0-4-1-20-1-21
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-21-1-22-release-0-4
   interval: 24h
@@ -174,7 +174,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.4
     testgrid-tab-name: capi-e2e-release-0-4-1-21-1-22
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-22-1-23-release-0-4
   interval: 24h
@@ -219,7 +219,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.4
     testgrid-tab-name: capi-e2e-release-0-4-1-22-1-23
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-23-latest-release-0-4
   interval: 24h
@@ -263,4 +263,4 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.4
     testgrid-tab-name: capi-e2e-release-0-4-1-23-latest
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-4.yaml
@@ -21,7 +21,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.4
     testgrid-tab-name: capi-test-release-0-4
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-release-0-4
   interval: 4h
   decorate: true
@@ -56,7 +56,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.4
     testgrid-tab-name: capi-e2e-release-0-4
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-mink8s-release-0-4
   interval: 4h
   decorate: true
@@ -95,7 +95,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-0.4
     testgrid-tab-name: capi-e2e-mink8s-release-0-4
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-verify-book-links-release-0-4
   interval: 24h
   decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-0-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-0-upgrades.yaml
@@ -42,7 +42,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.0
     testgrid-tab-name: capi-e2e-release-1-0-1-18-1-19
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-19-1-20-release-1-0
   interval: 24h
@@ -86,7 +86,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.0
     testgrid-tab-name: capi-e2e-release-1-0-1-19-1-20
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-20-1-21-release-1-0
   interval: 24h
@@ -130,7 +130,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.0
     testgrid-tab-name: capi-e2e-release-1-0-1-20-1-21
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-21-1-22-release-1-0
   interval: 24h
@@ -174,7 +174,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.0
     testgrid-tab-name: capi-e2e-release-1-0-1-21-1-22
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-22-1-23-release-1-0
   interval: 24h
@@ -219,7 +219,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.0
     testgrid-tab-name: capi-e2e-release-1-0-1-22-1-23
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-23-latest-release-1-0
   interval: 24h
@@ -263,4 +263,4 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.0
     testgrid-tab-name: capi-e2e-release-1-0-1-23-latest
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-0.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-0.yaml
@@ -21,7 +21,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.0
     testgrid-tab-name: capi-test-release-1-0
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-upgrade-v0-3-to-release-1-0
   interval: 4h
   decorate: true
@@ -63,7 +63,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.0
     testgrid-tab-name: capi-e2e-upgrade-v0-3-to-release-1-0
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-release-1-0
   interval: 4h
   decorate: true
@@ -98,7 +98,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.0
     testgrid-tab-name: capi-e2e-release-1-0
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-mink8s-release-1-0
   interval: 4h
   decorate: true
@@ -137,7 +137,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.0
     testgrid-tab-name: capi-e2e-mink8s-release-1-0
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: "2"
+    testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-verify-book-links-release-1-0
   interval: 24h
   decorate: true


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Increase the number of failures required to trigger an email alert from 2 to 4 across the Cluster API test files to descreace noise and improve the overall signal on the email list.

Fixes: #https://github.com/kubernetes-sigs/cluster-api/issues/6037