### PR TITLE
Add e2e/upgrade/conformance presubmit and periodic tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-ci.yaml
@@ -1,42 +1,5 @@
-periodics:
-- name: ci-cluster-api-provider-vsphere-ova-e2e
-  labels:
-    preset-dind-enabled: "true"
-    preset-cluster-api-provider-vsphere-e2e-config: "true"
-    preset-kind-volume-mounts: "true"
-  decorate: true
-  interval: 24h
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: cluster-api-provider-vsphere
-    base_ref: master
-    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-1.23
-      command:
-      - runner.sh
-      args:
-      - ./hack/e2e.sh
-      # we need privileged mode in order to do docker in docker
-      securityContext:
-        privileged: true
-        capabilities:
-          add: ["NET_ADMIN"]
-      resources:
-        requests:
-          cpu: "4000m"
-          memory: "6Gi"
-  annotations:
-    testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
-    testgrid-tab-name: periodic-e2e
-    testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@vmware.co
-    description: Runs periodic e2e tests
-    testgrid-num-columns-recent: '20'
-
 postsubmits:
   kubernetes-sigs/cluster-api-provider-vsphere:
-
   # Deploys images and binaries after all merges to master
   - name: post-cluster-api-provider-vsphere-deploy
     labels:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics.yaml
@@ -1,0 +1,114 @@
+periodics:
+  - name: periodic-cluster-api-provider-vsphere-e2e-main
+    labels:
+      preset-dind-enabled: "true"
+      preset-cluster-api-provider-vsphere-e2e-config: "true"
+      preset-cluster-api-provider-vsphere-gcs-creds: "true"
+      preset-kind-volume-mounts: "true"
+    decorate: true
+    interval: 12h
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: cluster-api-provider-vsphere
+        base_ref: master
+        path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-1.23
+          command:
+            - runner.sh
+          args:
+            - ./hack/e2e.sh
+          env:
+            - name: GINKGO_SKIP
+              value: "\\[Conformance\\] \\[clusterctl-Upgrade\\]"
+          # we need privileged mode in order to do docker in docker
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["NET_ADMIN"]
+          resources:
+            requests:
+              cpu: "4000m"
+              memory: "6Gi"
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      testgrid-tab-name: periodic-e2e-main
+      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      description: Runs all the e2e tests
+
+  - name: periodic-cluster-api-provider-vsphere-conformance-main
+    labels:
+      preset-dind-enabled: "true"
+      preset-cluster-api-provider-vsphere-e2e-config: "true"
+      preset-cluster-api-provider-vsphere-gcs-creds: "true"
+      preset-kind-volume-mounts: "true"
+    decorate: true
+    interval: 12h
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: cluster-api-provider-vsphere
+        base_ref: master
+        path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-1.23
+          command:
+            - runner.sh
+          args:
+            - ./hack/e2e.sh
+          env:
+            - name: GINKGO_FOCUS
+              value: "\\[Conformance\\]"
+          # we need privileged mode in order to do docker in docker
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["NET_ADMIN"]
+          resources:
+            requests:
+              cpu: "4000m"
+              memory: "6Gi"
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      testgrid-tab-name: periodic-conformance-main
+      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      description: Runs conformance tests for CAPV
+
+  - name: periodic-cluster-api-provider-vsphere-upgrade-main
+    labels:
+      preset-dind-enabled: "true"
+      preset-cluster-api-provider-vsphere-e2e-config: "true"
+      preset-cluster-api-provider-vsphere-gcs-creds: "true"
+      preset-kind-volume-mounts: "true"
+    decorate: true
+    interval: 12h
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: cluster-api-provider-vsphere
+        base_ref: master
+        path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-1.23
+          command:
+            - runner.sh
+          args:
+            - ./hack/e2e.sh
+          env:
+            - name: GINKGO_FOCUS
+              value: "\\[clusterctl-Upgrade\\]"
+          # we need privileged mode in order to do docker in docker
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["NET_ADMIN"]
+          resources:
+            requests:
+              cpu: "4000m"
+              memory: "6Gi"
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      testgrid-tab-name: periodic-clusterctl-upgrade-main
+      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      description: Runs clusterctl upgrade tests for CAPV

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -136,7 +136,7 @@ presubmits:
 
   - name: pull-cluster-api-provider-vsphere-verify-crds
     always_run: false
-    run_if_changed: '^((api|cmd|config|contrib|controllers|pkg)/|Makefile|hack/verify-crds\.sh)'
+    run_if_changed: '^((api|cmd|config|contrib|controllers|pkg)/|Makefile|hack/verify-crds\.sh|go\.mod|go\.sum)'
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
@@ -152,7 +152,7 @@ presubmits:
 
   - name: pull-cluster-api-provider-vsphere-test
     always_run: false
-    run_if_changed: '^((api|cmd|config|contrib|controllers|pkg|test)/|Makefile)'
+    run_if_changed: '^((api|cmd|config|contrib|controllers|pkg|test)/|Makefile|go\.mod|go\.sum)'
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
@@ -177,7 +177,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
-    run_if_changed: '^((api|cmd|config|contrib|controllers|pkg|test)/|Makefile)'
+    run_if_changed: '^((api|cmd|config|contrib|controllers|pkg|test)/|Makefile|go\.mod|go\.sum)'
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     branches:
@@ -206,13 +206,16 @@ presubmits:
       description: Runs integration tests
 
   - name: pull-cluster-api-provider-vsphere-e2e
+    branches:
+      - ^master$
+      - ^release-1.*
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-e2e-config: "true"
       preset-cluster-api-provider-vsphere-gcs-creds: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
-    run_if_changed: '^((api|cmd|config|contrib|controllers|pkg|test)/|Dockerfile|Makefile|hack/e2e\.sh)'
+    run_if_changed: '^((api|cmd|config|contrib|controllers|packaging|pkg|test)/|Dockerfile|Makefile|hack/e2e\.sh|go\.mod|go\.sum)'
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     max_concurrency: 3
@@ -223,6 +226,9 @@ presubmits:
         - runner.sh
         args:
         - ./hack/e2e.sh
+        env:
+        - name: GINKGO_FOCUS
+          value: "\\[PR-Blocking\\]"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -237,3 +243,39 @@ presubmits:
       testgrid-tab-name: pr-e2e
       testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
       description: Runs e2e tests
+
+  - name: pull-cluster-api-provider-vsphere-e2e-v1alpha
+    branches:
+      - ^release-0.7$
+      - ^release-0.8$
+    labels:
+      preset-dind-enabled: "true"
+      preset-cluster-api-provider-vsphere-e2e-config: "true"
+      preset-cluster-api-provider-vsphere-gcs-creds: "true"
+      preset-kind-volume-mounts: "true"
+    always_run: false
+    run_if_changed: '^((api|cmd|config|contrib|controllers|packaging|pkg|test)/|Dockerfile|Makefile|hack/e2e\.sh|go\.mod|go\.sum)'
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    max_concurrency: 3
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-1.23
+          command:
+            - runner.sh
+          args:
+            - ./hack/e2e.sh
+          # we need privileged mode in order to do docker in docker
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["NET_ADMIN"]
+          resources:
+            requests:
+              cpu: "4000m"
+              memory: "6Gi"
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      testgrid-tab-name: pr-e2e-v1alpha
+      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      description: Runs e2e tests for v1alpha3 and v1alpha4 types


### PR DESCRIPTION
This PR introduces the following changes to the CAPV jobs- 
1. Run `clusterctl upgrade`, `e2e` and `conformance` tests every 12h
2. Run `e2e` upgrade tests for every PR(presubmit job) without the clusterctl upgrade tests
3. Run all the presubmit test jobs when changes are made to `go.sum` and `go.mod` 