### PR TITLE
kubernetes-sigs/descheduler: pin kind 1.20 image to 1.20.7

### DIFF
--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.21.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.21.yaml
@@ -104,7 +104,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBERNETES_VERSION
-          value: "v1.20.10"
+          value: "v1.20.7"
         - name: KIND_E2E
           value: "true"
         args:


### PR DESCRIPTION
Based on https://hub.docker.com/r/kindest/node/tags?page=1&name=v1.20
1.20.7 is the latest kind image

See https://github.com/kubernetes-sigs/descheduler/pull/746 and https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_descheduler/746/pull-descheduler-test-e2e-k8s-1-21-1-20/1497313342530785280:
```
Creating cluster "kind" ...
 • Ensuring node image (kindest/node:v1.20.10) 🖼  ...
 ✗ Ensuring node image (kindest/node:v1.20.10) 🖼
ERROR: failed to create cluster: failed to pull image "kindest/node:v1.20.10": command "docker pull kindest/node:v1.20.10" failed with error: exit status 1
```