### PR TITLE
Prow binaries emit correct version info to prometheus

### DIFF
--- a/prow/cmd/hook/BUILD.bazel
+++ b/prow/cmd/hook/BUILD.bazel
@@ -68,6 +68,7 @@ go_library(
         "//prow/plugins/ownersconfig:go_default_library",
         "//prow/repoowners:go_default_library",
         "//prow/slack:go_default_library",
+        "//prow/version:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -48,6 +48,8 @@ import (
 	"k8s.io/test-infra/prow/plugins/ownersconfig"
 	"k8s.io/test-infra/prow/repoowners"
 	"k8s.io/test-infra/prow/slack"
+
+	_ "k8s.io/test-infra/prow/version"
 )
 
 const (

--- a/prow/cmd/prow-controller-manager/BUILD.bazel
+++ b/prow/cmd/prow-controller-manager/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//prow/pjutil:go_default_library",
         "//prow/pjutil/pprof:go_default_library",
         "//prow/plank:go_default_library",
+        "//prow/version:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/labels:go_default_library",
         "@io_k8s_apimachinery//pkg/util/errors:go_default_library",

--- a/prow/cmd/prow-controller-manager/main.go
+++ b/prow/cmd/prow-controller-manager/main.go
@@ -42,6 +42,8 @@ import (
 	"k8s.io/test-infra/prow/logrusutil"
 	"k8s.io/test-infra/prow/metrics"
 	"k8s.io/test-infra/prow/plank"
+
+	_ "k8s.io/test-infra/prow/version"
 )
 
 var allControllers = sets.NewString(plank.ControllerName)

--- a/prow/cmd/sinker/main.go
+++ b/prow/cmd/sinker/main.go
@@ -46,7 +46,7 @@ import (
 	"k8s.io/test-infra/prow/logrusutil"
 	"k8s.io/test-infra/prow/metrics"
 	"k8s.io/test-infra/prow/pjutil"
-	"k8s.io/test-infra/prow/version"
+	_ "k8s.io/test-infra/prow/version"
 )
 
 type options struct {
@@ -457,7 +457,6 @@ func (c *controller) clean() {
 	for k, v := range metrics.prowJobsCleaningErrors {
 		sinkerMetrics.prowJobsCleaningErrors.WithLabelValues(k).Set(float64(v))
 	}
-	version.GatherProwVersion(c.logger)
 	c.logger.Info("Sinker reconciliation complete.")
 }
 

--- a/prow/plank/reconciler.go
+++ b/prow/plank/reconciler.go
@@ -186,7 +186,6 @@ func (r *reconciler) syncMetrics(ctx context.Context) error {
 				continue
 			}
 			kube.GatherProwJobMetrics(r.log, pjs.Items)
-			version.GatherProwVersion(r.log)
 		}
 	}
 }

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -46,7 +46,7 @@ import (
 	"k8s.io/test-infra/prow/pjutil"
 	"k8s.io/test-infra/prow/tide/blockers"
 	"k8s.io/test-infra/prow/tide/history"
-	"k8s.io/test-infra/prow/version"
+	_ "k8s.io/test-infra/prow/version"
 )
 
 // For mocking out sleep during unit tests.
@@ -367,7 +367,6 @@ func (c *Controller) Sync() error {
 		c.logger.WithField("duration", duration.String()).Info("Synced")
 		tideMetrics.syncDuration.Set(duration.Seconds())
 		tideMetrics.syncHeartbeat.WithLabelValues("sync").Inc()
-		version.GatherProwVersion(c.logger)
 	}()
 	defer c.changedFiles.prune()
 	c.config().BranchProtectionWarnings(c.logger, c.config().PresubmitsStatic)

--- a/prow/version/metrics.go
+++ b/prow/version/metrics.go
@@ -30,15 +30,21 @@ var (
 
 func init() {
 	prometheus.MustRegister(prowVersion)
+	// For components that import current package, if `gatherProwVersion` if not
+	// explicitly called, there will be no metrics for `prow_version`, and when
+	// querying prometheus for `prow_version` the value will be zero, which
+	// is inaccurate. Since the version would not change for the running binary,
+	//  doing this once when binary starts should be fine.
+	gatherProwVersion()
 }
 
-// GatherProwVersion reports prow version
-func GatherProwVersion(l *logrus.Entry) {
+// gatherProwVersion reports prow version
+func gatherProwVersion() {
 	// record prow version
 	version, err := VersionTimestamp()
 	if err != nil {
 		// Not worth panicking
-		l.WithError(err).Debug("Failed to get version timestamp")
+		logrus.WithError(err).Debug("Failed to get version timestamp")
 		prowVersion.Set(-1)
 	} else {
 		prowVersion.Set(float64(version))


### PR DESCRIPTION
Looking at prometheus metrics, some prow components emit correct version info as prometheus metrics, some of them emit 0, the problem is that some explicitly call GatherProwVersion() while some not

/cc @cjwagner @petr-muller 