### PR TITLE
kops-grid-scenario-gcr-mirror: use containerProxy

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -449,8 +449,7 @@ def generate_misc():
         build_test(name_override="kops-grid-scenario-gcr-mirror",
                    runs_per_day=24,
                    cloud="aws",
-                   extra_flags=['--set=spec.assets.containerRegistry=registry-sandbox.k8s.io'],
-                   feature_flags=['ContainerRegistryIsMirror'],
+                   extra_flags=['--set=spec.assets.containerProxy=registry-sandbox.k8s.io'],
                    extra_dashboards=['kops-misc']),
 
         # A one-off scenario testing arm64

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -2,7 +2,7 @@
 # 24 jobs, total of 686 runs per week
 periodics:
 
-# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--set=spec.assets.containerRegistry=registry-sandbox.k8s.io --discovery-store=s3://k8s-kops-prow/discovery", "feature_flags": "ContainerRegistryIsMirror", "k8s_version": "latest", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--set=spec.assets.containerProxy=registry-sandbox.k8s.io --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "latest", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
 - name: e2e-kops-grid-scenario-gcr-mirror
   cron: '6 0-23/1 * * *'
   labels:
@@ -31,8 +31,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220131' --channel=alpha --networking=kubenet --container-runtime=containerd --set=spec.assets.containerRegistry=registry-sandbox.k8s.io --discovery-store=s3://k8s-kops-prow/discovery" \
-          --env=KOPS_FEATURE_FLAGS=ContainerRegistryIsMirror \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220131' --channel=alpha --networking=kubenet --container-runtime=containerd --set=spec.assets.containerProxy=registry-sandbox.k8s.io --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/latest.txt \
           --test=kops \
@@ -58,8 +57,7 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: containerd
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --set=spec.assets.containerRegistry=registry-sandbox.k8s.io --discovery-store=s3://k8s-kops-prow/discovery
-    test.kops.k8s.io/feature_flags: ContainerRegistryIsMirror
+    test.kops.k8s.io/extra_flags: --set=spec.assets.containerProxy=registry-sandbox.k8s.io --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: latest
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''


### PR DESCRIPTION
This means we don't need the feature-flag (or the PR that implements it!)
