### PR TITLE
Add ability to pin highlighted lines.

### DIFF
--- a/prow/io/opener.go
+++ b/prow/io/opener.go
@@ -61,6 +61,13 @@ type Attributes struct {
 	ContentEncoding string
 	// Size is the size of the blob's content in bytes.
 	Size int64
+	// Metadata includes user-metadata associated with the file
+	Metadata map[string]string
+}
+
+type ObjectAttrsToUpdate struct {
+	ContentEncoding *string
+	Metadata        map[string]string
 }
 
 // Opener has methods to read and write paths
@@ -71,6 +78,7 @@ type Opener interface {
 	Attributes(ctx context.Context, path string) (Attributes, error)
 	SignedURL(ctx context.Context, path string, opts SignedURLOptions) (string, error)
 	Iterator(ctx context.Context, prefix, delimiter string) (ObjectIterator, error)
+	UpdateAtributes(context.Context, string, ObjectAttrsToUpdate) (*Attributes, error)
 }
 
 type opener struct {
@@ -316,6 +324,7 @@ func (o *opener) Attributes(ctx context.Context, path string) (Attributes, error
 		return Attributes{
 			ContentEncoding: attr.ContentEncoding,
 			Size:            attr.Size,
+			Metadata:        attr.Metadata,
 		}, nil
 	}
 
@@ -331,6 +340,33 @@ func (o *opener) Attributes(ctx context.Context, path string) (Attributes, error
 	return Attributes{
 		ContentEncoding: attr.ContentEncoding,
 		Size:            attr.Size,
+		Metadata:        attr.Metadata,
+	}, nil
+}
+
+func (o *opener) UpdateAtributes(ctx context.Context, path string, attrs ObjectAttrsToUpdate) (*Attributes, error) {
+	if !strings.HasPrefix(path, providers.GS+"://") {
+		return nil, fmt.Errorf("unsupported provider: %q", path)
+	}
+
+	g, err := o.openGCS(path)
+	if err != nil {
+		return nil, fmt.Errorf("open: %w", err)
+	}
+	up := storage.ObjectAttrsToUpdate{
+		Metadata: attrs.Metadata,
+	}
+	if attrs.ContentEncoding != nil {
+		up.ContentEncoding = *attrs.ContentEncoding
+	}
+	oa, err := g.Update(ctx, up)
+	if err != nil {
+		return nil, fmt.Errorf("update: %w", err)
+	}
+	return &Attributes{
+		ContentEncoding: oa.ContentEncoding,
+		Size:            oa.Size,
+		Metadata:        oa.Metadata,
 	}, nil
 }
 

--- a/prow/spyglass/BUILD.bazel
+++ b/prow/spyglass/BUILD.bazel
@@ -25,6 +25,7 @@ go_test(
         "//prow/spyglass/lenses:go_default_library",
         "//prow/spyglass/lenses/common:go_default_library",
         "@com_github_fsouza_fake_gcs_server//fakestorage:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_googlecloudplatform_testgrid//pb/config:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",

--- a/prow/spyglass/api/spyglass.go
+++ b/prow/spyglass/api/spyglass.go
@@ -56,6 +56,10 @@ type Artifact interface {
 	ReadTail(n int64) ([]byte, error)
 	// Size gets the size of the artifact in bytes, may make a network call
 	Size() (int64, error)
+	// Metadata fetches the custom metadata associated with the artifact
+	Metadata() (map[string]string, error)
+	// UpdateMetadata modifies the custom metadata associated with the artifact
+	UpdateMetadata(map[string]string) error
 }
 
 // RequestAction defines the action for a request

--- a/prow/spyglass/lenses/buildlog/buildlog.css
+++ b/prow/spyglass/lenses/buildlog/buildlog.css
@@ -7,6 +7,51 @@ html {
     overflow-x: hidden;
 }
 
+.annotate-pin {
+    border-radius: 0.25em;
+    color: #ccc;
+    cursor: pointer;
+    padding: 0.25em;
+    position: absolute;
+    z-index: 1;
+    top: -1em;
+    left: -.5em;
+}
+
+.highlighted-line .annotate-pin {
+  background: #42425A;
+}
+
+.annotate-pin:hover {
+  background: #555568;
+}
+
+.annotate-pin i.material-icons {
+  transform: rotate(-20deg);
+  font-size: 1.2em;
+  margin: 0.05em 0.03em 0 0;
+}
+
+.shown > div {
+  position: relative;
+}
+
+.focus-clip {
+  position: absolute;
+  top: -1.5em;
+  left: -1.5em;
+  background: none;
+  color: #ccc;
+  margin: 0.5em;
+  padding: 0.25em;
+  border: none;
+}
+
+.focus-clip i.material-icons {
+  transform: rotate(-60deg);
+  font-size: 2em;
+}
+
 .linetext button, .linenum button {
     font-size: 1em;
     text-align: left;
@@ -41,6 +86,7 @@ html {
     word-break: break-all;
     overflow-wrap: break-word;
 }
+
 .line-highlighted {
     color: rgba(255, 224, 0, 1.0);
 }
@@ -79,7 +125,15 @@ html {
 }
 
 .highlighted-line {
-    background-color: #555;
+    background: #555;
+}
+
+.highlighted-line.focus-line {
+  background: #555568;
+}
+
+.focus-line {
+  background: #42425A;
 }
 
 /* ansi colors from https://en.wikipedia.org/wiki/ANSI_escape_code#Colors */

--- a/prow/spyglass/lenses/buildlog/template.html
+++ b/prow/spyglass/lenses/buildlog/template.html
@@ -8,7 +8,7 @@
   <div>
     <button class="show-all-button" data-artifact="{{$log.ArtifactName}}">Show all hidden lines</button>
     {{if .ShowRawLog}}<a href="{{$log.ArtifactLink}}" style="padding-left:15px;">Raw {{$log.ArtifactName}}<i class="material-icons" style="padding-left: 3px;">open_in_new</i></a>{{end}}
-    <div class="loglines" id="{{$log.ArtifactName}}-content">
+    <div class="loglines{{if .CanSave}} savable{{end}}" id="{{$log.ArtifactName}}-content">
       {{block "line groups" $log.LineGroups}}
       {{range . }}
         {{if .Skip}}
@@ -34,9 +34,12 @@
           {{end}}
         {{else}}
           {{block "shown group" . }}
-          <div class="shown">
-          {{range .LogLines}}
-            <div id="{{.ArtifactName}}:{{.Number}}">
+            <div class="shown">
+            {{range .LogLines}}
+            <div id="{{.ArtifactName}}:{{.Number}}"{{if .Focused}}class="focus-line"{{end}}>
+              {{if .Clip}}
+                <button class="focus-clip" id="focus-clip"><i class="material-icons">attachment</i></button>
+              {{end}}
               <div class="linenum"><a href="#{{.ArtifactName}}:{{.Number}}" data-artifact="{{.ArtifactName}}" data-line-number="{{.Number}}">{{.Number}}</a></div>
               <div class="linetext">
                 <span {{if .Highlighted}}class="line-highlighted"{{end}}>
@@ -44,8 +47,8 @@
                 </span>
               </div>
             </div>
-          {{end}}
-          </div>
+            {{end}}
+            </div>
           {{end}}
         {{end}}
       {{end}}

--- a/prow/spyglass/lenses/fake/fake.go
+++ b/prow/spyglass/lenses/fake/fake.go
@@ -25,6 +25,7 @@ import (
 type Artifact struct {
 	Path    string
 	Content []byte
+	Meta    map[string]string
 }
 
 func (fa *Artifact) JobPath() string {
@@ -34,6 +35,17 @@ func (fa *Artifact) JobPath() string {
 func (fa *Artifact) Size() (int64, error) {
 	return int64(len(fa.Content)), nil
 }
+
+func (fa *Artifact) Metadata() (map[string]string, error) {
+	return fa.Meta, nil
+}
+
+func (fa *Artifact) UpdateMetadata(now map[string]string) error {
+	fa.Meta = now
+	return nil
+}
+
+const NotFound = "linknotfound.io/404"
 
 func (fa *Artifact) CanonicalLink() string {
 	return "linknotfound.io/404"

--- a/prow/spyglass/lenses/html/html_test.go
+++ b/prow/spyglass/lenses/html/html_test.go
@@ -46,6 +46,14 @@ func (fa *FakeArtifact) Size() (int64, error) {
 	return int64(len(fa.content)), nil
 }
 
+func (fa *FakeArtifact) Metadata() (map[string]string, error) {
+	return nil, nil
+}
+
+func (fa *FakeArtifact) UpdateMetadata(map[string]string) error {
+	return nil
+}
+
 func (fa *FakeArtifact) CanonicalLink() string {
 	return fa.path
 }

--- a/prow/spyglass/lenses/junit/lens_test.go
+++ b/prow/spyglass/lenses/junit/lens_test.go
@@ -56,6 +56,14 @@ func (fa *FakeArtifact) CanonicalLink() string {
 	return fakeCanonicalLink
 }
 
+func (fa *FakeArtifact) Metadata() (map[string]string, error) {
+	return nil, nil
+}
+
+func (fa *FakeArtifact) UpdateMetadata(map[string]string) error {
+	return nil
+}
+
 func (fa *FakeArtifact) ReadAt(b []byte, off int64) (int, error) {
 	r := bytes.NewReader(fa.content)
 	return r.ReadAt(b, off)

--- a/prow/spyglass/podlogartifact.go
+++ b/prow/spyglass/podlogartifact.go
@@ -188,3 +188,11 @@ func (a *PodLogArtifact) Size() (int64, error) {
 	return int64(len(logs)), nil
 
 }
+
+func (a *PodLogArtifact) Metadata() (map[string]string, error) {
+	return nil, nil
+}
+
+func (a *PodLogArtifact) UpdateMetadata(meta map[string]string) error {
+	return errors.New("not implemented")
+}

--- a/prow/spyglass/spyglass_test.go
+++ b/prow/spyglass/spyglass_test.go
@@ -88,6 +88,9 @@ func TestMain(m *testing.M) {
 			BucketName: "test-bucket",
 			Name:       "logs/example-ci-run/403/build-log.txt",
 			Content:    []byte("Oh wow\nlogs\nthis is\ncrazy"),
+			Metadata: map[string]string{
+				"foo": "bar",
+			},
 		},
 		{
 			BucketName: "test-bucket",

--- a/prow/spyglass/storageartifact_fetcher.go
+++ b/prow/spyglass/storageartifact_fetcher.go
@@ -190,6 +190,10 @@ func (h *storageArtifactHandle) Attrs(ctx context.Context) (pkgio.Attributes, er
 	return h.Opener.Attributes(ctx, h.Name)
 }
 
+func (h *storageArtifactHandle) UpdateAttrs(ctx context.Context, attrs pkgio.ObjectAttrsToUpdate) (*pkgio.Attributes, error) {
+	return h.UpdateAtributes(ctx, h.Name, attrs)
+}
+
 // Artifact constructs a GCS artifact from the given GCS bucket and key. Uses the golang GCS library
 // to get read handles. If the artifactName is not a valid key in the bucket a handle will still be
 // constructed and returned, but all read operations will fail (dictated by behavior of golang GCS lib).

--- a/prow/spyglass/storageartifact_fetcher_test.go
+++ b/prow/spyglass/storageartifact_fetcher_test.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
@@ -241,17 +242,21 @@ func TestFetchArtifacts_GCS(t *testing.T) {
 	testAf := NewStorageArtifactFetcher(io.NewGCSOpener(fakeGCSClient), cfg, false)
 	maxSize := int64(500e6)
 	testCases := []struct {
-		name         string
-		artifactName string
-		source       string
-		expectedSize int64
-		expectErr    bool
+		name             string
+		artifactName     string
+		source           string
+		expectedSize     int64
+		expectedMetadata map[string]string
+		expectErr        bool
 	}{
 		{
 			name:         "Fetch build-log.txt from valid source",
 			artifactName: "build-log.txt",
 			source:       "test-bucket/logs/example-ci-run/403",
 			expectedSize: 25,
+			expectedMetadata: map[string]string{
+				"foo": "bar",
+			},
 		},
 		{
 			name:         "Fetch build-log.txt from invalid source",
@@ -264,6 +269,9 @@ func TestFetchArtifacts_GCS(t *testing.T) {
 			artifactName: "build-log.txt",
 			source:       "gs://test-bucket/logs/example-ci-run/403",
 			expectedSize: 25,
+			expectedMetadata: map[string]string{
+				"foo": "bar",
+			},
 		},
 		{
 			name:         "Fetch build-log.txt from invalid source",
@@ -274,21 +282,33 @@ func TestFetchArtifacts_GCS(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		artifact, err := testAf.Artifact(context.Background(), tc.source, tc.artifactName, maxSize)
-		if err != nil {
-			t.Errorf("Failed to get artifacts: %v", err)
-		}
-		size, err := artifact.Size()
-		if err != nil && !tc.expectErr {
-			t.Fatalf("%s failed getting size for artifact %s, err: %v", tc.name, artifact.JobPath(), err)
-		}
-		if err == nil && tc.expectErr {
-			t.Errorf("%s expected error, got no error", tc.name)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			artifact, err := testAf.Artifact(context.Background(), tc.source, tc.artifactName, maxSize)
+			if err != nil {
+				t.Errorf("Failed to get artifacts: %v", err)
+			}
+			size, err := artifact.Size()
+			if err != nil && !tc.expectErr {
+				t.Fatalf("Failed getting size for artifact %s, err: %v", artifact.JobPath(), err)
+			}
+			if err == nil && tc.expectErr {
+				t.Error("Expected error, got no error")
+			}
 
-		if size != tc.expectedSize {
-			t.Errorf("%s expected artifact with size %d but got %d", tc.name, tc.expectedSize, size)
-		}
+			if size != tc.expectedSize {
+				t.Errorf("Expected artifact with size %d but got %d", tc.expectedSize, size)
+			}
+			meta, err := artifact.Metadata()
+			if err != nil && !tc.expectErr {
+				t.Fatalf("Failed getting metadata for artifact %s, err: %v", artifact.JobPath(), err)
+			}
+			if err == nil && tc.expectErr {
+				t.Errorf("Expected error, got no error")
+			}
+			if diff := cmp.Diff(tc.expectedMetadata, meta); diff != "" {
+				t.Errorf("Metadata got unexpected diff (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 

--- a/prow/spyglass/storageartifact_test.go
+++ b/prow/spyglass/storageartifact_test.go
@@ -67,6 +67,20 @@ func (h *fakeArtifactHandle) Attrs(ctx context.Context) (pkgio.Attributes, error
 	return h.oAttrs, nil
 }
 
+func (h *fakeArtifactHandle) UpdateAttrs(ctx context.Context, cur pkgio.ObjectAttrsToUpdate) (*pkgio.Attributes, error) {
+	if cur.ContentEncoding != nil {
+		h.oAttrs.ContentEncoding = *cur.ContentEncoding
+	}
+	for name, value := range cur.Metadata {
+		if value != "" {
+			cur.Metadata[name] = value
+		} else if cur.Metadata[name] != "" {
+			delete(cur.Metadata, name)
+		}
+	}
+	return &h.oAttrs, nil
+}
+
 func (h *fakeArtifactHandle) NewRangeReader(ctx context.Context, offset, length int64) (io.ReadCloser, error) {
 	if bytes.Equal(h.contents, []byte("unreadable contents")) {
 		return nil, fmt.Errorf("cannot read unreadable contents")


### PR DESCRIPTION
Allows a user to select a block of log lines and pin them.
The next time (or person) who loads this log, we will default to showing these lines.

Works by extending adding the start/end line number as metadata fields on the artifact.


<img width="479" alt="image" src="https://user-images.githubusercontent.com/940341/154601764-2a02796b-6da7-4405-a4bb-a264f74d11a4.png">
