### PR TITLE
sig-k8s-infra: change container image for node throughput tests

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -35,6 +35,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --cluster=
+      - --env=CONTAINER_IMAGE=registry-sandbox.k8s.io/pause:3.1 #TODO(ameukam): revert when registry.k8s.io is ready
       - --extract=ci/latest
       - --gcp-node-image=gci
       - --gcp-nodes=1
@@ -95,6 +96,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --cluster=
+      - --env=CONTAINER_IMAGE=registry-sandbox.k8s.io/pause:3.1 #TODO(ameukam): revert when registry.k8s.io is ready
       - --extract=ci/latest
       - --gcp-node-image=gci
       - --gcp-nodes=1


### PR DESCRIPTION
SIG K8s Infra is currently working on the migration from k8s.gcr.io to
registry.k8s.io.
`registry-sandbox.k8s.io` is a proxy for k8s.gcr.io allowing us to build
confidence in the tooling we are working on.

See design doc: https://docs.google.com/document/d/1yNQ7DaDE5LbDJf9ku82YtlKZK0tcg5Wpk9L72-x2S2k/edit

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>