### PR TITLE
Prow sub component exits when there is a failure

### DIFF
--- a/prow/cmd/sub/main.go
+++ b/prow/cmd/sub/main.go
@@ -174,7 +174,7 @@ func main() {
 	pullServer := subscriber.NewPullServer(s)
 	interrupts.Run(func(ctx context.Context) {
 		if err := pullServer.Run(ctx); err != nil {
-			logrus.WithError(err).Error("Failed to run Pull Server")
+			logrus.WithError(err).Fatal("Failed to run Pull Server")
 		}
 	})
 


### PR DESCRIPTION
Without this change, sub service idles waiting for interruption even when sub thread exited

/cc @cjwagner @mpherman2 