### PR TITLE
Add securityContext privileged to cloud-provider-aws e2e job

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-config.yaml
@@ -61,6 +61,8 @@ presubmits:
         - make
         - test-e2e
         - KOPS_STATE_STORE=s3://cloud-provider-aws-e2e
+        securityContext:
+          privileged: true
     annotations:
       testgrid-dashboards: provider-aws-cloud-provider-aws
       testgrid-tab-name: e2e


### PR DESCRIPTION
In the cloud-provider-aws e2e job, I'm seeing: 

```
error: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
make: *** [Makefile:48: docker-build-amd64] Error 1
+ EXIT_VALUE=2
+ set +o xtrace
Cleaning up after docker in docker.
================================================================================
Cleaning up after docker
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
Stopping Docker: dockerProgram process in pidfile '/var/run/docker-ssd.pid', 1 process(es), refused to die.
```

See: https://github.com/kubernetes/cloud-provider-aws/pull/311, https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/cloud-provider-aws/311/pull-cloud-provider-aws-e2e/1498973814153809920/build-log.txt