### PR TITLE
sig-k8s-infra: add hearbeat jobs for build clusters

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/periodics.yaml
@@ -1,0 +1,29 @@
+periodics:
+- name: ci-k8s-infra-build-cluster-prow-build
+  cron: "*/5 * * * *" #Every 5 minutes
+  cluster: k8s-infra-prow-build
+  decorate: true
+  max_concurrency: 1
+  extra_refs:
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-prow
+    testgrid-tab-name: gke-prow-build-heartbeat
+    testgrid-num-failures-to-alert: '6'
+    testgrid-alert-email: k8s-infra-alerts@kubernetes.io, k8s-infra-prow-oncall@kubernetes.io
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
+      command:
+      - "echo"
+      args:
+      - "Everything is fine!"
+      resources:
+        limits:
+          cpu: 100m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 512Mi

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-prow.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-prow.yaml
@@ -74,6 +74,35 @@ postsubmits:
         report_template: 'Deploying k8s-infra-prow-build-trusted cluster: {{.Status.State}}. Commit: <{{.Spec.Refs.BaseLink}}|{{printf "%.7s" .Spec.Refs.BaseSHA}}> | <{{.Status.URL}}|Spyglass> | <https://testgrid.k8s.io/sig-k8s-infra-prow#deploy-prow-build-trusted|Testgrid> | <https://prow.k8s.io/?job={{.Spec.Job}}|Deck>'
 
 periodics:
+- name: ci-k8s-infra-build-cluster-prow-build-trusted
+  cron: "*/5 * * * *" #Every 5 minutes
+  cluster: k8s-infra-prow-build-trusted
+  decorate: true
+  max_concurrency: 1
+  extra_refs:
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-prow
+    testgrid-tab-name: gke-prow-build-trusted-heartbeat
+    testgrid-num-failures-to-alert: '6'
+    testgrid-alert-email: k8s-infra-alerts@kubernetes.io, k8s-infra-prow-oncall@kubernetes.io
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
+      command:
+      - "echo"
+      args:
+      - "Everything is fine!"
+      resources:
+        limits:
+          cpu: 100m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 512Mi
+
 - name: ci-k8sio-autobump-prow-build-clusters
   cron: "15 14-20/5 * * 1-5"  # Run at :15 every hour between 9:15 and 6:15 PM PST Mon-Fri
   cluster: k8s-infra-prow-build-trusted


### PR DESCRIPTION
Add periodic jobs acting as heartbeats against the build clusters.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>