### PR TITLE
capdo: add job for e2e k8s upgrade tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
@@ -116,6 +116,8 @@ presubmits:
         env:
           - name: GINKGO_FOCUS
             value: "Cluster API E2E tests"
+          - name: GINKGO_SKIP
+            value: "\\[K8s-Upgrade\\]|API Version Upgrade"
         securityContext:
           privileged: true
         resources:
@@ -125,6 +127,38 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
       testgrid-tab-name: capdo-pr-capi-e2e
+  - name: pull-cluster-api-provider-digitalocean-e2e-workload-upgrade
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-do-credential: "true"
+    path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
+    branches:
+    - ^main$
+    always_run: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220214-0aa8fe1d3a-1.23
+          args:
+            - runner.sh
+            - "./scripts/ci-e2e.sh"
+          env:
+            - name: GINKGO_FOCUS
+              value: "\\[K8s-Upgrade\\]"
+          # we need privileged mode in order to do docker in docker
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "9000Mi"
+              cpu: 2000m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
+      testgrid-tab-name: capdo-pr-e2e-upgrade
   - name: pull-cluster-api-provider-digitalocean-conformance
     always_run: false
     optional: true


### PR DESCRIPTION
- capdo: add job for e2e k8s upgrade tests

Related to https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/pull/302


/assign @timoreimann @MorrisLaw @prksu 