### PR TITLE
sig-k8s-infra: change latency container image for kubermark tests

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -171,6 +171,7 @@ periodics:
       - --kubemark-nodes=100
       - --provider=gce
       - --metadata-sources=cl2-metadata.json
+      - --env=CL2_LATENCY_POD_IMAGE=registry-sandbox.k8s.io/pause:3.1
       - --test=false
       - --test_args=--ginkgo.focus=xxxx
       - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
@@ -403,6 +404,7 @@ periodics:
       - --kubemark
       - --kubemark-nodes=500
       - --metadata-sources=cl2-metadata.json
+      - --env=CL2_LATENCY_POD_IMAGE=registry-sandbox.k8s.io/pause:3.1
       - --provider=gce
       - --test=false
       - --test_args=--ginkgo.focus=xxxx
@@ -483,6 +485,7 @@ periodics:
       - --kubemark-nodes=5000
       - --provider=gce
       - --metadata-sources=cl2-metadata.json
+      - --env=CL2_LATENCY_POD_IMAGE=registry-sandbox.k8s.io/pause:3.1
       # With APF only sum of --max-requests-inflight and --max-mutating-requests-inflight matters, so set --max-mutating-requests-inflight to 0.
       - --env=KUBEMARK_APISERVER_TEST_ARGS=--max-requests-inflight=640 --max-mutating-requests-inflight=0
       - --test=false


### PR DESCRIPTION
SIG K8s Infra is currently working on the migration from k8s.gcr.io to
registry.k8s.io.
registry-sandbox.k8s.io is a proxy for k8s.gcr.io allowing us to build
confidence in the tooling we are working on.

Tests changed:
- ci-kubernetes-kubemark-100-gce
- ci-kubernetes-kubemark-500-gce
- ci-kubernetes-kubemark-gce-scale

See design doc: docs.google.com/document/d/1yNQ7DaDE5LbDJf9ku82YtlKZK0tcg5Wpk9L72-x2S2k/edit

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>