### PR TITLE
kops: gce test: shorten cluster name.

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
@@ -157,7 +157,7 @@ periodics:
       - name: CLOUD_PROVIDER
         value: "gce"
       - name: CLUSTER_NAME
-        value: "upgrade-leader-migration.test-cncf-gce.k8s.local"
+        value: "ha-migration.k8s.local"
       - name: GCE_EXTRA_CREATE_ARGS
         value: --gce-service-account=default
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220216-aa6d36a90c-master


### PR DESCRIPTION
gcp has limit on resource names: Must be a match of regex '[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?|[1-9][0-9]{0,19}

This PR shortens cluster name, and thus resource names, to match the said regex.