### PR TITLE
Fix a typo

### DIFF
--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -316,7 +316,7 @@ testSuites:
     - --timeout=180m
     - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly)\] --minStartupPods=8
     cluster: k8s-infra-prow-build
-  betaapis: # copied from "default" for now.  Eventaully the args should specifically choose tests tagged for Beta, but this is to get us started.
+  betaapis: # copied from "default" for now.  Eventually the args should specifically choose tests tagged for Beta, but this is to get us started.
     args:
     - --timeout=120m
     - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]


### PR DESCRIPTION
There was a typo in https://github.com/kubernetes/test-infra/pull/25163 which somehow caused a failure in https://github.com/jetstack/testing/pull/628#issuecomment-1033756702

I'm not sure why this wasn't flagged by the CI in this repo. You have a bazel target for it:

```
bazelisk test //hack:verify-spelling 
2022/02/09 14:01:45 Downloading https://releases.bazel.build/3.4.1/release/bazel-3.4.1-linux-x86_64...
Extracting Bazel installation...
Starting local Bazel server and connecting to it...
INFO: SHA256 (https://golang.org/dl/?mode=json&include=all) = e82cd88c3616ce55e651e4269f544942807677411066b0f5eb485cb33839b757
INFO: Analyzed target //hack:verify-spelling (430 packages loaded, 11468 targets configured).
INFO: Found 1 test target...
FAIL: //hack:verify-spelling (see /home/richard/.cache/bazel/_bazel_richard/2e463e1f5606f0c3a19a5c210379f86b/execroot/io_k8s_test_infra/bazel-out/k8-fastbuild/testlogs/hack/verify-spelling/test.log)
INFO: From Testing //hack:verify-spelling:
==================== Test output for //hack:verify-spelling:
Validating spelling...
./releng/test_config.yaml:319:46: "Eventaully" is a misspelling of "Eventually"
ERROR: bad spelling, fix with hack/update-spelling.sh
================================================================================
Target //hack:verify-spelling up-to-date:
  bazel-bin/hack/verify-spelling
INFO: Elapsed time: 101.279s, Critical Path: 32.31s
INFO: 44 processes: 44 linux-sandbox.
INFO: Build completed, 1 test FAILED, 48 total actions
//hack:verify-spelling                                                   FAILED in 11.5s
  /home/richard/.cache/bazel/_bazel_richard/2e463e1f5606f0c3a19a5c210379f86b/execroot/io_k8s_test_infra/bazel-out/k8-fastbuild/testlogs/hack/verify-spelling/test.log

INFO: Build completed, 1 test FAILED, 48 total actions

```

