### PR TITLE
capg: pass the git directory to be able to get some information to build the image

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
@@ -121,6 +121,7 @@ postsubmits:
               - --project=k8s-staging-cluster-api-gcp
               - --scratch-bucket=gs://k8s-staging-cluster-api-gcp-gcb
               - --env-passthrough=PULL_BASE_REF
+              - --with-git-dir
               - .
   kubernetes-sigs/cluster-api-provider-nested:
     - name: post-cluster-api-provider-nested-push-images


### PR DESCRIPTION
- capg: pass the git directory to be able to get some information to build the image

during the build, we set some LD flags to build some information to expose some version information for the user when need to debug, but then without the git information we get a blank ldflags

this enables the git and we will be able to have the ld flags set up correctly

/assign @dims 

Signed-off-by: Carlos Panato <ctadeu@gmail.com>