### PR TITLE
jira: move fake client to jira client package

### DIFF
--- a/prow/jira/BUILD.bazel
+++ b/prow/jira/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "fake.go",
         "jira.go",
         "metrics.go",
     ],

--- a/prow/jira/fakejira/fake.go
+++ b/prow/jira/fakejira/fake.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fakejira
+
+import (
+	"fmt"
+
+	"github.com/andygrunwald/go-jira"
+	jiraclient "k8s.io/test-infra/prow/jira"
+)
+
+type FakeClient struct {
+	ExistingIssues []jira.Issue
+	ExistingLinks  map[string][]jira.RemoteLink
+	NewLinks       []jira.RemoteLink
+	GetIssueError  error
+}
+
+func (f *FakeClient) ListProjects() (*jira.ProjectList, error) {
+	return nil, nil
+}
+
+func (f *FakeClient) GetIssue(id string) (*jira.Issue, error) {
+	if f.GetIssueError != nil {
+		return nil, f.GetIssueError
+	}
+	for _, existingIssue := range f.ExistingIssues {
+		if existingIssue.ID == id {
+			return &existingIssue, nil
+		}
+	}
+	return nil, jiraclient.NewNotFoundError(fmt.Errorf("No issue %s found", id))
+}
+
+func (f *FakeClient) GetRemoteLinks(id string) ([]jira.RemoteLink, error) {
+	return f.ExistingLinks[id], nil
+}
+
+func (f *FakeClient) AddRemoteLink(id string, link *jira.RemoteLink) error {
+	if _, err := f.GetIssue(id); err != nil {
+		return err
+	}
+	f.NewLinks = append(f.NewLinks, *link)
+	return nil
+}
+
+func (f *FakeClient) JiraClient() *jira.Client {
+	panic("not implemented")
+}
+
+const FakeJiraUrl = "https://my-jira.com"
+
+func (f *FakeClient) JiraURL() string {
+	return FakeJiraUrl
+}
+
+func (f *FakeClient) UpdateRemoteLink(id string, link *jira.RemoteLink) error {
+	if _, err := f.GetIssue(id); err != nil {
+		return err
+	}
+	if _, found := f.ExistingLinks[id]; !found {
+		return jiraclient.NewNotFoundError(fmt.Errorf("Link for issue %s not found", id))
+	}
+	f.NewLinks = append(f.NewLinks, *link)
+	return nil
+}

--- a/prow/plugins/jira/BUILD.bazel
+++ b/prow/plugins/jira/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
     tags = ["manual"],
     deps = [
         "//prow/github:go_default_library",
+        "//prow/github/fakegithub:go_default_library",
         "//prow/jira:go_default_library",
         "//prow/plugins:go_default_library",
         "@com_github_andygrunwald_go_jira//:go_default_library",

--- a/prow/plugins/jira/jira_test.go
+++ b/prow/plugins/jira/jira_test.go
@@ -28,7 +28,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/github/fakegithub"
 	jiraclient "k8s.io/test-infra/prow/jira"
+	"k8s.io/test-infra/prow/jira/fakejira"
 	"k8s.io/test-infra/prow/plugins"
 )
 
@@ -99,62 +101,6 @@ func TestRegex(t *testing.T) {
 	}
 }
 
-type fakeJiraClient struct {
-	existingIssues []jira.Issue
-	existingLinks  map[string][]jira.RemoteLink
-	newLinks       []jira.RemoteLink
-	getIssueError  error
-}
-
-func (f *fakeJiraClient) ListProjects() (*jira.ProjectList, error) {
-	return nil, nil
-}
-
-func (f *fakeJiraClient) GetIssue(id string) (*jira.Issue, error) {
-	if f.getIssueError != nil {
-		return nil, f.getIssueError
-	}
-	for _, existingIssue := range f.existingIssues {
-		if existingIssue.ID == id {
-			return &existingIssue, nil
-		}
-	}
-	return nil, jiraclient.NewNotFoundError(fmt.Errorf("No issue %s found", id))
-}
-
-func (f *fakeJiraClient) GetRemoteLinks(id string) ([]jira.RemoteLink, error) {
-	return f.existingLinks[id], nil
-}
-
-func (f *fakeJiraClient) AddRemoteLink(id string, link *jira.RemoteLink) error {
-	if _, err := f.GetIssue(id); err != nil {
-		return err
-	}
-	f.newLinks = append(f.newLinks, *link)
-	return nil
-}
-
-func (f *fakeJiraClient) UpdateRemoteLink(id string, link *jira.RemoteLink) error {
-	if _, err := f.GetIssue(id); err != nil {
-		return err
-	}
-	if _, found := f.existingLinks[id]; !found {
-		return jiraclient.NewNotFoundError(fmt.Errorf("Link for issue %s not found", id))
-	}
-	f.newLinks = append(f.newLinks, *link)
-	return nil
-}
-
-func (f *fakeJiraClient) JiraClient() *jira.Client {
-	panic("not implemented")
-}
-
-const fakeJiraUrl = "https://my-jira.com"
-
-func (f *fakeJiraClient) JiraURL() string {
-	return fakeJiraUrl
-}
-
 type fakeGitHubClient struct {
 	editedComments map[string]string
 }
@@ -186,7 +132,7 @@ func TestHandle(t *testing.T) {
 		existingIssues         []jira.Issue
 		existingLinks          map[string][]jira.RemoteLink
 		expectedNewLinks       []jira.RemoteLink
-		expectedCommentUpdates map[string]string
+		expectedCommentUpdates []string
 	}{
 		{
 			name: "No issue referenced, nothing to do",
@@ -212,7 +158,7 @@ func TestHandle(t *testing.T) {
 				},
 			},
 			}},
-			expectedCommentUpdates: map[string]string{"org/repo:1": "Some text and also [ABC-123](https://my-jira.com/browse/ABC-123)"},
+			expectedCommentUpdates: []string{"org/repo#1:Some text and also [ABC-123](https://my-jira.com/browse/ABC-123)"},
 		},
 		{
 			name: "Link is created based on body with pasted link",
@@ -257,7 +203,7 @@ func TestHandle(t *testing.T) {
 				},
 			},
 			}},
-			expectedCommentUpdates: map[string]string{"org/repo:1": "Some text and also [ABC-123](https://my-jira.com/browse/ABC-123)"},
+			expectedCommentUpdates: []string{"org/repo#1:Some text and also [ABC-123](https://my-jira.com/browse/ABC-123)"},
 		},
 		{
 			name: "Link is created based on title",
@@ -301,7 +247,7 @@ func TestHandle(t *testing.T) {
 				},
 			},
 			}},
-			expectedCommentUpdates: map[string]string{"org/repo:1": "Some text and also [ABC-123](https://my-jira.com/browse/ABC-123) and again [ABC-123](https://my-jira.com/browse/ABC-123)"},
+			expectedCommentUpdates: []string{"org/repo#1:Some text and also [ABC-123](https://my-jira.com/browse/ABC-123) and again [ABC-123](https://my-jira.com/browse/ABC-123)"},
 		},
 		{
 			name: "Referenced issue doesn't exist, nothing to do",
@@ -388,22 +334,22 @@ func TestHandle(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			jiraClient := &fakeJiraClient{
-				existingIssues: tc.existingIssues,
-				existingLinks:  tc.existingLinks,
-				getIssueError:  tc.getIssueClientError,
+			jiraClient := &fakejira.FakeClient{
+				ExistingIssues: tc.existingIssues,
+				ExistingLinks:  tc.existingLinks,
+				GetIssueError:  tc.getIssueClientError,
 			}
-			githubClient := &fakeGitHubClient{}
+			githubClient := fakegithub.NewFakeClient()
 
 			if err := handleWithProjectCache(jiraClient, githubClient, tc.cfg, logrus.NewEntry(logrus.New()), &tc.event, tc.projectCache); err != nil {
 				t.Fatalf("handle failed: %v", err)
 			}
 
-			if diff := cmp.Diff(jiraClient.newLinks, tc.expectedNewLinks); diff != "" {
+			if diff := cmp.Diff(jiraClient.NewLinks, tc.expectedNewLinks); diff != "" {
 				t.Errorf("new links differs from expected new links: %s", diff)
 			}
 
-			if diff := cmp.Diff(githubClient.editedComments, tc.expectedCommentUpdates); diff != "" {
+			if diff := cmp.Diff(githubClient.IssueCommentsEdited, tc.expectedCommentUpdates); diff != "" {
 				t.Errorf("comment updates differ from expected: %s", diff)
 			}
 		})
@@ -508,7 +454,7 @@ is very important` + "\n```bash\n" +
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if diff := cmp.Diff(insertLinksIntoComment(tc.body, []string{issueName}, fakeJiraUrl), tc.expected); diff != "" {
+			if diff := cmp.Diff(insertLinksIntoComment(tc.body, []string{issueName}, fakejira.FakeJiraUrl), tc.expected); diff != "" {
 				t.Errorf("actual result differs from expected result: %s", diff)
 			}
 		})
@@ -526,20 +472,20 @@ func TestProjectCachingJiraClient(t *testing.T) {
 	}{
 		{
 			name:           "404 gets served from cache",
-			client:         &fakeJiraClient{},
+			client:         &fakejira.FakeClient{},
 			issueToRequest: "issue-123",
 			cache:          &threadsafeSet{data: sets.String{}},
 			expectedError:  jiraclient.NewNotFoundError(errors.New("404 from cache")),
 		},
 		{
 			name:           "Success",
-			client:         &fakeJiraClient{existingIssues: []jira.Issue{{ID: "issue-123"}}},
+			client:         &fakejira.FakeClient{ExistingIssues: []jira.Issue{{ID: "issue-123"}}},
 			issueToRequest: "issue-123",
 			cache:          &threadsafeSet{data: sets.NewString("issue")},
 		},
 		{
 			name:           "Success case-insensitive",
-			client:         &fakeJiraClient{existingIssues: []jira.Issue{{ID: "ISSUE-123"}}},
+			client:         &fakejira.FakeClient{ExistingIssues: []jira.Issue{{ID: "ISSUE-123"}}},
 			issueToRequest: "ISSUE-123",
 			cache:          &threadsafeSet{data: sets.NewString("issue")},
 		},


### PR DESCRIPTION
This PR moves the fake JIRA client to the JIRA package instead of in the
JIRA plugin. It also makes the `EditComment` function of the
`fakegithub` client functional so it can be used in the JIRA plugin
tests.

/cc @bradmwilliams 