### PR TITLE
Adding the ability to set the Bugzilla authMethod

### DIFF
--- a/prow/bugzilla/client.go
+++ b/prow/bugzilla/client.go
@@ -101,7 +101,7 @@ type Client interface {
 }
 
 // NewClient returns a bugzilla client.
-func NewClient(getAPIKey func() []byte, endpoint string, githubExternalTrackerId uint) Client {
+func NewClient(getAPIKey func() []byte, endpoint string, githubExternalTrackerId uint, authMethod string) Client {
 	return &client{
 		logger: logrus.WithField("client", "bugzilla"),
 		delegate: &delegate{
@@ -109,6 +109,7 @@ func NewClient(getAPIKey func() []byte, endpoint string, githubExternalTrackerId
 			endpoint:                endpoint,
 			githubExternalTrackerId: githubExternalTrackerId,
 			getAPIKey:               getAPIKey,
+			authMethod:              authMethod,
 		},
 	}
 }

--- a/prow/flagutil/bugzilla.go
+++ b/prow/flagutil/bugzilla.go
@@ -84,5 +84,5 @@ func (o *BugzillaOptions) BugzillaClient() (bugzilla.Client, error) {
 		generator = &generatorFunc
 	}
 
-	return bugzilla.NewClient(*generator, o.endpoint, o.githubExternalTrackerId), nil
+	return bugzilla.NewClient(*generator, o.endpoint, o.githubExternalTrackerId, o.authMethod), nil
 }


### PR DESCRIPTION
Support was added, in #23808, to allow for the bugzilla client to utilize the `Authorization: bearer` request header.  Unfortunately, there does not appear to be a way to set the `authMethod`.  This PR updates the `NewClient` API to accept an `authMethod` parameter and updates the corresponding flagutil library to pass along the commandline option.