### PR TITLE
Clonerefs, initupload, sidecar images use default entrypoints

### DIFF
--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -266,11 +266,10 @@ func CloneLogPath(logMount coreapi.VolumeMount) string {
 
 // Exposed for testing
 const (
-	entrypointName   = "place-entrypoint"
-	initUploadName   = "initupload"
-	sidecarName      = "sidecar"
-	cloneRefsName    = "clonerefs"
-	cloneRefsCommand = "/clonerefs"
+	entrypointName = "place-entrypoint"
+	initUploadName = "initupload"
+	sidecarName    = "sidecar"
+	cloneRefsName  = "clonerefs"
 )
 
 // cloneEnv encodes clonerefs Options into json and puts it into an environment variable
@@ -498,7 +497,6 @@ func CloneRefs(pj prowapi.ProwJob, codeMount, logMount coreapi.VolumeMount) (*co
 	container := coreapi.Container{
 		Name:         cloneRefsName,
 		Image:        pj.Spec.DecorationConfig.UtilityImages.CloneRefs,
-		Command:      []string{cloneRefsCommand},
 		Args:         cloneArgs,
 		Env:          env,
 		VolumeMounts: append([]coreapi.VolumeMount{logMount, codeMount}, cloneMounts...),
@@ -652,9 +650,8 @@ func InitUpload(config *prowapi.DecorationConfig, gcsOptions gcsupload.Options, 
 		return nil, fmt.Errorf("could not encode initupload configuration as JSON: %w", err)
 	}
 	container := &coreapi.Container{
-		Name:    initUploadName,
-		Image:   config.UtilityImages.InitUpload,
-		Command: []string{"/initupload"}, // TODO(fejta): remove this, use image's entrypoint and delete /initupload symlink
+		Name:  initUploadName,
+		Image: config.UtilityImages.InitUpload,
 		Env: KubeEnv(map[string]string{
 			downwardapi.JobSpecEnv:      encodedJobSpec,
 			initupload.JSONConfigEnvVar: initUploadConfigEnv,
@@ -887,9 +884,8 @@ func Sidecar(config *prowapi.DecorationConfig, gcsOptions gcsupload.Options, blo
 	}
 
 	container := &coreapi.Container{
-		Name:    sidecarName,
-		Image:   config.UtilityImages.Sidecar,
-		Command: []string{"/sidecar"}, // TODO(fejta): remove, use image's entrypoint
+		Name:  sidecarName,
+		Image: config.UtilityImages.Sidecar,
 		Env: KubeEnv(map[string]string{
 			sidecar.JSONConfigEnvVar: sidecarConfigEnv,
 			downwardapi.JobSpecEnv:   encodedJobSpec, // TODO: shouldn't need this?

--- a/prow/pod-utils/decorate/podspec_test.go
+++ b/prow/pod-utils/decorate/podspec_test.go
@@ -202,8 +202,7 @@ func TestCloneRefs(t *testing.T) {
 				},
 			},
 			expected: &coreapi.Container{
-				Name:    cloneRefsName,
-				Command: []string{cloneRefsCommand},
+				Name: cloneRefsName,
 				Env: envOrDie(clonerefs.Options{
 					GitRefs:            []prowapi.Refs{{}},
 					GitUserEmail:       clonerefs.DefaultGitUserEmail,
@@ -227,8 +226,7 @@ func TestCloneRefs(t *testing.T) {
 				},
 			},
 			expected: &coreapi.Container{
-				Name:    cloneRefsName,
-				Command: []string{cloneRefsCommand},
+				Name: cloneRefsName,
 				Env: envOrDie(clonerefs.Options{
 					GitRefs:            []prowapi.Refs{{}},
 					GitUserEmail:       clonerefs.DefaultGitUserEmail,
@@ -253,8 +251,7 @@ func TestCloneRefs(t *testing.T) {
 				},
 			},
 			expected: &coreapi.Container{
-				Name:    cloneRefsName,
-				Command: []string{cloneRefsCommand},
+				Name: cloneRefsName,
 				Env: envOrDie(clonerefs.Options{
 					GitRefs:            []prowapi.Refs{{Org: "first"}, {Org: "second"}, {Org: "third"}},
 					GitUserEmail:       clonerefs.DefaultGitUserEmail,
@@ -279,8 +276,7 @@ func TestCloneRefs(t *testing.T) {
 				},
 			},
 			expected: &coreapi.Container{
-				Name:    cloneRefsName,
-				Command: []string{cloneRefsCommand},
+				Name: cloneRefsName,
 				Env: envOrDie(clonerefs.Options{
 					GitRefs:            []prowapi.Refs{{}},
 					GitUserEmail:       clonerefs.DefaultGitUserEmail,
@@ -312,8 +308,7 @@ func TestCloneRefs(t *testing.T) {
 				},
 			},
 			expected: &coreapi.Container{
-				Name:    cloneRefsName,
-				Command: []string{cloneRefsCommand},
+				Name: cloneRefsName,
 				Env: envOrDie(clonerefs.Options{
 					GitRefs:            []prowapi.Refs{{}},
 					GitUserEmail:       clonerefs.DefaultGitUserEmail,
@@ -339,9 +334,8 @@ func TestCloneRefs(t *testing.T) {
 				},
 			},
 			expected: &coreapi.Container{
-				Name:    cloneRefsName,
-				Command: []string{cloneRefsCommand},
-				Args:    []string{"--cookiefile=" + cookiePathOnly("oatmeal")},
+				Name: cloneRefsName,
+				Args: []string{"--cookiefile=" + cookiePathOnly("oatmeal")},
 				Env: envOrDie(clonerefs.Options{
 					CookiePath:         cookiePathOnly("oatmeal"),
 					GitRefs:            []prowapi.Refs{{}},
@@ -367,8 +361,7 @@ func TestCloneRefs(t *testing.T) {
 				},
 			},
 			expected: &coreapi.Container{
-				Name:    cloneRefsName,
-				Command: []string{cloneRefsCommand},
+				Name: cloneRefsName,
 				Env: envOrDie(clonerefs.Options{
 					GitRefs:            []prowapi.Refs{{}},
 					GitUserEmail:       clonerefs.DefaultGitUserEmail,
@@ -396,8 +389,7 @@ func TestCloneRefs(t *testing.T) {
 				},
 			},
 			expected: &coreapi.Container{
-				Name:    cloneRefsName,
-				Command: []string{cloneRefsCommand},
+				Name: cloneRefsName,
 				Env: envOrDie(clonerefs.Options{
 					GitRefs:            []prowapi.Refs{{}},
 					GitUserEmail:       clonerefs.DefaultGitUserEmail,
@@ -445,8 +437,7 @@ func TestCloneRefs(t *testing.T) {
 				},
 			},
 			expected: &coreapi.Container{
-				Name:    cloneRefsName,
-				Command: []string{cloneRefsCommand},
+				Name: cloneRefsName,
 				Env: envOrDie(clonerefs.Options{
 					GitRefs:                 []prowapi.Refs{{}},
 					GitUserEmail:            clonerefs.DefaultGitUserEmail,
@@ -500,8 +491,7 @@ func TestCloneRefs(t *testing.T) {
 				},
 			},
 			expected: &coreapi.Container{
-				Name:    cloneRefsName,
-				Command: []string{cloneRefsCommand},
+				Name: cloneRefsName,
 				Env: envOrDie(clonerefs.Options{
 					GitRefs:                 []prowapi.Refs{{}},
 					GitUserEmail:            clonerefs.DefaultGitUserEmail,

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_1.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_1.yaml
@@ -70,9 +70,7 @@ spec:
     - mountPath: /home/prow/go
       name: code
     workingDir: /home/prow/go/src/somewhere/else
-  - command:
-    - /sidecar
-    env:
+  - env:
     - name: JOB_SPEC
       value: '{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"},"decoration_config":{"timeout":"2h0m0s","grace_period":"10s","utility_images":{"clonerefs":"clonerefs:tag","initupload":"initupload:tag","entrypoint":"entrypoint:tag","sidecar":"sidecar:tag"},"gcs_configuration":{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","mediaTypes":{"log":"text/plain"}},"gcs_credentials_secret":"secret-name","cookiefile_secret":"yummy/.gitcookies"}}'
     - name: SIDECAR_OPTIONS
@@ -89,8 +87,6 @@ spec:
   initContainers:
   - args:
     - --cookiefile=/secrets/cookiefile/.gitcookies
-    command:
-    - /clonerefs
     env:
     - name: CLONEREFS_OPTIONS
       value: '{"src_root":"/home/prow/go","log":"/logs/clone.json","git_user_name":"ci-robot","git_user_email":"ci-robot@k8s.io","refs":[{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}],"cookie_path":"/secrets/cookiefile/.gitcookies","github_api_endpoints":["https://api.github.com"]}'
@@ -108,9 +104,7 @@ spec:
     - mountPath: /secrets/cookiefile
       name: cookiefile
       readOnly: true
-  - command:
-    - /initupload
-    env:
+  - env:
     - name: INITUPLOAD_OPTIONS
       value: '{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","mediaTypes":{"log":"text/plain"},"gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false,"log":"/logs/clone.json"}'
     - name: JOB_SPEC

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_2.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_2.yaml
@@ -70,9 +70,7 @@ spec:
     - mountPath: /home/prow/go
       name: code
     workingDir: /home/prow/go/src/somewhere/else
-  - command:
-    - /sidecar
-    env:
+  - env:
     - name: JOB_SPEC
       value: '{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"},"decoration_config":{"timeout":"2h0m0s","grace_period":"10s","utility_images":{"clonerefs":"clonerefs:tag","initupload":"initupload:tag","entrypoint":"entrypoint:tag","sidecar":"sidecar:tag"},"gcs_configuration":{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes"},"gcs_credentials_secret":"secret-name","cookiefile_secret":"yummy"}}'
     - name: SIDECAR_OPTIONS
@@ -89,8 +87,6 @@ spec:
   initContainers:
   - args:
     - --cookiefile=/secrets/cookiefile/yummy
-    command:
-    - /clonerefs
     env:
     - name: CLONEREFS_OPTIONS
       value: '{"src_root":"/home/prow/go","log":"/logs/clone.json","git_user_name":"ci-robot","git_user_email":"ci-robot@k8s.io","refs":[{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}],"cookie_path":"/secrets/cookiefile/yummy","github_api_endpoints":["https://api.github.com"]}'
@@ -108,9 +104,7 @@ spec:
     - mountPath: /secrets/cookiefile
       name: cookiefile
       readOnly: true
-  - command:
-    - /initupload
-    env:
+  - env:
     - name: INITUPLOAD_OPTIONS
       value: '{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false,"log":"/logs/clone.json"}'
     - name: JOB_SPEC

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_3.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_3.yaml
@@ -70,9 +70,7 @@ spec:
     - mountPath: /home/prow/go
       name: code
     workingDir: /home/prow/go/src/somewhere/else
-  - command:
-    - /sidecar
-    env:
+  - env:
     - name: JOB_SPEC
       value: '{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"},"decoration_config":{"timeout":"2h0m0s","grace_period":"10s","utility_images":{"clonerefs":"clonerefs:tag","initupload":"initupload:tag","entrypoint":"entrypoint:tag","sidecar":"sidecar:tag"},"gcs_configuration":{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes"},"gcs_credentials_secret":"secret-name","ssh_key_secrets":["ssh-1","ssh-2"],"ssh_host_fingerprints":["hello","world"]}}'
     - name: SIDECAR_OPTIONS
@@ -87,9 +85,7 @@ spec:
     - mountPath: /secrets/gcs
       name: gcs-credentials
   initContainers:
-  - command:
-    - /clonerefs
-    env:
+  - env:
     - name: CLONEREFS_OPTIONS
       value: '{"src_root":"/home/prow/go","log":"/logs/clone.json","git_user_name":"ci-robot","git_user_email":"ci-robot@k8s.io","refs":[{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}],"key_files":["/secrets/ssh/ssh-1","/secrets/ssh/ssh-2"],"host_fingerprints":["hello","world"],"github_api_endpoints":["https://api.github.com"]}'
     image: clonerefs:tag
@@ -109,9 +105,7 @@ spec:
       readOnly: true
     - mountPath: /tmp
       name: clonerefs-tmp
-  - command:
-    - /initupload
-    env:
+  - env:
     - name: INITUPLOAD_OPTIONS
       value: '{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false,"log":"/logs/clone.json"}'
     - name: JOB_SPEC

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_4.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_4.yaml
@@ -70,9 +70,7 @@ spec:
     - mountPath: /home/prow/go
       name: code
     workingDir: /home/prow/go/src/somewhere/else
-  - command:
-    - /sidecar
-    env:
+  - env:
     - name: JOB_SPEC
       value: '{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"},"decoration_config":{"timeout":"2h0m0s","grace_period":"10s","utility_images":{"clonerefs":"clonerefs:tag","initupload":"initupload:tag","entrypoint":"entrypoint:tag","sidecar":"sidecar:tag"},"gcs_configuration":{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes"},"gcs_credentials_secret":"secret-name","ssh_key_secrets":["ssh-1","ssh-2"]}}'
     - name: SIDECAR_OPTIONS
@@ -87,9 +85,7 @@ spec:
     - mountPath: /secrets/gcs
       name: gcs-credentials
   initContainers:
-  - command:
-    - /clonerefs
-    env:
+  - env:
     - name: CLONEREFS_OPTIONS
       value: '{"src_root":"/home/prow/go","log":"/logs/clone.json","git_user_name":"ci-robot","git_user_email":"ci-robot@k8s.io","refs":[{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}],"key_files":["/secrets/ssh/ssh-1","/secrets/ssh/ssh-2"],"github_api_endpoints":["https://api.github.com"]}'
     image: clonerefs:tag
@@ -109,9 +105,7 @@ spec:
       readOnly: true
     - mountPath: /tmp
       name: clonerefs-tmp
-  - command:
-    - /initupload
-    env:
+  - env:
     - name: INITUPLOAD_OPTIONS
       value: '{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false,"log":"/logs/clone.json"}'
     - name: JOB_SPEC

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_5.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_5.yaml
@@ -49,9 +49,7 @@ spec:
       name: logs
     - mountPath: /tools
       name: tools
-  - command:
-    - /sidecar
-    env:
+  - env:
     - name: JOB_SPEC
       value: '{"type":"periodic","job":"job-name","buildid":"blabla","prowjobid":"pod","decoration_config":{"timeout":"2h0m0s","grace_period":"10s","utility_images":{"clonerefs":"clonerefs:tag","initupload":"initupload:tag","entrypoint":"entrypoint:tag","sidecar":"sidecar:tag"},"gcs_configuration":{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes"},"gcs_credentials_secret":"secret-name","ssh_key_secrets":["ssh-1","ssh-2"]}}'
     - name: SIDECAR_OPTIONS
@@ -66,9 +64,7 @@ spec:
     - mountPath: /secrets/gcs
       name: gcs-credentials
   initContainers:
-  - command:
-    - /initupload
-    env:
+  - env:
     - name: INITUPLOAD_OPTIONS
       value: '{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false}'
     - name: JOB_SPEC

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_6.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_6.yaml
@@ -67,9 +67,7 @@ spec:
       name: logs
     - mountPath: /tools
       name: tools
-  - command:
-    - /sidecar
-    env:
+  - env:
     - name: JOB_SPEC
       value: '{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"},"extra_refs":[{"org":"extra-org","repo":"extra-repo"}],"decoration_config":{"timeout":"2h0m0s","grace_period":"10s","utility_images":{"clonerefs":"clonerefs:tag","initupload":"initupload:tag","entrypoint":"entrypoint:tag","sidecar":"sidecar:tag"},"gcs_configuration":{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes"},"gcs_credentials_secret":"secret-name","ssh_key_secrets":["ssh-1","ssh-2"],"skip_cloning":true}}'
     - name: SIDECAR_OPTIONS
@@ -84,9 +82,7 @@ spec:
     - mountPath: /secrets/gcs
       name: gcs-credentials
   initContainers:
-  - command:
-    - /initupload
-    env:
+  - env:
     - name: INITUPLOAD_OPTIONS
       value: '{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false}'
     - name: JOB_SPEC

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_7.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_7.yaml
@@ -121,9 +121,7 @@ spec:
     - mountPath: /home/prow/go
       name: code
     workingDir: /home/prow/go/src/somewhere/else
-  - command:
-    - /sidecar
-    env:
+  - env:
     - name: JOB_SPEC
       value: '{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"},"extra_refs":[{"org":"extra-org","repo":"extra-repo"}],"decoration_config":{"timeout":"2h0m0s","grace_period":"10s","utility_images":{"clonerefs":"clonerefs:tag","initupload":"initupload:tag","entrypoint":"entrypoint:tag","sidecar":"sidecar:tag"},"gcs_configuration":{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes"},"gcs_credentials_secret":"secret-name","ssh_key_secrets":["ssh-1","ssh-2"],"cookiefile_secret":"yummy"}}'
     - name: SIDECAR_OPTIONS
@@ -140,8 +138,6 @@ spec:
   initContainers:
   - args:
     - --cookiefile=/secrets/cookiefile/yummy
-    command:
-    - /clonerefs
     env:
     - name: CLONEREFS_OPTIONS
       value: '{"src_root":"/home/prow/go","log":"/logs/clone.json","git_user_name":"ci-robot","git_user_email":"ci-robot@k8s.io","refs":[{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"},{"org":"extra-org","repo":"extra-repo"}],"key_files":["/secrets/ssh/ssh-1","/secrets/ssh/ssh-2"],"cookie_path":"/secrets/cookiefile/yummy","github_api_endpoints":["https://api.github.com"]}'
@@ -165,9 +161,7 @@ spec:
     - mountPath: /secrets/cookiefile
       name: cookiefile
       readOnly: true
-  - command:
-    - /initupload
-    env:
+  - env:
     - name: INITUPLOAD_OPTIONS
       value: '{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false,"log":"/logs/clone.json"}'
     - name: JOB_SPEC

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_8.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_8.yaml
@@ -70,9 +70,7 @@ spec:
     - mountPath: /home/prow/go
       name: code
     workingDir: /home/prow/go/src/somewhere/else
-  - command:
-    - /sidecar
-    env:
+  - env:
     - name: JOB_SPEC
       value: '{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"},"decoration_config":{"timeout":"2h0m0s","grace_period":"10s","utility_images":{"clonerefs":"clonerefs:tag","initupload":"initupload:tag","entrypoint":"entrypoint:tag","sidecar":"sidecar:tag"},"gcs_configuration":{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","mediaTypes":{"log":"text/plain"}},"default_service_account_name":"default-SA","cookiefile_secret":"yummy/.gitcookies"}}'
     - name: SIDECAR_OPTIONS
@@ -87,8 +85,6 @@ spec:
   initContainers:
   - args:
     - --cookiefile=/secrets/cookiefile/.gitcookies
-    command:
-    - /clonerefs
     env:
     - name: CLONEREFS_OPTIONS
       value: '{"src_root":"/home/prow/go","log":"/logs/clone.json","git_user_name":"ci-robot","git_user_email":"ci-robot@k8s.io","refs":[{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}],"cookie_path":"/secrets/cookiefile/.gitcookies","github_api_endpoints":["https://api.github.com"]}'
@@ -106,9 +102,7 @@ spec:
     - mountPath: /secrets/cookiefile
       name: cookiefile
       readOnly: true
-  - command:
-    - /initupload
-    env:
+  - env:
     - name: INITUPLOAD_OPTIONS
       value: '{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","mediaTypes":{"log":"text/plain"},"dry_run":false,"log":"/logs/clone.json"}'
     - name: JOB_SPEC

--- a/prow/pod-utils/decorate/testdata/zz_fixture_TestDecorate_basic_happy_case.yaml
+++ b/prow/pod-utils/decorate/testdata/zz_fixture_TestDecorate_basic_happy_case.yaml
@@ -22,9 +22,7 @@ containers:
   - mountPath: /home/prow/go
     name: code
   workingDir: /home/prow/go/src/github.com/org/repo
-- command:
-  - /sidecar
-  env:
+- env:
   - name: JOB_SPEC
   - name: SIDECAR_OPTIONS
     value: '{"gcs_options":{"items":["/logs/artifacts"],"bucket":"bucket","path_strategy":"single","default_org":"org","default_repo":"repo","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false},"entries":[{"args":["/bin/ls","-l","-a"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"censoring_options":{}}'
@@ -41,9 +39,7 @@ containers:
   - mountPath: /secrets/gcs
     name: gcs-credentials
 initContainers:
-- command:
-  - /clonerefs
-  env:
+- env:
   - name: CLONEREFS_OPTIONS
     value: '{"src_root":"/home/prow/go","log":"/logs/clone.json","git_user_name":"ci-robot","git_user_email":"ci-robot@k8s.io","refs":[{"org":"org","repo":"repo","base_ref":"main","base_sha":"abcd1234","pulls":[{"number":1,"author":"","sha":"aksdjhfkds"}]},{"org":"other","repo":"something","base_ref":"release","base_sha":"sldijfsd"}],"github_api_endpoints":["https://api.github.com"]}'
   image: cloneimage
@@ -60,9 +56,7 @@ initContainers:
     name: code
   - mountPath: /tmp
     name: clonerefs-tmp
-- command:
-  - /initupload
-  env:
+- env:
   - name: INITUPLOAD_OPTIONS
     value: '{"bucket":"bucket","path_strategy":"single","default_org":"org","default_repo":"repo","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false,"log":"/logs/clone.json"}'
   - name: JOB_SPEC

--- a/prow/pod-utils/decorate/testdata/zz_fixture_TestDecorate_censor_secrets_in_sidecar.yaml
+++ b/prow/pod-utils/decorate/testdata/zz_fixture_TestDecorate_censor_secrets_in_sidecar.yaml
@@ -22,9 +22,7 @@ containers:
   - mountPath: /home/prow/go
     name: code
   workingDir: /home/prow/go/src/github.com/org/repo
-- command:
-  - /sidecar
-  env:
+- env:
   - name: JOB_SPEC
   - name: SIDECAR_OPTIONS
     value: '{"gcs_options":{"items":["/logs/artifacts"],"bucket":"bucket","path_strategy":"single","default_org":"org","default_repo":"repo","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false},"entries":[{"args":["/bin/ls","-l","-a"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"censoring_options":{"secret_directories":["/secret"]}}'
@@ -43,9 +41,7 @@ containers:
   - mountPath: /secret
     name: secret
 initContainers:
-- command:
-  - /clonerefs
-  env:
+- env:
   - name: CLONEREFS_OPTIONS
     value: '{"src_root":"/home/prow/go","log":"/logs/clone.json","git_user_name":"ci-robot","git_user_email":"ci-robot@k8s.io","refs":[{"org":"org","repo":"repo","base_ref":"main","base_sha":"abcd1234","pulls":[{"number":1,"author":"","sha":"aksdjhfkds"}]},{"org":"other","repo":"something","base_ref":"release","base_sha":"sldijfsd"}],"github_api_endpoints":["https://api.github.com"]}'
   image: cloneimage
@@ -62,9 +58,7 @@ initContainers:
     name: code
   - mountPath: /tmp
     name: clonerefs-tmp
-- command:
-  - /initupload
-  env:
+- env:
   - name: INITUPLOAD_OPTIONS
     value: '{"bucket":"bucket","path_strategy":"single","default_org":"org","default_repo":"repo","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false,"log":"/logs/clone.json"}'
   - name: JOB_SPEC

--- a/prow/pod-utils/decorate/testdata/zz_fixture_TestDecorate_ignore_interrupts_in_sidecar.yaml
+++ b/prow/pod-utils/decorate/testdata/zz_fixture_TestDecorate_ignore_interrupts_in_sidecar.yaml
@@ -22,9 +22,7 @@ containers:
   - mountPath: /home/prow/go
     name: code
   workingDir: /home/prow/go/src/github.com/org/repo
-- command:
-  - /sidecar
-  env:
+- env:
   - name: JOB_SPEC
   - name: SIDECAR_OPTIONS
     value: '{"gcs_options":{"items":["/logs/artifacts"],"bucket":"bucket","path_strategy":"single","default_org":"org","default_repo":"repo","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false},"entries":[{"args":["/bin/ls","-l","-a"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true,"censoring_options":{}}'
@@ -41,9 +39,7 @@ containers:
   - mountPath: /secrets/gcs
     name: gcs-credentials
 initContainers:
-- command:
-  - /clonerefs
-  env:
+- env:
   - name: CLONEREFS_OPTIONS
     value: '{"src_root":"/home/prow/go","log":"/logs/clone.json","git_user_name":"ci-robot","git_user_email":"ci-robot@k8s.io","refs":[{"org":"org","repo":"repo","base_ref":"main","base_sha":"abcd1234","pulls":[{"number":1,"author":"","sha":"aksdjhfkds"}]},{"org":"other","repo":"something","base_ref":"release","base_sha":"sldijfsd"}],"github_api_endpoints":["https://api.github.com"]}'
   image: cloneimage
@@ -60,9 +56,7 @@ initContainers:
     name: code
   - mountPath: /tmp
     name: clonerefs-tmp
-- command:
-  - /initupload
-  env:
+- env:
   - name: INITUPLOAD_OPTIONS
     value: '{"bucket":"bucket","path_strategy":"single","default_org":"org","default_repo":"repo","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false,"log":"/logs/clone.json"}'
   - name: JOB_SPEC

--- a/prow/pod-utils/decorate/testdata/zz_fixture_TestSidecar_basic_case.yaml
+++ b/prow/pod-utils/decorate/testdata/zz_fixture_TestSidecar_basic_case.yaml
@@ -1,5 +1,3 @@
-command:
-- /sidecar
 env:
 - name: JOB_SPEC
   value: spec

--- a/prow/pod-utils/decorate/testdata/zz_fixture_TestSidecar_with_secrets.yaml
+++ b/prow/pod-utils/decorate/testdata/zz_fixture_TestSidecar_with_secrets.yaml
@@ -1,5 +1,3 @@
-command:
-- /sidecar
 env:
 - name: JOB_SPEC
   value: spec


### PR DESCRIPTION
Currently they are used by explicitly set command as symlink of the real binaries. This is not really necessary, as these images already has entrypoints set to the true paths of the binaries.

I have manually inspected the images from today, as well as the images from one year ago, and confirmed that the entrypoints of these images are set correctly. For example:

```
$ docker inspect gcr.io/k8s-prow/sidecar:v20210215-f94bc1dc87 | grep Entrypoint -A 3
            "Entrypoint": [
                "/app/prow/cmd/sidecar/app.binary"
            ],
            "OnBuild": null,
```

This will partially help unblock the effort of building these images using `ko`, as the binaries are placed at different path in the image

/cc @cjwagner @alvaroaleman @fejta 