### PR TITLE
releng: update kubekins/krte to Go 1.17.7 / 1.16.14

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.17.6
+    GO_VERSION: 1.17.7
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
@@ -22,25 +22,25 @@ variants:
     KIND_VERSION: 0.10.0
   master:
     CONFIG: master
-    GO_VERSION: 1.17.6
+    GO_VERSION: 1.17.7
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.23':
     CONFIG: '1.23'
-    GO_VERSION: 1.17.6
+    GO_VERSION: 1.17.7
     K8S_RELEASE: stable-1.23
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.22':
     CONFIG: '1.22'
-    GO_VERSION: 1.16.13
+    GO_VERSION: 1.16.14
     K8S_RELEASE: stable-1.22
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.21':
     CONFIG: '1.21'
-    GO_VERSION: 1.16.13
+    GO_VERSION: 1.16.14
     K8S_RELEASE: stable-1.21
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
Update kubekins/krte to Go 1.17.7 / 1.16.14.

xref https://github.com/kubernetes/release/issues/2425

/hold
waiting for https://github.com/kubernetes/kubernetes/pull/108102, https://github.com/kubernetes/kubernetes/pull/108101, https://github.com/kubernetes/kubernetes/pull/108100

/assign @saschagrunert @cpanato @puerco @palnabarun @justaugustus @BenTheElder 
cc @kubernetes/release-engineering 