### PR TITLE
Increase build count for Golang in perf-dash

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
@@ -62,6 +62,7 @@ periodics:
   cluster: k8s-infra-prow-build
   tags:
   - "perfDashPrefix: golang-tip-k8s-1-23"
+  - "perfDashBuildsCount: 500"
   - "perfDashJobType: performance"
   labels:
     preset-service-account: "true"


### PR DESCRIPTION
Attempting to pinpoint the moment in time when memory bump in apiserver took place.

/assign @mborsz