### PR TITLE
Separate prow images built with ko from integration test

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -115,6 +115,39 @@ presubmits:
     annotations:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: integration
+  - name: pull-test-infra-integration-with-ko
+    branches:
+    - master
+    always_run: false
+    decorate: true
+    labels:
+      preset-service-account: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-test-infra
+        command:
+        - runner.sh
+        args:
+        - ./prow/test/integration/integration-test.sh
+        - --config=ci
+        env:
+        - name: PUSH_IMAEG_WITH_KO
+          value: "true"
+        - name: BAZEL_FETCH_PLEASE
+          value: "true" # integration test fetches a very specific set of targets, define them in integration-test.sh instead of here
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1.9 # Peak usage around 1.5 cpu
+            memory: "8Gi" # Rough estimated usage of memory
+    annotations:
+      testgrid-dashboards: presubmits-test-infra
+      testgrid-tab-name: integration-with-ko
   - name: pull-test-infra-unit-test
     branches:
     - master

--- a/prow/test/integration/integration-test.sh
+++ b/prow/test/integration/integration-test.sh
@@ -33,9 +33,12 @@ function retry() {
 function setup() {
   "${bazel}" run //prow/test/integration:setup-local-registry "$@" || ( echo "FAILED: set up local registry">&2; return 1 )
 
-  PUSH=true KO_DOCKER_REPO="localhost:5001" ./prow/prow-images.sh
-  # testimage-push builds images, could fail due to network flakiness
-  (retry "${bazel}" run //prow:testimage-push "$@") || ( echo "FAILED: pushing images">&2; return 1 )
+  if [[ "${PUSH_IMAEG_WITH_KO:-}" == "true" ]]; then
+    PUSH=true KO_DOCKER_REPO="localhost:5001" ./prow/prow-images.sh
+  else
+    # testimage-push builds images, could fail due to network flakiness
+    (retry "${bazel}" run //prow:testimage-push "$@") || ( echo "FAILED: pushing images">&2; return 1 )
+  fi
   "${bazel}" run //prow/test/integration:setup-cluster "$@" || ( echo "FAILED: setup cluster">&2; return 1 )
 }
 


### PR DESCRIPTION
Currently prow images are built using both ko and bazel in integration test, which makes integration test much longer. Separating this part out and add an optional job

/cc @cjwagner @BenTheElder 