### PR TITLE
Add cluster upgrade tests (1.19.6-1.20.3) for CAPA

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
@@ -40,6 +40,50 @@ periodics:
     testgrid-tab-name: periodic-e2e-main
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
+- name: periodic-cluster-api-provider-aws-e2e-upgrade-1-19-1-20-main
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  interval: 24h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-aws
+    base_ref: main
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211217-ea95cec1d4-1.23
+      args:
+        - "runner.sh"
+        - "./scripts/ci-e2e.sh"
+      env:
+      - name: BOSKOS_HOST
+        value: "boskos.test-pods.svc.cluster.local"
+      - name: AWS_REGION
+        value: "us-west-2"
+      - name: KUBERNETES_VERSION_UPGRADE_FROM
+        value: "1.19.6"
+      - nme: KUBERNETES_VERSION_UPGRADE_TO
+        value: "1.20.3"
+      - name: GINKGO_FOCUS
+        value: "\\[K8s-Upgrade\\]"
+    securityContext:
+      privileged: true
+    resources:
+      requests:
+        cpu: 2
+        memory: "9Gi"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+    testgrid-tab-name: periodic-e2e-main
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-provider-aws-eks-e2e
   decorate: true
   decoration_config:


### PR DESCRIPTION
This PR adds a periodics for cluster upgrade test for CAPA.

Signed-off-by: Rayan Das <rayandas91@gmail.com>

Fixes: https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/3087