### PR TITLE
cluster-api: remove cluster-api-admins alias

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -254,11 +254,6 @@ aliases:
     - mrbobbytables # subproject owner
 
   # copied from sigs.k8s.io/cluster-api-provider-vsphere/OWNERS_ALIASES
-  cluster-api-admins:
-    - detiber
-    - justinsb
-    - davidewatson
-    - vincepri
   cluster-api-vsphere-maintainers:
     - frapposelli
     - yastij

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-nested/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-nested/OWNERS
@@ -4,14 +4,12 @@ reviewers:
 - charleszheng44
 - christopherhein
 - Fei-Guo
-- cluster-api-admins
 - sig-cluster-lifecycle-leads
 - vincepri
 approvers:
 - charleszheng44
 - christopherhein
 - Fei-Guo
-- cluster-api-admins
 - sig-cluster-lifecycle-leads
 - vincepri
 

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/OWNERS
@@ -3,14 +3,12 @@
 reviewers:
   - sig-cluster-lifecycle-leads
   - provider-vmware
-  - cluster-api-admins
   - cluster-api-vsphere-maintainers
   - figo
   - akutz
 approvers:
   - sig-cluster-lifecycle-leads
   - provider-vmware
-  - cluster-api-admins
   - cluster-api-vsphere-maintainers
   - figo
   - akutz


### PR DESCRIPTION
Hey folks,

this alias was only used in CAPN/CAPV. I would propose to delete it as it's not universally used in CAPI providers and we don't keep the member list of the alias up-to-date.

P.S. standard practice seems to be to inline provider owners so that no top-level approval is required to change approvers/reviewers