### PR TITLE
prow.k8s.io: add skip reason to Spyglass JUnit lens

### DIFF
--- a/prow/spyglass/lenses/junit/lens.go
+++ b/prow/spyglass/lenses/junit/lens.go
@@ -105,6 +105,14 @@ func (jr JunitResult) Status() testStatus {
 	return res
 }
 
+func (jr JunitResult) SkippedReason() string {
+	res := ""
+	if jr.Skipped != nil {
+		res = *jr.Skipped
+	}
+	return res
+}
+
 // TestResult holds data about a test extracted from junit output
 type TestResult struct {
 	Junit []JunitResult

--- a/prow/spyglass/lenses/junit/template.html
+++ b/prow/spyglass/lenses/junit/template.html
@@ -156,7 +156,11 @@
       {{range .Skipped}}
         {{$firstTest := index .Junit 0}}
         <tr>
-          <td class="mdl-data-table__cell--non-numeric test-name">{{$firstTest.ClassName}}: {{$firstTest.Name}}</td>
+	   {{if eq $firstTest.SkippedReason "" }}
+	   <td class="mdl-data-table__cell--non-numeric test-name">{{$firstTest.ClassName}}: {{$firstTest.Name}}</td>
+	   {{else}}
+	   <td class="mdl-data-table__cell--non-numeric test-name">{{$firstTest.ClassName}}: {{$firstTest.Name}}</br> </br><b>Reason:</b> {{$firstTest.SkippedReason}}</td>
+	   {{end}}
           <td class="mdl-data-table__cell--non-numeric">{{$firstTest.Duration}}</td>
         </tr>
       {{end}}
@@ -166,3 +170,4 @@
 </div>
 {{end}}
 {{end}}
+


### PR DESCRIPTION
**What does this PR do:**

At present, when an e2e test is skipped, the reason for the skip (if passed to the `e2eskipper.Skipf` function) is reflected in the artifacts/junit-*.xml files, but not on the Prow Spyglass JUnit lens: 

For example, in case of the following job:
- JUnit file: https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-csi-1-21-on-kubernetes-master/1491563973357604864/artifacts/junit_parallel.xml
- Spyglass lens: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-csi-1-21-on-kubernetes-master/1491563973357604864

This PR adds the skipped reason to the JUnit spyglass lens's [`template.html`](https://github.com/kubernetes/test-infra/blob/master/prow/spyglass/lenses/junit/template.html#L159) file (wherever passed). 

The outcome is as follows: 

<img width="1786" alt="Screenshot 2022-02-11 at 3 05 52 PM" src="https://user-images.githubusercontent.com/30499743/153568411-f5cec9c9-6e5d-4fd1-89bb-96057adbe437.png">
<img width="1789" alt="Screenshot 2022-02-11 at 3 06 06 PM" src="https://user-images.githubusercontent.com/30499743/153568418-bef215e8-b0fa-4bfb-a938-8be8ed79238b.png">

---

**Addresses Issue:**

Fixes https://github.com/kubernetes/test-infra/issues/24209

