### PR TITLE
Add presumits for 1.21 & 1.22. Bump go version to 1.17 in master

### DIFF
--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.21.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.21.yaml
@@ -1,54 +1,54 @@
 # sigs.k8s.io/scheduler-plugins presubmits
 presubmits:
   kubernetes-sigs/scheduler-plugins:
-  - name: pull-scheduler-plugins-verify
+  - name: pull-scheduler-plugins-verify-gofmt-release-1-21
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
-    - ^master$
+    - ^release-1.21$
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.6
+      - image: golang:1.16.7
         command:
         - make
         args:
         - verify
-  - name: pull-scheduler-plugins-verify-build-master
+  - name: pull-scheduler-plugins-verify-build-release-1-21
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
-    - ^master$
+    - ^release-1.21$
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.6
+      - image: golang:1.16.7
         command:
         - make
         args:
         - build
-  - name: pull-scheduler-plugins-unit-test-master
+  - name: pull-scheduler-plugins-unit-test-release-1-21
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
-    - ^master$
+    - ^release-1.21$
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.6
+      - image: golang:1.16.7
         command:
         - make
         args:
         - unit-test
-  - name: pull-scheduler-plugins-integration-test-master
+  - name: pull-scheduler-plugins-integration-test-release-1-21
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
-    - ^master$
+    - ^release-1.21$
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.6
+      - image: golang:1.16.7
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.22.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-release-1.22.yaml
@@ -1,54 +1,54 @@
 # sigs.k8s.io/scheduler-plugins presubmits
 presubmits:
   kubernetes-sigs/scheduler-plugins:
-  - name: pull-scheduler-plugins-verify
+  - name: pull-scheduler-plugins-verify-gofmt-release-1-22
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
-    - ^master$
+    - ^release-1.22$
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.6
+      - image: golang:1.16.7
         command:
         - make
         args:
         - verify
-  - name: pull-scheduler-plugins-verify-build-master
+  - name: pull-scheduler-plugins-verify-build-release-1-22
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
-    - ^master$
+    - ^release-1.22$
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.6
+      - image: golang:1.16.7
         command:
         - make
         args:
         - build
-  - name: pull-scheduler-plugins-unit-test-master
+  - name: pull-scheduler-plugins-unit-test-release-1-22
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
-    - ^master$
+    - ^release-1.22$
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.6
+      - image: golang:1.16.7
         command:
         - make
         args:
         - unit-test
-  - name: pull-scheduler-plugins-integration-test-master
+  - name: pull-scheduler-plugins-integration-test-release-1-22
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins
     branches:
-    - ^master$
+    - ^release-1.22$
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.6
+      - image: golang:1.16.7
         command:
         - make
         args:


### PR DESCRIPTION
go version needs to be bumped to 1.17 due to indirective deps
(by kubernetes-sigs/json) on reflect#StructField.IsExported which is
new function in go 1.17.