### PR TITLE
populate bool as true when omitempty

### DIFF
--- a/pkg/genyaml/populate_struct.go
+++ b/pkg/genyaml/populate_struct.go
@@ -123,6 +123,10 @@ func PopulateStruct(in interface{}) interface{} {
 			concreteMap.SetMapIndex(key, value)
 
 			valueOf.Elem().Field(i).Set(concreteMap)
+		case reflect.Bool:
+			if strings.Contains(typeOf.Elem().Field(i).Tag.Get("json"), ",omitempty") {
+				valueOf.Elem().Field(i).SetBool(true)
+			}
 		}
 
 	}

--- a/pkg/genyaml/populate_struct_test.go
+++ b/pkg/genyaml/populate_struct_test.go
@@ -157,6 +157,18 @@ func TestPopulateStructSetsStrings(t *testing.T) {
 	}
 }
 
+func TestPopulateStructBool(t *testing.T) {
+	s := struct {
+		Bool   bool   `json:"bool,omitempty"`
+		String string `json:"string,omitempty"`
+	}{}
+
+	PopulateStruct(&s)
+	if !s.Bool {
+		t.Fatalf("Bool field didn't get set, struct: %+v", s)
+	}
+}
+
 func TestPopulateStructHandlesUnexportedFields(_ *testing.T) {
 	s := struct {
 		unexported *struct {

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -326,6 +326,7 @@ deck:
     # config applies to and a value of: `RerunAuthConfig` struct to define the users/groups authorized to rerun jobs.
     rerun_auth_configs:
         "":
+            allow_anyone: true
             github_orgs:
               - ""
             github_team_ids:
@@ -358,6 +359,11 @@ deck:
         # They are mapped by org, org/repo or '*' which is the default value.
         gcs_browser_prefixes:
             "": ""
+
+        # HidePRHistLink allows prow hiding PR History link from deck, this is handy especially for
+        # prow instances that only serves gerrit.
+        # This might become obsolete once https://github.com/kubernetes/test-infra/issues/24130 is fixed.
+        hide_pr_history_link: true
 
         # Lenses is a list of lens configurations.
         lenses:
@@ -527,6 +533,12 @@ owners_dir_blacklist:
     default:
       - ""
 
+    # By default, some directories like ".git", "_output" and "vendor/.*/OWNERS"
+    # are preconfigured to be denylisted.
+    # If set, IgnorePreconfiguredDefaults will not add these preconfigured directories
+    # to the denylist.
+    ignore_preconfigured_defaults: true
+
     # Repos configures a directory denylist per repo (or org)
     repos:
         "": null
@@ -540,6 +552,12 @@ owners_dir_denylist:
     # are already preconfigured to be denylisted, and need not be included here.
     default:
       - ""
+
+    # By default, some directories like ".git", "_output" and "vendor/.*/OWNERS"
+    # are preconfigured to be denylisted.
+    # If set, IgnorePreconfiguredDefaults will not add these preconfigured directories
+    # to the denylist.
+    ignore_preconfigured_defaults: true
 
     # Repos configures a directory denylist per repo (or org)
     repos:
@@ -961,6 +979,10 @@ plank:
     # JobURLTemplateString compiles into JobURLTemplate at load time.
     job_url_template: ' '
 
+    # JobURLPrefixDisableAppendStorageProvider disables that the storageProvider is
+    # automatically appended to the JobURLPrefix
+    jobURLPrefixDisableAppendStorageProvider: true
+
     # PodPendingTimeout is after how long the controller will perform a garbage
     # collection on pending pods. Defaults to 10 minutes.
     pod_pending_timeout: 0s
@@ -1159,6 +1181,11 @@ tide:
         # whether to consider unknown contexts optional (skip) or required.
         skip-unknown-contexts: false
 
+    # DisplayAllQueriesInStatus controls if Tide should mention all queries in the status it
+    # creates. The default is to only mention the one to which we are closest (Calculated
+    # by total number of requirements - fulfilled number of requirements).
+    display_all_tide_queries_in_status: true
+
     # A key/value pair of an org/repo as the key and Go template to override
     # the default merge commit title and/or message. Template is passed the
     # PullRequest struct (prow/github/types.go#PullRequest)
@@ -1222,6 +1249,7 @@ tide:
           - ""
         repos:
           - ""
+        reviewApprovedRequired: true
 
     # RebaseLabel is an optional label that is used to identify PRs that should
     # always be rebased and merged.

--- a/prow/plugins/plugin-config-documented.yaml
+++ b/prow/plugins/plugin-config-documented.yaml
@@ -10,6 +10,14 @@ approve:
     # * A REQUEST_CHANGES github review is equivalent to leaving an /approve cancel" message.
     ignore_review_state: false
 
+    # IssueRequired indicates if an associated issue is required for approval in
+    # the specified repos.
+    issue_required: true
+
+    # LgtmActsAsApprove indicates that the lgtm command should be used to
+    # indicate approval
+    lgtm_acts_as_approve: true
+
     # PrProcessLink is the link to the help page which explains the code review process.
     # The default value is "https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process".
     pr_process_link: ' '
@@ -43,9 +51,25 @@ blockades:
     repos:
       - ""
 blunderbuss:
+    # ExcludeApprovers controls whether approvers are considered to be
+    # reviewers. By default, approvers are considered as reviewers if
+    # insufficient reviewers are available. If ExcludeApprovers is true,
+    # approvers will never be considered as reviewers.
+    exclude_approvers: true
+
+    # IgnoreDrafts instructs the plugin to ignore assigning reviewers
+    # to the PR that is in Draft state. Default it's false.
+    ignore_drafts: true
+
     # ReviewerCount is the minimum number of reviewers to request
     # reviews from. Defaults to requesting reviews from 2 reviewers
     request_count: 0
+
+    # UseStatusAvailability controls whether blunderbuss will consider GitHub's
+    # status availability when requesting reviews for users. This will use at one
+    # additional token per successful reviewer (and potentially more depending on
+    # how many busy reviewers it had to pass over).
+    use_status_availability: true
 branch_cleaner:
     # PreservedBranches is a map of org/repo branches
     # format:
@@ -370,8 +394,19 @@ config_updater:
 
             # Name of ConfigMap
             name: ' '
+
+            # UseFullPathAsKey controls if the full path of the original file relative to the
+            # repository root should be used as the configmap key. Slashes will be replaced by
+            # dashes. Using this avoids the need for unique file names in the original repo.
+            use_full_path_as_key: true
 dco:
     "":
+        # SkipDCOCheckForCollaborators is used to skip DCO check for trusted org members
+        skip_dco_check_for_collaborators: true
+
+        # SkipDCOCheckForMembers is used to skip DCO check for trusted org members
+        skip_dco_check_for_members: true
+
         # TrustedApps defines list of apps which commits will not be checked for DCO singoff.
         # The list should contain usernames of each GitHub App without [bot] suffix.
         # By default, this option is ignored.
@@ -442,6 +477,14 @@ lgtm:
     repos:
       - ""
 
+    # ReviewActsAsLgtm indicates that a GitHub review of "approve" or "request changes"
+    # acts as adding or removing the lgtm label
+    review_acts_as_lgtm: true
+
+    # StoreTreeHash indicates if tree_hash should be stored inside a comment to detect
+    # squashed commits before removing lgtm labels
+    store_tree_hash: true
+
     # WARNING: This disables the security mechanism that prevents a malicious member (or
     # compromised GitHub account) from merging arbitrary code. Use with caution.
 
@@ -451,6 +494,8 @@ lgtm:
 milestone_applier:
     "": null
 override:
+    allow_top_level_owners: true
+
     # AllowedGitHubTeams is a map of orgs and/or repositories (eg "org" or "org/repo") to list of GitHub team slugs,
     # members of which are allowed to override contexts
     allowed_github_teams:
@@ -554,6 +599,9 @@ require_matching_label:
     # Defaults to '5s'.
     grace_period: ' '
 
+    # Issues is a bool indicating if this config applies to issues.
+    issues: true
+
     # MissingComment is the comment to post when we add the MissingLabel to an
     # issue. This is typically used to explain why MissingLabel was added and
     # how to move forward.
@@ -567,6 +615,9 @@ require_matching_label:
     # Org is the GitHub organization that this config applies to.
     org: ' '
 
+    # PRs is a bool indicating if this config applies to PRs.
+    prs: true
+
     # Regexp is the string specifying the regular expression used to look for
     # matching labels.
     regexp: ' '
@@ -574,6 +625,9 @@ require_matching_label:
     # Repo is the GitHub repository within Org that this config applies to.
     # This fields may be omitted to apply this config across all repos in Org.
     repo: ' '
+retitle:
+    # AllowClosedIssues allows retitling closed/merged issues and PRs.
+    allow_closed_issues: true
 sigmention:
     # Regexp parses comments and should return matches to team mentions.
     # These mentions enable labeling issues or PRs with sig/team labels.
@@ -611,14 +665,25 @@ slack:
         repos:
           - ""
 triggers:
-  - # JoinOrgURL is a link that redirects users to a location where they
+  - # IgnoreOkToTest makes trigger ignore /ok-to-test comments.
+    # This is a security mitigation to only allow testing from trusted users.
+    ignore_ok_to_test: true
+
+    # JoinOrgURL is a link that redirects users to a location where they
     # should be able to read more about joining the organization in order
     # to become trusted members. Defaults to the GitHub link of TrustedOrg.
     join_org_url: ' '
 
+    # OnlyOrgMembers requires PRs and/or /ok-to-test comments to come from org members.
+    # By default, trigger also include repo collaborators.
+    only_org_members: true
+
     # Repos is either of the form org/repos or just org.
     repos:
       - ""
+
+    # TriggerGitHubWorkflows enables workflows run by github to be triggered by prow.
+    trigger_github_workflows: true
 
     # TrustedApps is the explicit list of GitHub apps whose PRs will be automatically
     # considered as trusted. The list should contain usernames of each GitHub App without [bot] suffix.


### PR DESCRIPTION
In order for bool fields that are tagged as `json:xyz,omitempty` to appear on the generated yaml we need to populate them to the non-empty value of `true`. I attempted to solve this problem in a number of other ways (trying to change the tag, type, etc..), and nothing else that I came up with is possible. The downside to this solution is that the bools will show as `true` in the output yaml, but we currently have all strings showing as " ", for instance. This doesn't seem to deviate from that expectation.