### PR TITLE
Prow gerrit: deprecating default label logs Debug instead of Warn

### DIFF
--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -472,7 +472,7 @@ func (c *Controller) processChange(logger logrus.FieldLogger, instance string, c
 		labels[client.GerritPatchset] = strconv.Itoa(change.Revisions[change.CurrentRevision].Number)
 
 		if _, ok := labels[client.GerritReportLabel]; !ok {
-			logger.WithField("job", jSpec.spec.Job).Warn("Job uses default value of 'Code-Review' for 'prow.k8s.io/gerrit-report-label' label. This default will removed in March 2022.")
+			logger.WithField("job", jSpec.spec.Job).Debug("Job uses default value of 'Code-Review' for 'prow.k8s.io/gerrit-report-label' label. This default will removed in March 2022.")
 			labels[client.GerritReportLabel] = client.CodeReview
 		}
 


### PR DESCRIPTION
These logs are only monitored by prow operators, who normally don't control which label a prow job reports to. Log on warning level caused spam in log stream

/cc @cjwagner 