### PR TITLE
cluster-api: enable dind ipv6 for all CAPI jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-0-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-0-4.yaml
@@ -180,6 +180,9 @@ presubmits:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
+          # enable IPV6 in bootstrap image
+          - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+            value: "true"
           - name: GINKGO_FOCUS
             value: "\\[PR-Blocking\\]"
           - name: IP_FAMILY

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-0.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-0.yaml
@@ -180,6 +180,9 @@ presubmits:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
+          # enable IPV6 in bootstrap image
+          - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+            value: "true"
           - name: GINKGO_FOCUS
             value: "\\[PR-Blocking\\]"
           - name: IP_FAMILY

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-1.yaml
@@ -211,6 +211,9 @@ presubmits:
           - runner.sh
           - "./scripts/ci-e2e.sh"
         env:
+          # enable IPV6 in bootstrap image
+          - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+            value: "true"
           - name: GINKGO_FOCUS
             value: "\\[IPv6\\] \\[PR-Informing\\]"
           - name: IP_FAMILY


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

Apparently enabling dind (for the main presubmit job) fixed it. (https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api/6087/pull-cluster-api-e2e-informing-ipv6-main/1491504061407563776)

Let's fix all our IPv6 jobs.

Fixes https://github.com/kubernetes-sigs/cluster-api/issues/6086