### PR TITLE
owners update for vsphere-csi-driver

### DIFF
--- a/config/jobs/kubernetes-sigs/vsphere-csi-driver/OWNERS
+++ b/config/jobs/kubernetes-sigs/vsphere-csi-driver/OWNERS
@@ -1,11 +1,17 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 reviewers:
-- akutz
-- codenrhoden
-- dvonthenen
-- figo
-- frapposelli
+- divyenpatel
+- SandeepPissay
+- xing-yang
+- BaluDontu
+- deepakkinni
 approvers:
+- divyenpatel
+- SandeepPissay
+- xing-yang
+- BaluDontu
+- deepakkinni
+emeritus_approvers:
 - akutz
 - codenrhoden
 - dvonthenen


### PR DESCRIPTION
updating owners update for vsphere-csi-driver

adding owner of `vsphere-csi-driver` repository - https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/OWNERS 

cc: @xing-yang @SandeepPissay @BaluDontu @chethanv28 @deepakkinni