### PR TITLE
Bump Containerd to 1.6.0 release candidate rc.3

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -285,8 +285,8 @@ presubmits:
             - --
             - --build=quick
             - --cluster=
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.9
-            - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.3
+            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0-rc.3
+            - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
             - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
@@ -344,8 +344,8 @@ presubmits:
             - --
             - --build=quick
             - --cluster=
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.9
-            - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.3
+            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0-rc.3
+            - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
             - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
@@ -474,8 +474,8 @@ periodics:
           - --scenario=kubernetes_e2e
           - --
           - --check-leaked-resources
-          - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.9
-          - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.3
+          - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0-rc.3
+          - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
           - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
           - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
           - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -37,8 +37,8 @@ presubmits:
         - --build=quick
         - --extract=local
         - --env=ALLOW_PRIVILEGED=true
-        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.9
-        - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.3
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0-rc.3
+        - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
         - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
@@ -104,8 +104,8 @@ presubmits:
         - --env=ALLOW_PRIVILEGED=true
         - --env=NETWORK_POLICY_PROVIDER=calico
         - --env=KUBE_FEATURE_GATES=NetworkPolicyEndPort=true
-        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.9
-        - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.3
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0-rc.3
+        - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
         - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
@@ -173,8 +173,8 @@ presubmits:
         args:
         - --build=quick
         - --env=ALLOW_PRIVILEGED=true
-        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.9
-        - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.3
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0-rc.3
+        - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
         - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
@@ -680,8 +680,8 @@ periodics:
       - --env=ALLOW_PRIVILEGED=true
       - --env=NETWORK_POLICY_PROVIDER=calico
       - --env=KUBE_FEATURE_GATES=NetworkPolicyEndPort=true
-      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.9
-      - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.3
+      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0-rc.3
+      - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
       - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
       - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
       - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu


### PR DESCRIPTION
Bumping containerd to 1.6.0-rc.3 to have soak time before 1.6 release 

/sig node
cc @endocrimes @dims @SergeyKanzhelev 

Signed-off-by: Aditi Sharma <adi.sky17@gmail.com>