### PR TITLE
Add more fields in GetBranch error

### DIFF
--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -459,7 +459,8 @@ func strictBranchesConfig(c config.ProwConfig) (*orgRepoConfig, error) {
 				for branchName := range repo.Branches {
 					branch, err := repo.GetBranch(branchName)
 					if err != nil {
-						return nil, err
+						return nil, fmt.Errorf("error for repo=%s/%s and branch=%s: %w",
+							orgName, repoName, branchName, err)
 					}
 					if policyIsStrict(branch.Policy) {
 						strict = true


### PR DESCRIPTION
```
{"component":"unset","file":"prow/cmd/checkconfig/main.go:90","func":"main.reportWarning","level":"warning","msg":"defined branch policies must set protect","severity":"warning","time":"2022-02-21T14:24:47Z"}
```

It is hard to tell which org/repo/branch violated the rule.

