### PR TITLE
update e2e-framework to use go 1.17

### DIFF
--- a/config/jobs/kubernetes-sigs/e2e-framework/e2e-framework-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/e2e-framework/e2e-framework-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     path_alias: sigs.k8s.io/e2e-framework
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
         imagePullPolicy: Always
         command:
         - make


### PR DESCRIPTION
- needed by https://github.com/kubernetes-sigs/e2e-framework/pull/105

/assign @vladimirvivien