### PR TITLE
Support e2e-ccm-vmss tests on capz

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -304,6 +304,8 @@ presubmits:
               value: "true"
             - name: AZURE_LOADBALANCER_SKU
               value: "standard"
+            - name: KUBERNETES_VERSION
+              value: 1.23.1
             - name: GINKGO_ARGS
               value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --test.parallel=30
     annotations:
@@ -353,6 +355,103 @@ presubmits:
       testgrid-dashboards: provider-azure-cloud-provider-azure
       testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-capz
       description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+      testgrid-num-columns-recent: '30'
+  - name: pull-cloud-provider-azure-e2e-ccm-vmss-capz
+    always_run: false
+    #skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+      - master
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: cluster-api-provider-azure
+        base_ref: release-1.0
+        path_alias: sigs.k8s.io/cluster-api-provider-azure
+        workdir: true
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-1.23
+          command:
+          - runner.sh
+          args:
+          - ./scripts/ci-entrypoint.sh
+          - bash
+          - -c
+          - >-
+            cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+            make test-ccm-e2e
+          securityContext:
+            privileged: true
+          env:
+            - name: TEST_CCM
+              value: "true"
+            - name: EXP_MACHINE_POOL
+              value: "true"
+            - name: KUBERNETES_VERSION
+              value: 1.23.1
+            - name: AZURE_LOADBALANCER_SKU
+              value: "standard"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-capz
+      description: "Runs Azure specific tests (VMSS) with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+      testgrid-num-columns-recent: '30'
+  - name: pull-cloud-provider-azure-e2e-ccm-vmss-basic-lb-capz
+    always_run: false
+    #skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+      - master
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: cluster-api-provider-azure
+        base_ref: release-1.0
+        path_alias: sigs.k8s.io/cluster-api-provider-azure
+        workdir: true
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220124-681f3531ec-1.23
+          command:
+          - runner.sh
+          args:
+          - ./scripts/ci-entrypoint.sh
+          - bash
+          - -c
+          - >-
+            cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+            make test-e2e
+          securityContext:
+            privileged: true
+          env:
+            - name: TEST_CCM
+              value: "true"
+            - name: EXP_MACHINE_POOL
+              value: "true"
+            - name: KUBERNETES_VERSION
+              value: 1.23.1
+            - name: AZURE_LOADBALANCER_SKU
+              value: "standard"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-basic-lb-capz
+      description: "Runs Azure specific tests (VMSS + basic LB) with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
       testgrid-num-columns-recent: '30'
   - name: pull-cloud-provider-azure-unit
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-0.7.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-0.7.yaml
@@ -358,6 +358,104 @@ presubmits:
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-capz-1-20
         description: "Runs Azure specific tests with cloud-provider-azure release-0.7 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
         testgrid-num-columns-recent: '30'
+    - name: pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-20
+      always_run: false
+      #skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
+      optional: true
+      decorate: true
+      decoration_config:
+        timeout: 5h
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      branches:
+        - release-0.7
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+        preset-azure-cred-only: "true"
+        preset-azure-anonymous-pull: "true"
+      extra_refs:
+        - org: kubernetes-sigs
+          repo: cluster-api-provider-azure
+          base_ref: release-1.0
+          path_alias: sigs.k8s.io/cluster-api-provider-azure
+          workdir: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211217-ea95cec1d4-1.22
+            command:
+            - runner.sh
+            - ./scripts/ci-entrypoint.sh
+            args:
+            - bash
+            - -c
+            - >-
+              cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+              make test-ccm-e2e
+            securityContext:
+              privileged: true
+            env:
+              - name: TEST_CCM
+                value: "true"
+              - name: EXP_MACHINE_POOL
+                value: "true"
+              - name: AZURE_LOADBALANCER_SKU
+                value: "standard"
+              - name: KUBERNETES_VERSION
+                value: 1.20.9
+      annotations:
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-20-presubmit
+        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-capz-1-20
+        description: "Runs Azure specific tests (VMSS) with cloud-provider-azure release-0.7 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+        testgrid-num-columns-recent: '30'
+    - name: pull-cloud-provider-azure-e2e-ccm-vmss-basic-lb-capz-1-20
+      always_run: false
+      #skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
+      optional: true
+      decorate: true
+      decoration_config:
+        timeout: 5h
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      branches:
+        - release-0.7
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+        preset-azure-cred-only: "true"
+        preset-azure-anonymous-pull: "true"
+      extra_refs:
+        - org: kubernetes-sigs
+          repo: cluster-api-provider-azure
+          base_ref: release-1.0
+          path_alias: sigs.k8s.io/cluster-api-provider-azure
+          workdir: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211217-ea95cec1d4-1.22
+            command:
+            - runner.sh
+            - ./scripts/ci-entrypoint.sh
+            args:
+            - bash
+            - -c
+            - >-
+              cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+              make test-ccm-e2e
+            securityContext:
+              privileged: true
+            env:
+              - name: TEST_CCM
+                value: "true"
+              - name: EXP_MACHINE_POOL
+                value: "true"
+              - name: AZURE_LOADBALANCER_SKU
+                value: "basic"
+              - name: KUBERNETES_VERSION
+                value: 1.20.9
+      annotations:
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-20-presubmit
+        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-basic-lb-capz-1-20
+        description: "Runs Azure specific tests (VMSS + Basic LB) with cloud-provider-azure release-0.7 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+        testgrid-num-columns-recent: '30'
     - name: pull-cloud-provider-azure-unit-1-20
       skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
       decorate: true

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.0.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.0.yaml
@@ -359,6 +359,104 @@ presubmits:
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-capz-1-21
         description: "Runs Azure specific tests with cloud-provider-azure release-1.0 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
         testgrid-num-columns-recent: '30'
+    - name: pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-21
+      always_run: false
+      #skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
+      optional: true
+      decorate: true
+      decoration_config:
+        timeout: 5h
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      branches:
+        - release-1.0
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+        preset-azure-cred-only: "true"
+        preset-azure-anonymous-pull: "true"
+      extra_refs:
+        - org: kubernetes-sigs
+          repo: cluster-api-provider-azure
+          base_ref: release-1.0
+          path_alias: sigs.k8s.io/cluster-api-provider-azure
+          workdir: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211217-ea95cec1d4-1.22
+            command:
+            - runner.sh
+            - ./scripts/ci-entrypoint.sh
+            args:
+            - bash
+            - -c
+            - >-
+              cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+              make test-ccm-e2e
+            securityContext:
+              privileged: true
+            env:
+              - name: TEST_CCM
+                value: "true"
+              - name: EXP_MACHINE_POOL
+                value: "true"
+              - name: AZURE_LOADBALANCER_SKU
+                value: "standard"
+              - name: KUBERNETES_VERSION
+                value: 1.21.5
+      annotations:
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-21-presubmit
+        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-capz-1-21
+        description: "Runs Azure specific tests (VMSS) with cloud-provider-azure release-1.0 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+        testgrid-num-columns-recent: '30'
+    - name: pull-cloud-provider-azure-e2e-ccm-vmss-basic-lb-capz-1-21
+      always_run: false
+      #skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
+      optional: true
+      decorate: true
+      decoration_config:
+        timeout: 5h
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      branches:
+        - release-1.0
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+        preset-azure-cred-only: "true"
+        preset-azure-anonymous-pull: "true"
+      extra_refs:
+        - org: kubernetes-sigs
+          repo: cluster-api-provider-azure
+          base_ref: release-1.0
+          path_alias: sigs.k8s.io/cluster-api-provider-azure
+          workdir: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211217-ea95cec1d4-1.22
+            command:
+            - runner.sh
+            - ./scripts/ci-entrypoint.sh
+            args:
+            - bash
+            - -c
+            - >-
+              cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+              make test-ccm-e2e
+            securityContext:
+              privileged: true
+            env:
+              - name: TEST_CCM
+                value: "true"
+              - name: EXP_MACHINE_POOL
+                value: "true"
+              - name: AZURE_LOADBALANCER_SKU
+                value: "basic"
+              - name: KUBERNETES_VERSION
+                value: 1.21.5
+      annotations:
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-21-presubmit
+        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-basic-lb-capz-1-21
+        description: "Runs Azure specific tests (VMSS + Basic LB) with cloud-provider-azure release-1.0 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+        testgrid-num-columns-recent: '30'
     - name: pull-cloud-provider-azure-unit-1-21
       skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
       decorate: true

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.1.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.1.yaml
@@ -359,6 +359,104 @@ presubmits:
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-capz-1-22
         description: "Runs Azure specific tests with cloud-provider-azure release-1.1 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
         testgrid-num-columns-recent: '30'
+    - name: pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-22
+      always_run: false
+      #skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
+      optional: true
+      decorate: true
+      decoration_config:
+        timeout: 5h
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      branches:
+        - release-1.1
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+        preset-azure-cred-only: "true"
+        preset-azure-anonymous-pull: "true"
+      extra_refs:
+        - org: kubernetes-sigs
+          repo: cluster-api-provider-azure
+          base_ref: release-1.0
+          path_alias: sigs.k8s.io/cluster-api-provider-azure
+          workdir: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211217-ea95cec1d4-1.22
+            command:
+            - runner.sh
+            - ./scripts/ci-entrypoint.sh
+            args:
+            - bash
+            - -c
+            - >-
+              cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+              make test-ccm-e2e
+            securityContext:
+              privileged: true
+            env:
+              - name: TEST_CCM
+                value: "true"
+              - name: EXP_MACHINE_POOL
+                value: "true"
+              - name: AZURE_LOADBALANCER_SKU
+                value: "standard"
+              - name: KUBERNETES_VERSION
+                value: 1.22.2
+      annotations:
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-22-presubmit
+        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-capz-1-22
+        description: "Runs Azure specific tests (VMSS) with cloud-provider-azure release-1.1 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+        testgrid-num-columns-recent: '30'
+    - name: pull-cloud-provider-azure-e2e-ccm-vmss-basic-lb-capz-1-22
+      always_run: false
+      #skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
+      optional: true
+      decorate: true
+      decoration_config:
+        timeout: 5h
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      branches:
+        - release-1.1
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+        preset-azure-cred-only: "true"
+        preset-azure-anonymous-pull: "true"
+      extra_refs:
+        - org: kubernetes-sigs
+          repo: cluster-api-provider-azure
+          base_ref: release-1.0
+          path_alias: sigs.k8s.io/cluster-api-provider-azure
+          workdir: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211217-ea95cec1d4-1.22
+            command:
+            - runner.sh
+            - ./scripts/ci-entrypoint.sh
+            args:
+            - bash
+            - -c
+            - >-
+              cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+              make test-ccm-e2e
+            securityContext:
+              privileged: true
+            env:
+              - name: TEST_CCM
+                value: "true"
+              - name: EXP_MACHINE_POOL
+                value: "true"
+              - name: AZURE_LOADBALANCER_SKU
+                value: "basic"
+              - name: KUBERNETES_VERSION
+                value: 1.22.2
+      annotations:
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-22-presubmit
+        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-basic-lb-capz-1-22
+        description: "Runs Azure specific tests (VMSS + Basic LB) with cloud-provider-azure release-1.1 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+        testgrid-num-columns-recent: '30'
     - name: pull-cloud-provider-azure-unit-1-22
       skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
       decorate: true

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.23.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.23.yaml
@@ -359,6 +359,104 @@ presubmits:
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-capz-1-23
         description: "Runs Azure specific tests with cloud-provider-azure release-1.23 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
         testgrid-num-columns-recent: '30'
+    - name: pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-23
+      always_run: false
+      #skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
+      optional: true
+      decorate: true
+      decoration_config:
+        timeout: 5h
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      branches:
+        - release-1.23
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+        preset-azure-cred-only: "true"
+        preset-azure-anonymous-pull: "true"
+      extra_refs:
+        - org: kubernetes-sigs
+          repo: cluster-api-provider-azure
+          base_ref: release-1.0
+          path_alias: sigs.k8s.io/cluster-api-provider-azure
+          workdir: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211217-ea95cec1d4-1.23
+            command:
+              - runner.sh
+              - ./scripts/ci-entrypoint.sh
+            args:
+              - bash
+              - -c
+              - >-
+                cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+                make test-ccm-e2e
+            securityContext:
+              privileged: true
+            env:
+              - name: TEST_CCM
+                value: "true"
+              - name: EXP_MACHINE_POOL
+                value: "true"
+              - name: AZURE_LOADBALANCER_SKU
+                value: "standard"
+              - name: KUBERNETES_VERSION
+                value: 1.23.1
+      annotations:
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-23-presubmit
+        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-capz-1-23
+        description: "Runs Azure specific tests (VMSS) with cloud-provider-azure release-1.23 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+        testgrid-num-columns-recent: '30'
+    - name: pull-cloud-provider-azure-e2e-ccm-vmss-basic-lb-capz-1-23
+      always_run: false
+      #skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
+      optional: true
+      decorate: true
+      decoration_config:
+        timeout: 5h
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      branches:
+        - release-1.23
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+        preset-azure-cred-only: "true"
+        preset-azure-anonymous-pull: "true"
+      extra_refs:
+        - org: kubernetes-sigs
+          repo: cluster-api-provider-azure
+          base_ref: release-1.0
+          path_alias: sigs.k8s.io/cluster-api-provider-azure
+          workdir: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211217-ea95cec1d4-1.23
+            command:
+              - runner.sh
+              - ./scripts/ci-entrypoint.sh
+            args:
+              - bash
+              - -c
+              - >-
+                cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+                make test-ccm-e2e
+            securityContext:
+              privileged: true
+            env:
+              - name: TEST_CCM
+                value: "true"
+              - name: EXP_MACHINE_POOL
+                value: "true"
+              - name: AZURE_LOADBALANCER_SKU
+                value: "basic"
+              - name: KUBERNETES_VERSION
+                value: 1.23.1
+      annotations:
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-23-presubmit
+        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-basic-lb-capz-1-23
+        description: "Runs Azure specific tests (VMSS + Basic LB) with cloud-provider-azure release-1.23 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+        testgrid-num-columns-recent: '30'
     - name: pull-cloud-provider-azure-unit-1-23
       skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
       decorate: true


### PR DESCRIPTION
* pr-cloud-provider-azure-e2e-ccm-vmss
* pr-cloud-provider-azure-e2e-ccm-vmss-basic-lb
* specify K8s ver for pull-cloud-provider-azure-e2e-capz

Signed-off-by: Zhecheng Li <zhechengli@microsoft.com>