### PR TITLE
CAPZ: remove periodic jobs running on alpha branches at k8s main

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-release-v1alpha3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-release-v1alpha3.yaml
@@ -32,42 +32,6 @@ periodics:
     testgrid-tab-name: capz-periodic-conformance-v1alpha3
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
     description: Runs conformance & node conformance tests on a stable k8s version with cluster-api-provider-azure release-0.4 (v1alpha3)
-- name: periodic-cluster-api-provider-azure-conformance-with-ci-artifacts-v1alpha3
-  decorate: true
-  decoration_config:
-    timeout: 4h
-  interval: 24h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
-  extra_refs:
-    - org: kubernetes-sigs
-      repo: cluster-api-provider-azure
-      base_ref: release-0.4
-      path_alias: "sigs.k8s.io/cluster-api-provider-azure"
-  spec:
-    containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20211111-d096cb0c5f-1.18
-        command:
-          - runner.sh
-        args:
-          - ./scripts/ci-conformance.sh
-        env:
-        - name: E2E_ARGS
-          value: "-kubetest.use-ci-artifacts"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 2
-            memory: "9Gi"
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-conformance-k8s-ci-v1alpha3
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
-    description: Runs conformance & node conformance tests on latest kubernetes main with cluster-api-provider-azure release-0.4 (v1alpha3)
 - name: periodic-cluster-api-provider-azure-capi-e2e-v1alpha3
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-release-v1alpha4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-release-v1alpha4.yaml
@@ -32,42 +32,6 @@ periodics:
     testgrid-tab-name: capz-periodic-conformance-v1alpha4
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
     description: Runs conformance & node conformance tests on a stable k8s version with cluster-api-provider-azure release-0.5 (v1alpha4)
-- name: periodic-cluster-api-provider-azure-conformance-with-ci-artifacts-v1alpha4
-  decorate: true
-  decoration_config:
-    timeout: 4h
-  interval: 24h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
-  extra_refs:
-    - org: kubernetes-sigs
-      repo: cluster-api-provider-azure
-      base_ref: release-0.5
-      path_alias: "sigs.k8s.io/cluster-api-provider-azure"
-  spec:
-    containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220221-c13e827224-1.21
-        command:
-          - runner.sh
-        args:
-          - ./scripts/ci-conformance.sh
-        env:
-        - name: E2E_ARGS
-          value: "-kubetest.use-ci-artifacts"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 2
-            memory: "9Gi"
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-conformance-k8s-ci-v1alpha4
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
-    description: Runs conformance & node conformance tests on latest kubernetes main with cluster-api-provider-azure release-0.5 (v1alpha4)
 - name: periodic-cluster-api-provider-azure-capi-e2e-v1alpha4
   decorate: true
   decoration_config:


### PR DESCRIPTION
CAPI won't support k8s 1.24 for v1alpha3 and v1alpha4 and jobs broke with recent kubeadm updates to remove deprecated node labels. Removing the jobs since there are no plans to fix them.

Slack thread for context: https://kubernetes.slack.com/archives/C8TSNPY4T/p1645695866726779?thread_ts=1645095835.007129&cid=C8TSNPY4T