### PR TITLE
OpenShift testgrid - Add OCP 4.10 and 4.11 single-node live-iso testgrid

### DIFF
--- a/config/testgrids/openshift/single-node.yaml
+++ b/config/testgrids/openshift/single-node.yaml
@@ -244,3 +244,57 @@ dashboards:
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+  - name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-single-node-live-iso
+    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-single-node-live-iso
+    base_options: width=10
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    file_bug_template:
+      options:
+      - key: classification
+        value: Red Hat
+      - key: product
+        value: OpenShift Container Platform
+      - key: cf_internal_whiteboard
+        value: buildcop
+      - key: short_desc
+        value: 'test: <test-name>'
+      - key: cf_environment
+        value: 'test: <test-name>'
+      - key: comment
+        value: 'test: <test-name> failed, see job: <test-url>'
+      url: https://bugzilla.redhat.com/enter_bug.cgi
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+  - name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-single-node-live-iso
+    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-single-node-live-iso
+    base_options: width=10
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    file_bug_template:
+      options:
+      - key: classification
+        value: Red Hat
+      - key: product
+        value: OpenShift Container Platform
+      - key: cf_internal_whiteboard
+        value: buildcop
+      - key: short_desc
+        value: 'test: <test-name>'
+      - key: cf_environment
+        value: 'test: <test-name>'
+      - key: comment
+        value: 'test: <test-name> failed, see job: <test-url>'
+      url: https://bugzilla.redhat.com/enter_bug.cgi
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>


### PR DESCRIPTION
We already had 4.9 and 4.8, this will create one for 4.10 and 4.11 as well