### PR TITLE
sidecar/censoring: allow opting into fast failure

### DIFF
--- a/prow/cmd/sidecar/main.go
+++ b/prow/cmd/sidecar/main.go
@@ -18,8 +18,12 @@ package main
 
 import (
 	"context"
+	"io"
+	"os"
+	"path/filepath"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/version"
 
 	"k8s.io/test-infra/prow/logrusutil"
 	"k8s.io/test-infra/prow/pod-utils/options"
@@ -39,6 +43,22 @@ func main() {
 		logrus.Fatalf("Invalid options: %v", err)
 	}
 
+	// also write our logs to a file so that we can expose our output somehow,
+	// even if it will be truncated during upload
+	tempDir, err := os.MkdirTemp("", version.Name)
+	if err != nil {
+		logrus.WithError(err).Fatalf("Failed to create log dir.")
+	}
+	o.GcsOptions.Items = append(o.GcsOptions.Items, tempDir)
+	logFile, err := os.Create(filepath.Join(tempDir, version.Name + ".log"))
+	if err != nil {
+		logrus.WithError(err).Fatalf("Failed to create log file.")
+	}
+	logrus.AddHook(&formattingHook{
+		formatter: logrus.StandardLogger().Formatter,
+		writer:    logFile,
+	})
+
 	failures, err := o.Run(context.Background())
 	if err != nil {
 		logrus.WithError(err).Error("Failed to report job status")
@@ -46,4 +66,22 @@ func main() {
 	if failures > 0 && o.EntryError {
 		logrus.Fatalf("%d containers failed", failures)
 	}
+}
+
+type formattingHook struct {
+	formatter logrus.Formatter
+	writer    io.Writer
+}
+
+func (hook *formattingHook) Fire(entry *logrus.Entry) error {
+	line, err := hook.formatter.Format(entry)
+	if err != nil {
+		return err
+	}
+	_, err = hook.writer.Write(line)
+	return err
+}
+
+func (hook *formattingHook) Levels() []logrus.Level {
+	return logrus.AllLevels
 }

--- a/prow/sidecar/options.go
+++ b/prow/sidecar/options.go
@@ -93,6 +93,10 @@ type Options struct {
 }
 
 type CensoringOptions struct {
+	// Strict determines whether errors in the censoring process should cause the full
+	// sidecar process to error out as well, before anything is uploaded.
+	Strict bool `json:"strict,omitempty"`
+
 	// SecretDirectories are paths to directories containing secret data. The contents
 	// of these secret data files will be censored from the logs and artifacts uploaded
 	// to the cloud.

--- a/prow/sidecar/run.go
+++ b/prow/sidecar/run.go
@@ -203,7 +203,12 @@ func (o Options) preUpload() {
 
 	if o.CensoringOptions != nil {
 		if err := o.censor(); err != nil {
-			logrus.Warnf("Failed to censor data: %v", err)
+			log := logrus.WithError(err)
+			handler := log.Warnf
+			if o.CensoringOptions.Strict {
+				handler = log.Fatalf
+			}
+			handler("Failed to censor data: %v", err)
 		}
 	}
 }


### PR DESCRIPTION
If a user has set up secret censoring on output and knows that it should
succeed in most cases, it may be useful for them to stop treating the
censoring process as best-effort. In such a case, failures during
censoring would cause the whole `sidecar` process to crash. This would
lead to terrible UX for the user of an affected job, but we can do no
better, as even uploading the job logs may be unsafe in such a
situation.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @petr-muller 