### PR TITLE
Support highlighting multiple build log lines

### DIFF
--- a/prow/cmd/deck/runlocal
+++ b/prow/cmd/deck/runlocal
@@ -28,7 +28,9 @@ curl "${HOST}/tide-history.js?var=tideHistory" > tide-history.js
 curl "${HOST}/plugin-help.js?var=allHelp" > plugin-help.js
 curl "${HOST}/pr-data.js" > pr-data.js
 
-bazel run //prow/cmd/deck:deck -- \
+bazel=$(command -v bazelisk || command -v bazel)
+
+"$bazel" run //prow/cmd/deck:deck -- \
   --pregenerated-data=${DIR}/localdata \
   --static-files-location=./prow/cmd/deck/static \
   --template-files-location=./prow/cmd/deck/template \


### PR DESCRIPTION
Currently we just support:

* select nothing
  - https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-crio-cgroupv1-node-e2e-features/1491881066670067712/
* select a single line
  - https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-crio-cgroupv1-node-e2e-features/1491881066670067712/#1:build-log.txt%3A49

This adds the ability to select a range of lines:
* https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-crio-cgroupv1-node-e2e-features/1491881066670067712/#1:build-log.txt%3A49-72 


<img width="739" alt="image" src="https://user-images.githubusercontent.com/940341/153505265-f271427e-13fd-48ef-984c-9f44852b53bb.png">
