### PR TITLE
Standardize the lgtm/approve workflow for bom, release-sdk, and release-utils repositories

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -86,6 +86,8 @@ approve:
   - kubernetes-sigs/kubetest2
   - kubernetes-sigs/mdtoc
   - kubernetes-sigs/release-notes
+  - kubernetes-sigs/release-sdk
+  - kubernetes-sigs/release-utils
   - kubernetes-sigs/security-profiles-operator
   - kubernetes-sigs/slack-infra
   - kubernetes-sigs/zeitgeist
@@ -162,6 +164,8 @@ lgtm:
   - kubernetes-sigs/kubetest2
   - kubernetes-sigs/mdtoc
   - kubernetes-sigs/release-notes
+  - kubernetes-sigs/release-sdk
+  - kubernetes-sigs/release-utils
   - kubernetes-sigs/security-profiles-operator
   - kubernetes-sigs/zeitgeist
   - kubernetes/k8s.io

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -75,6 +75,7 @@ approve:
   ignore_review_state: true
 - repos:
   - bazelbuild
+  - kubernetes-sigs/bom
   - kubernetes-sigs/boskos
   - kubernetes-sigs/cluster-api-provider-digitalocean
   - kubernetes-sigs/cluster-api-provider-gcp
@@ -151,6 +152,7 @@ label:
 lgtm:
 - repos:
   - bazelbuild
+  - kubernetes-sigs/bom
   - kubernetes-sigs/boskos
   - kubernetes-sigs/controller-runtime
   - kubernetes-sigs/cluster-api-provider-digitalocean


### PR DESCRIPTION
This PR standardizes the lgtm/approve workflow for bom, release-sdk, and release-utils repositories to be in sync with other SIG Release repositories. With this PR, approving the PR on GitHub will act as lgtm + approve.

See https://github.com/kubernetes/sig-release/issues/1464 for more details.

Fixes https://github.com/kubernetes-sigs/bom/issues/28

/assign @saschagrunert @cpanato @puerco @palnabarun 
cc @kubernetes/release-engineering 