### PR TITLE
Add e2e test presubmits to cloud-provider-aws

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-config.yaml
@@ -42,3 +42,27 @@ presubmits:
       testgrid-tab-name: test
       description: aws cloud provider tests
       testgrid-num-columns-recent: '30'
+  - name: pull-cloud-provider-aws-e2e
+    always_run: true
+    decorate: true
+    skip_branches:
+    - gh-pages
+    path_alias: k8s.io/cloud-provider-aws
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-aws-credential-aws-oss-testing: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220221-c13e827224-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - test-e2e
+        - KOPS_STATE_STORE=s3://cloud-provider-aws-e2e
+    annotations:
+      testgrid-dashboards: provider-aws-cloud-provider-aws
+      testgrid-tab-name: e2e
+      description: aws cloud provider e2e tests
+      testgrid-num-columns-recent: '30'


### PR DESCRIPTION
Adds a job that uses https://github.com/kubernetes/cloud-provider-aws/pull/304