### PR TITLE
Always run pull-release-sdk-integration-test

### DIFF
--- a/config/jobs/kubernetes-sigs/release-sdk/release-sdk-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/release-sdk/release-sdk-presubmits.yaml
@@ -20,10 +20,7 @@ presubmits:
       testgrid-alert-email: release-managers+alerts@kubernetes.io
       testgrid-num-columns-recent: '30'
   - name: pull-release-sdk-integration-test
-    # TODO(xmudrii): Make this job always run and required after
-    # https://github.com/kubernetes-sigs/release-sdk/pull/31 is merged
-    always_run: false
-    optional: true
+    always_run: true
     decorate: true
     path_alias: "sigs.k8s.io/release-sdk"
     labels:


### PR DESCRIPTION
https://github.com/kubernetes-sigs/release-sdk/pull/31 got merged, so we can always run the `pull-release-sdk-integration-test` job and make it required.

/assign @puerco @saschagrunert @cpanato 
cc @kubernetes/release-engineering 