### PR TITLE
kubetest: GKE: wait for operation to complete before trying to delete cluster.

### DIFF
--- a/kubetest/gke.go
+++ b/kubetest/gke.go
@@ -894,6 +894,24 @@ func (g *gkeDeployer) Down() error {
 	}
 	g.instanceGroups = nil
 
+	operationNameBytes, err := control.Output(exec.Command(
+		"gcloud", g.containerArgs("operations", "list", "--project="+g.project,
+			g.location, "--format=value(name)", fmt.Sprintf("--filter=(status=RUNNING AND targetLink ~ /clusters/%s$)", g.cluster))...))
+	if err != nil {
+		return fmt.Errorf("failed to list RUNNING operations for cluster %s: %w", g.cluster, err)
+	}
+
+	operationName := strings.TrimSpace(string(operationNameBytes))
+	if operationName != "" {
+		log.Printf("Found RUNNING operation %q blocking cluster deletion. Will wait for its completion.", operationName)
+		err := control.FinishRunning(exec.Command(
+			"gcloud", g.containerArgs("operations", "wait", "--project="+g.project,
+				g.location, operationName)...))
+		if err != nil {
+			return fmt.Errorf("error waiting for operation %s to finish: %w", operationName, err)
+		}
+	}
+
 	// We best-effort try all of these and report errors as appropriate.
 	errCluster := control.FinishRunning(exec.Command(
 		"gcloud", g.containerArgs("clusters", "delete", "-q", g.cluster,


### PR DESCRIPTION
Context: It happens that cluster deletion fails with error like:
```
ERROR: (gcloud.beta.container.clusters.delete) Some requests did not succeed:
 - ResponseError: code=400, message=Operation operation-1640353517079-0c49a431 is currently repairing cluster a-b-c-d. Please wait and try again once it is done.
 -
```
The goal of this PR is to ensure that there is no operation running when we start cluster deletion.

Tested manually:
* happy path (no operation in flight)
* operation in flight (waiting for completion)