### PR TITLE
Build podutils with ko

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -11,19 +11,23 @@
 baseImageOverrides:
   k8s.io/test-infra/prow/cmd/branchprotector: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
   k8s.io/test-infra/prow/cmd/checkconfig: gcr.io/k8s-prow/git:v20220215-ddc3ad9
+  k8s.io/test-infra/prow/cmd/clonerefs: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/config-bootstrapper: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/deck: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/exporter: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
   k8s.io/test-infra/prow/cmd/crier: gcr.io/k8s-prow/git:v20220215-ddc3ad9
+  k8s.io/test-infra/prow/cmd/entrypoint: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/generic-autobumper: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/grandmatriarch: gcr.io/cloud-builders/gcloud@sha256:5b49dfb5e366dd75a5fc6d5d447be584f8f229c5a790ee0c3b0bd0cf70ec41dd
   k8s.io/test-infra/prow/cmd/gcsupload: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
   k8s.io/test-infra/prow/cmd/hook: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/hmac: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
   k8s.io/test-infra/prow/cmd/horologium: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
+  k8s.io/test-infra/prow/cmd/initupload: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/invitations-accepter: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
   k8s.io/test-infra/prow/cmd/jenkins-operator: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/peribolos: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
+  k8s.io/test-infra/prow/cmd/sidecar: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/prow/cmd/sinker: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
   k8s.io/test-infra/prow/cmd/status-reconciler: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
   k8s.io/test-infra/prow/cmd/sub: gcr.io/k8s-prow/git:v20220215-ddc3ad9

--- a/hack/prowimagebuilder/main.go
+++ b/hack/prowimagebuilder/main.go
@@ -48,7 +48,7 @@ const (
 	defaultRetry = 3
 
 	// noOpKoDocerRepo is used when images are not pushed
-	noOpKoDocerRepo = "do.not/matter/at/all"
+	noOpKoDocerRepo = "ko.local"
 )
 
 var (

--- a/hack/prowimagebuilder/main.go
+++ b/hack/prowimagebuilder/main.go
@@ -25,8 +25,10 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"context"
 
@@ -44,8 +46,7 @@ const (
 	defaultProwImageListFile = "prow/.prow-images.yaml"
 
 	defaultWorkersCount = 10
-
-	defaultRetry = 3
+	defaultRetry        = 3
 
 	// noOpKoDocerRepo is used when images are not pushed
 	noOpKoDocerRepo = "ko.local"
@@ -242,6 +243,12 @@ func main() {
 	}
 	if err := os.Setenv("KO_DOCKER_REPO", o.koDockerRepo); err != nil {
 		logrus.WithError(err).Error("Failed setting KO_DOCKER_REPO")
+		os.Exit(1)
+	}
+	// By default ensures timestamp of images, ref:
+	// https://github.com/google/ko#why-are-my-images-all-created-in-1970
+	if err := os.Setenv("SOURCE_DATE_EPOCH", strconv.Itoa(int(time.Now().Unix()))); err != nil {
+		logrus.WithError(err).Error("Failed setting SOURCE_DATE_EPOCH")
 		os.Exit(1)
 	}
 

--- a/prow/.prow-images.yaml
+++ b/prow/.prow-images.yaml
@@ -25,6 +25,15 @@ images:
   - dir: prow/cmd/tot
   - dir: prow/cmd/pipeline
   - dir: prow/cmd/prow-controller-manager
+  # pod utils
+  - dir: prow/cmd/clonerefs
+    arch: all
+  - dir: prow/cmd/entrypoint
+    arch: all
+  - dir: prow/cmd/initupload
+    arch: all
+  - dir: prow/cmd/sidecar
+    arch: all
   - dir: prow/external-plugins/needs-rebase
   - dir: prow/external-plugins/cherrypicker
   - dir: prow/external-plugins/refresh

--- a/prow/Makefile
+++ b/prow/Makefile
@@ -21,8 +21,8 @@ PROW_IMAGES ?=
 
 .PHONY: push-images
 push-images:
-	../hack/make-rules/go-run/arbitrary.sh run ./hack/prowimagebuilder --ko-docker-repo="${REGISTRY}" --push
+	../hack/make-rules/go-run/arbitrary.sh run ./hack/prowimagebuilder --ko-docker-repo="${REGISTRY}" --push=true
 
 .PHONY: build-images
 build-images:
-	../hack/make-rules/go-run/arbitrary.sh run ./hack/prowimagebuilder --push=false
+	../hack/make-rules/go-run/arbitrary.sh run ./hack/prowimagebuilder --ko-docker-repo="ko.local" --push=false

--- a/prow/cmd/entrypoint/main_test.go
+++ b/prow/cmd/entrypoint/main_test.go
@@ -38,10 +38,7 @@ func TestCopy(t *testing.T) {
 		},
 	}
 
-	srcDir, err := ioutil.TempDir("", "test-prow-entrypoint-main")
-	if err != nil {
-		t.Fatalf("Failed preparing temp dir: %v", err)
-	}
+	srcDir := t.TempDir()
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {

--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -508,6 +508,18 @@ func CloneRefs(pj prowapi.ProwJob, codeMount, logMount coreapi.VolumeMount) (*co
 	return &container, refs, cloneVolumes, nil
 }
 
+// binaryPathBasedOnImage figures out the path of binary inside the image.
+// Historically images built with bazel bin placed binaries at root level,
+// this is not the case for images built with `ko`, the binaries are placed
+// under `/ko-app`. For backward compatibility dynamically configures binary
+// path based on image tag, to use this feature the tag must have `-ko` postfix.
+func binaryPathBasedOnImage(binaryPath, image string) string {
+	if strings.HasSuffix(image, "-ko") {
+		binaryPath = "/ko-app" + binaryPath
+	}
+	return binaryPath
+}
+
 func processLog(log coreapi.VolumeMount, prefix string) string {
 	if prefix == "" {
 		return filepath.Join(log.MountPath, "process-log.txt")

--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -508,18 +508,6 @@ func CloneRefs(pj prowapi.ProwJob, codeMount, logMount coreapi.VolumeMount) (*co
 	return &container, refs, cloneVolumes, nil
 }
 
-// binaryPathBasedOnImage figures out the path of binary inside the image.
-// Historically images built with bazel bin placed binaries at root level,
-// this is not the case for images built with `ko`, the binaries are placed
-// under `/ko-app`. For backward compatibility dynamically configures binary
-// path based on image tag, to use this feature the tag must have `-ko` postfix.
-func binaryPathBasedOnImage(binaryPath, image string) string {
-	if strings.HasSuffix(image, "-ko") {
-		binaryPath = "/ko-app" + binaryPath
-	}
-	return binaryPath
-}
-
 func processLog(log coreapi.VolumeMount, prefix string) string {
 	if prefix == "" {
 		return filepath.Join(log.MountPath, "process-log.txt")


### PR DESCRIPTION
Now that the git base image contains default github fingerprint, all pod utils images can be built with ko

/cc @cjwagner 