### PR TITLE
Changed Golang image version from 1.13.10 to 1.17.1 for sig-storage-lib-external-provisioner.yaml

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-storage-lib-external-provisioner/sig-storage-lib-external-provisioner.yaml
+++ b/config/jobs/kubernetes-sigs/sig-storage-lib-external-provisioner/sig-storage-lib-external-provisioner.yaml
@@ -10,7 +10,7 @@ presubmits:
       description: Build test in sig-storage-lib-external-provisioner repo.
     spec:
       containers:
-      - image: golang:1.13.10
+      - image: golang:1.17.1
         command:
         # Plain make runs also verify
         - make
@@ -25,7 +25,7 @@ presubmits:
       description: Unit tests in sig-storage-lib-external-provisioner repo.
     spec:
       containers:
-      - image: golang:1.13.10
+      - image: golang:1.17.1
         command:
         - make
         args:


### PR DESCRIPTION
### Why this is needed
While migrating leader election from `endpoints` to `leaseAPI` in
 [kubernetes-sigs/sig-storage-lib-external-provisioner](https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner) through this [PR](https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/pull/120), jobs are failing because [sig-storage-lib-external-provisioner.yaml](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-sigs/sig-storage-lib-external-provisioner/sig-storage-lib-external-provisioner.yaml) needs newer `golang version`.