### PR TITLE
feat: enable priviliged mode for CAPA verify jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -43,6 +43,9 @@ presubmits:
         command:
         - "make"
         - "verify"
+        # docker-in-docker needs privileged mode
+        securityContext:
+            privileged: true
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
       testgrid-tab-name: pr-verify


### PR DESCRIPTION
The CAPA verify job needs to run a container to verify its documents so
we need to enable priviliged mode.

Signed-off-by: Richard Case <richard@weave.works>