### PR TITLE
Add a GCE e2e optional presubmit to test registry sandbox

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -9,6 +9,11 @@ presets:
   env:
   - name: CREATE_CUSTOM_NETWORK
     value: "true"
+- labels:
+    preset-pull-registry-sandbox-repo-list: "true"
+  env:
+  - name: KUBE_TEST_REPO_LIST
+    value: https://raw.githubusercontent.com/kubernetes/test-infra/master/config/jobs/kubernetes/sig-cloud-provider/gcp/registry/default-sandbox.yaml
 
 presubmits:
   kubernetes/kubernetes:
@@ -273,6 +278,67 @@ presubmits:
       preset-dind-enabled: "true"
       preset-pull-kubernetes-e2e: "true"
       preset-pull-kubernetes-e2e-gce: "true"
+    spec:
+      containers:
+        - args:
+            - --root=/go/src
+            - --repo=k8s.io/kubernetes=$(PULL_REFS)
+            - --repo=k8s.io/release
+            - --upload=gs://kubernetes-jenkins/pr-logs
+            - --timeout=105
+            - --scenario=kubernetes_e2e
+            - --
+            - --build=quick
+            - --cluster=
+            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0
+            - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
+            - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
+            - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
+            - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
+            - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-2004-focal-v20200423
+            - --env=KUBE_GCE_MASTER_PROJECT=ubuntu-os-cloud
+            - --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu
+            - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2004-focal-v20200423
+            - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
+            - --extract=local
+            - --gcp-master-image=ubuntu
+            - --gcp-node-image=ubuntu
+            - --gcp-zone=us-west1-b
+            - --ginkgo-parallel=30
+            - --provider=gce
+            - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-ubuntu-containerd
+            - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
+            - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
+          image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220221-c13e827224-master
+          resources:
+            limits:
+              cpu: 4
+              memory: "14Gi"
+            requests:
+              cpu: 4
+              memory: "14Gi"
+          securityContext:
+            privileged: true
+
+  - name: pull-kubernetes-e2e-gce-registry-sandbox
+    cluster: k8s-infra-prow-build
+    always_run: false
+    skip_report: false
+    skip_branches:
+      - release-\d+\.\d+ # per-release image
+    annotations:
+      fork-per-release: "true"
+      testgrid-alert-stale-results-hours: "24"
+      testgrid-create-test-group: "true"
+      testgrid-num-failures-to-alert: "10"
+      testgrid-dashboards: google-gce
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-dind-enabled: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+      preset-pull-registry-sandbox-repo-list: "true"
     spec:
       containers:
         - args:

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/registry/default-sandbox.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/registry/default-sandbox.yaml
@@ -1,0 +1,6 @@
+promoterE2eRegistry: registry-sandbox.k8s.io/e2e-test-images
+buildImageRegistry: registry-sandbox.k8s.io/build-image
+gcEtcdRegistry: registry-sandbox.k8s.io
+gcRegistry: registry-sandbox.k8s.io
+sigStorageRegistry: registry-sandbox.k8s.io/sig-storage
+cloudProviderGcpRegistry: registry-sandbox.k8s.io/cloud-provider-gcp

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/registry/default.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/registry/default.yaml
@@ -1,0 +1,11 @@
+gcAuthenticatedRegistry: gcr.io/authenticated-image-pulling
+promoterE2eRegistry: k8s.gcr.io/e2e-test-images
+buildImageRegistry: k8s.gcr.io/build-image
+invalidRegistry: invalid.registry.k8s.io/invalid
+gcEtcdRegistry: k8s.gcr.io
+gcRegistry: k8s.gcr.io
+sigStorageRegistry: k8s.gcr.io/sig-storage
+privateRegistry: gcr.io/k8s-authenticated-test
+microsoftRegistry: mcr.microsoft.com
+dockerLibraryRegistry: docker.io/library
+cloudProviderGcpRegistry: k8s.gcr.io/cloud-provider-gcp


### PR DESCRIPTION
presubmit to see how the registry sandbox based on oci proxy holds up.

We will need https://github.com/kubernetes/kubernetes/pull/108429 to test this.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>