### PR TITLE
Add more env vars to preset-pull-registry-sandbox-repo-list

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -14,6 +14,10 @@ presets:
   env:
   - name: KUBE_TEST_REPO_LIST
     value: https://raw.githubusercontent.com/kubernetes/test-infra/master/config/jobs/kubernetes/sig-cloud-provider/gcp/registry/default-sandbox.yaml
+  - name: KUBE_DOCKER_REGISTRY
+    value: registry-sandbox.k8s.io
+  - name: KUBE_ADDON_REGISTRY
+    value: registry-sandbox.k8s.io
 
 presubmits:
   kubernetes/kubernetes:


### PR DESCRIPTION
throw more env vars like `KUBE_DOCKER_REGISTRY` and `KUBE_ADDON_REGISTRY` so we can test the alternate sandbox proxy/registry

See https://cs.k8s.io/?q=KUBE_(DOCKER%7CADDON)_REGISTRY&i=nope&files=&excludeFiles=&repos=kubernetes/kubernetes on what these values affect

Signed-off-by: Davanum Srinivas <davanum@gmail.com>