### PR TITLE
Pass git dir into CAPDO post image job

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
@@ -98,6 +98,7 @@ postsubmits:
               - --project=k8s-staging-cluster-api-do
               - --scratch-bucket=gs://k8s-staging-cluster-api-do-gcb
               - --env-passthrough=PULL_BASE_REF
+              - --with-git-dir
               - .
   kubernetes-sigs/cluster-api-provider-gcp:
     - name: post-cluster-api-provider-gcp-push-images


### PR DESCRIPTION
we use the ldflags to set some version information but the job is missing the git directory, this fix that

/assign @timoreimann @MorrisLaw @prksu 