### PR TITLE
Cc branch 1.23 release

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.20.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.20.yaml
@@ -4,6 +4,9 @@ presubmits:
   - name: pull-cluster-capacity-verify-gofmt-release-1-20
     decorate: true
     path_alias: sigs.k8s.io/cluster-capacity
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.20$
     always_run: true
     spec:
       containers:
@@ -15,6 +18,9 @@ presubmits:
   - name: pull-cluster-capacity-verify-build-release-1-20
     decorate: true
     path_alias: sigs.k8s.io/cluster-capacity
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.20$
     always_run: true
     spec:
       containers:
@@ -26,6 +32,9 @@ presubmits:
   - name: pull-cluster-capacity-unit-test-release-1-20
     decorate: true
     path_alias: sigs.k8s.io/cluster-capacity
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.20$
     always_run: true
     spec:
       containers:

--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.21.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.21.yaml
@@ -4,6 +4,9 @@ presubmits:
   - name: pull-cluster-capacity-verify-gofmt-release-1-21
     decorate: true
     path_alias: sigs.k8s.io/cluster-capacity
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.21$
     always_run: true
     spec:
       containers:
@@ -15,6 +18,9 @@ presubmits:
   - name: pull-cluster-capacity-verify-build-release-1-21
     decorate: true
     path_alias: sigs.k8s.io/cluster-capacity
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.21$
     always_run: true
     spec:
       containers:
@@ -26,6 +32,9 @@ presubmits:
   - name: pull-cluster-capacity-unit-test-release-1-21
     decorate: true
     path_alias: sigs.k8s.io/cluster-capacity
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.21$
     always_run: true
     spec:
       containers:

--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.22.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.22.yaml
@@ -1,12 +1,12 @@
 # sigs.k8s.io/cluster-capacity presubmits
 presubmits:
   kubernetes-sigs/cluster-capacity:
-  - name: pull-cluster-capacity-verify-gofmt
+  - name: pull-cluster-capacity-verify-gofmt-release-1-22
     decorate: true
     path_alias: sigs.k8s.io/cluster-capacity
     branches:
     # The script this job runs is not in all branches.
-    - ^master$
+    - ^release-1.22$
     always_run: true
     spec:
       containers:
@@ -15,12 +15,12 @@ presubmits:
         - make
         args:
         - verify-gofmt
-  - name: pull-cluster-capacity-verify-build
+  - name: pull-cluster-capacity-verify-build-release-1-22
     decorate: true
     path_alias: sigs.k8s.io/cluster-capacity
     branches:
     # The script this job runs is not in all branches.
-    - ^master$
+    - ^release-1.22$
     always_run: true
     spec:
       containers:
@@ -29,12 +29,12 @@ presubmits:
         - make
         args:
         - build
-  - name: pull-cluster-capacity-unit-test
+  - name: pull-cluster-capacity-unit-test-release-1-22
     decorate: true
     path_alias: sigs.k8s.io/cluster-capacity
     branches:
     # The script this job runs is not in all branches.
-    - ^master$
+    - ^release-1.22$
     always_run: true
     spec:
       containers:
@@ -43,10 +43,10 @@ presubmits:
         - make
         args:
         - test-unit
-  - name: pull-cluster-capacity-test-e2e-k8s-master-1-23
+  - name: pull-cluster-capacity-test-e2e-k8s-release-1-22-1-22
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-master-1.23
+      testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-release-1.22-1.22
     decorate: true
     decoration_config:
       timeout: 20m
@@ -56,38 +56,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     branches:
-    - master
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220214-0aa8fe1d3a-master
-        command:
-        # generic runner script, handles DIND, bazelrc for caching, etc.
-        - runner.sh
-        env:
-        - name: KUBERNETES_VERSION
-          value: "v1.23.3"
-        - name: KIND_E2E
-          value: "true"
-        args:
-        - make
-        - test-e2e
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-  - name: pull-cluster-capacity-test-e2e-k8s-master-1-22
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-master-1.22
-    decorate: true
-    decoration_config:
-      timeout: 20m
-    path_alias: sigs.k8s.io/cluster-capacity
-    always_run: true
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    branches:
-    - master
+    - release-1.22
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220214-0aa8fe1d3a-master
@@ -105,10 +74,10 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-  - name: pull-cluster-capacity-test-e2e-k8s-master-1-21
+  - name: pull-cluster-capacity-test-e2e-k8s-release-1-22-1-21
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-master-1.21
+      testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-release-1.22-1.21
     decorate: true
     decoration_config:
       timeout: 20m
@@ -118,7 +87,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     branches:
-    - master
+    - release-1.22
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220214-0aa8fe1d3a-master
@@ -128,6 +97,37 @@ presubmits:
         env:
         - name: KUBERNETES_VERSION
           value: "v1.21.2"
+        - name: KIND_E2E
+          value: "true"
+        args:
+        - make
+        - test-e2e
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+  - name: pull-cluster-capacity-test-e2e-k8s-release-1-22-1-20
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-release-1.22-1.20
+    decorate: true
+    decoration_config:
+      timeout: 20m
+    path_alias: sigs.k8s.io/cluster-capacity
+    always_run: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    branches:
+    - release-1.22
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220214-0aa8fe1d3a-master
+        command:
+        # generic runner script, handles DIND, bazelrc for caching, etc.
+        - runner.sh
+        env:
+        - name: KUBERNETES_VERSION
+          value: "v1.20.7"
         - name: KIND_E2E
           value: "true"
         args:

--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits.yaml
@@ -4,6 +4,9 @@ presubmits:
   - name: pull-cluster-capacity-verify-gofmt
     decorate: true
     path_alias: sigs.k8s.io/cluster-capacity
+    branches:
+    # The script this job runs is not in all branches.
+    - ^master$
     always_run: true
     spec:
       containers:
@@ -15,6 +18,9 @@ presubmits:
   - name: pull-cluster-capacity-verify-build
     decorate: true
     path_alias: sigs.k8s.io/cluster-capacity
+    branches:
+    # The script this job runs is not in all branches.
+    - ^master$
     always_run: true
     spec:
       containers:
@@ -26,6 +32,9 @@ presubmits:
   - name: pull-cluster-capacity-unit-test
     decorate: true
     path_alias: sigs.k8s.io/cluster-capacity
+    branches:
+    # The script this job runs is not in all branches.
+    - ^master$
     always_run: true
     spec:
       containers:

--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.7
+      - image: golang:1.17.1
         command:
         - make
         args:
@@ -24,7 +24,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.7
+      - image: golang:1.17.1
         command:
         - make
         args:
@@ -38,7 +38,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.7
+      - image: golang:1.17.1
         command:
         - make
         args:


### PR DESCRIPTION
To test https://github.com/kubernetes-sigs/cluster-capacity/pull/145

`kindest/node:v1.23.3` as the latest image: https://hub.docker.com/r/kindest/node/tags?page=1&name=v1.23