### PR TITLE
Switch cgroupv2 jobs to use cos-beta image family

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -1069,8 +1069,8 @@ periodics:
       - --gcp-nodes=4
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=30
-      # Using cos-dev to pick up cgroupv2 enabled by default as of cos-dev-97-16778-0-0.
-      - --image-family=cos-dev
+      # Using cos-beta to pick up cgroupv2 enabled by default as of cos-beta-97-16919-0-3.
+      - --image-family=cos-beta
       - --image-project=cos-cloud
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8

--- a/jobs/e2e_node/containerd/containerd-master/cgroupv2/image-config-cgroupv2-serial.yaml
+++ b/jobs/e2e_node/containerd/containerd-master/cgroupv2/image-config-cgroupv2-serial.yaml
@@ -1,7 +1,7 @@
 images:
   cos-stable:
-    # Using cos-dev to pick up cgroupv2 enabled by default as of cos-dev-97-16778-0-0.
-    image_family: cos-dev
+    # Using cos-beta to pick up cgroupv2 enabled by default as of cos-beta-97-16919-0-3.
+    image_family: cos-beta
     project: cos-cloud
     machine: n1-standard-2 # These tests need a lot of memory
     metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-master/cgroupv2/env-cgroupv2,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/containerd/containerd-master/cgroupv2/image-config-cgroupv2.yaml
+++ b/jobs/e2e_node/containerd/containerd-master/cgroupv2/image-config-cgroupv2.yaml
@@ -1,6 +1,6 @@
 images:
   cos-stable:
-    # Using cos-dev to pick up cgroupv2 enabled by default as of cos-dev-97-16778-0-0.
-    image_family: cos-dev
+    # Using cos-beta to pick up cgroupv2 enabled by default as of cos-beta-97-16919-0-3.
+    image_family: cos-beta
     project: cos-cloud
     metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-master/cgroupv2/env-cgroupv2,gci-update-strategy=update_disabled"


### PR DESCRIPTION
cgroupv2 is enabled in COS M97 version. COS M97 was previously only in
the `cos-dev` image family. M97 has now graduated to beta, so let's
switch over the image family to target cos-beta. See
https://cloud.google.com/container-optimized-os/docs/release-notes/m97

![image](https://user-images.githubusercontent.com/486583/156284782-16f55342-9a90-4a8f-a4a9-b32f09a3c771.png)


Signed-off-by: David Porter <porterdavid@google.com>