### PR TITLE
Fix minio console port setting in starter-s3.yaml

### DIFF
--- a/config/prow/cluster/starter/starter-s3.yaml
+++ b/config/prow/cluster/starter/starter-s3.yaml
@@ -1321,8 +1321,10 @@ spec:
           value: "<<CHANGE_ME_MINIO_ROOT_PASSWORD>>"
         - name: MINIO_REGION_NAME
           value: minio
+        - name: MINIO_CONSOLE_ADDRESS
+          value: ":9001"
         ports:
-        - containerPort: 9000
+        - containerPort: 9001
         readinessProbe:
           httpGet:
             path: /minio/health/ready
@@ -1342,7 +1344,7 @@ spec:
   type: ClusterIP
   ports:
   - port: 80
-    targetPort: 9000
+    targetPort: 9001
     protocol: TCP
   selector:
     app: minio


### PR DESCRIPTION
Since quite some time `minio` outputs:
```
API: http://172.17.0.11:9000  http://127.0.0.1:9000 

Console: http://172.17.0.11:35987 http://127.0.0.1:35987 

Documentation: https://docs.min.io

WARNING: Console endpoint is listening on a dynamic port (35987), please use --console-address ":PORT" to choose a static port.
```

So, the solution would be to statically fix it. Since 9000 is now API, I would propose 9001.