### PR TITLE
Update CLA triage bot message to include /easycla

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
@@ -79,6 +79,7 @@ periodics:
         Send feedback to sig-contributor-experience at [kubernetes/community](https://github.com/kubernetes/community).
 
         /check-cla
+        /easycla
       - --template
       - --ceiling=10
       - --confirm


### PR DESCRIPTION
The /check-cla command does not appear to trigger a refresh of the cla status :(

It looks like there may have been a transient issue this morning with the EasyCLA service not reporting CLA status - you can see a few of the PRs here:
https://github.com/search?q=org%3Akubernetes+%22Unknown+CLA+label+state.%22&state=open&type=Issues

The bot response is not triggering an update of the status, but once you respond with `/easycla` it does. (ref: https://github.com/kubernetes/community/pull/6449#issuecomment-1036378339

/assign @cblecker 

