### PR TITLE
releng: Update go-canary presubmits to go1.18rc1

### DIFF
--- a/config/jobs/kubernetes/sig-testing/dependencies.yaml
+++ b/config/jobs/kubernetes/sig-testing/dependencies.yaml
@@ -60,7 +60,7 @@ presubmits:
       - name: main
         command:
         - runner.sh
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220216-aa6d36a90c-go-canary
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220221-c13e827224-go-canary
         args:
         - make
         - verify

--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -51,7 +51,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220216-aa6d36a90c-go-canary
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220221-c13e827224-go-canary
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes/sig-testing/make-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/make-test.yaml
@@ -92,7 +92,7 @@ presubmits:
         runAsUser: 2000
         allowPrivilegeEscalation: false
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220216-aa6d36a90c-go-canary
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220221-c13e827224-go-canary
           command:
             - make
             - test

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -65,7 +65,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220216-aa6d36a90c-go-canary
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220221-c13e827224-go-canary
         imagePullPolicy: Always
         command:
         - runner.sh


### PR DESCRIPTION
Blocks https://github.com/kubernetes/kubernetes/pull/107105.
Follow-up to https://github.com/kubernetes/test-infra/pull/25346 / https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-test-infra-push-kubekins-e2e/1495667670681391104.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @xmudrii @puerco @cpanato
cc: @kubernetes/release-engineering 