### PR TITLE
CAPDO: prow jobs updates

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
@@ -84,6 +84,7 @@ postsubmits:
         - ^main$
         - ^release-0.4$
         - ^release-0.5$
+        - ^release-1.*$
         # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
         - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       spec:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics-release-1-1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics-release-1-1.yaml
@@ -1,0 +1,31 @@
+periodics:
+- name: periodic-cluster-api-provider-digitalocean-conformance-release-1-1
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  interval: 24h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-do-credential: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-digitalocean
+      base_ref: release-1.1
+      path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-1.23
+      command:
+        - "runner.sh"
+        - "./scripts/ci-conformance.sh"
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 2
+          memory: "9Gi"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
+    testgrid-tab-name: capdo-periodic-conformance-release-1-1
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits-release-1-1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits-release-1-1.yaml
@@ -1,0 +1,156 @@
+presubmits:
+  kubernetes-sigs/cluster-api-provider-digitalocean:
+  - name: pull-cluster-api-provider-digitalocean-test-release-1-1
+    always_run: true
+    optional: false
+    decorate: true
+    path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
+    branches:
+    - ^release-1.1$
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-1.23
+        command:
+        - "./scripts/ci-test.sh"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
+      testgrid-tab-name: capdo-pr-test-release-1-1
+  - name: pull-cluster-api-provider-digitalocean-build-release-1-1
+    always_run: true
+    optional: false
+    decorate: true
+    path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
+    branches:
+    - ^release-1.1$
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-1.23
+        command:
+        - "./scripts/ci-build.sh"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
+      testgrid-tab-name: capdo-pr-build-release-1-1
+  - name: pull-cluster-api-provider-digitalocean-verify-release-1-1
+    always_run: true
+    optional: false
+    decorate: true
+    path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
+    branches:
+    - ^release-1.1$
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-1.23
+        command:
+        - make
+        args:
+        - verify
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
+      testgrid-tab-name: capdo-pr-verify-release-1-1
+  - name: pull-cluster-api-provider-digitalocean-lint-release-1-1
+    always_run: true
+    optional: false
+    decorate: true
+    path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
+    branches:
+    - ^release-1.1$
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-1.23
+        command:
+        - make
+        args:
+        - lint
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
+      testgrid-tab-name: capdo-pr-lint-release-1-1
+  - name: pull-cluster-api-provider-digitalocean-e2e-release-1-1
+    always_run: true
+    optional: false
+    decorate: true
+    path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
+    decoration_config:
+      timeout: 5h
+    max_concurrency: 1
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-do-credential: "true"
+    branches:
+    - ^release-1.1$
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-1.23
+        command:
+          - "runner.sh"
+          - "./scripts/ci-e2e.sh"
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1
+            memory: "4Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
+      testgrid-tab-name: capdo-pr-e2e-release-1-1
+  - name: pull-cluster-api-provider-digitalocean-capi-e2e-release-1-1
+    always_run: false
+    optional: true
+    decorate: true
+    path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
+    decoration_config:
+      timeout: 5h
+    max_concurrency: 1
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-do-credential: "true"
+    branches:
+    - ^release-1.1$
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-1.23
+        command:
+          - "runner.sh"
+          - "./scripts/ci-e2e.sh"
+        env:
+          - name: GINKGO_FOCUS
+            value: "Cluster API E2E tests"
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1
+            memory: "4Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
+      testgrid-tab-name: capdo-pr-capi-e2e-release-1-1
+  - name: pull-cluster-api-provider-digitalocean-conformance-release-1-1
+    always_run: false
+    optional: true
+    decorate: true
+    path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
+    decoration_config:
+      timeout: 5h
+    max_concurrency: 1
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-do-credential: "true"
+    branches:
+    - ^release-1.1$
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-1.23
+        command:
+          - "runner.sh"
+          - "./scripts/ci-conformance.sh"
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 2
+            memory: "9Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
+      testgrid-tab-name: capdo-pr-conformance-release-1-1

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-1.23
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -24,7 +24,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-1.23
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -39,7 +39,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-1.23
         command:
         - make
         args:
@@ -56,7 +56,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-1.22
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-1.23
         command:
         - make
         args:
@@ -80,7 +80,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-1.23
         command:
           - "runner.sh"
           - "./scripts/ci-e2e.sh"
@@ -109,7 +109,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-1.23
         command:
           - "runner.sh"
           - "./scripts/ci-e2e.sh"
@@ -141,7 +141,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-1.23
         command:
           - "runner.sh"
           - "./scripts/ci-conformance.sh"
@@ -170,7 +170,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-1.23
         command:
           - "runner.sh"
           - "./scripts/ci-e2e-experimental.sh"


### PR DESCRIPTION
- capdo: add release 1.* to run a post build job to build the image
- capdo: update base images to use kubekins 1.23 (go 1.17)
- capdo: add new pre/periodics jobs for release-1.1

the jobs for release-1.1 is a preparation for the branch cut

assign @timoreimann @MorrisLaw @prksu 