### PR TITLE
Update image config for lock contention and node perf e2e tests

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -1291,7 +1291,7 @@ periodics:
           - --deployment=node
           - --gcp-project-type=node-e2e-project
           - --gcp-zone=us-west1-b
-          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
+          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/image-config.yaml
           - --node-test-args=--kubelet-flags="--exit-on-lock-contention --lock-file=/var/run/kubelet.lock"
           - --node-tests=true
           - --provider=gce

--- a/jobs/e2e_node/perf-image-config.yaml
+++ b/jobs/e2e_node/perf-image-config.yaml
@@ -4,12 +4,12 @@ images:
     image_family: cos-89-lts
     project: cos-cloud
     machine: n1-standard-16
-    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
+    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"
     tests:
       - 'Node Performance Testing'
   ubuntu:
-    image: ubuntu-gke-1804-1-17-v20200605 # docker 19.03.2 / containerd 1.2.10
+    image: ubuntu-gke-2004-1-20-v20210401 # docker 19.03.8 / containerd 1.4.3
     project: ubuntu-os-gke-cloud
-    machine: n1-standard-16
+    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"
     tests:
       - 'Node Performance Testing'


### PR DESCRIPTION
specify correct image config for node perf and lock contention e2e tests, it is required for right installation of cni configs 
this cloud init installs containerd config and cni template
https://github.com/kubernetes/test-infra/blob/master/jobs/e2e_node/containerd/init.yaml

Fix for https://github.com/kubernetes/test-infra/issues/25372
cc @ipochi @Namanl2001 @SergeyKanzhelev 
/sig node

Signed-off-by: Aditi Sharma <adi.sky17@gmail.com>