### PR TITLE
Update entrypoint to binary names in prow jobs that consume gcr.io/k8…

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
@@ -12,7 +12,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20220222-8d1661c08e
       command:
-      - /app/robots/commenter/app.binary
+      - commenter
       args:
       # pull requests against master branches in the kubernetes org labeled kind/api-change
       # exclude PRs that are in progress, held, or need rebase (typically aren't ready for API review).
@@ -60,7 +60,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20220222-8d1661c08e
       command:
-      - /app/robots/commenter/app.binary
+      - commenter
       args:
       - |-
         --query=org:kubernetes
@@ -103,7 +103,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20220222-8d1661c08e
       command:
-      - /app/robots/commenter/app.binary
+      - commenter
       args:
       - |-
         --query=org:kubernetes
@@ -157,7 +157,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20220222-8d1661c08e
       command:
-      - /app/robots/commenter/app.binary
+      - commenter
       args:
       - |-
         --query=is:pr
@@ -225,7 +225,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20220222-8d1661c08e
       command:
-      - /app/robots/commenter/app.binary
+      - commenter
       args:
       - |-
         --query=org:kubernetes
@@ -280,7 +280,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20220222-8d1661c08e
       command:
-      - /app/robots/commenter/app.binary
+      - commenter
       args:
       - |-
         --query=org:kubernetes
@@ -336,7 +336,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20220222-8d1661c08e
       command:
-      - /app/robots/commenter/app.binary
+      - commenter
       args:
       - |-
         --query=org:kubernetes
@@ -385,7 +385,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/issue-creator:v20220222-8d1661c08e
       command:
-      - /app/robots/issue-creator/app.binary
+      - issue-creator
       args:
       - --dry-run=false
       - --alsologtostderr

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-prow.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-prow.yaml
@@ -129,7 +129,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20220222-8d1661c08e
       command:
-      - /app/prow/cmd/generic-autobumper/app.binary
+      - generic-autobumper
       args:
       - --config=hack/autobump-config.yaml
       volumeMounts:
@@ -168,7 +168,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20220222-8d1661c08e
       command:
-      - /app/prow/cmd/generic-autobumper/app.binary
+      - generic-autobumper
       args:
       - --config=hack/autobump-config.yaml
       - --labels-override=skip-review

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
@@ -125,7 +125,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20220222-8d1661c08e
       command:
-      - /app/prow/cmd/generic-autobumper/app.binary
+      - generic-autobumper
       args:
       - --config=config/prow/autobump-config/prow-job-autobump-config.yaml
       volumeMounts:
@@ -155,7 +155,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20220222-8d1661c08e
       command:
-      - /app/prow/cmd/generic-autobumper/app.binary
+      - generic-autobumper
       args:
       - --config=config/prow/autobump-config/prow-job-autobump-config.yaml
       - --labels-override=skip-review # This label is used by tide for identifying trusted PR

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -52,7 +52,7 @@ presubmits:
       containers:
       - image: gcr.io/k8s-prow/checkconfig:v20220222-8d1661c08e
         command:
-        - /ko-app/checkconfig
+        - checkconfig
         args:
         - --config-path=config/prow/config.yaml
         - --job-config-path=config/jobs

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -154,7 +154,7 @@ postsubmits:
       containers:
       - image: gcr.io/k8s-prow/hmac:v20220222-8d1661c08e
         command:
-        - /hmac
+        - hmac
         args:
         - --config-path=config/prow/config.yaml
         - --hook-url=https://prow.k8s.io/hook
@@ -630,7 +630,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20220222-8d1661c08e
       command:
-      - /app/prow/cmd/generic-autobumper/app.binary
+      - generic-autobumper
       args:
       - --config=config/prow/autobump-config/prow-component-autobump-config.yaml
       - --labels-override=skip-review # This label is used by tide for identifying trusted PR
@@ -667,7 +667,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20220222-8d1661c08e
       command:
-      - /app/prow/cmd/generic-autobumper/app.binary
+      - generic-autobumper
       args:
       - --config=config/prow/autobump-config/prow-component-autobump-config.yaml
       volumeMounts:
@@ -738,7 +738,7 @@ periodics:
     - name: branchprotector
       image: gcr.io/k8s-prow/branchprotector:v20220222-8d1661c08e
       command:
-      - /app/prow/cmd/branchprotector/app.binary
+      - branchprotector
       args:
       - --config-path=config/prow/config.yaml
       - --job-config-path=config/jobs
@@ -772,7 +772,7 @@ periodics:
     - name: label-sync
       image: gcr.io/k8s-prow/label_sync:v20220222-8d1661c08e
       command:
-      - /app/label_sync/app.binary
+      - label_sync
       args:
       - --config=/etc/config/labels.yaml
       - --confirm=true
@@ -818,7 +818,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/checkconfig:v20220222-8d1661c08e
       command:
-      - /ko-app/checkconfig
+      - checkconfig
       args:
       - --config-path=config/prow/config.yaml
       - --job-config-path=config/jobs


### PR DESCRIPTION
…s-prow images

Images are now built with ko, the binaries are placed under  instead of  in the past, fixing them with just binaries names.

I have manually tested two images: generic-autobumper and pr-creator, one built with git base image and the latter with distroless base image, and both worked

/cc @BenTheElder @cjwagner @alvaroaleman 