### PR TITLE
hook: fixes event dispatch for external plugins

### DIFF
--- a/prow/hook/BUILD.bazel
+++ b/prow/hook/BUILD.bazel
@@ -23,6 +23,8 @@ go_test(
         "//prow/plugins:go_default_library",
         "//prow/plugins/ownersconfig:go_default_library",
         "//prow/repoowners:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
+        "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
     ],
 )
 


### PR DESCRIPTION
If an event type is not handled by built-in plugins (e.g. is of `repository` type), it will not be properly dispatched by `hook` to the external plugins. In such a case it lacks `srcRepo` value leading to no external plugins being selected.

This PR adds failing test showing the problem (dbd66d5a44f720e50205fe9d74dc57e2b608f447) and introduces the fix (363d771c7f39c685d6c5149f3832909907e05856).