### PR TITLE
Add latest release, latest release candidate, and canary sidecar test

### DIFF
--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml
@@ -1,5 +1,5 @@
 periodics:
-- name: ci-gcp-compute-persistent-disk-csi-driver-release-1-3-k8s-master-integration
+- name: ci-gcp-compute-persistent-disk-csi-driver-release-k8s-master-integration
   interval: 4h
   labels:
     preset-service-account: "true"
@@ -8,7 +8,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220214-0aa8fe1d3a-master
       args:
-      - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver=release-1.3"
+      - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver"
       - "--root=/go/src"
       - "--upload=gs://kubernetes-jenkins/logs"
       - "--clean"
@@ -32,9 +32,45 @@ periodics:
         cpu: 2000m
   annotations:
     testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver
-    testgrid-tab-name: Kubernetes Master Driver Release 1.3
+    testgrid-tab-name: Kubernetes Master Driver Latest Release
     testgrid-alert-email: gke-managed-storage-alerts@google.com
-    description: Kubernetes Integration tests for Kubernetes Master branch and Driver Release 1.3
+    description: Kubernetes Integration tests for Kubernetes Master branch, Driver latest Release, and Stable Sidecars.  Used to verify stable is not broken by driver head.
+- name: ci-gcp-compute-persistent-disk-csi-driver-release-staging-k8s-master-integration
+  interval: 4h
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220214-0aa8fe1d3a-master
+      args:
+      - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver"
+      - "--root=/go/src"
+      - "--upload=gs://kubernetes-jenkins/logs"
+      - "--clean"
+      - "--timeout=180" # Minutes (120m runs consistently time out)
+      - "--scenario=execute"
+      - "--" # end bootstrap args, scenario args below
+      - "test/run-k8s-integration-ci.sh"
+      env:
+      - name: GCE_PD_OVERLAY_NAME
+        value: "prow-stable-sidecar-rc-master"
+      - name: GCE_PD_DO_DRIVER_BUILD
+        value: "false"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      requests:
+        # these are both a bit below peak usage during build
+        # this is mostly for building kubernetes
+        memory: "9000Mi"
+        # during the tests more like 3-20m is used
+        cpu: 2000m
+  annotations:
+    testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver
+    testgrid-tab-name: Kubernetes Master Driver Latest Release Candidate
+    testgrid-alert-email: gke-managed-storage-alerts@google.com
+    description: Kubernetes Integration tests for Kubernetes Master branch, Driver latest Release Candidate, and Stable Sidecars. Used to test release candidates when a new release is being cut.
 - name: ci-gcp-compute-persistent-disk-csi-driver-latest-k8s-master-integration
   interval: 4h
   labels:
@@ -70,7 +106,43 @@ periodics:
     testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver
     testgrid-tab-name: Kubernetes Master Driver Latest
     testgrid-alert-email: gke-managed-storage-alerts@google.com
-    description: Kubernetes Integration tests for Kubernetes Master branch and Driver latest build
+    description: Kubernetes Integration tests for Kubernetes Master branch, Driver latest build, and Stable Sidecars
+- name: ci-gcp-compute-persistent-disk-csi-driver-latest-k8s-master-integration-canary-sidecars
+  interval: 4h
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220214-0aa8fe1d3a-master
+      args:
+      - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver"
+      - "--root=/go/src"
+      - "--upload=gs://kubernetes-jenkins/logs"
+      - "--clean"
+      - "--timeout=180" # Minutes (120m times out)
+      - "--scenario=execute"
+      - "--" # end bootstrap args, scenario args below
+      - "test/run-k8s-integration-ci.sh"
+      env:
+      - name: GCE_PD_OVERLAY_NAME
+        value: "prow-canary-sidecar"
+      - name: GCE_PD_DO_DRIVER_BUILD
+        value: "true"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      requests:
+        # these are both a bit below peak usage during build
+        # this is mostly for building kubernetes
+        memory: "9000Mi"
+        # during the tests more like 3-20m is used
+        cpu: 2000m
+  annotations:
+    testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver
+    testgrid-tab-name: Kubernetes Master Driver Latest Canary Sidecars
+    testgrid-alert-email: gke-managed-storage-alerts@google.com
+    description: Kubernetes Integration tests for Kubernetes Master branch, Driver latest build, and Canary Sidecars. Used to test the latest sidecars.
 - name: ci-gcp-compute-persistent-disk-csi-driver-stable-k8s-master-migration
   interval: 4h
   labels:


### PR DESCRIPTION
This PR adds 3 tests to our OSS Testgrid. 

Job: ci-gcp-compute-persistent-disk-csi-driver-release-k8s-master-integration (replaces release 1.3 test)
Overlay: stable-master
Driver: latest release
Do driver build: false
Sidecars: stable

Job: ci-gcp-compute-persistent-disk-csi-driver-release-staging-k8s-master-integration
Overlay: prow-stable-sidecar-rc-master
Driver: latest release candidate 
Do driver build: false
Sidecars: stable
Old Internal Testgrid:  pd-master-sidecars-latest-k8s-master-on-gce

Job: ci-gcp-compute-persistent-disk-csi-driver-latest-k8s-master-integration-canary-sidecars
Overlay: prow-canary-sidecar
Driver: latest build (master branch)
Do driver build: true
Sidecars: canary
Old Internal Testgrid: pd-master-sidecars-staging-k8s-master-on-gce