### PR TITLE
Draft: Add security_contacts field to OWNERS

### DIFF
--- a/prow/plugins/verify-owners/verify-owners.go
+++ b/prow/plugins/verify-owners/verify-owners.go
@@ -367,6 +367,7 @@ func handle(ghc githubClient, gc git.ClientFactory, roc repoownersClient, log *l
 func parseOwnersFile(oc ownersClient, path string, c github.PullRequestChange, log *logrus.Entry, bannedLabels []string, filenames ownersconfig.Filenames) (*messageWithLine, []string) {
 	var reviewers []string
 	var approvers []string
+	var securityContacts []string
 	var labels []string
 
 	// by default we bind errors to line 1
@@ -404,12 +405,14 @@ func parseOwnersFile(oc ownersClient, path string, c github.PullRequestChange, l
 		for _, config := range full.Filters {
 			reviewers = append(reviewers, config.Reviewers...)
 			approvers = append(approvers, config.Approvers...)
+			securityContacts = append(securityContacts, config.SecurityContacts...)
 			labels = append(labels, config.Labels...)
 		}
 	} else {
 		// it's a SimpleConfig
 		reviewers = simple.Config.Reviewers
 		approvers = simple.Config.Approvers
+		securityContacts = simple.Config.SecurityContacts
 		labels = simple.Config.Labels
 	}
 	// Check labels against ban list
@@ -427,6 +430,8 @@ func parseOwnersFile(oc ownersClient, path string, c github.PullRequestChange, l
 		}, nil
 	}
 	owners := append(reviewers, approvers...)
+	owners = append(owners, securityContacts...)
+
 	return nil, owners
 }
 

--- a/prow/repoowners/repoowners.go
+++ b/prow/repoowners/repoowners.go
@@ -56,6 +56,7 @@ type dirOptions struct {
 type Config struct {
 	Approvers         []string `json:"approvers,omitempty"`
 	Reviewers         []string `json:"reviewers,omitempty"`
+	SecurityContacts  []string `json:"security_contacts,omitempty"`
 	RequiredReviewers []string `json:"required_reviewers,omitempty"`
 	Labels            []string `json:"labels,omitempty"`
 }
@@ -245,6 +246,7 @@ type RepoOwners struct {
 	approvers         map[string]map[*regexp.Regexp]sets.String
 	reviewers         map[string]map[*regexp.Regexp]sets.String
 	requiredReviewers map[string]map[*regexp.Regexp]sets.String
+	securityContacts  map[string]map[*regexp.Regexp]sets.String
 	labels            map[string]map[*regexp.Regexp]sets.String
 	options           map[string]dirOptions
 
@@ -466,6 +468,7 @@ func loadOwnersFrom(baseDir string, mdYaml bool, aliases RepoAliases, dirIgnorel
 		approvers:         make(map[string]map[*regexp.Regexp]sets.String),
 		reviewers:         make(map[string]map[*regexp.Regexp]sets.String),
 		requiredReviewers: make(map[string]map[*regexp.Regexp]sets.String),
+		securityContacts:  make(map[string]map[*regexp.Regexp]sets.String),
 		labels:            make(map[string]map[*regexp.Regexp]sets.String),
 		options:           make(map[string]dirOptions),
 
@@ -697,6 +700,12 @@ func (o *RepoOwners) applyConfigToPath(path string, re *regexp.Regexp, config *C
 			o.requiredReviewers[path] = make(map[*regexp.Regexp]sets.String)
 		}
 		o.requiredReviewers[path][re] = o.ExpandAliases(NormLogins(config.RequiredReviewers))
+	}
+	if len(config.SecurityContacts) > 0 {
+		if o.securityContacts[path] == nil {
+			o.securityContacts[path] = make(map[*regexp.Regexp]sets.String)
+		}
+		o.securityContacts[path][re] = o.ExpandAliases(NormLogins(config.SecurityContacts))
 	}
 	if len(config.Labels) > 0 {
 		if o.labels[path] == nil {

--- a/prow/repoowners/repoowners_test.go
+++ b/prow/repoowners/repoowners_test.go
@@ -48,6 +48,9 @@ reviewers:
 - bob
 required_reviewers:
 - chris
+security_contacts:
+- alice
+- bob
 labels:
 - EVERYTHING`),
 		"src/OWNERS": []byte(`approvers:
@@ -476,7 +479,7 @@ func testLoadRepoOwners(clients localgit.Clients, t *testing.T) {
 		branch                *string
 		extraBranchesAndFiles map[string]map[string][]byte
 
-		expectedApprovers, expectedReviewers, expectedRequiredReviewers, expectedLabels map[string]map[string]sets.String
+		expectedApprovers, expectedReviewers, expectedRequiredReviewers, expectedSecurityContacts, expectedLabels map[string]map[string]sets.String
 
 		expectedOptions  map[string]dirOptions
 		cacheOptions     *cacheOptions
@@ -500,6 +503,9 @@ func testLoadRepoOwners(clients localgit.Clients, t *testing.T) {
 			expectedRequiredReviewers: map[string]map[string]sets.String{
 				"":        patternAll("chris"),
 				"src/dir": patternAll("ben"),
+			},
+			expectedSecurityContacts: map[string]map[string]sets.String{
+				"": patternAll("alice", "bob"),
 			},
 			expectedLabels: map[string]map[string]sets.String{
 				"":        patternAll("EVERYTHING"),
@@ -531,6 +537,9 @@ func testLoadRepoOwners(clients localgit.Clients, t *testing.T) {
 			expectedRequiredReviewers: map[string]map[string]sets.String{
 				"":        patternAll("chris"),
 				"src/dir": patternAll("ben"),
+			},
+			expectedSecurityContacts: map[string]map[string]sets.String{
+				"": patternAll("alice", "bob"),
 			},
 			expectedLabels: map[string]map[string]sets.String{
 				"":        patternAll("EVERYTHING"),
@@ -564,6 +573,9 @@ func testLoadRepoOwners(clients localgit.Clients, t *testing.T) {
 			expectedRequiredReviewers: map[string]map[string]sets.String{
 				"":        patternAll("chris"),
 				"src/dir": patternAll("ben"),
+			},
+			expectedSecurityContacts: map[string]map[string]sets.String{
+				"": patternAll("alice", "bob"),
 			},
 			expectedLabels: map[string]map[string]sets.String{
 				"":             patternAll("EVERYTHING"),
@@ -603,6 +615,9 @@ func testLoadRepoOwners(clients localgit.Clients, t *testing.T) {
 				"":        patternAll("chris"),
 				"src/dir": patternAll("ben"),
 			},
+			expectedSecurityContacts: map[string]map[string]sets.String{
+				"": patternAll("alice", "bob"),
+			},
 			expectedLabels: map[string]map[string]sets.String{
 				"":        patternAll("EVERYTHING"),
 				"src/dir": patternAll("src-code"),
@@ -639,6 +654,9 @@ func testLoadRepoOwners(clients localgit.Clients, t *testing.T) {
 				"":        patternAll("chris"),
 				"src/dir": patternAll("ben"),
 			},
+			expectedSecurityContacts: map[string]map[string]sets.String{
+				"": patternAll("alice", "bob"),
+			},
 			expectedLabels: map[string]map[string]sets.String{
 				"":        patternAll("EVERYTHING"),
 				"src/dir": patternAll("src-code"),
@@ -669,6 +687,9 @@ func testLoadRepoOwners(clients localgit.Clients, t *testing.T) {
 			expectedRequiredReviewers: map[string]map[string]sets.String{
 				"":        patternAll("chris"),
 				"src/dir": patternAll("ben"),
+			},
+			expectedSecurityContacts: map[string]map[string]sets.String{
+				"": patternAll("alice", "bob"),
 			},
 			expectedLabels: map[string]map[string]sets.String{
 				"":        patternAll("EVERYTHING"),
@@ -720,6 +741,9 @@ func testLoadRepoOwners(clients localgit.Clients, t *testing.T) {
 				"":        patternAll("chris"),
 				"src/dir": patternAll("ben"),
 			},
+			expectedSecurityContacts: map[string]map[string]sets.String{
+				"": patternAll("alice", "bob"),
+			},
 			expectedLabels: map[string]map[string]sets.String{
 				"":             patternAll("EVERYTHING"),
 				"src/dir":      patternAll("src-code"),
@@ -754,6 +778,9 @@ func testLoadRepoOwners(clients localgit.Clients, t *testing.T) {
 			expectedRequiredReviewers: map[string]map[string]sets.String{
 				"":        patternAll("chris"),
 				"src/dir": patternAll("ben"),
+			},
+			expectedSecurityContacts: map[string]map[string]sets.String{
+				"": patternAll("alice", "bob"),
 			},
 			expectedLabels: map[string]map[string]sets.String{
 				"":             patternAll("EVERYTHING"),
@@ -790,6 +817,9 @@ func testLoadRepoOwners(clients localgit.Clients, t *testing.T) {
 				"":        patternAll("chris"),
 				"src/dir": patternAll("ben"),
 			},
+			expectedSecurityContacts: map[string]map[string]sets.String{
+				"": patternAll("alice", "bob"),
+			},
 			expectedLabels: map[string]map[string]sets.String{
 				"":        patternAll("EVERYTHING"),
 				"src/dir": patternAll("src-code"),
@@ -824,6 +854,9 @@ func testLoadRepoOwners(clients localgit.Clients, t *testing.T) {
 			expectedRequiredReviewers: map[string]map[string]sets.String{
 				"":        patternAll("chris"),
 				"src/dir": patternAll("ben"),
+			},
+			expectedSecurityContacts: map[string]map[string]sets.String{
+				"": patternAll("alice", "bob"),
 			},
 			expectedLabels: map[string]map[string]sets.String{
 				"":        patternAll("EVERYTHING"),
@@ -870,6 +903,9 @@ func testLoadRepoOwners(clients localgit.Clients, t *testing.T) {
 			expectedRequiredReviewers: map[string]map[string]sets.String{
 				"":        patternAll("chris"),
 				"src/dir": patternAll("ben"),
+			},
+			expectedSecurityContacts: map[string]map[string]sets.String{
+				"": patternAll("alice", "bob"),
 			},
 			expectedLabels: map[string]map[string]sets.String{
 				"":             patternAll("EVERYTHING"),
@@ -950,6 +986,7 @@ func testLoadRepoOwners(clients localgit.Clients, t *testing.T) {
 			check("approvers", test.expectedApprovers, ro.approvers)
 			check("reviewers", test.expectedReviewers, ro.reviewers)
 			check("required_reviewers", test.expectedRequiredReviewers, ro.requiredReviewers)
+			check("security_contacts", test.expectedSecurityContacts, ro.securityContacts)
 			check("labels", test.expectedLabels, ro.labels)
 			if !reflect.DeepEqual(test.expectedOptions, ro.options) {
 				t.Errorf("Expected options to be:\n%#v\ngot:\n%#v.", test.expectedOptions, ro.options)


### PR DESCRIPTION
Supports: https://github.com/kubernetes/committee-security-response/issues/149

Marked as draft for now, the PR for the guidelines change should be agreed upon and merged in first:

https://github.com/kubernetes/community/pull/6484