### PR TITLE
Fix pull-local-node-e2e job

### DIFF
--- a/config/jobs/kubernetes/sig-testing/local-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/local-e2e.yaml
@@ -17,6 +17,11 @@ presubmits:
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220221-c13e827224-master
+        env:
+        - name: DOCKER_IN_DOCKER_IPV6_ENABLED
+          value: "true"
+        - name: CONTAINER_RUNTIME_ENDPOINT
+          value: "/var/run/docker/containerd/containerd.sock"
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"


### PR DESCRIPTION
enable ipv6 and add containerd addr
This is required to migrate the job to containerd
https://github.com/kubernetes/test-infra/issues/24715
Signed-off-by: Aditi Sharma <adi.sky17@gmail.com>