### PR TITLE
crier: GenerateReport: don't report blank URLs

### DIFF
--- a/prow/crier/reporters/gerrit/reporter.go
+++ b/prow/crier/reporters/gerrit/reporter.go
@@ -51,6 +51,11 @@ const (
 	jobReportFormatWithoutURL = "%s %s %s\n"
 	errorLinePrefix           = "NOTE FROM PROW"
 
+	// Stub for the URL field (when using jobReportFormat), if the URL is
+	// legitimately not set (e.g., because the job never got scheduled). This is
+	// what the user will see in place of an actual URL.
+	urlNotFound = "URL_NOT_FOUND"
+
 	// lgtm means all presubmits passed, but need someone else to approve before merge (looks good to me).
 	lgtm = "+1"
 	// lbtm means some presubmits failed, perfer not merge (looks bad to me).
@@ -594,6 +599,13 @@ func GenerateReport(pjs []*v1.ProwJob, customCommentSizeLimit int) JobReport {
 	linesWithURLs := make([]string, len(report.Jobs))
 	linesWithoutURLs := make([]string, len(report.Jobs))
 	for i, job := range report.Jobs {
+		// If the URL cannot be found (for example, because the job has not been
+		// scheduled due to some other failure), then use the string
+		// URL_NOT_FOUND in its place instead. This way, we don't report jobs
+		// with an empty URL field.
+		if job.URL == "" {
+			job.URL = urlNotFound
+		}
 		linesWithURLs[i] = job.serialize()
 		remainingSize -= len(linesWithURLs[i])
 	}

--- a/prow/crier/reporters/gerrit/reporter_test.go
+++ b/prow/crier/reporters/gerrit/reporter_test.go
@@ -2150,6 +2150,16 @@ func TestGenerateReport(t *testing.T) {
 			wantHeader:       "Prow Status: 2 out of 3 pjs passed! 👉 Comment '/test all' to rerun all tests\n",
 			wantMessage:      "[NOTE FROM PROW: Prow failed to report all jobs, are there excessive amount of prow jobs?]",
 		},
+		{
+			// Check cases where the job could legitimately not have its URL
+			// field set (because the job did not even get scheduled).
+			name: "missing URLs",
+			jobs: []*v1.ProwJob{
+				job("right", "", v1.ErrorState),
+			},
+			wantHeader:  "Prow Status: 0 out of 1 pjs passed! 👉 Comment '/retest' to rerun all failed tests\n",
+			wantMessage: "🚫 right ERROR - URL_NOT_FOUND\n",
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
If the URL is empty, we don't want to use `jobReportFormat`. So, just use `URL_NOT_FOUND` as a fallback instead.
