### PR TITLE
Update Descheduler Go images for 1.16/1.17

### DIFF
--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
@@ -13,7 +13,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.3
+      - image: golang:1.17.6
         command:
         - make
         args:
@@ -30,7 +30,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.3
+      - image: golang:1.17.6
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
     run_if_changed: '\.go$'
     spec:
       containers:
-      - image: golang:1.17.3
+      - image: golang:1.17.6
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.21.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.21.yaml
@@ -13,7 +13,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.7
+      - image: golang:1.16.14
         command:
         - make
         args:
@@ -30,7 +30,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.7
+      - image: golang:1.16.14
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
     run_if_changed: '\.go$'
     spec:
       containers:
-      - image: golang:1.16.7
+      - image: golang:1.16.14
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.22.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.22.yaml
@@ -13,7 +13,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.7
+      - image: golang:1.16.14
         command:
         - make
         args:
@@ -30,7 +30,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.7
+      - image: golang:1.16.14
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
     run_if_changed: '\.go$'
     spec:
       containers:
-      - image: golang:1.16.7
+      - image: golang:1.16.14
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.23.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.23.yaml
@@ -13,7 +13,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.3
+      - image: golang:1.17.6
         command:
         - make
         args:
@@ -30,7 +30,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.3
+      - image: golang:1.17.6
         command:
         - make
         args:
@@ -48,7 +48,7 @@ presubmits:
     run_if_changed: '\.go$'
     spec:
       containers:
-      - image: golang:1.17.3
+      - image: golang:1.17.6
         command:
         - make
         args:


### PR DESCRIPTION
Pointed out by https://github.com/kubernetes-sigs/descheduler/pull/744

[CVE-2021-44716](https://github.com/advisories/GHSA-vc3p-29h2-gpcp) affects Go 1.17 and 1.16

Relevant PRs:
* https://github.com/kubernetes-sigs/descheduler/pull/744
* https://github.com/kubernetes-sigs/descheduler/pull/742
* https://github.com/kubernetes-sigs/descheduler/pull/745
* https://github.com/kubernetes-sigs/descheduler/pull/746