### PR TITLE
Prow integration test stops using prod prow image

### DIFF
--- a/prow/test/integration/prow/cluster/deck_tenant_deployment.yaml
+++ b/prow/test/integration/prow/cluster/deck_tenant_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck-tenanted
-        image: gcr.io/k8s-prow/deck:v20220222-1df1eebe10
+        image: localhost:5001/deck
         imagePullPolicy: Always
         ports:
           - name: http


### PR DESCRIPTION
It was an oversight that previously prow integration test still uses deck image from gcr.io/k8s-prow instead of the image produced during test

/cc @mpherman2 