### PR TITLE
Enable accelerated networking for Windows jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -217,6 +217,8 @@ periodics:
             value: "latest"
           - name: WINDOWS_FLAVOR
             value: "containerd"
+          - name: AZURE_NODE_MACHINE_TYPE
+            value: "Standard_D4s_v3"
         securityContext:
           privileged: true
         resources:
@@ -303,6 +305,8 @@ periodics:
             value: "latest"
           - name: WINDOWS_FLAVOR
             value: "containerd-2022"
+          - name: AZURE_NODE_MACHINE_TYPE
+            value: "Standard_D4s_v3"
         securityContext:
           privileged: true
         resources:
@@ -679,6 +683,8 @@ periodics:
             value: "containerd"
           - name: WINDOWS_CONTAINERD_URL
             value: "https://github.com/kubernetes-sigs/sig-windows-tools/releases/download/windows-containerd-nightly/windows-containerd.tar.gz"
+          - name: AZURE_NODE_MACHINE_TYPE
+            value: "Standard_D4s_v3"
         securityContext:
           privileged: true
         resources:


### PR DESCRIPTION
Updates the windows node types for capz clusters to use accelerated networking. CAPZ enables accelerating networking automatically if the sku supports it.  

This will make tests on par with aks-engine tests that are using this sku which enables accelereated networking in 1.23 tests and main tests.  Accelerated networking for windows also greatly improves overall CPU usage which is a benefit for the tests.

/sig windows

