### PR TITLE
update list team members to use new api

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -3725,7 +3725,7 @@ func (c *client) ListTeamMembers(org string, id int, role string) ([]TeamMember,
 	if err != nil {
 		return nil, err
 	}
-	path := fmt.Sprintf("/organizations/%d/teams/%d/members", organization.Id, id)
+	path := fmt.Sprintf("/organizations/%d/team/%d/members", organization.Id, id)
 	var teamMembers []TeamMember
 	err = c.readPaginatedResultsWithValues(
 		path,
@@ -3762,7 +3762,7 @@ func (c *client) ListTeamMembersBySlug(org, teamSlug, role string) ([]TeamMember
 	if c.fake {
 		return nil, nil
 	}
-	path := fmt.Sprintf("/organizations/%s/teams/%s/members", org, teamSlug)
+	path := fmt.Sprintf("/orgs/%s/teams/%s/members", org, teamSlug)
 	var teamMembers []TeamMember
 	err := c.readPaginatedResultsWithValues(
 		path,

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -196,6 +196,7 @@ type TeamClient interface {
 	UpdateTeamMembership(org string, id int, user string, maintainer bool) (*TeamMembership, error)
 	RemoveTeamMembership(org string, id int, user string) error
 	ListTeamMembers(org string, id int, role string) ([]TeamMember, error)
+	ListTeamMembersBySlug(org, teamSlug, role string) ([]TeamMember, error)
 	ListTeamRepos(org string, id int) ([]Repo, error)
 	UpdateTeamRepo(id int, org, repo string, permission TeamPermission) error
 	RemoveTeamRepo(id int, org, repo string) error
@@ -3710,16 +3711,23 @@ func (c *client) RemoveTeamMembership(org string, id int, user string) error {
 // Role options are "all", "maintainer" and "member"
 //
 // https://developer.github.com/v3/teams/members/#list-team-members
+// Deprecated: please use ListTeamMembersBySlug
 func (c *client) ListTeamMembers(org string, id int, role string) ([]TeamMember, error) {
+	c.logger.WithField("methodName", "ListTeamMembers").
+		Warn("method is deprecated, and will result in multiple api calls to achieve result")
 	durationLogger := c.log("ListTeamMembers", id, role)
 	defer durationLogger()
 
 	if c.fake {
 		return nil, nil
 	}
-	path := fmt.Sprintf("/teams/%d/members", id)
+	organization, err := c.GetOrg(org)
+	if err != nil {
+		return nil, err
+	}
+	path := fmt.Sprintf("/organizations/%d/teams/%d/members", organization.Id, id)
 	var teamMembers []TeamMember
-	err := c.readPaginatedResultsWithValues(
+	err = c.readPaginatedResultsWithValues(
 		path,
 		url.Values{
 			"per_page": []string{"100"},
@@ -3728,6 +3736,41 @@ func (c *client) ListTeamMembers(org string, id int, role string) ([]TeamMember,
 		// This accept header enables the nested teams preview.
 		// https://developer.github.com/changes/2017-08-30-preview-nested-teams/
 		"application/vnd.github.hellcat-preview+json",
+		org,
+		func() interface{} {
+			return &[]TeamMember{}
+		},
+		func(obj interface{}) {
+			teamMembers = append(teamMembers, *(obj.(*[]TeamMember))...)
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return teamMembers, nil
+}
+
+// ListTeamMembersBySlug gets a list of team members for the given team slug
+//
+// Role options are "all", "maintainer" and "member"
+//
+// https://docs.github.com/en/rest/reference/teams#list-team-members
+func (c *client) ListTeamMembersBySlug(org, teamSlug, role string) ([]TeamMember, error) {
+	durationLogger := c.log("ListTeamMembersBySlug", org, teamSlug, role)
+	defer durationLogger()
+
+	if c.fake {
+		return nil, nil
+	}
+	path := fmt.Sprintf("/organizations/%s/teams/%s/members", org, teamSlug)
+	var teamMembers []TeamMember
+	err := c.readPaginatedResultsWithValues(
+		path,
+		url.Values{
+			"per_page": []string{"100"},
+			"role":     []string{role},
+		},
+		"application/vnd.github.v3+json",
 		org,
 		func() interface{} {
 			return &[]TeamMember{}
@@ -4544,6 +4587,7 @@ func (c *client) DeleteProjectCard(org string, projectCardID int) error {
 }
 
 // TeamHasMember checks if a user belongs to a team
+// Deprecated: use TeamBySlugHasMember
 func (c *client) TeamHasMember(org string, teamID int, memberLogin string) (bool, error) {
 	durationLogger := c.log("TeamHasMember", teamID, memberLogin)
 	defer durationLogger()

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -1900,7 +1900,7 @@ func TestListTeamMembers(t *testing.T) {
 
 		var result interface{}
 		switch r.URL.Path {
-		case "/organizations/1/teams/1/members":
+		case "/organizations/1/team/1/members":
 			result = []TeamMember{{Login: "foo"}}
 		case "/orgs/orgName":
 			result = Organization{Login: "orgName", Id: 1}
@@ -1929,7 +1929,7 @@ func TestListTeamMembers(t *testing.T) {
 }
 
 func TestListTeamMembersBySlug(t *testing.T) {
-	ts := simpleTestServer(t, "/organizations/orgName/teams/team-name/members", []TeamMember{{Login: "foo"}})
+	ts := simpleTestServer(t, "/orgs/orgName/teams/team-name/members", []TeamMember{{Login: "foo"}})
 	defer ts.Close()
 	c := getClient(ts.URL)
 	teamMembers, err := c.ListTeamMembersBySlug("orgName", "team-name", RoleAll)

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -1084,6 +1084,7 @@ type Organization struct {
 	// Login has the same meaning as Name, but it's more reliable to use as Name can sometimes be empty,
 	// see https://developer.github.com/v3/orgs/#list-organizations
 	Login string `json:"login"`
+	Id    int    `json:"id"`
 	// BillingEmail holds private billing address
 	BillingEmail string `json:"billing_email"`
 	Company      string `json:"company"`


### PR DESCRIPTION
Begins to fix: https://github.com/kubernetes/test-infra/issues/25457

https://github.blog/changelog/2022-02-22-sunset-notice-deprecated-teams-api-endpoints/ mentions the deprecated endpoints that are being sunset, and the steps to upgrade.

This PR is an example of what I plan to do with each of the affected methods:
1. Create a new `..BySlug` method using the new endpoint
2. Deprecate the old method, and make a call to `getOrg` from that method with a warning message so that it still functions

Once these new methods are in place I will update the usages in `prow` to the new methods