### PR TITLE
fix: ensure verify runs with runner.sh

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -41,6 +41,7 @@ presubmits:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220211-6df2c53026-master
         command:
+        - "runner.sh"
         - "make"
         - "verify"
         # docker-in-docker needs privileged mode


### PR DESCRIPTION
Ensure that when running make verify presubmit job that we wrap it and
execute via runner.sh so that we get DIND setup correctly.

Signed-off-by: Richard Case <richard@weave.works>