### PR TITLE
sig-release: fix location for ci-fast-forward

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -145,3 +145,34 @@ periodics:
     github_team_slugs:
       - org: kubernetes
         slug: release-managers
+
+- interval: 6h
+  name: ci-fast-forward
+  cluster: k8s-infra-prow-build-trusted
+  decorate: true
+  spec:
+    serviceAccountName: gcb-builder
+    containers:
+    - image: gcr.io/k8s-staging-releng/k8s-ci-builder:latest-default
+      imagePullPolicy: Always
+      command:
+      - wrapper.sh
+      - /krel
+      - fast-forward
+      - --non-interactive
+      - --submit
+      resources:
+        requests:
+          cpu: 4
+          memory: "8Gi"
+        limits:
+          cpu: 4
+          memory: "8Gi"
+  rerun_auth_config:
+    github_team_slugs:
+      - org: kubernetes
+        slug: release-managers
+  annotations:
+    testgrid-alert-email: release-managers+alerts@kubernetes.io
+    testgrid-dashboards: sig-release-releng-informing
+    testgrid-tab-name: git-repo-kubernetes-fast-forward

--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -164,34 +164,3 @@ periodics:
     testgrid-alert-email: release-managers+alerts@kubernetes.io
     testgrid-dashboards: sig-release-releng-informing
     testgrid-tab-name: build-packages-rpms
-
-- interval: 6h
-  name: ci-fast-forward
-  cluster: k8s-infra-prow-build
-  decorate: true
-  spec:
-    serviceAccountName: gcb-builder
-    containers:
-    - image: gcr.io/k8s-staging-releng/k8s-ci-builder:latest-default
-      imagePullPolicy: Always
-      command:
-      - wrapper.sh
-      - /krel
-      - fast-forward
-      - --non-interactive
-      - --submit
-      resources:
-        requests:
-          cpu: 4
-          memory: "8Gi"
-        limits:
-          cpu: 4
-          memory: "8Gi"
-  rerun_auth_config:
-    github_team_slugs:
-      - org: kubernetes
-        slug: release-managers
-  annotations:
-    testgrid-alert-email: release-managers+alerts@kubernetes.io
-    testgrid-dashboards: sig-release-releng-informing
-    testgrid-tab-name: git-repo-kubernetes-fast-forward


### PR DESCRIPTION
Related:
 - https://github.com/kubernetes/release/issues/2386

Followup of:
 - https://github.com/kubernetes/test-infra/pull/24901

The test `TestK8sInfraTrusted` only allow postsubmits and periodics
running on `k8s-infra-prow-build-trusted` cluster to be located in path
`kubernetes/sig-k8s-infra/trusted`.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>