### PR TITLE
add plugins settings for kubernetes-sigs/prow repo

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -86,6 +86,7 @@ approve:
   - kubernetes-sigs/kind
   - kubernetes-sigs/kubetest2
   - kubernetes-sigs/mdtoc
+  - kubernetes-sigs/prow
   - kubernetes-sigs/release-notes
   - kubernetes-sigs/release-sdk
   - kubernetes-sigs/release-utils
@@ -165,6 +166,7 @@ lgtm:
   - kubernetes-sigs/kind
   - kubernetes-sigs/kubetest2
   - kubernetes-sigs/mdtoc
+  - kubernetes-sigs/prow
   - kubernetes-sigs/release-notes
   - kubernetes-sigs/release-sdk
   - kubernetes-sigs/release-utils
@@ -929,6 +931,15 @@ plugins:
     - milestone
 
   kubernetes/test-infra:
+    plugins:
+    - config-updater
+    - milestone
+    - override
+    - project
+    - require-matching-label
+
+  # Use the same settings as kubernetes/test-infra.
+  kubernetes-sigs/prow:
     plugins:
     - config-updater
     - milestone


### PR DESCRIPTION
We try to follow kubernets/test-infra (k/t-i) settings as much as
possible because this is already what the Prow developers are using
today (i.e., k/t-i is where Prow development takes place).

/cc @cjwagner