### PR TITLE
Promote kubelet QPS limits bump to scalability presubmits

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -312,7 +312,7 @@ presets:
     preset-e2e-scalability-presubmits: "true"
   env:
   - name: KUBELET_TEST_ARGS
-    value: "--enable-debugging-handlers"
+    value: "--enable-debugging-handlers --kube-api-qps=100 --kube-api-burst=100"
 
 - labels:
     preset-e2e-scalability-periodics: "true"


### PR DESCRIPTION
Continuation of https://github.com/kubernetes/test-infra/pull/25454

As mentioned in https://github.com/kubernetes/test-infra/pull/25454#issuecomment-1056498376 it looks good in postsubmits (including older versions), so promoting it to presubmits.

Ref https://github.com/kubernetes/perf-tests/issues/1311

/assign @mborsz 