### PR TITLE
Revert experimental-prometheus-snapshot-to-report-dir in  ci-golang-tip-k8s-1-23 

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
@@ -107,7 +107,6 @@ periodics:
       - --test-cmd-args=cluster-loader2
       - --test-cmd-args=--experimental-gcp-snapshot-prometheus-disk=true
       - --test-cmd-args=--experimental-prometheus-disk-snapshot-name=$(JOB_NAME)-$(BUILD_ID)
-      - --test-cmd-args=--experimental-prometheus-snapshot-to-report-dir=true
       - --test-cmd-args=--nodes=2500
       - --test-cmd-args=--provider=kubemark
       - --test-cmd-args=--report-dir=$(ARTIFACTS)


### PR DESCRIPTION
It's not supported in that perf-tests version and tests are failing with:

```
F0209 07:54:49.697224  165389 clusterloader.go:241] Flag parse failed: unknown flag: --experimental-prometheus-snapshot-to-report-dir

```

e.g. https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-golang-tip-k8s-1-23/1491315476792348672

/assign @marseel 


