### PR TITLE
releng: Add required testgrid dashboard name for post-bom-push-images

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-bom.yaml
+++ b/config/jobs/image-pushing/k8s-staging-bom.yaml
@@ -3,7 +3,7 @@ postsubmits:
     - name: post-bom-push-images
       cluster: k8s-infra-prow-build-trusted
       annotations:
-        testgrid-dashboards: sig-release-image-pushes
+        testgrid-dashboards: sig-release-image-pushes, sig-k8s-infra-gcb
         testgrid-alert-email: release-managers+alerts@kubernetes.io
       decorate: true
       branches:


### PR DESCRIPTION
Related:
  - https://github.com/kubernetes-sigs/bom/pull/45

Followup of:
  - https://github.com/kubernetes/test-infra/pull/25436

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>