### PR TITLE
capdo: use kubekins instead of golangci image and let the capdo decide on the golangci version

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits-release-0-5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits-release-0-5.yaml
@@ -56,7 +56,7 @@ presubmits:
     - ^release-0.5$
     spec:
       containers:
-      - image: golangci/golangci-lint:v1.21.0
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-1.22
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits-release-1-0.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits-release-1-0.yaml
@@ -56,7 +56,7 @@ presubmits:
     - ^release-1.0$
     spec:
       containers:
-      - image: golangci/golangci-lint:v1.43.0
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-1.22
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
@@ -56,7 +56,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: golangci/golangci-lint:v1.43.0
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-1.22
         command:
         - make
         args:


### PR DESCRIPTION
- capdo: use kubekins instead of golangci image and let the capdo decide on the golangci version

to avoid this error, ie https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-digitalocean/297/pull-cluster-api-provider-digitalocean-lint-release-0-5/1489512851151261696

/assign @timoreimann @MorrisLaw @prksu 