### PR TITLE
Checkconfig prow jobs binary path updated to the one work with ko

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -52,7 +52,7 @@ presubmits:
       containers:
       - image: gcr.io/k8s-prow/checkconfig:v20220222-8d1661c08e
         command:
-        - /checkconfig
+        - /ko-app/checkconfig
         args:
         - --config-path=config/prow/config.yaml
         - --job-config-path=config/jobs

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -818,7 +818,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/checkconfig:v20220222-8d1661c08e
       command:
-      - /checkconfig
+      - /ko-app/checkconfig
       args:
       - --config-path=config/prow/config.yaml
       - --job-config-path=config/jobs


### PR DESCRIPTION
It's pretty unfortunate that prow jobs don't respect entrypoint from an image, updating the path