### PR TITLE
cluster-api: fix branches config of postsubmit image push

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
@@ -9,7 +9,6 @@ postsubmits:
       decorate: true
       branches:
         - ^main$
-        - ^release-0.2$
         # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
         - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       spec:


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

No strong opinions, but we should either push images on postsubmit for all release-branches or none.

@fabriziopandini @enxebre @vincepri @CecileRobertMichon 

Please let me know what you prefer.

I went with removing the config, because apparently nobody missed those images for >= v0.3