### PR TITLE
chore: reducing the parallelization for eks e2e ci temporarily

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
@@ -68,7 +68,7 @@ postsubmits:
                 value: "us-west-2"
               # Parallelize tests
               - name: GINKGO_ARGS
-                value: "-nodes 20"
+                value: "-nodes 10"
             securityContext:
               privileged: true
             resources:


### PR DESCRIPTION
The parallelization of 20 is sometimes causing an issue with the post submit job. Temporarily reducing.

Will investigate a longer term fix.

Relates to: https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/3185
 