### PR TITLE
Prow image build presubmit job runs on high cpu node

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -175,14 +175,18 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        resources:
-          requests:
-            # This job is very CPU intensive as building prow images in
-            # parallel, so want to ensure that this job runs on a node without
-            # any other job running.
-            # The node pool has 7.91 allocatable CPUs, requesting 7300m here +
-            # 400m requested by pod utils = 7700m requested.
-            cpu: 7300m
+      tolerations:
+      - key: "highcpu"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+      nodeSelector:
+        highcpu: "true"
+      resources:
+        requests:
+          # This job is very CPU intensive as building prow images in
+          # parallel
+          cpu: "15"
     annotations:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: prow-image-build-test


### PR DESCRIPTION
Noticed that the image build job takes ~16 minutes normally, could be up to 25 minutes (https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-test-infra-prow-image-build-test). The CPU profile from GKE reveals that the job uses all the CPU from a 8 cpu node. Updating the job so that it only runs on a nodepool with highcpu label.

/hold
the nodepool doesn't exist yet

/cc @cjwagner 