### PR TITLE
kops: add missing envs for Leader Migration test.

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
@@ -154,6 +154,10 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: KUBE_SSH_USER
         value: prow
+      - name: CLOUD_PROVIDER
+        value: "gce"
+      - name: CLUSTER_NAME
+        value: "upgrade-leader-migration.test-cncf-gce.k8s.io"
       - name: GCE_EXTRA_CREATE_ARGS
         value: --gce-service-account=default
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220214-0aa8fe1d3a-master


### PR DESCRIPTION
These env variables are not bound automatically. setting them in the job yaml.