### PR TITLE
Change cookiefile config to be global

### DIFF
--- a/prow/git/v2/client_factory.go
+++ b/prow/git/v2/client_factory.go
@@ -280,7 +280,7 @@ func (c *clientFactory) ClientFor(org, repo string) (RepoClient, error) {
 			return nil, err
 		}
 		if len(c.cookieFilePath) > 0 {
-			err := repoClient.Config("http.cookiefile", c.cookieFilePath)
+			err := repoClient.Config("--global", "http.cookiefile", c.cookieFilePath)
 			if err != nil {
 				return nil, fmt.Errorf("unable to configure http.cookiefile: %w", err)
 			}


### PR DESCRIPTION
IIUC we need to use global config because we can't clone without the cookiefile, and we can't use regular config before we clone.

/assign @chaodaiG @cjwagner 