### PR TITLE
Bump kubelet QPS in scalability tests

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -153,8 +153,6 @@ presets:
     value: "--enable-pprof"
   - name: CONTROLLER_MANAGER_TEST_ARGS
     value: "--profiling --kube-api-qps=100 --kube-api-burst=100"
-  - name: KUBELET_TEST_ARGS
-    value: "--enable-debugging-handlers"
   - name: KUBEPROXY_TEST_ARGS
     # TODO(#74011): Remove metrics-bind-address if the default is set.
     value: "--profiling --metrics-bind-address=0.0.0.0"
@@ -292,8 +290,6 @@ presets:
   # system pods in 1-node cluster.
   - name: MAX_PODS_PER_NODE
     value: "128"
-  - name: KUBELET_TEST_ARGS
-    value: "--enable-debugging-handlers --kube-api-qps=100 --kube-api-burst=100"
   - name: KUBEPROXY_TEST_ARGS
     value: "--profiling"
   - name: SCHEDULER_TEST_ARGS
@@ -315,10 +311,15 @@ presets:
 - labels:
     preset-e2e-scalability-presubmits: "true"
   env:
+  - name: KUBELET_TEST_ARGS
+    value: "--enable-debugging-handlers"
 
 - labels:
     preset-e2e-scalability-periodics: "true"
   env:
+  # TODO(wojtek-t): Promote it to preset-e2e-scalability-common and preset-e2e-scalability-node.
+  - name: KUBELET_TEST_ARGS
+    value: "--enable-debugging-handlers --kube-api-qps=100 --kube-api-burst=100"
 
 - labels:
     preset-e2e-scalability-periodics-master: "true"


### PR DESCRIPTION
This serves two reasons:
1. In 5k-node clusters, with 5 QPS limit, kubelets can in theory generate 25k QPS, which we will not be able to handle anyway. With P&F getting in better and better shape we should reduce this artificial limit and start relying more and more on server-side rate-limitting.
2. This is a step towards ensuring that QPS are not a limiting factor for pods startup latency (we know they aren't the only one as described in https://github.com/kubernetes/perf-tests/issues/1311 but this build towards eliminating this limit completely).

/assign @mborsz @marseel 