### PR TITLE
log grabbing: obtain timestamps on extra services

### DIFF
--- a/logexporter/cluster/log-dump.sh
+++ b/logexporter/cluster/log-dump.sh
@@ -377,7 +377,7 @@ function save-logs() {
         log-dump-ssh "${node_name}" "sudo journalctl --output=short-precise -k" > "${dir}/kern.log" || true
 
         for svc in "${services[@]}"; do
-            log-dump-ssh "${node_name}" "sudo journalctl --output=cat -u ${svc}.service" > "${dir}/${svc}.log" || true
+            log-dump-ssh "${node_name}" "sudo journalctl --output=short-precise -u ${svc}.service" > "${dir}/${svc}.log" || true
         done
 
         if [[ "$dump_systemd_journal" == "true" ]]; then


### PR DESCRIPTION
Previously if any test jobs added additional log dumps, such as
`containerd-installation` for example, the logs would grabbed with `sudo
journalctl --output=cat`. `--output=cat` excludes timestamps which makes
debugging difficult. Let's use `short-precise` output similar to to the
other log grabbing commands which includes timestamps.