### PR TITLE
Define prow image build resource request on container level

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -175,6 +175,11 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+        resources:
+          requests:
+            # This job is very CPU intensive as building prow images in
+            # parallel
+            cpu: "14"
       tolerations:
       - key: "highcpu"
         operator: "Equal"
@@ -182,11 +187,6 @@ presubmits:
         effect: "NoSchedule"
       nodeSelector:
         highcpu: "true"
-      resources:
-        requests:
-          # This job is very CPU intensive as building prow images in
-          # parallel
-          cpu: "15"
     annotations:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: prow-image-build-test


### PR DESCRIPTION
Not sure why resources defined under spec did not work https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/test-infra/25413/pull-test-infra-prow-image-build-test/1496911888175337472

/cc @cjwagner 