### PR TITLE
Add daisy to testgrid; fix cit periodics

### DIFF
--- a/config/testgrids/gcp-guest/gcp-guest.yaml
+++ b/config/testgrids/gcp-guest/gcp-guest.yaml
@@ -9,7 +9,9 @@ test_groups:
 - name: gcp-guest-osconfig-presubmit-gocheck
   gcs_prefix: oss-prow/pr-logs/directory/osconfig-presubmit-gocheck
 - name: gcp-guest-cloud-image-tests
-  gcs_prefix: gcp-guest-testgrid/logs/cit-periodic
+  gcs_prefix: oss-prow/logs/cit-periodic
+- name: gcp-guest-daisy-e2e
+  gcs_prefix: oss-prow/logs/compute-daisy-e2e
 
 #
 # Define dashboards
@@ -25,3 +27,5 @@ dashboards:
     test_group_name: gcp-guest-osconfig-presubmit-gocheck
   - name: CIT periodics
     test_group_name: gcp-guest-cloud-image-tests
+  - name: Daisy e2e
+    test_group_name: gcp-guest-daisy-e2e


### PR DESCRIPTION
Adding testgrid for [these tests](https://github.com/GoogleCloudPlatform/oss-test-infra/blob/de5d85b3b336301ee3998d440d46c2be8a0ab775/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-daisy.yaml)

Also fixing the [testgrid for CIT tests](https://k8s-testgrid.appspot.com/google-gcp-guest#CIT%20periodics). It looks like it's currently stale, and the logs are being written to [gs://oss-prow/logs/cit-periodics](https://console.cloud.google.com/storage/browser/oss-prow/logs/cit-periodics)

@hopkiw 