### PR TITLE
Add cache for PR mergeability

### DIFF
--- a/prow/external-plugins/needs-rebase/plugin/plugin.go
+++ b/prow/external-plugins/needs-rebase/plugin/plugin.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	githubql "github.com/shurcooL/githubv4"
@@ -72,23 +73,32 @@ func HandlePullRequestEvent(log *logrus.Entry, ghc githubClient, pre *github.Pul
 	if pre.Action != github.PullRequestActionOpened && pre.Action != github.PullRequestActionSynchronize && pre.Action != github.PullRequestActionReopened {
 		return nil
 	}
-
 	return handle(log, ghc, &pre.PullRequest)
 }
 
 // HandleIssueCommentEvent handles a GitHub issue comment event and adds or removes a
 // "needs-rebase" label if the issue is a PR based on whether the GitHub api considers
 // the PR mergeable
-func HandleIssueCommentEvent(log *logrus.Entry, ghc githubClient, ice *github.IssueCommentEvent) error {
+func HandleIssueCommentEvent(log *logrus.Entry, ghc githubClient, ice *github.IssueCommentEvent, cache *Cache) error {
 	if !ice.Issue.IsPullRequest() {
 		return nil
 	}
+
+	if cache.validTime > 0 && cache.Get(ice.Issue.ID) {
+		return nil
+	}
+
 	pr, err := ghc.GetPullRequest(ice.Repo.Owner.Login, ice.Repo.Name, ice.Issue.Number)
 	if err != nil {
 		return err
 	}
+	err = handle(log, ghc, pr)
 
-	return handle(log, ghc, pr)
+	if cache.validTime > 0 && err == nil {
+		cache.Set(ice.Issue.ID)
+	}
+
+	return err
 }
 
 // handle handles a GitHub PR to determine if the "needs-rebase"
@@ -122,7 +132,6 @@ func handle(log *logrus.Entry, ghc githubClient, pr *github.PullRequest) error {
 		return err
 	}
 	hasLabel := github.HasLabel(labels.NeedsRebase, issueLabels)
-
 	return takeAction(ghc, org, repo, number, pr.User.Login, hasLabel, mergeable)
 }
 
@@ -131,7 +140,11 @@ const searchQueryPrefix = "archived:false is:pr is:open"
 // HandleAll checks all orgs and repos that enabled this plugin for open PRs to
 // determine if the "needs-rebase" label needs to be added or removed. It
 // depends on GitHub's mergeability check to decide the need for a rebase.
-func HandleAll(log *logrus.Entry, ghc githubClient, config *plugins.Configuration, usesAppsAuth bool) error {
+func HandleAll(log *logrus.Entry, ghc githubClient, config *plugins.Configuration, usesAppsAuth bool, issueCache *Cache) error {
+	if issueCache.validTime > 0 {
+		issueCache.Flush()
+	}
+
 	log.Info("Checking all PRs.")
 	orgs, repos := config.EnabledReposForExternalPlugin(PluginName)
 	if len(orgs) == 0 && len(repos) == 0 {
@@ -378,4 +391,53 @@ func constructQueries(log *logrus.Entry, now time.Time, orgs, repos []string, us
 	}
 
 	return result
+}
+
+type timeNow func() time.Time
+
+type Cache struct {
+	cache       map[int]time.Time
+	validTime   time.Duration
+	currentTime timeNow
+	flush       func(cache *Cache)
+	mutex       sync.Mutex
+}
+
+func (cache *Cache) Get(key int) bool {
+	cache.mutex.Lock()
+	defer cache.mutex.Unlock()
+
+	insertTime := cache.cache[key]
+	curTime := cache.currentTime()
+	age := curTime.Sub(insertTime)
+	if age > 0 && age < cache.validTime {
+		return true
+	}
+	delete(cache.cache, key)
+	return false
+}
+
+func (cache *Cache) Set(key int) {
+	if cache.validTime > 0 {
+		cache.mutex.Lock()
+		defer cache.mutex.Unlock()
+
+		cache.cache[key] = cache.currentTime()
+	}
+}
+
+func (cache *Cache) Flush() {
+	cache.mutex.Lock()
+	defer cache.mutex.Unlock()
+
+	cache.flush(cache)
+}
+
+func NewCache(validTime int) *Cache {
+	return &Cache{
+		cache:       make(map[int]time.Time),
+		validTime:   time.Second * time.Duration(validTime),
+		currentTime: func() time.Time { return time.Now() },
+		flush:       func(cache *Cache) { cache.cache = make(map[int]time.Time) },
+	}
 }

--- a/prow/external-plugins/needs-rebase/plugin/plugin_test.go
+++ b/prow/external-plugins/needs-rebase/plugin/plugin_test.go
@@ -241,7 +241,8 @@ func TestHandleIssueCommentEvent(t *testing.T) {
 				tc.pr.Merged = tc.merged
 				tc.pr.State = tc.state
 			}
-			if err := HandleIssueCommentEvent(logrus.WithField("plugin", PluginName), fake, ice); err != nil {
+			cache := NewCache(0)
+			if err := HandleIssueCommentEvent(logrus.WithField("plugin", PluginName), fake, ice, cache); err != nil {
 				t.Fatalf("error handling issue comment event: %v", err)
 			}
 			fake.compareExpected(t, "org", "repo", 5, tc.expectedAdded, tc.expectedRemoved, tc.expectComment, tc.expectDeletion)
@@ -401,8 +402,9 @@ func TestHandleAll(t *testing.T) {
 
 		ExternalPlugins: map[string][]plugins.ExternalPlugin{"/": {{Name: PluginName}}},
 	}
+	issueCache := NewFakeCache(0)
 
-	if err := HandleAll(logrus.WithField("plugin", PluginName), fake, config, false); err != nil {
+	if err := HandleAll(logrus.WithField("plugin", PluginName), fake, config, false, issueCache); err != nil {
 		t.Fatalf("Unexpected error handling all prs: %v.", err)
 	}
 	for i, pr := range testPRs {
@@ -546,5 +548,75 @@ func TestConstructQueries(t *testing.T) {
 				t.Errorf("expected result differs from actual: %s", diff)
 			}
 		})
+	}
+}
+
+func NewFakeCache(validTime time.Duration) *Cache {
+	return &Cache{
+		cache:       make(map[int]time.Time),
+		validTime:   time.Second * validTime,
+		currentTime: getFakeTime(),
+		flush:       func(cache *Cache) { cache.cache = make(map[int]time.Time) },
+	}
+}
+
+func getFakeTime() timeNow {
+	var i = 0
+	now := time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)
+	return func() time.Time {
+		i = i + 1
+		return now.Add(time.Duration(i) * time.Second)
+	}
+}
+
+func TestCache(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name      string
+		validTime time.Duration
+		keys      []int
+
+		expected []bool
+	}{
+		{
+			name:      "Test cache - disabled",
+			validTime: 0,
+
+			keys:     []int{11, 22, 22, 11},
+			expected: []bool{false, false, false, false},
+		},
+		{
+			name:      "Test cache - all miss",
+			validTime: 100,
+
+			keys:     []int{11, 22, 33, 44},
+			expected: []bool{false, false, false, false},
+		},
+		{
+			name:      "Test cache - one key hits, other missed",
+			validTime: 100,
+
+			keys:     []int{11, 22, 33, 11},
+			expected: []bool{false, false, false, true},
+		},
+		{
+			name:      "Test cache - repeated requested same key",
+			validTime: 100,
+
+			keys:     []int{11, 11, 11, 11},
+			expected: []bool{false, true, true, true},
+		},
+	}
+
+	for _, tc := range testCases {
+		fake := NewFakeCache(tc.validTime)
+		t.Logf("Running test scenario: %q", tc.name)
+		for idx, key := range tc.keys {
+			age := fake.Get(key)
+			if age != tc.expected[idx] {
+				t.Errorf("Unexpected cache age %t, expected %t.", age, tc.expected[idx])
+			}
+			fake.Set(key)
+		}
 	}
 }


### PR DESCRIPTION
Currently, `needs-rebase` check mergeability for every commits, which used a lot of tokens.

This PR adds a cache layer to that. `needs-rebase` now cache mergeability results for PRs in memory. Only the first event of a PR will hit GitHub, and the following will use the cached results.
