### PR TITLE
update golangci-lint image for vSphere CSI Driver

### DIFF
--- a/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
@@ -45,7 +45,7 @@ presubmits:
     path_alias: sigs.k8s.io/vsphere-csi-driver
     spec:
       containers:
-        - image: golangci/golangci-lint:v1.29.0
+        - image: golangci/golangci-lint:v1.44.2
           command:
             - make
           args:


### PR DESCRIPTION
Updating `golangci-lint` image for vSphere CSI Driver.

cc: @xing-yang 