### PR TITLE
Separate ts rollup from codegen

### DIFF
--- a/hack/make-rules/update/codegen.sh
+++ b/hack/make-rules/update/codegen.sh
@@ -224,11 +224,6 @@ EOF
   unset HOME
 }
 
-gen-ts-bundle() {
-  ./hack/make-rules/update/ts-rollup.sh prow/cmd/deck/.ts-packages
-  ./hack/make-rules/update/ts-rollup.sh gopherage/.ts-packages
-}
-
 export GO111MODULE=off
 ensure-in-gopath
 old=${GOCACHE:-}
@@ -247,5 +242,3 @@ gen-informer
 gen-spyglass-bindata
 gen-prowjob-crd
 export GO111MODULE=on
-
-gen-ts-bundle

--- a/hack/make-rules/verify/all.sh
+++ b/hack/make-rules/verify/all.sh
@@ -86,6 +86,12 @@ if [[ "${VERIFY_YAMLLINT:-true}" == "true" ]]; then
   hack/make-rules/verify/yamllint.sh || { FAILED+=($name); echo "ERROR: $name failed"; }
   cd "${REPO_ROOT}"
 fi
+if [[ "${VERIFY_TS_ROLLUP:-true}" == "true" ]]; then
+  name="rollup typescripts"
+  echo "verifying $name"
+  hack/make-rules/verify/ts-rollup.sh || { FAILED+=($name); echo "ERROR: $name failed"; }
+  cd "${REPO_ROOT}"
+fi
 
 # exit based on verify scripts
 if [[ "${#FAILED[@]}" == 0 ]]; then

--- a/hack/make-rules/verify/codegen.sh
+++ b/hack/make-rules/verify/codegen.sh
@@ -30,8 +30,7 @@ DIFFROOT="${REPO_ROOT}"
 TMP_DIFFROOT="$(TMPDIR="${BINDIR}" mktemp -d "${BINDIR}/verify-codegen.XXXXX")"
 
 mkdir -p "${TMP_DIFFROOT}/prow"
-cp -a "${DIFFROOT}"/prow/{apis,client,config,spyglass,cmd/deck/static} "${TMP_DIFFROOT}/prow"
-cp -a "${DIFFROOT}"/gopherage "${TMP_DIFFROOT}"
+cp -a "${DIFFROOT}"/prow/{apis,client,config} "${TMP_DIFFROOT}/prow"
 mkdir -p "${TMP_DIFFROOT}/config/prow/cluster/prowjob-crd"
 cp -a "${DIFFROOT}/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml" "${TMP_DIFFROOT}/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml"
 
@@ -42,10 +41,9 @@ ret=0
 diff -Naupr "${DIFFROOT}/prow/apis" "${TMP_DIFFROOT}/prow/apis" || ret=$?
 diff -Naupr "${DIFFROOT}/prow/client" "${TMP_DIFFROOT}/prow/client" || ret=$?
 diff -Naupr "${DIFFROOT}/prow/config" "${TMP_DIFFROOT}/prow/config" || ret=$?
-diff -Naupr "${DIFFROOT}/prow/spyglass" "${TMP_DIFFROOT}/prow/spyglass" || ret=$?
 diff -Naupr "${DIFFROOT}/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml" "${TMP_DIFFROOT}/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml" || ret=$?
 # Restore so that verify codegen doesn't modify workspace
-cp -a "${TMP_DIFFROOT}/prow"/{apis,client,config,spyglass} "${DIFFROOT}"/prow
+cp -a "${TMP_DIFFROOT}/prow"/{apis,client,config} "${DIFFROOT}"/prow
 cp -a "${TMP_DIFFROOT}/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml" "${DIFFROOT}/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml"
 
 # Clean up

--- a/hack/make-rules/verify/ts-rollup.sh
+++ b/hack/make-rules/verify/ts-rollup.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"
+cd $REPO_ROOT
+
+TS_PACKAGES_FILES=(
+    # Only verify gopherage, as deck is already verified by `make -C prow
+    # build-images`.
+    # "prow/cmd/deck/.ts-packages"
+    "gopherage/.ts-packages"
+)
+
+for ts_packages_files in "${TS_PACKAGES_FILES[@]}"; do
+    ./hack/make-rules/update/ts-rollup.sh "${ts_packages_files}"
+    CLEAN=true ./hack/make-rules/update/ts-rollup.sh "${ts_packages_files}"
+done


### PR DESCRIPTION
Typescript rollup is done as part of image building process, the generated code is not sourced controlled, so they should not be part of codegen

/cc @cjwagner 