### PR TITLE
Bring back the breaking change on protected=false

### DIFF
--- a/prow/cmd/branchprotector/protect.go
+++ b/prow/cmd/branchprotector/protect.go
@@ -435,7 +435,7 @@ func (p *protector) UpdateBranch(orgName, repo string, branchName string, branch
 	if branch.Unmanaged != nil && *branch.Unmanaged {
 		return nil
 	}
-	bp, err := p.cfg.GetPolicy(orgName, repo, branchName, branch, p.cfg.PresubmitsStatic[orgName+"/"+repo], &protected)
+	bp, err := p.cfg.GetPolicy(orgName, repo, branchName, branch, p.cfg.PresubmitsStatic[orgName+"/"+repo])
 	if err != nil {
 		return fmt.Errorf("get policy: %w", err)
 	}

--- a/prow/config/branch_protection.go
+++ b/prow/config/branch_protection.go
@@ -344,11 +344,11 @@ func (c *Config) GetBranchProtection(org, repo, branch string, presubmits []Pres
 		return nil, err
 	}
 
-	return c.GetPolicy(org, repo, branch, *b, presubmits, nil)
+	return c.GetPolicy(org, repo, branch, *b, presubmits)
 }
 
 // GetPolicy returns the protection policy for the branch, after merging in presubmits.
-func (c *Config) GetPolicy(org, repo, branch string, b Branch, presubmits []Presubmit, protectedOnGitHub *bool) (*Policy, error) {
+func (c *Config) GetPolicy(org, repo, branch string, b Branch, presubmits []Presubmit) (*Policy, error) {
 	policy := b.Policy
 
 	// Automatically require contexts from prow which must always be present
@@ -356,11 +356,6 @@ func (c *Config) GetPolicy(org, repo, branch string, b Branch, presubmits []Pres
 		// Error if protection is disabled
 		if policy.Protect != nil && !*policy.Protect {
 			if c.BranchProtection.AllowDisabledJobPolicies != nil && *c.BranchProtection.AllowDisabledJobPolicies {
-				if protectedOnGitHub != nil && *protectedOnGitHub {
-					logrus.WithField("branch", fmt.Sprintf("%s/%s/%s", org, repo, branch)).
-						Warn("'protect: false' configuration causes branchprotector to not manage branch protection settings at all. " +
-							"If this a desired behavior, use 'unmanaged: true' instead.")
-				}
 				return nil, nil
 			}
 			return nil, fmt.Errorf("required prow jobs require branch protection")
@@ -453,7 +448,7 @@ func (c *Config) unprotectedBranches(presubmits map[string][]Presubmit) []string
 				if err != nil {
 					continue
 				}
-				policy, err := c.GetPolicy(orgName, repoName, branchName, *b, []Presubmit{}, nil)
+				policy, err := c.GetPolicy(orgName, repoName, branchName, *b, []Presubmit{})
 				if err != nil || policy == nil {
 					continue
 				}

--- a/prow/config/branch_protection.go
+++ b/prow/config/branch_protection.go
@@ -356,7 +356,9 @@ func (c *Config) GetPolicy(org, repo, branch string, b Branch, presubmits []Pres
 		// Error if protection is disabled
 		if policy.Protect != nil && !*policy.Protect {
 			if c.BranchProtection.AllowDisabledJobPolicies != nil && *c.BranchProtection.AllowDisabledJobPolicies {
-				return nil, nil
+				return &Policy{
+					Protect: policy.Protect,
+				}, nil
 			}
 			return nil, fmt.Errorf("required prow jobs require branch protection")
 		}

--- a/prow/config/branch_protection_test.go
+++ b/prow/config/branch_protection_test.go
@@ -872,7 +872,7 @@ func TestConfig_GetBranchProtection(t *testing.T) {
 					},
 				},
 			},
-			expected: nil,
+			expected: &Policy{Protect: no},
 		},
 	}
 


### PR DESCRIPTION
This PR brings back https://github.com/kubernetes/test-infra/pull/14495 which is reverted by https://github.com/kubernetes/test-infra/pull/14573: `projected: false` means two meanings and it has users for both.

The user whose case is broken can now use `unmanaged: true` introduced in https://github.com/kubernetes/test-infra/pull/21999.

With this PR, `projected: false` means disabling BP. No other other meaning.