### PR TITLE
Entrypoint image can run in copy only mode

### DIFF
--- a/prow/cmd/entrypoint/BUILD.bazel
+++ b/prow/cmd/entrypoint/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("//prow:def.bzl", "prow_image")
 
 go_library(
@@ -52,4 +52,11 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["main_test.go"],
+    embed = [":go_default_library"],
+    tags = ["manual"],
 )

--- a/prow/cmd/entrypoint/main_test.go
+++ b/prow/cmd/entrypoint/main_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+)
+
+func TestCopy(t *testing.T) {
+	tests := []struct {
+		name     string
+		fileMode os.FileMode
+	}{
+		{
+			name:     "base",
+			fileMode: 0644,
+		},
+		{
+			name:     "another-mode",
+			fileMode: 0755,
+		},
+	}
+
+	srcDir, err := ioutil.TempDir("", "test-prow-entrypoint-main")
+	if err != nil {
+		t.Fatalf("Failed preparing temp dir: %v", err)
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			src := path.Join(srcDir, tc.name)
+			ioutil.WriteFile(src, []byte(tc.name+"\nsome\nother\ncontent"), tc.fileMode)
+
+			// One level down, for exercising dir creation logic
+			dst := path.Join(srcDir, "dst", tc.name)
+			if err := copy(src, dst); err != nil {
+				t.Fatalf("Failed copying: %v", err)
+			}
+
+			info, err := os.Stat(dst)
+			if err != nil {
+				t.Fatalf("Failed stat %q: %v", dst, err)
+			}
+			if want, got := tc.fileMode, info.Mode(); want != got {
+				t.Errorf("File mode mismatch. Want: %s, got: %s", want, got)
+			}
+
+			gotContent, err := ioutil.ReadFile(dst)
+			if err != nil {
+				t.Fatalf("Failed read %q: %v", dst, err)
+			}
+
+			if want, got := tc.name+"\nsome\nother\ncontent", string(gotContent); want != got {
+				t.Errorf("File content mismatch. Want: %s, got: %s", want, got)
+			}
+		})
+	}
+}

--- a/prow/entrypoint/options.go
+++ b/prow/entrypoint/options.go
@@ -25,6 +25,8 @@ import (
 	"k8s.io/test-infra/prow/pod-utils/wrapper"
 )
 
+const defaultCopyDst = "/tools/entrypoint"
+
 // NewOptions returns an empty Options with no nil fields
 func NewOptions() *Options {
 	return &Options{
@@ -59,6 +61,9 @@ type Options struct {
 	// AlwaysZero will cause entrypoint to exit zero, regardless of the marker it writes.
 	// Primarily useful in case a subsequent entrypoint will read this entrypoint's marker
 	AlwaysZero bool `json:"always_zero,omitempty"`
+
+	CopyModeOnly bool   `json:"copy_mode_only,omitempty"`
+	CopyDst      string `json:"copy_dst,omitempty"`
 
 	*wrapper.Options
 }
@@ -96,6 +101,8 @@ func (o *Options) AddFlags(flags *flag.FlagSet) {
 	flags.DurationVar(&o.Timeout, "timeout", DefaultTimeout, "Timeout for the test command.")
 	flags.DurationVar(&o.GracePeriod, "grace-period", DefaultGracePeriod, "Grace period after timeout for the test command.")
 	flags.StringVar(&o.ArtifactDir, "artifact-dir", "", "directory where test artifacts should be placed for upload to persistent storage")
+	flags.BoolVar(&o.CopyModeOnly, "copy-mode-only", false, "If true, copy current binary to /tools/entrypoint, dst can be overridden by --copy-destination")
+	flags.StringVar(&o.CopyDst, "copy-destination", defaultCopyDst, "Must be used with --copy-mode-only, default is /tools/entrypoint")
 	o.Options.AddFlags(flags)
 }
 

--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -572,8 +572,7 @@ func PlaceEntrypoint(config *prowapi.DecorationConfig, toolsMount coreapi.Volume
 	container := coreapi.Container{
 		Name:         entrypointName,
 		Image:        config.UtilityImages.Entrypoint,
-		Command:      []string{"/bin/cp"},
-		Args:         []string{"/entrypoint", entrypointLocation(toolsMount)},
+		Args:         []string{"--copy-mode-only"},
 		VolumeMounts: []coreapi.VolumeMount{toolsMount},
 	}
 	if config.Resources != nil && config.Resources.PlaceEntrypoint != nil {

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_1.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_1.yaml
@@ -119,10 +119,7 @@ spec:
     - mountPath: /secrets/gcs
       name: gcs-credentials
   - args:
-    - /entrypoint
-    - /tools/entrypoint
-    command:
-    - /bin/cp
+    - --copy-mode-only
     image: entrypoint:tag
     name: place-entrypoint
     resources: {}

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_2.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_2.yaml
@@ -119,10 +119,7 @@ spec:
     - mountPath: /secrets/gcs
       name: gcs-credentials
   - args:
-    - /entrypoint
-    - /tools/entrypoint
-    command:
-    - /bin/cp
+    - --copy-mode-only
     image: entrypoint:tag
     name: place-entrypoint
     resources: {}

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_3.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_3.yaml
@@ -120,10 +120,7 @@ spec:
     - mountPath: /secrets/gcs
       name: gcs-credentials
   - args:
-    - /entrypoint
-    - /tools/entrypoint
-    command:
-    - /bin/cp
+    - --copy-mode-only
     image: entrypoint:tag
     name: place-entrypoint
     resources: {}

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_4.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_4.yaml
@@ -120,10 +120,7 @@ spec:
     - mountPath: /secrets/gcs
       name: gcs-credentials
   - args:
-    - /entrypoint
-    - /tools/entrypoint
-    command:
-    - /bin/cp
+    - --copy-mode-only
     image: entrypoint:tag
     name: place-entrypoint
     resources: {}

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_5.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_5.yaml
@@ -77,10 +77,7 @@ spec:
     - mountPath: /secrets/gcs
       name: gcs-credentials
   - args:
-    - /entrypoint
-    - /tools/entrypoint
-    command:
-    - /bin/cp
+    - --copy-mode-only
     image: entrypoint:tag
     name: place-entrypoint
     resources: {}

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_6.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_6.yaml
@@ -95,10 +95,7 @@ spec:
     - mountPath: /secrets/gcs
       name: gcs-credentials
   - args:
-    - /entrypoint
-    - /tools/entrypoint
-    command:
-    - /bin/cp
+    - --copy-mode-only
     image: entrypoint:tag
     name: place-entrypoint
     resources: {}

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_7.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_7.yaml
@@ -176,10 +176,7 @@ spec:
     - mountPath: /secrets/gcs
       name: gcs-credentials
   - args:
-    - /entrypoint
-    - /tools/entrypoint
-    command:
-    - /bin/cp
+    - --copy-mode-only
     image: entrypoint:tag
     name: place-entrypoint
     resources: {}

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_8.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_8.yaml
@@ -115,10 +115,7 @@ spec:
     - mountPath: /logs
       name: logs
   - args:
-    - /entrypoint
-    - /tools/entrypoint
-    command:
-    - /bin/cp
+    - --copy-mode-only
     image: entrypoint:tag
     name: place-entrypoint
     resources: {}

--- a/prow/pod-utils/decorate/testdata/zz_fixture_TestDecorate_basic_happy_case.yaml
+++ b/prow/pod-utils/decorate/testdata/zz_fixture_TestDecorate_basic_happy_case.yaml
@@ -73,10 +73,7 @@ initContainers:
   - mountPath: /secrets/gcs
     name: gcs-credentials
 - args:
-  - /entrypoint
-  - /tools/entrypoint
-  command:
-  - /bin/cp
+  - --copy-mode-only
   image: entrypointimage
   name: place-entrypoint
   resources:

--- a/prow/pod-utils/decorate/testdata/zz_fixture_TestDecorate_censor_secrets_in_sidecar.yaml
+++ b/prow/pod-utils/decorate/testdata/zz_fixture_TestDecorate_censor_secrets_in_sidecar.yaml
@@ -75,10 +75,7 @@ initContainers:
   - mountPath: /secrets/gcs
     name: gcs-credentials
 - args:
-  - /entrypoint
-  - /tools/entrypoint
-  command:
-  - /bin/cp
+  - --copy-mode-only
   image: entrypointimage
   name: place-entrypoint
   resources:

--- a/prow/pod-utils/decorate/testdata/zz_fixture_TestDecorate_ignore_interrupts_in_sidecar.yaml
+++ b/prow/pod-utils/decorate/testdata/zz_fixture_TestDecorate_ignore_interrupts_in_sidecar.yaml
@@ -73,10 +73,7 @@ initContainers:
   - mountPath: /secrets/gcs
     name: gcs-credentials
 - args:
-  - /entrypoint
-  - /tools/entrypoint
-  command:
-  - /bin/cp
+  - --copy-mode-only
   image: entrypointimage
   name: place-entrypoint
   resources:


### PR DESCRIPTION
Currently entrypoint container runs `cp /entrypoint /tools/entrypoint` in a prow job, which is the last prow image that cannot use binary as entrypoint. Adding a copy mode so that entrypoint container can use the binary as entrypoint.

Note that this is a workaround, but it should not be worse than the workaround of running cp from the container

Following @alvaroaleman 's creative idea from https://github.com/kubernetes/test-infra/pull/25281#issuecomment-1041918936

/cc @alvaroaleman @cjwagner 