### PR TITLE
Yaml lint from make rule, remove one job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,4 +100,7 @@ verify-codegen:
 .PHONY: verify-boilerplate
 verify-boilerplate:
 	hack/make-rules/verify/boilerplate.sh
+.PHONY: verify-yamllint
+verify-yamllint:
+	hack/make-rules/verify/yamllint.sh
 #################################################################################

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -44,22 +44,6 @@ presubmits:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: gubernator
 
-  - name: pull-test-infra-yamllint
-    always_run: true
-    decorate: true
-    spec:
-      containers:
-      - image: quay.io/kubermatic/yamllint:0.1
-        command:
-        - yamllint
-        - -c
-        - config/jobs/.yamllint.conf
-        - config/jobs
-        - config/prow/cluster
-    annotations:
-      testgrid-dashboards: presubmits-test-infra
-      testgrid-tab-name: verify-yaml
-
   # Please keep this in sync with the `ci-test-infra-prow-checkconfig` job
   - name: pull-test-infra-prow-checkconfig
     decorate: true

--- a/hack/make-rules/verify/all.sh
+++ b/hack/make-rules/verify/all.sh
@@ -80,6 +80,12 @@ if [[ "${VERIFY_BOILERPLATE:-true}" == "true" ]]; then
   hack/make-rules/verify/boilerplate.sh || { FAILED+=($name); echo "ERROR: $name failed"; }
   cd "${REPO_ROOT}"
 fi
+if [[ "${VERIFY_YAMLLINT:-true}" == "true" ]]; then
+  name="yamllint"
+  echo "verifying $name"
+  hack/make-rules/verify/yamllint.sh || { FAILED+=($name); echo "ERROR: $name failed"; }
+  cd "${REPO_ROOT}"
+fi
 
 # exit based on verify scripts
 if [[ "${#FAILED[@]}" == 0 ]]; then

--- a/hack/make-rules/verify/yamllint.sh
+++ b/hack/make-rules/verify/yamllint.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"
+cd "${REPO_ROOT}"
+
+DOCKER=(docker)
+
+if [[ -n "${NO_DOCKER:-}" ]]; then
+  DOCKER=(echo docker)
+elif ! (command -v docker >/dev/null); then
+  echo "WARNING: docker not installed; please install docker or try setting NO_DOCKER=true" >&2
+  exit 1
+fi
+
+LINT_COMMAND=("yamllint" "-c" "config/jobs/.yamllint.conf" "config/jobs" "config/prow/cluster")
+
+"${DOCKER[@]}" run \
+    --rm -i \
+    -v "${REPO_ROOT:?}:${REPO_ROOT:?}" -w "${REPO_ROOT}" \
+    "quay.io/kubermatic/yamllint:0.1" \
+    "${LINT_COMMAND[@]}"
+
+if [[ -n "${NO_DOCKER:-}" ]]; then
+  (
+    set -o xtrace
+    "${LINT_COMMAND[@]}"
+  )
+fi


### PR DESCRIPTION
Verify yamllint from make rule, it can be invoked as part of `make verify`.

/cc @cjwagner @alvaroaleman 