### PR TITLE
Add etcd repository to preset-pull-registry-sandbox-repo-list

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -18,6 +18,8 @@ presets:
     value: registry-sandbox.k8s.io
   - name: KUBE_ADDON_REGISTRY
     value: registry-sandbox.k8s.io
+  - name: TEST_ETCD_DOCKER_REPOSITORY
+    value: registry-sandbox.k8s.io/etcd
 
 presubmits:
   kubernetes/kubernetes:


### PR DESCRIPTION
We should inject the etcd repo location explicitly for the ci jobs that use the alternate registry proxy. This is a follow up to https://github.com/kubernetes/test-infra/pull/25466

Here's how the flow happens for this env variable:
https://cs.k8s.io/?q=etcd_docker_repository&i=fosho&files=&excludeFiles=&repos=kubernetes/kubernetes,kubernetes/test-infra

Signed-off-by: Davanum Srinivas <davanum@gmail.com>