### PR TITLE
add unit tests around pr_status_base_urls

### DIFF
--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -2955,6 +2955,31 @@ tide:
 			},
 		},
 		{
+			name: "tide specific pr_status_base_urls respected",
+			prowConfig: `
+tide:
+  pr_status_base_urls:
+    "*": https://star.tide.com/pr
+    "org": https://org.tide.com/pr
+    "org/repo": https://repo.tide.com/pr
+`,
+			verify: func(c *Config) error {
+				orgRepo := OrgRepo{Org: "other-org", Repo: "other-repo"}
+				if got, expected := c.Tide.GetPRStatusBaseURL(orgRepo), "https://star.tide.com/pr"; got != expected {
+					return fmt.Errorf("expected PR Status Base URL for %q to be %q, but got %q", orgRepo.String(), expected, got)
+				}
+				orgRepo = OrgRepo{Org: "org", Repo: "other-repo"}
+				if got, expected := c.Tide.GetPRStatusBaseURL(orgRepo), "https://org.tide.com/pr"; got != expected {
+					return fmt.Errorf("expected PR Status Base URL for %q to be %q, but got %q", orgRepo.String(), expected, got)
+				}
+				orgRepo = OrgRepo{Org: "org", Repo: "repo"}
+				if got, expected := c.Tide.GetPRStatusBaseURL(orgRepo), "https://repo.tide.com/pr"; got != expected {
+					return fmt.Errorf("expected PR Status Base URL for %q to be %q, but got %q", orgRepo.String(), expected, got)
+				}
+				return nil
+			},
+		},
+		{
 			name: "postsubmit without explicit 'always_run' sets this field to nil by default",
 			jobConfigs: []string{
 				`

--- a/prow/tide/status_test.go
+++ b/prow/tide/status_test.go
@@ -1067,7 +1067,10 @@ func TestTargetUrl(t *testing.T) {
 				},
 				HeadRefName: "head",
 			},
-			config:      config.Tide{PRStatusBaseURLs: map[string]string{"testOrg": "byorg.pr.status.com"}},
+			config: config.Tide{PRStatusBaseURLs: map[string]string{
+				"*":       "default.pr.status.com",
+				"testOrg": "byorg.pr.status.com"},
+			},
 			expectedURL: "byorg.pr.status.com?query=is%3Apr+repo%3AtestOrg%2FtestRepo+author%3Aauthor+head%3Ahead",
 		},
 		{
@@ -1090,6 +1093,7 @@ func TestTargetUrl(t *testing.T) {
 				HeadRefName: "head",
 			},
 			config: config.Tide{PRStatusBaseURLs: map[string]string{
+				"*":                "default.pr.status.com",
 				"testOrg":          "byorg.pr.status.com",
 				"testOrg/testRepo": "byrepo.pr.status.com"},
 			},


### PR DESCRIPTION
During my attempt to get to the bottom of why our configuration for `pr_status_base_urls` doesn't behave properly I added some additional test cases. None of this was an issue, but I figured the extra coverage would be good to have.