### PR TITLE
Add apidiff to CAPA pre-submit jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -16,6 +16,25 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
       testgrid-tab-name: pr-test
+  - name: pull-cluster-api-provider-aws-apidiff-main
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-aws
+    always_run: true
+    optional: true
+    labels:
+      preset-service-account: "true"
+    branches:
+    # The script this job runs is not in all branches.
+    - ^main$
+    spec:
+      containers:
+      - command:
+        - runner.sh
+        - ./scripts/ci-apidiff.sh
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220214-0aa8fe1d3a-master
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+      testgrid-tab-name: pr-apidiff-main
   - name: pull-cluster-api-provider-aws-build
     always_run: true
     optional: false


### PR DESCRIPTION
Signed-off-by: Meghana Jangi mjangi@vmware.com

This PR adds a pre-submit job for apidiff to CAPA, similar to [this one](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml#L21-L39).

[Parent issue in CAPA repo](https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/3169).

Fixes #25292 