### PR TITLE
Separate out prow image build check to a separate job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ OUT_DIR=$(REPO_ROOT)/_output
 ################################################################################
 # ================================= Testing ====================================
 # unit tests (hermetic)
-unit: go-unit py-unit image-build
+unit: go-unit py-unit
 .PHONY: unit
 go-unit:
 	hack/make-rules/go-test/unit.sh
@@ -28,9 +28,6 @@ go-unit:
 py-unit:
 	hack/make-rules/py-test/all.sh
 .PHONY: py-unit
-image-build:
-	(make -C prow build-images)
-.PHONY: image-build
 # integration tests
 # integration:
 #	hack/make-rules/go-test/integration.sh

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -170,6 +170,32 @@ presubmits:
     annotations:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: unit-test
+  - name: pull-test-infra-prow-image-build-test
+    branches:
+    - master
+    run_if_changed: '^(hack/make-rules|prow|ghproxy|label_sync/.+\.go|robots/commenter|robots/pr-creator|robots/issue-creator|testgrid/cmd|gcsweb)'
+    # TODO(chaodaiG): make it required once confirmed working
+    optional: true
+    decorate: true
+    labels:
+      # Building deck requires docker for typescript compilation.
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220211-6df2c53026-test-infra
+        command:
+        - runner.sh
+        args:
+        - make
+        - -C
+        - prow
+        - build-images
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+    annotations:
+      testgrid-dashboards: presubmits-test-infra
+      testgrid-tab-name: prow-image-build-test
   - name: pull-test-infra-verify-lint
     branches:
     - master

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -227,7 +227,7 @@ postsubmits:
     run_if_changed: '^(hack/make-rules|prow|ghproxy|label_sync/.+\.go|robots/commenter|robots/pr-creator|robots/issue-creator|testgrid/cmd|gcsweb)'
     decorate: true
     labels:
-      # Need dind for building typescript
+      # Building deck requires docker for typescript compilation.
       preset-dind-enabled: "true"
     branches:
     - ^master$


### PR DESCRIPTION
Prow image building takes ~9 minutes, adding this on top of unit test make it the longest leg for presubmit. Separating out to a new job so that presubmit can run faster

/cc @cjwagner 