### PR TITLE
Support expanding up and down

### DIFF
--- a/prow/cmd/deck/runlocal
+++ b/prow/cmd/deck/runlocal
@@ -59,6 +59,8 @@ if [[ "${1:-}" != '--skip-pregenerated' ]]; then
   fi
   update-pregenerated "$HOST"
   shift || true
+else
+  shift
 fi
 
 compile-typescript() {
@@ -66,7 +68,7 @@ compile-typescript() {
   ./gather-static.sh
 }
 
-if [[ -n "${GO_RUN:-}" ]]; then 
+if [[ -n "${GO_RUN:-}" ]]; then
   if [[ "${1:-}" != '--skip-typescript' ]]; then
     compile-typescript
   fi

--- a/prow/spyglass/lenses/BUILD.bazel
+++ b/prow/spyglass/lenses/BUILD.bazel
@@ -62,6 +62,7 @@ filegroup(
         "//prow/spyglass/lenses/buildlog:all-srcs",
         "//prow/spyglass/lenses/common:all-srcs",
         "//prow/spyglass/lenses/coverage:all-srcs",
+        "//prow/spyglass/lenses/fake:all-srcs",
         "//prow/spyglass/lenses/html:all-srcs",
         "//prow/spyglass/lenses/junit:all-srcs",
         "//prow/spyglass/lenses/links:all-srcs",
@@ -81,6 +82,7 @@ go_test(
     deps = [
         "//prow/config:go_default_library",
         "//prow/spyglass/api:go_default_library",
+        "//prow/spyglass/lenses/fake:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )

--- a/prow/spyglass/lenses/buildlog/BUILD.bazel
+++ b/prow/spyglass/lenses/buildlog/BUILD.bazel
@@ -64,4 +64,10 @@ go_test(
     srcs = ["lens_test.go"],
     embed = [":go_default_library"],
     tags = ["manual"],
+    deps = [
+        "//prow/config:go_default_library",
+        "//prow/spyglass/api:go_default_library",
+        "//prow/spyglass/lenses/fake:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
+    ],
 )

--- a/prow/spyglass/lenses/buildlog/buildlog.css
+++ b/prow/spyglass/lenses/buildlog/buildlog.css
@@ -7,7 +7,7 @@ html {
     overflow-x: hidden;
 }
 
-.linetext button {
+.linetext button, .linenum button {
     font-size: 1em;
     text-align: left;
     background: none;
@@ -18,9 +18,23 @@ html {
     cursor: pointer;
 }
 
+.loglines .material-icons {
+  font-size: 1em;
+  vertical-align: middle;
+}
+
+.show-skipped.showable:hover {
+    background-color: #666;
+}
+.show-skipped.showable {
+    background-color: #505050;
+}
+
 .loglines {
     color: #fff;
     width: calc(100% - 30px);
+    font-family: monospace;
+    margin-top: 15px;
 }
 .loglines .linetext span {
     white-space: pre-wrap;

--- a/prow/spyglass/lenses/buildlog/lens.go
+++ b/prow/spyglass/lenses/buildlog/lens.go
@@ -69,7 +69,7 @@ func (lens Lens) Config() lenses.LensConfig {
 
 // Header executes the "header" section of the template.
 func (lens Lens) Header(artifacts []api.Artifact, resourceDir string, config json.RawMessage, spyglassConfig prowconfig.Spyglass) string {
-	return executeTemplate(resourceDir, "header", BuildLogsView{})
+	return executeTemplate(resourceDir, "header", buildLogsView{})
 }
 
 // defaultErrRE matches keywords and glog error messages.
@@ -88,7 +88,7 @@ type SubLine struct {
 
 // LogLine represents a line displayed in the LogArtifactView.
 type LogLine struct {
-	ArtifactName string
+	ArtifactName *string
 	Number       int
 	Length       int
 	Highlighted  bool
@@ -100,8 +100,15 @@ type LogLine struct {
 type LineGroup struct {
 	Skip                   bool
 	Start, End             int // closed, open
-	ByteOffset, ByteLength int
+	ByteOffset, ByteLength int64
 	LogLines               []LogLine
+	ArtifactName           *string
+}
+
+const moreLines = 20
+
+func (g LineGroup) Expand() bool {
+	return len(g.LogLines) >= moreLines
 }
 
 // LineRequest represents a request for output lines from an artifact. If Offset is 0 and Length
@@ -111,6 +118,8 @@ type LineRequest struct {
 	Offset    int64  `json:"offset"`
 	Length    int64  `json:"length"`
 	StartLine int    `json:"startLine"`
+	Top       int    `json:"top"`
+	Bottom    int    `json:"bottom"`
 }
 
 // LinesSkipped returns the number of lines skipped in a line group.
@@ -127,8 +136,8 @@ type LogArtifactView struct {
 	ShowRawLog   bool
 }
 
-// BuildLogsView holds each log file view
-type BuildLogsView struct {
+// buildLogsView holds each log file view
+type buildLogsView struct {
 	LogViews []LogArtifactView
 }
 
@@ -164,7 +173,7 @@ func getConfig(rawConfig json.RawMessage) parsedConfig {
 
 // Body returns the <body> content for a build log (or multiple build logs)
 func (lens Lens) Body(artifacts []api.Artifact, resourceDir string, data string, rawConfig json.RawMessage, spyglassConfig prowconfig.Spyglass) string {
-	buildLogsView := BuildLogsView{
+	buildLogsView := buildLogsView{
 		LogViews: []LogArtifactView{},
 	}
 
@@ -181,7 +190,8 @@ func (lens Lens) Body(artifacts []api.Artifact, resourceDir string, data string,
 			logrus.WithError(err).Info("Error reading log.")
 			continue
 		}
-		av.LineGroups = groupLines(highlightLines(lines, 0, av.ArtifactName, conf.highlightRegex))
+		artifact := av.ArtifactName
+		av.LineGroups = groupLines(&artifact, highlightLines(lines, 0, &artifact, conf.highlightRegex))
 		av.ViewAll = true
 		buildLogsView.LogViews = append(buildLogsView.LogViews, av)
 	}
@@ -189,16 +199,19 @@ func (lens Lens) Body(artifacts []api.Artifact, resourceDir string, data string,
 	return executeTemplate(resourceDir, "body", buildLogsView)
 }
 
+const failedUnmarshal = "Failed to unmarshal request"
+const missingArtifact = "No artifact named %s"
+
 // Callback is used to retrieve new log segments
 func (lens Lens) Callback(artifacts []api.Artifact, resourceDir string, data string, rawConfig json.RawMessage, spyglassConfig prowconfig.Spyglass) string {
 	var request LineRequest
 	err := json.Unmarshal([]byte(data), &request)
 	if err != nil {
-		return "failed to unmarshal request"
+		return failedUnmarshal
 	}
 	artifact, ok := artifactByName(artifacts, request.Artifact)
 	if !ok {
-		return "no artifact named " + request.Artifact
+		return fmt.Sprintf(missingArtifact, request.Artifact)
 	}
 
 	var lines []string
@@ -208,12 +221,60 @@ func (lens Lens) Callback(artifacts []api.Artifact, resourceDir string, data str
 		lines, err = logLines(artifact, request.Offset, request.Length)
 	}
 	if err != nil {
-		return fmt.Sprintf("failed to retrieve log lines: %v", err)
+		return fmt.Sprintf("Failed to retrieve log lines: %v", err)
 	}
 
+	var skipFirst bool
+	var skipLines []string
+	skipRequest := request
+	// Should we expand all the lines? Or just some from the top/bottom.
+	if t, n := request.Top, len(lines); t > 0 && t < n {
+		skipLines = lines[request.Top:]
+		lines = lines[:request.Top]
+		skipRequest.StartLine += t
+		for _, line := range lines {
+			b := int64(len(line) + 1)
+			skipRequest.Offset += b
+			skipRequest.Length -= b
+		}
+	} else if b := request.Bottom; b > 0 && b < n {
+		skipLines = lines[:n-b]
+		lines = lines[n-b:]
+		request.StartLine += (n - b)
+		for _, line := range lines {
+			skipRequest.Length -= int64(len(line) + 1)
+		}
+		skipFirst = true
+	}
+	var skipGroup *LineGroup
 	conf := getConfig(rawConfig)
-	logLines := highlightLines(lines, request.StartLine, request.Artifact, conf.highlightRegex)
-	return executeTemplate(resourceDir, "line group", logLines)
+	if len(skipLines) > 0 {
+		logLines := highlightLines(skipLines, skipRequest.StartLine, &request.Artifact, conf.highlightRegex)
+		skipGroup = &LineGroup{
+			Skip:         true,
+			Start:        skipRequest.StartLine,
+			End:          skipRequest.StartLine + len(logLines),
+			ByteOffset:   skipRequest.Offset,
+			ByteLength:   skipRequest.Length,
+			ArtifactName: &request.Artifact,
+			LogLines:     logLines,
+		}
+	}
+	groups := make([]*LineGroup, 0, 2)
+
+	if skipGroup != nil && skipFirst {
+		groups = append(groups, skipGroup)
+		skipGroup = nil
+	}
+	logLines := highlightLines(lines, request.StartLine, &request.Artifact, conf.highlightRegex)
+	groups = append(groups, &LineGroup{
+		LogLines:     logLines,
+		ArtifactName: &request.Artifact,
+	})
+	if skipGroup != nil {
+		groups = append(groups, skipGroup)
+	}
+	return executeTemplate(resourceDir, "line groups", groups)
 }
 
 func artifactByName(artifacts []api.Artifact, name string) (api.Artifact, bool) {
@@ -252,7 +313,7 @@ func logLines(artifact api.Artifact, offset, length int64) ([]string, error) {
 	return strings.Split(string(b), "\n"), nil
 }
 
-func highlightLines(lines []string, startLine int, artifact string, highlightRegex *regexp.Regexp) []LogLine {
+func highlightLines(lines []string, startLine int, artifact *string, highlightRegex *regexp.Regexp) []LogLine {
 	// mark highlighted lines
 	logLines := make([]LogLine, 0, len(lines))
 	for i, text := range lines {
@@ -281,7 +342,7 @@ func highlightLines(lines []string, startLine int, artifact string, highlightReg
 }
 
 // breaks lines into important/unimportant groups
-func groupLines(logLines []LogLine) []LineGroup {
+func groupLines(artifact *string, logLines []LogLine) []LineGroup {
 	// show highlighted lines and their neighboring lines
 	for i, line := range logLines {
 		if line.Highlighted {
@@ -297,14 +358,14 @@ func groupLines(logLines []LogLine) []LineGroup {
 		}
 	}
 	// break into groups
-	currentOffset := 0
-	previousOffset := 0
+	var currentOffset int64
+	var previousOffset int64
 	var lineGroups []LineGroup
-	curGroup := LineGroup{}
+	var curGroup LineGroup
 	for i, line := range logLines {
 		if line.Skip == curGroup.Skip {
 			curGroup.LogLines = append(curGroup.LogLines, line)
-			currentOffset += line.Length
+			currentOffset += int64(line.Length)
 		} else {
 			curGroup.End = i
 			curGroup.ByteLength = currentOffset - previousOffset - 1 // -1 for trailing newline
@@ -318,12 +379,13 @@ func groupLines(logLines []LogLine) []LineGroup {
 				lineGroups = append(lineGroups, curGroup)
 			}
 			curGroup = LineGroup{
-				Skip:       line.Skip,
-				Start:      i,
-				LogLines:   []LogLine{line},
-				ByteOffset: currentOffset,
+				Skip:         line.Skip,
+				Start:        i,
+				LogLines:     []LogLine{line},
+				ByteOffset:   currentOffset,
+				ArtifactName: artifact,
 			}
-			currentOffset += line.Length
+			currentOffset += int64(line.Length)
 		}
 	}
 	curGroup.End = len(logLines)

--- a/prow/spyglass/lenses/buildlog/template.html
+++ b/prow/spyglass/lenses/buildlog/template.html
@@ -7,37 +7,51 @@
 {{range $log := .LogViews}}
   <div>
     <button class="show-all-button" data-artifact="{{$log.ArtifactName}}">Show all hidden lines</button>
-    {{if .ShowRawLog}}<a href="{{$log.ArtifactLink}}" style="padding-left:15px;">Raw {{$log.ArtifactName}}<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>{{end}}
-    <div class="loglines" id="{{$log.ArtifactName}}-content" style="font-family: monospace; margin-top: 15px;">
-      {{range $g := $log.LineGroups}}
-        {{if $g.Skip}}
-          <div class="show-skipped" data-artifact="{{$log.ArtifactName}}" data-offset="{{$g.ByteOffset}}" data-length="{{$g.ByteLength}}" data-start-line="{{$g.Start}}" data-end-line="{{$g.End}}">
+    {{if .ShowRawLog}}<a href="{{$log.ArtifactLink}}" style="padding-left:15px;">Raw {{$log.ArtifactName}}<i class="material-icons" style="padding-left: 3px;">open_in_new</i></a>{{end}}
+    <div class="loglines" id="{{$log.ArtifactName}}-content">
+      {{block "line groups" $log.LineGroups}}
+      {{range . }}
+        {{if .Skip}}
+          {{block "skipped group" . }}
+          <div class="show-skipped" data-artifact="{{.ArtifactName}}" data-offset="{{.ByteOffset}}" data-length="{{.ByteLength}}" data-start-line="{{.Start}}" data-end-line="{{.End}}">
+            {{if .Expand }}
             <div>
-              <div class="linenum"></div>
-              <div class="linetext"><button> skipped {{$g.LinesSkipped}} lines <i class="material-icons" style="font-size: 1em; vertical-align: middle;">unfold_more</i></button></div>
+              <div class="linenum"><button title="Expand down" class="top"><i class="material-icons">expand_more</i></button></div>
+              <div class="linetext"></div>
             </div>
+            {{end}}
+            <div>
+              <div class="linenum"><button title="Show all"><i class="material-icons">{{if .Expand}}more_vert{{else}}unfold_more{{end}}</i></button></div>
+              <div class="linetext"><button>{{.LinesSkipped}} skipped lines...</button></div>
+            </div>
+            {{if .Expand }}
+            <div>
+              <div class="linenum"><button title="Expand up" class="bottom"><i class="material-icons">expand_less</i></button></div>
+              <div class="linetext"></div>
+            </div>
+            {{end}}
           </div>
+          {{end}}
         {{else}}
+          {{block "shown group" . }}
           <div class="shown">
-          {{template "line group" $g.LogLines}}
+          {{range .LogLines}}
+            <div id="{{.ArtifactName}}:{{.Number}}">
+              <div class="linenum"><a href="#{{.ArtifactName}}:{{.Number}}" data-artifact="{{.ArtifactName}}" data-line-number="{{.Number}}">{{.Number}}</a></div>
+              <div class="linetext">
+                <span {{if .Highlighted}}class="line-highlighted"{{end}}>
+                  {{- range .SubLines -}}<span {{if .Highlighted}}class="match-highlighted"{{end}}>{{.Text}}</span>{{- end -}}
+                </span>
+              </div>
+            </div>
+          {{end}}
           </div>
+          {{end}}
         {{end}}
+      {{end}}
       {{end}}
     </div>
   </div>
 {{end}}
 </div>
-{{end}}
-
-{{define "line group"}}
-  {{range .}}
-    <div id="{{.ArtifactName}}:{{.Number}}">
-      <div class="linenum"><a href="#{{.ArtifactName}}:{{.Number}}" data-artifact="{{.ArtifactName}}" data-line-number="{{.Number}}">{{.Number}}</a></div>
-      <div class="linetext">
-        <span {{if .Highlighted}}class="line-highlighted"{{end}}>
-          {{- range .SubLines -}}<span {{if .Highlighted}}class="match-highlighted"{{end}}>{{.Text}}</span>{{- end -}}
-        </span>
-      </div>
-    </div>
-  {{end}}
 {{end}}

--- a/prow/spyglass/lenses/fake/BUILD.bazel
+++ b/prow/spyglass/lenses/fake/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["fake.go"],
+    importpath = "k8s.io/test-infra/prow/spyglass/lenses/fake",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/spyglass/lenses/fake/fake.go
+++ b/prow/spyglass/lenses/fake/fake.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+)
+
+type Artifact struct {
+	Path    string
+	Content []byte
+}
+
+func (fa *Artifact) JobPath() string {
+	return fa.Path
+}
+
+func (fa *Artifact) Size() (int64, error) {
+	return int64(len(fa.Content)), nil
+}
+
+func (fa *Artifact) CanonicalLink() string {
+	return "linknotfound.io/404"
+}
+
+func (fa *Artifact) ReadAt(b []byte, off int64) (int, error) {
+	r := bytes.NewReader(fa.Content)
+	return r.ReadAt(b, off)
+}
+
+func (fa *Artifact) ReadAll() ([]byte, error) {
+	r := bytes.NewReader(fa.Content)
+	return ioutil.ReadAll(r)
+}
+
+func (fa *Artifact) ReadTail(n int64) ([]byte, error) {
+	size, err := fa.Size()
+	if err != nil {
+		return nil, err
+	}
+	buf := make([]byte, n)
+	_, err = fa.ReadAt(buf, size-n)
+	return buf, err
+}
+
+func (fa *Artifact) UseContext(ctx context.Context) error {
+	return nil
+}
+
+func (fa *Artifact) ReadAtMost(n int64) ([]byte, error) {
+	buf := make([]byte, n)
+	_, err := fa.ReadAt(buf, 0)
+	return buf, err
+}


### PR DESCRIPTION
* Allows expanding a few skipped lines up or down
* Currently we only support expanding the entire block
* Add unit test coverage to the `Callback()` function
* Fixes to `runlocal`
* Can now click either the text or the icon (not just the text)

<img width="577" alt="image" src="https://user-images.githubusercontent.com/940341/153936298-9533c523-5bf5-4bac-b726-d6917275cc1e.png">
