### PR TITLE
[CAPV] Change default branch from `master` to `main`

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-ci.yaml
@@ -1,13 +1,12 @@
 postsubmits:
   kubernetes-sigs/cluster-api-provider-vsphere:
-  # Deploys images and binaries after all merges to master
+  # Deploys images and binaries after all merges to main
   - name: post-cluster-api-provider-vsphere-deploy
     labels:
       preset-dind-enabled: "true"
       preset-cluster-api-provider-vsphere-gcs-creds: "true"
     branches:
     - ^main$
-    - ^master$
     always_run: false
     run_if_changed: '^((api|cmd|config|contrib|controllers|pkg|test|examples)/|Dockerfile|Makefile)'
     decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics.yaml
@@ -10,7 +10,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-vsphere
-        base_ref: master
+        base_ref: main
         path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
@@ -48,7 +48,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-vsphere
-        base_ref: master
+        base_ref: main
         path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
@@ -86,7 +86,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-vsphere
-        base_ref: master
+        base_ref: main
         path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
@@ -120,11 +120,11 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-vsphere
-        base_ref: master
+        base_ref: main
         path_alias: sigs.k8s.io/cluster-api-provider-vsphere
       - org: kubernetes
         repo: test-infra
-        base_ref: master
+        base_ref: main
         path_alias: k8s.io/test-infra
     spec:
       containers:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -182,7 +182,6 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     branches:
     - ^main$
-    - ^master$
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220221-c13e827224-1.23
@@ -209,7 +208,6 @@ presubmits:
   - name: pull-cluster-api-provider-vsphere-e2e
     branches:
       - ^main$
-      - ^master$
       - ^release-1.*
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
This PR changes all the `base_ref` in the CAPV prow jobs from `master` to `main`. 
⚠️ This is a breaking change and the prow jobs will fail till the CAPV default branch name is changed from `master` to `main`. 
This is part of the ongoing activity https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/949 

cc: @srm09 