### PR TITLE
Ensure using linux jq running test in container

### DIFF
--- a/metrics/Makefile
+++ b/metrics/Makefile
@@ -17,8 +17,12 @@ include ../Makefile.base.mk
 REPO_ROOT:=${CURDIR}/..
 
 ensure-jq:
-# ./get_jq.sh script returns the path of jq
-	$(eval JQ_BIN=$(shell ./get_jq.sh))
+# ./get_jq.sh script returns the path of jq. The script downloads two versoins
+# of jq, one is `jq-linux64` that's required to run in the container, the other
+# one is `jq-<ARCH>` based on host OS, whis is copied over to `jq`. This target
+# is only used for running in container, so make sure using the one that works
+# in container.
+	$(eval JQ_BIN=$(shell ./get_jq.sh)-linux64)
 
 run: ensure-jq ensure-py-requirements3
 	../hack/run-in-python-container.sh ./metrics/bigquery.py --jq=${JQ_BIN}

--- a/metrics/get_jq.sh
+++ b/metrics/get_jq.sh
@@ -27,13 +27,25 @@ if [[ -f "${JQ_BIN}" ]]; then
     exit 0
 fi
 
-mkdir -p "${JQ_DIR}"
-URL=https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
-if [[ "$(uname)" == Darwin ]]; then
-    URL=https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64
-fi
+bin-path() {
+    echo "${REPO_ROOT}/${JQ_DIR}/$1"
+}
 
-curl -fsSL "${URL}" -o "${JQ_BIN}"
-chmod a+x "${JQ_BIN}"
+download() {
+    local name="$1"
+    local path="$(bin-path $name)"
+    curl -fsSL "https://github.com/stedolan/jq/releases/download/jq-1.5/$name" -o "$path"
+    chmod a+x "$path"
+    cp "$path" "$JQ_BIN"
+}
+
+mkdir -p "${JQ_DIR}"
+# linux64 is used by CI, making sure that this is used in CI as well
+download jq-linux64
+# ensure that `_bin/jq-1.5/jq` is compitable with host, so that python3 test
+# won't fail locally
+if [[ "$(uname)" == Darwin ]]; then
+    download jq-osx-amd64
+fi
 
 echo "$JQ_BIN"


### PR DESCRIPTION
currently _bin/jq-1.5/jq is downloaded as mac compatible binary, which would fail if use it in container

I have encountered this locally

/cc @BenTheElder 