### PR TITLE
save prometheus snapshot for gce-100-performance presubmit

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -54,6 +54,9 @@ presubmits:
         - --test-cmd-args=cluster-loader2
         - --test-cmd-args=--nodes=100
         - --test-cmd-args=--provider=gce
+        - --test-cmd-args=--experimental-gcp-snapshot-prometheus-disk=true
+        - --test-cmd-args=--experimental-prometheus-disk-snapshot-name=$(JOB_NAME)-$(BUILD_ID)
+        - --test-cmd-args=--experimental-prometheus-snapshot-to-report-dir=true
         - --test-cmd-args=--report-dir=$(ARTIFACTS)
         - --test-cmd-args=--testconfig=testing/load/config.yaml
         - --test-cmd-args=--testconfig=testing/huge-service/config.yaml


### PR DESCRIPTION
I'm [adding new metrics in client-go](https://github.com/kubernetes/kubernetes/pull/106911/commits/da4b0e9a2a3f8ecf23352db55cec4e6a9c0c4173) and I can't find a good way to check them.
This also benefit other work that @MikeSpreitzer is doing on the apiserver, because we can check before merge the impact of changes on a 100 node cluster.

