### PR TITLE
Update minikube prow job to point to v0.0.2 image

### DIFF
--- a/config/jobs/kubernetes/minikube/OWNERS
+++ b/config/jobs/kubernetes/minikube/OWNERS
@@ -2,21 +2,20 @@
 
 reviewers:
   - sig-cluster-lifecycle-leads
-  - tstromberg
   - afbjorklund
   - sharifelgamal
-  - RA489
   - medyagh
   - blueelvis
   - prasadkatti
-  - ilya-zuyev
-  - prezha	
+  - prezha
+  - spowelljr
+  - klaases
 approvers:
   - sig-cluster-lifecycle-leads
-  - tstromberg
   - afbjorklund
   - sharifelgamal
   - medyagh
-  - ilya-zuyev
+  - spowelljr
+  - prezha
 labels:
-- sig/cluster-lifecycle
+  - sig/cluster-lifecycle

--- a/config/jobs/kubernetes/minikube/minikube.yaml
+++ b/config/jobs/kubernetes/minikube/minikube.yaml
@@ -23,7 +23,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-minikube/prow-test:v0.0.1
+      - image: gcr.io/k8s-minikube/prow-test:v0.0.2
         # we add --force since minikube is running as root
         command:
         - wrapper.sh


### PR DESCRIPTION
Updating the OWNERS file to reflect the current state of minikube maintainers, and pointing the prow job to v0.0.2, which has a new golang version.