### PR TITLE
cluster-api: add sbueringer to job approvers/reviewers

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api/OWNERS
@@ -7,6 +7,7 @@ reviewers:
 - fabriziopandini
 - JoelSpeed
 - justinsb
+- sbueringer
 - timothysc
 - vincepri
 approvers:
@@ -15,6 +16,7 @@ approvers:
 - detiber
 - fabriziopandini
 - justinsb
+- sbueringer
 - timothysc
 - vincepri
 emeritus_approvers:


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

Follow-up to: https://github.com/kubernetes-sigs/cluster-api/pull/5504

/assign @fabriziopandini 