### PR TITLE
branchprotector: allow branch policies that only set `unmanaged: true`

### DIFF
--- a/prow/config/branch_protection.go
+++ b/prow/config/branch_protection.go
@@ -318,8 +318,8 @@ func (r Repo) GetBranch(name string) (*Branch, error) {
 	b, ok := r.Branches[name]
 	if ok {
 		b.Policy = r.Apply(b.Policy)
-		if b.Protect == nil {
-			return nil, errors.New("defined branch policies must set protect")
+		if b.Protect == nil && (b.Unmanaged == nil || !*b.Unmanaged) {
+			return nil, errors.New("defined branch policies must set protect or unmanaged=true")
 		}
 	} else {
 		b.Policy = r.Policy


### PR DESCRIPTION
We see strict checkconfig prevent us from using the following config:

```yaml
branch-protection:
  orgs:
    org:
      repos:
        repo:
          branches:
            main:
              unmanaged: true
```

with errors like:

```json
{
   "component":"checkconfig",
   "file":"k8s.io/test-infra/prow/cmd/checkconfig/main.go:90",
   "func":"main.reportWarning",
   "level":"warning",
   "msg":"error for repo=kata-containers/kata-containers and branch=main: defined branch policies must set protect",
   "severity":"warning",
}

```

With introducting of `unmanaged`, such configuration should be valid, so
suppress make the `GetBranch` method from returning an error when
`unmanaged=true`.
