### PR TITLE
prep CAPV jobs to switch to main

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-ci.yaml
@@ -6,6 +6,7 @@ postsubmits:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-gcs-creds: "true"
     branches:
+    - ^main$
     - ^master$
     always_run: false
     run_if_changed: '^((api|cmd|config|contrib|controllers|pkg|test|examples)/|Dockerfile|Makefile)'
@@ -31,7 +32,7 @@ postsubmits:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: post-deploy
       testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
-      description: Pushes new images and binaries from master
+      description: Pushes new images and binaries from main
 
   # Deploys images and binaries for tagged releases
   - name: post-cluster-api-provider-vsphere-release

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -181,6 +181,7 @@ presubmits:
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     branches:
+    - ^main$
     - ^master$
     spec:
       containers:
@@ -207,6 +208,7 @@ presubmits:
 
   - name: pull-cluster-api-provider-vsphere-e2e
     branches:
+      - ^main$
       - ^master$
       - ^release-1.*
     labels:


### PR DESCRIPTION
This PR allows the CAPV jobs to run on `main` branch as well. 
This is part of ongoing activity to migrate CAPV from `master` to `main`