### PR TITLE
spyglass: Add support for custom title and help info in HTML lens

### DIFF
--- a/prow/spyglass/lenses/html/BUILD.bazel
+++ b/prow/spyglass/lenses/html/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//prow/spyglass/api:go_default_library",
         "//prow/spyglass/lenses:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@org_golang_x_net//html:go_default_library",
     ],
 )
 

--- a/prow/spyglass/lenses/html/html_test.go
+++ b/prow/spyglass/lenses/html/html_test.go
@@ -98,6 +98,27 @@ func TestRenderBody(t *testing.T) {
 				content: []byte(`<body>"Hello world!"</body>`),
 			},
 		},
+		{
+			name: "With title",
+			artifact: FakeArtifact{
+				path:    "https://s3.internal/bucket/file.html",
+				content: []byte(`<head><title>Custom Title</title><body>Hello world!</body>`),
+			},
+		},
+		{
+			name: "With description",
+			artifact: FakeArtifact{
+				path:    "https://s3.internal/bucket/file.html",
+				content: []byte(`<head><meta name="description" content="Loki is a log aggregation system"></head><body>Hello world!</body>`),
+			},
+		},
+		{
+			name: "With description and title",
+			artifact: FakeArtifact{
+				path:    "https://s3.internal/bucket/file.html",
+				content: []byte(`<head><meta name="description" content="Loki is a log aggregation system"><title>Custom tools</title><body></body>`),
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/prow/spyglass/lenses/html/template.html
+++ b/prow/spyglass/lenses/html/template.html
@@ -5,15 +5,15 @@
 
 {{define "body"}}
   <table class="mdl-data-table mdl-js-data-table mdl-shadow--2dp">
-    {{ range $title, $content:= . }}
+    {{ range $documents:= . }}
     <tr class="header section-expander">
-      <td class="mdl-data-table__cell--non-numeric expander failed" colspan="1"><h6>{{$title}}</h6></td>
+      <td class="mdl-data-table__cell--non-numeric expander failed" colspan="1"><h6>{{.Title}}</h6></td>
       <td class="mdl-data-table__cell--non-numeric expander"><i class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
     </tr>
     {{/* Do _not_ hide this by default, that will break inner javascript that dynamically resizes. Hiding post-render is ok, so we hide on first resize request */}}
-    <tr class="initial" id="{{$title}}-tr">
+    <tr class="initial" id="{{.Filename}}-tr">
       <td colspan="2" style="border: 0px; padding: 0px;">
-        <iframe srcdoc="{{$content}}" title="{{$title}}" sandbox="allow-scripts allow-popups allow-same-origin" id="{{$title}}" width="100%" scrolling="no"></iframe>
+        <iframe srcdoc="{{.Content}}" title="{{.Filename}}" sandbox="allow-scripts allow-popups allow-same-origin" id="{{.Filename}}" width="100%" scrolling="no"></iframe>
       </td>
     </tr>
     {{end}}

--- a/prow/spyglass/lenses/html/testdata/TestRenderBody_With_description.yaml
+++ b/prow/spyglass/lenses/html/testdata/TestRenderBody_With_description.yaml
@@ -1,0 +1,28 @@
+
+  <table class="mdl-data-table mdl-js-data-table mdl-shadow--2dp">
+    
+    <tr class="header section-expander">
+      <td class="mdl-data-table__cell--non-numeric expander failed" colspan="1"><h6>file.html <abbr class="icon material-icons" title="Loki is a log aggregation system">info</abbr></h6></td>
+      <td class="mdl-data-table__cell--non-numeric expander"><i class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
+    </tr>
+    
+    <tr class="initial" id="file.html-tr">
+      <td colspan="2" style="border: 0px; padding: 0px;">
+        <iframe srcdoc="<div id=&quot;wrapper&quot;><head><meta name=&quot;description&quot; content=&quot;Loki is a log aggregation system&quot;></head><body>Hello world!</body></div><script type=&quot;text/javascript&quot;>
+window.addEventListener(&quot;load&quot;, function(){
+    if(window.self === window.top) return; // if w.self === w.top, we are not in an iframe
+    send_height_to_parent_function = function(){
+        var height = document.getElementById(&quot;wrapper&quot;).offsetHeight;
+        parent.postMessage({&quot;height&quot; : height , &quot;id&quot;: &quot;file.html&quot;}, &quot;*&quot;);
+    }
+    send_height_to_parent_function(); //whenever the page is loaded
+    window.addEventListener(&quot;resize&quot;, send_height_to_parent_function); // whenever the page is resized
+    var observer = new MutationObserver(send_height_to_parent_function);           // whenever DOM changes PT1
+    var config = { attributes: true, childList: true, characterData: true, subtree:true}; // PT2
+    observer.observe(window.document, config);                                            // PT3
+});
+</script>" title="file.html" sandbox="allow-scripts allow-popups allow-same-origin" id="file.html" width="100%" scrolling="no"></iframe>
+      </td>
+    </tr>
+    
+  </table>

--- a/prow/spyglass/lenses/html/testdata/TestRenderBody_With_description_and_title.yaml
+++ b/prow/spyglass/lenses/html/testdata/TestRenderBody_With_description_and_title.yaml
@@ -1,0 +1,28 @@
+
+  <table class="mdl-data-table mdl-js-data-table mdl-shadow--2dp">
+    
+    <tr class="header section-expander">
+      <td class="mdl-data-table__cell--non-numeric expander failed" colspan="1"><h6>Custom tools <abbr class="icon material-icons" title="Loki is a log aggregation system">info</abbr></h6></td>
+      <td class="mdl-data-table__cell--non-numeric expander"><i class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
+    </tr>
+    
+    <tr class="initial" id="file.html-tr">
+      <td colspan="2" style="border: 0px; padding: 0px;">
+        <iframe srcdoc="<div id=&quot;wrapper&quot;><head><meta name=&quot;description&quot; content=&quot;Loki is a log aggregation system&quot;><title>Custom tools</title><body></body></div><script type=&quot;text/javascript&quot;>
+window.addEventListener(&quot;load&quot;, function(){
+    if(window.self === window.top) return; // if w.self === w.top, we are not in an iframe
+    send_height_to_parent_function = function(){
+        var height = document.getElementById(&quot;wrapper&quot;).offsetHeight;
+        parent.postMessage({&quot;height&quot; : height , &quot;id&quot;: &quot;file.html&quot;}, &quot;*&quot;);
+    }
+    send_height_to_parent_function(); //whenever the page is loaded
+    window.addEventListener(&quot;resize&quot;, send_height_to_parent_function); // whenever the page is resized
+    var observer = new MutationObserver(send_height_to_parent_function);           // whenever DOM changes PT1
+    var config = { attributes: true, childList: true, characterData: true, subtree:true}; // PT2
+    observer.observe(window.document, config);                                            // PT3
+});
+</script>" title="file.html" sandbox="allow-scripts allow-popups allow-same-origin" id="file.html" width="100%" scrolling="no"></iframe>
+      </td>
+    </tr>
+    
+  </table>

--- a/prow/spyglass/lenses/html/testdata/TestRenderBody_With_title.yaml
+++ b/prow/spyglass/lenses/html/testdata/TestRenderBody_With_title.yaml
@@ -1,0 +1,28 @@
+
+  <table class="mdl-data-table mdl-js-data-table mdl-shadow--2dp">
+    
+    <tr class="header section-expander">
+      <td class="mdl-data-table__cell--non-numeric expander failed" colspan="1"><h6>Custom Title</h6></td>
+      <td class="mdl-data-table__cell--non-numeric expander"><i class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
+    </tr>
+    
+    <tr class="initial" id="file.html-tr">
+      <td colspan="2" style="border: 0px; padding: 0px;">
+        <iframe srcdoc="<div id=&quot;wrapper&quot;><head><title>Custom Title</title><body>Hello world!</body></div><script type=&quot;text/javascript&quot;>
+window.addEventListener(&quot;load&quot;, function(){
+    if(window.self === window.top) return; // if w.self === w.top, we are not in an iframe
+    send_height_to_parent_function = function(){
+        var height = document.getElementById(&quot;wrapper&quot;).offsetHeight;
+        parent.postMessage({&quot;height&quot; : height , &quot;id&quot;: &quot;file.html&quot;}, &quot;*&quot;);
+    }
+    send_height_to_parent_function(); //whenever the page is loaded
+    window.addEventListener(&quot;resize&quot;, send_height_to_parent_function); // whenever the page is resized
+    var observer = new MutationObserver(send_height_to_parent_function);           // whenever DOM changes PT1
+    var config = { attributes: true, childList: true, characterData: true, subtree:true}; // PT2
+    observer.observe(window.document, config);                                            // PT3
+});
+</script>" title="file.html" sandbox="allow-scripts allow-popups allow-same-origin" id="file.html" width="100%" scrolling="no"></iframe>
+      </td>
+    </tr>
+    
+  </table>


### PR DESCRIPTION
This extracts the html `<title>` tag as an alternative to the filename
for the HTML lens, if present. It also allows optionally specifying help
by using a `meta` tag:

  `<meta name="description" content="Custom tools contains links to Loki and Prometheus"/>`

If the HTML doesn't contain a title or meta tag, the existing behavior is maintained.

![image](https://user-images.githubusercontent.com/429763/155520470-8abf14c0-46a5-46ad-89cb-84f5b78347f7.png)
