### PR TITLE
CAPZ: update milestone applier for 1.2 release

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -390,7 +390,8 @@ milestone_applier:
     release-0.7: v0.7.x
     release-0.6: v0.6.x
   kubernetes-sigs/cluster-api-provider-azure:
-    main: v1.1
+    main: v1.2
+    release-1.1: v1.1
     release-1.0: v1.0
     release-0.5: v0.5
     release-0.4: v0.4


### PR DESCRIPTION
This should have been done when v1.1 was released, doing it now.

/assign @shysank @mboersma 