### PR TITLE
Update jobs to use containerd 1.6.0

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -285,7 +285,7 @@ presubmits:
             - --
             - --build=quick
             - --cluster=
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0-rc.3
+            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0
             - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -344,7 +344,7 @@ presubmits:
             - --
             - --build=quick
             - --cluster=
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0-rc.3
+            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0
             - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -474,7 +474,7 @@ periodics:
           - --scenario=kubernetes_e2e
           - --
           - --check-leaked-resources
-          - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0-rc.3
+          - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0
           - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
           - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
           - --env=CONTAINER_RUNTIME_TEST_HANDLER=true

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -37,7 +37,7 @@ presubmits:
         - --build=quick
         - --extract=local
         - --env=ALLOW_PRIVILEGED=true
-        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0-rc.3
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0
         - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -104,7 +104,7 @@ presubmits:
         - --env=ALLOW_PRIVILEGED=true
         - --env=NETWORK_POLICY_PROVIDER=calico
         - --env=KUBE_FEATURE_GATES=NetworkPolicyEndPort=true
-        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0-rc.3
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0
         - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -173,7 +173,7 @@ presubmits:
         args:
         - --build=quick
         - --env=ALLOW_PRIVILEGED=true
-        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0-rc.3
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0
         - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -680,7 +680,7 @@ periodics:
       - --env=ALLOW_PRIVILEGED=true
       - --env=NETWORK_POLICY_PROVIDER=calico
       - --env=KUBE_FEATURE_GATES=NetworkPolicyEndPort=true
-      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0-rc.3
+      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0
       - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
       - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
       - --env=CONTAINER_RUNTIME_TEST_HANDLER=true

--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -181,8 +181,8 @@ presubmits:
         - --gcp-node-image=ubuntu
         - --image-family=ubuntu-2004-lts
         - --image-project=ubuntu-os-cloud
-        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.9
-        - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.3
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0
+        - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
         - --gcp-zone=us-west1-b
         - --provider=gce
         - --ginkgo-parallel=30
@@ -227,8 +227,8 @@ presubmits:
         - --gcp-node-image=ubuntu
         - --image-family=ubuntu-2004-lts
         - --image-project=ubuntu-os-cloud
-        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.9
-        - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.3
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0
+        - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
         - --gcp-zone=us-west1-b
         - --provider=gce
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-iscsi-serial
@@ -300,8 +300,8 @@ periodics:
       - --gcp-node-image=ubuntu
       - --image-family=ubuntu-2004-lts
       - --image-project=ubuntu-os-cloud
-      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.9
-      - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.3
+      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0
+      - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
       - --gcp-zone=us-west1-b
       - --provider=gce
       - --ginkgo-parallel=30
@@ -327,8 +327,8 @@ periodics:
       - --gcp-node-image=ubuntu
       - --image-family=ubuntu-2004-lts
       - --image-project=ubuntu-os-cloud
-      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.5.9
-      - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.3
+      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0
+      - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
       - --gcp-zone=us-west1-b
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Driver:.iscsi\].*(\[Serial\]|\[Disruptive\]) --ginkgo.skip=\[Flaky\] --minStartupPods=8


### PR DESCRIPTION
containerd 1.6.0 was released 🎉 

Release Notes: https://github.com/containerd/containerd/releases/tag/v1.6.0