### PR TITLE
Consider cookie-auth links savable.

### DIFF
--- a/prow/spyglass/lenses/buildlog/BUILD.bazel
+++ b/prow/spyglass/lenses/buildlog/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//prow/config:go_default_library",
+        "//prow/io:go_default_library",
         "//prow/spyglass/api:go_default_library",
         "//prow/spyglass/lenses:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/prow/spyglass/lenses/buildlog/lens.go
+++ b/prow/spyglass/lenses/buildlog/lens.go
@@ -31,6 +31,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	prowconfig "k8s.io/test-infra/prow/config"
+	pkgio "k8s.io/test-infra/prow/io"
 	"k8s.io/test-infra/prow/spyglass/api"
 	"k8s.io/test-infra/prow/spyglass/lenses"
 )
@@ -217,11 +218,15 @@ func (lens Lens) Body(artifacts []api.Artifact, resourceDir string, data string,
 		}
 		av.LineGroups = groupLines(&artifact, start, end, highlightLines(lines, 0, &artifact, conf.highlightRegex)...)
 		av.ViewAll = true
-		av.CanSave = strings.Contains(a.CanonicalLink(), "storage.googleapis.com/")
+		av.CanSave = canSave(a.CanonicalLink())
 		buildLogsView.LogViews = append(buildLogsView.LogViews, av)
 	}
 
 	return executeTemplate(resourceDir, "body", buildLogsView)
+}
+
+func canSave(link string) bool {
+	return strings.Contains(link, pkgio.GSAnonHost) || strings.Contains(link, pkgio.GSCookieHost)
 }
 
 const failedUnmarshal = "Failed to unmarshal request"

--- a/prow/spyglass/lenses/buildlog/lens_test.go
+++ b/prow/spyglass/lenses/buildlog/lens_test.go
@@ -248,6 +248,10 @@ func TestGroupLines(t *testing.T) {
 func pstr(s string) *string { return &s }
 
 func TestBody(t *testing.T) {
+	const (
+		anonLink   = "https://storage.googleapis.com/bucket/object/build-log.txt"
+		cookieLink = "https://storage.cloud.google.com/bucket/object/build-log.txt"
+	)
 	render := func(views ...LogArtifactView) string {
 		return executeTemplate(".", "body", buildLogsView{LogViews: views})
 	}
@@ -315,6 +319,66 @@ func TestBody(t *testing.T) {
 					},
 				},
 			})),
+		},
+		{
+			name: "cookie savable",
+			artifact: &fake.Artifact{
+				Path:    "foo",
+				Content: []byte("hello"),
+				Link:    pstr(cookieLink),
+			},
+			want: render(func() LogArtifactView {
+				lav := view("foo", cookieLink, []LineGroup{
+					{
+						Start:        1,
+						End:          1,
+						ArtifactName: pstr("foo"),
+						LogLines: []LogLine{
+							{
+								ArtifactName: pstr("foo"),
+								Number:       1,
+								SubLines: []SubLine{
+									{
+										Text: "hello",
+									},
+								},
+							},
+						},
+					},
+				})
+				lav.CanSave = true
+				return lav
+			}()),
+		},
+		{
+			name: "savable",
+			artifact: &fake.Artifact{
+				Path:    "foo",
+				Content: []byte("hello"),
+				Link:    pstr(anonLink),
+			},
+			want: render(func() LogArtifactView {
+				lav := view("foo", anonLink, []LineGroup{
+					{
+						Start:        1,
+						End:          1,
+						ArtifactName: pstr("foo"),
+						LogLines: []LogLine{
+							{
+								ArtifactName: pstr("foo"),
+								Number:       1,
+								SubLines: []SubLine{
+									{
+										Text: "hello",
+									},
+								},
+							},
+						},
+					},
+				})
+				lav.CanSave = true
+				return lav
+			}()),
 		},
 		{
 			name: "focus",

--- a/prow/spyglass/lenses/fake/fake.go
+++ b/prow/spyglass/lenses/fake/fake.go
@@ -26,6 +26,7 @@ type Artifact struct {
 	Path    string
 	Content []byte
 	Meta    map[string]string
+	Link    *string
 }
 
 func (fa *Artifact) JobPath() string {
@@ -48,7 +49,10 @@ func (fa *Artifact) UpdateMetadata(now map[string]string) error {
 const NotFound = "linknotfound.io/404"
 
 func (fa *Artifact) CanonicalLink() string {
-	return "linknotfound.io/404"
+	if fa.Link == nil {
+		return NotFound
+	}
+	return *fa.Link
 }
 
 func (fa *Artifact) ReadAt(b []byte, off int64) (int, error) {


### PR DESCRIPTION
Currently we look for a storage.googleapis.com link in order to know we can pin the lines.
This will miss when deck uses cookie auth, giving us storage.cloud.google.com links.