### PR TITLE
Remove redundent jobs and reduce frequency of CAPI jobs.

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -180,34 +180,3 @@ periodics:
     testgrid-tab-name: capi-e2e-mink8s-main
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
-- name: periodic-cluster-api-verify-book-links-main
-  interval: 6h
-  decorate: true
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: cluster-api
-    base_ref: main
-    path_alias: sigs.k8s.io/cluster-api
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220221-c13e827224-1.23
-      command:
-      - "runner.sh"
-      - "make"
-      - "verify-book-links"
-      env:
-      - name: GITHUB_TOKEN
-        valueFrom:
-          secretKeyRef:
-            name: cluster-lifecycle-github-token
-            key: cluster-lifecycle-github-token
-  volumes:
-  - name: cluster-lifecycle-github-token
-    secret:
-      secretName: cluster-lifecycle-github-token
-      items:
-      - key: cluster-lifecycle-github-token
-        path: cluster-lifecycle-github-token
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-    testgrid-tab-name: capi-verify-book-links-main

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-3.yaml
@@ -1,6 +1,6 @@
 periodics:
 - name: periodic-cluster-api-test-release-0-3
-  interval: 4h
+  interval: 12h
   decorate: true
   labels:
     preset-service-account: "true"
@@ -23,7 +23,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-release-0-3
-  interval: 4h
+  interval: 12h
   decorate: true
   labels:
     preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-4-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-4-upgrades.yaml
@@ -1,7 +1,7 @@
 periodics:
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-18-1-19-release-0-4
-  interval: 24h
+  interval: 48h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -45,7 +45,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-19-1-20-release-0-4
-  interval: 24h
+  interval: 48h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -89,7 +89,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-20-1-21-release-0-4
-  interval: 24h
+  interval: 48h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -133,7 +133,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-21-1-22-release-0-4
-  interval: 24h
+  interval: 48h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -177,7 +177,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-22-1-23-release-0-4
-  interval: 24h
+  interval: 48h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -222,7 +222,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-23-latest-release-0-4
-  interval: 24h
+  interval: 48h
   decorate: true
   labels:
     preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-4.yaml
@@ -1,6 +1,6 @@
 periodics:
 - name: periodic-cluster-api-test-release-0-4
-  interval: 4h
+  interval: 12h
   decorate: true
   labels:
     preset-service-account: "true"
@@ -23,7 +23,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-release-0-4
-  interval: 4h
+  interval: 12h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -58,7 +58,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-mink8s-release-0-4
-  interval: 4h
+  interval: 12h
   decorate: true
   labels:
     preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-0-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-0-upgrades.yaml
@@ -1,7 +1,7 @@
 periodics:
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-18-1-19-release-1-0
-  interval: 24h
+  interval: 48h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -45,7 +45,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-19-1-20-release-1-0
-  interval: 24h
+  interval: 48h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -89,7 +89,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-20-1-21-release-1-0
-  interval: 24h
+  interval: 48h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -133,7 +133,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-21-1-22-release-1-0
-  interval: 24h
+  interval: 48h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -177,7 +177,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-22-1-23-release-1-0
-  interval: 24h
+  interval: 48h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -222,7 +222,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
 
 - name: periodic-cluster-api-e2e-workload-upgrade-1-23-latest-release-1-0
-  interval: 24h
+  interval: 48h
   decorate: true
   labels:
     preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-0.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-0.yaml
@@ -1,6 +1,6 @@
 periodics:
 - name: periodic-cluster-api-test-release-1-0
-  interval: 4h
+  interval: 12h
   decorate: true
   labels:
     preset-service-account: "true"
@@ -23,7 +23,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-upgrade-v0-3-to-release-1-0
-  interval: 4h
+  interval: 12h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -65,7 +65,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-release-1-0
-  interval: 4h
+  interval: 12h
   decorate: true
   labels:
     preset-dind-enabled: "true"
@@ -100,7 +100,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 - name: periodic-cluster-api-e2e-mink8s-release-1-0
-  interval: 4h
+  interval: 12h
   decorate: true
   labels:
     preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-1.yaml
@@ -180,34 +180,3 @@ periodics:
     testgrid-tab-name: capi-e2e-mink8s-release-1-1
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
-- name: periodic-cluster-api-verify-book-links-release-1-1
-  interval: 24h
-  decorate: true
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: cluster-api
-    base_ref: release-1.1
-    path_alias: sigs.k8s.io/cluster-api
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220221-c13e827224-1.23
-      command:
-      - "runner.sh"
-      - "make"
-      - "verify-book-links"
-      env:
-      - name: GITHUB_TOKEN
-        valueFrom:
-          secretKeyRef:
-            name: cluster-lifecycle-github-token
-            key: cluster-lifecycle-github-token
-  volumes:
-  - name: cluster-lifecycle-github-token
-    secret:
-      secretName: cluster-lifecycle-github-token
-      items:
-      - key: cluster-lifecycle-github-token
-        path: cluster-lifecycle-github-token
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.1
-    testgrid-tab-name: capi-verify-book-links-release-1-1


### PR DESCRIPTION
This PR implements part 2-4 of https://github.com/kubernetes-sigs/cluster-api/issues/6141
1. Removes `periodic-cluster-api-verify-book-links-main` and `periodic-cluster-api-verify-book-links-release-1-1` jobs from CAPI periodics. 
2. Reduces frequency of release-0.4/1.0 upgrade tests to 48h.
3. Reduces frequency of release-0.3/0.4/1.0 tests to 12h.
