### PR TITLE
Pass git dir into CAPZ image push job

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
@@ -70,6 +70,7 @@ postsubmits:
               - --project=k8s-staging-cluster-api-azure
               - --scratch-bucket=gs://k8s-staging-cluster-api-azure-gcb
               - --env-passthrough=PULL_BASE_REF
+              - --with-git-dir
               - .
   kubernetes-sigs/cluster-api-provider-digitalocean:
     - name: post-cluster-api-provider-digitalocean-push-images


### PR DESCRIPTION
This change passes the git directory into the CAPZ image push job so we can generate version info using git commands. Thanks to #25182