### PR TITLE
branchprotector: log branches that should be unmanaged

### DIFF
--- a/prow/cmd/branchprotector/protect.go
+++ b/prow/cmd/branchprotector/protect.go
@@ -435,7 +435,7 @@ func (p *protector) UpdateBranch(orgName, repo string, branchName string, branch
 	if branch.Unmanaged != nil && *branch.Unmanaged {
 		return nil
 	}
-	bp, err := p.cfg.GetPolicy(orgName, repo, branchName, branch, p.cfg.PresubmitsStatic[orgName+"/"+repo])
+	bp, err := p.cfg.GetPolicy(orgName, repo, branchName, branch, p.cfg.PresubmitsStatic[orgName+"/"+repo], &protected)
 	if err != nil {
 		return fmt.Errorf("get policy: %w", err)
 	}

--- a/prow/config/branch_protection.go
+++ b/prow/config/branch_protection.go
@@ -344,11 +344,11 @@ func (c *Config) GetBranchProtection(org, repo, branch string, presubmits []Pres
 		return nil, err
 	}
 
-	return c.GetPolicy(org, repo, branch, *b, presubmits)
+	return c.GetPolicy(org, repo, branch, *b, presubmits, nil)
 }
 
 // GetPolicy returns the protection policy for the branch, after merging in presubmits.
-func (c *Config) GetPolicy(org, repo, branch string, b Branch, presubmits []Presubmit) (*Policy, error) {
+func (c *Config) GetPolicy(org, repo, branch string, b Branch, presubmits []Presubmit, protectedOnGitHub *bool) (*Policy, error) {
 	policy := b.Policy
 
 	// Automatically require contexts from prow which must always be present
@@ -356,6 +356,11 @@ func (c *Config) GetPolicy(org, repo, branch string, b Branch, presubmits []Pres
 		// Error if protection is disabled
 		if policy.Protect != nil && !*policy.Protect {
 			if c.BranchProtection.AllowDisabledJobPolicies != nil && *c.BranchProtection.AllowDisabledJobPolicies {
+				if protectedOnGitHub != nil && *protectedOnGitHub {
+					logrus.WithField("branch", fmt.Sprintf("%s/%s/%s", org, repo, branch)).
+						Warn("'protect: false' configuration causes branchprotector to not manage branch protection settings at all. " +
+							"If this a desired behavior, use 'unmanaged: true' instead.")
+				}
 				return nil, nil
 			}
 			return nil, fmt.Errorf("required prow jobs require branch protection")
@@ -448,7 +453,7 @@ func (c *Config) unprotectedBranches(presubmits map[string][]Presubmit) []string
 				if err != nil {
 					continue
 				}
-				policy, err := c.GetPolicy(orgName, repoName, branchName, *b, []Presubmit{})
+				policy, err := c.GetPolicy(orgName, repoName, branchName, *b, []Presubmit{}, nil)
 				if err != nil || policy == nil {
 					continue
 				}


### PR DESCRIPTION
The added logging helps to detect the branches that should use `unmanaged: true` before merging https://github.com/kubernetes/test-infra/pull/25363.