### PR TITLE
cluster-api: enable dind ipv6

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -185,6 +185,9 @@ presubmits:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
+          # enable IPV6 in bootstrap image
+          - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+            value: "true"
           - name: GINKGO_FOCUS
             value: "\\[IPv6\\] \\[PR-Informing\\]"
           - name: IP_FAMILY


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

I have no clue why the test suddenly started to fail, but now that I realized that there is `DOCKER_IN_DOCKER_IPV6_ENABLED` env var to enable IPv6 in Docker I wonder how it could ever have worked before.

I would like to try this change on the main job to test if this fixes the issue and if it does roll it out in a follow-up PR to all our ipv6 jobs (on the other branches)

xref: https://github.com/kubernetes/test-infra/blob/882045fa58c930c112d82e9715a400a28d1a9de2/images/bootstrap/runner.sh#L44-L60