### PR TITLE
BranchProtection: add the missing fields

### DIFF
--- a/prow/cmd/branchprotector/protect.go
+++ b/prow/cmd/branchprotector/protect.go
@@ -499,7 +499,9 @@ func equalBranchProtections(state *github.BranchProtection, request *github.Bran
 			equalAdminEnforcement(state.EnforceAdmins, request.EnforceAdmins) &&
 			equalRequiredPullRequestReviews(state.RequiredPullRequestReviews, request.RequiredPullRequestReviews) &&
 			equalRestrictions(state.Restrictions, request.Restrictions) &&
-			equalAllowForcePushes(state.AllowForcePushes, request.AllowForcePushes)
+			equalAllowForcePushes(state.AllowForcePushes, request.AllowForcePushes) &&
+			equalRequiredLinearHistory(state.RequiredLinearHistory, request.RequiredLinearHistory) &&
+			equalAllowDeletions(state.AllowDeletions, request.AllowDeletions)
 	default:
 		return false
 	}
@@ -536,6 +538,14 @@ func equalStringSlices(s1, s2 *[]string) bool {
 	default:
 		return false
 	}
+}
+
+func equalRequiredLinearHistory(state github.RequiredLinearHistory, request bool) bool {
+	return state.Enabled == request
+}
+
+func equalAllowDeletions(state github.AllowDeletions, request bool) bool {
+	return state.Enabled == request
 }
 
 func equalAllowForcePushes(state github.AllowForcePushes, request bool) bool {

--- a/prow/cmd/branchprotector/protect.go
+++ b/prow/cmd/branchprotector/protect.go
@@ -498,7 +498,8 @@ func equalBranchProtections(state *github.BranchProtection, request *github.Bran
 		return equalRequiredStatusChecks(state.RequiredStatusChecks, request.RequiredStatusChecks) &&
 			equalAdminEnforcement(state.EnforceAdmins, request.EnforceAdmins) &&
 			equalRequiredPullRequestReviews(state.RequiredPullRequestReviews, request.RequiredPullRequestReviews) &&
-			equalRestrictions(state.Restrictions, request.Restrictions)
+			equalRestrictions(state.Restrictions, request.Restrictions) &&
+			equalAllowForcePushes(state.AllowForcePushes, request.AllowForcePushes)
 	default:
 		return false
 	}
@@ -535,6 +536,10 @@ func equalStringSlices(s1, s2 *[]string) bool {
 	default:
 		return false
 	}
+}
+
+func equalAllowForcePushes(state github.AllowForcePushes, request bool) bool {
+	return state.Enabled == request
 }
 
 func equalAdminEnforcement(state github.EnforceAdmins, request *bool) bool {

--- a/prow/cmd/branchprotector/protect_test.go
+++ b/prow/cmd/branchprotector/protect_test.go
@@ -1618,6 +1618,17 @@ func TestEqualBranchProtection(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name: "AllowForcePushes is recognized",
+			state: &github.BranchProtection{
+				AllowForcePushes: github.AllowForcePushes{
+					Enabled: false,
+				},
+			},
+			request: &github.BranchProtectionRequest{
+				AllowForcePushes: true,
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -2195,6 +2195,9 @@ func TestGetBranchProtection(t *testing.T) {
 			Restrictions: &Restrictions{
 				Teams: pushers,
 			},
+			AllowForcePushes: AllowForcePushes{
+				Enabled: true,
+			},
 		}
 		b, err := json.Marshal(&bp)
 		if err != nil {
@@ -2209,6 +2212,8 @@ func TestGetBranchProtection(t *testing.T) {
 		t.Errorf("Didn't expect error: %v", err)
 	}
 	switch {
+	case !bp.AllowForcePushes.Enabled:
+		t.Errorf("AllowForcePushes is not enabled")
 	case bp.Restrictions == nil:
 		t.Errorf("RestrictionsRequest unset")
 	case bp.Restrictions.Teams == nil:

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -560,6 +560,18 @@ type BranchProtection struct {
 	RequiredPullRequestReviews *RequiredPullRequestReviews `json:"required_pull_request_reviews"`
 	Restrictions               *Restrictions               `json:"restrictions"`
 	AllowForcePushes           AllowForcePushes            `json:"allow_force_pushes"`
+	RequiredLinearHistory      RequiredLinearHistory       `json:"required_linear_history"`
+	AllowDeletions             AllowDeletions              `json:"allow_deletions"`
+}
+
+// AllowDeletions specifies whether to permit users with push access to delete matching branches.
+type AllowDeletions struct {
+	Enabled bool `json:"enabled"`
+}
+
+// RequiredLinearHistory specifies whether to prevent merge commits from being pushed to matching branches.
+type RequiredLinearHistory struct {
+	Enabled bool `json:"enabled"`
 }
 
 // AllowForcePushes specifies whether to permit force pushes for all users with push access.

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -559,6 +559,12 @@ type BranchProtection struct {
 	EnforceAdmins              EnforceAdmins               `json:"enforce_admins"`
 	RequiredPullRequestReviews *RequiredPullRequestReviews `json:"required_pull_request_reviews"`
 	Restrictions               *Restrictions               `json:"restrictions"`
+	AllowForcePushes           AllowForcePushes            `json:"allow_force_pushes"`
+}
+
+// AllowForcePushes specifies whether to permit force pushes for all users with push access.
+type AllowForcePushes struct {
+	Enabled bool `json:"enabled"`
 }
 
 // EnforceAdmins specifies whether to enforce the


### PR DESCRIPTION
Ref. https://docs.github.com/en/rest/reference/branches#protected-branches

To fix:
https://github.com/kubernetes/test-infra/issues/25327

/cc @petr-muller @alvaroaleman 

