### PR TITLE
Set env for local-up-cluster periodic job

### DIFF
--- a/config/jobs/kubernetes/sig-testing/local-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/local-e2e.yaml
@@ -62,6 +62,11 @@ periodics:
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220221-c13e827224-master
+      env:
+      - name: DOCKER_IN_DOCKER_IPV6_ENABLED
+        value: "true"
+      - name: CONTAINER_RUNTIME_ENDPOINT
+        value: "/var/run/docker/containerd/containerd.sock"
       args:
       - "--timeout=140"
       - "--bare"


### PR DESCRIPTION
Signed-off-by: Aditi Sharma <adi.sky17@gmail.com>
Same as we done for Pull job https://github.com/kubernetes/test-infra/pull/25352 forgot to add for periodic job 🙈 
The pull job is passing now, https://github.com/kubernetes/kubernetes/pull/108295