### PR TITLE
kubernetes-sigs/cluster-capacity: bump the 1.20 jobs to 1.20.15

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits.yaml
@@ -56,7 +56,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBERNETES_VERSION
-          value: "v1.20.0"
+          value: "v1.20.15"
         - name: KIND_E2E
           value: "true"
         args:


### PR DESCRIPTION
For https://github.com/kubernetes-sigs/cluster-capacity/pull/141.