### PR TITLE
Prow integration test uses deck image built during test

### DIFF
--- a/prow/test/integration/prow/cluster/deck_deployment.yaml
+++ b/prow/test/integration/prow/cluster/deck_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20220204-7977a74ad8
+        image: localhost:5000/deck
         imagePullPolicy: Always
         ports:
           - name: http


### PR DESCRIPTION
It was omitted previously and the deck integration test had been running against a deck image from prod, updating the image registry so that it's testing what needs to be tested

/cc @cjwagner 