### PR TITLE
kubekins/krte: Build `go-canary` variant using go1.18rc1

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -9,7 +9,7 @@ variants:
     UPGRADE_DOCKER: 'true'
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.18beta1
+    GO_VERSION: 1.18rc1
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
Part of https://github.com/kubernetes/release/issues/2307.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @cpanato @puerco 
/cc kubernetes/release-engineering 