### PR TITLE
SPO: Revert required_approving_review_count

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -517,8 +517,6 @@ branch-protection:
         security-profiles-operator:
           enforce_admins: true
           required_linear_history: true
-          required_pull_request_reviews:
-            required_approving_review_count: 1
           restrictions:
             users:
             - k8s-ci-robot


### PR DESCRIPTION
Removes the use of `required_approving_review_count` in the [security-profiles-operator](https://github.com/kubernetes-sigs/security-profiles-operator) project. 
This is inteded to fix the issue in which tide enters the merge pool but continuosly fail without yielding error messages depending on the user who approved the PR.

cc @saschagrunert 