### PR TITLE
capg: add new capg job to test e2e workload k8s upgrade

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-main.yaml
@@ -231,6 +231,8 @@ presubmits:
               value: "boskos.test-pods.svc.cluster.local"
             - name: GINKGO_FOCUS
               value: "Cluster API E2E tests"
+            - name: GINKGO_SKIP
+              value: "\\[K8s-Upgrade\\]|API Version Upgrade"
           command:
             - "runner.sh"
             - "./scripts/ci-e2e.sh"
@@ -243,3 +245,37 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-capi-e2e-test
+  - name: pull-cluster-api-provider-gcp-e2e-workload-upgrade
+    labels:
+      preset-service-account: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
+    branches:
+    - ^main$
+    always_run: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 3h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220211-6df2c53026-1.23
+          args:
+            - runner.sh
+            - "./scripts/ci-e2e.sh"
+          env:
+            - name: GINKGO_FOCUS
+              value: "\\[K8s-Upgrade\\]"
+          # we need privileged mode in order to do docker in docker
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "9000Mi"
+              cpu: 2000m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
+      testgrid-tab-name: pr-e2e-upgrade


### PR DESCRIPTION
- capg: add new capg job to test e2e workload k8s upgrade

related to https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/519

/assign @dims 