### PR TITLE
kops: use k8s.local instead of k8s.io

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
@@ -157,7 +157,7 @@ periodics:
       - name: CLOUD_PROVIDER
         value: "gce"
       - name: CLUSTER_NAME
-        value: "upgrade-leader-migration.test-cncf-gce.k8s.io"
+        value: "upgrade-leader-migration.test-cncf-gce.k8s.local"
       - name: GCE_EXTRA_CREATE_ARGS
         value: --gce-service-account=default
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220216-aa6d36a90c-master


### PR DESCRIPTION
because we want to use gossip DNS, and we do not have access to DNS API anyways.

Setting domain to end with `k8s.local` tells the kops-deployer we want such case.