### PR TITLE
kubernetes-sigs/cluster-capacity: bump go version to address CVE and branch release-1.23

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.20.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.20.yaml
@@ -10,7 +10,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.1
+      - image: golang:1.16.14
         command:
         - make
         args:
@@ -24,7 +24,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.1
+      - image: golang:1.16.14
         command:
         - make
         args:
@@ -38,7 +38,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.1
+      - image: golang:1.16.14
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.21.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.21.yaml
@@ -10,7 +10,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.7
+      - image: golang:1.16.14
         command:
         - make
         args:
@@ -24,7 +24,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.7
+      - image: golang:1.16.14
         command:
         - make
         args:
@@ -38,7 +38,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.7
+      - image: golang:1.16.14
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.22.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.22.yaml
@@ -10,7 +10,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.7
+      - image: golang:1.16.14
         command:
         - make
         args:
@@ -24,7 +24,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.7
+      - image: golang:1.16.14
         command:
         - make
         args:
@@ -38,7 +38,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.16.7
+      - image: golang:1.16.14
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.23.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.23.yaml
@@ -1,0 +1,138 @@
+# sigs.k8s.io/cluster-capacity presubmits
+presubmits:
+  kubernetes-sigs/cluster-capacity:
+  - name: pull-cluster-capacity-verify-gofmt-release-1-23
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-capacity
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.23$
+    always_run: true
+    spec:
+      containers:
+      - image: golang:1.17.6
+        command:
+        - make
+        args:
+        - verify-gofmt
+  - name: pull-cluster-capacity-verify-build-release-1-23
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-capacity
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.23$
+    always_run: true
+    spec:
+      containers:
+      - image: golang:1.17.6
+        command:
+        - make
+        args:
+        - build
+  - name: pull-cluster-capacity-unit-test-release-1-23
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-capacity
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.23$
+    always_run: true
+    spec:
+      containers:
+      - image: golang:1.17.6
+        command:
+        - make
+        args:
+        - test-unit
+  - name: pull-cluster-capacity-test-e2e-k8s-release-1-23-1-23
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-release-1.23-1.23
+    decorate: true
+    decoration_config:
+      timeout: 20m
+    path_alias: sigs.k8s.io/cluster-capacity
+    always_run: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    branches:
+    - release-1.23
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220221-c13e827224-master
+        command:
+        # generic runner script, handles DIND, bazelrc for caching, etc.
+        - runner.sh
+        env:
+        - name: KUBERNETES_VERSION
+          value: "v1.23.3"
+        - name: KIND_E2E
+          value: "true"
+        args:
+        - make
+        - test-e2e
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+  - name: pull-cluster-capacity-test-e2e-k8s-release-1-23-1-22
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-release-1.23-1.22
+    decorate: true
+    decoration_config:
+      timeout: 20m
+    path_alias: sigs.k8s.io/cluster-capacity
+    always_run: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    branches:
+    - release-1.23
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220221-c13e827224-master
+        command:
+        # generic runner script, handles DIND, bazelrc for caching, etc.
+        - runner.sh
+        env:
+        - name: KUBERNETES_VERSION
+          value: "v1.22.5"
+        - name: KIND_E2E
+          value: "true"
+        args:
+        - make
+        - test-e2e
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+  - name: pull-cluster-capacity-test-e2e-k8s-release-1-23-1-21
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-release-1.23-1.21
+    decorate: true
+    decoration_config:
+      timeout: 20m
+    path_alias: sigs.k8s.io/cluster-capacity
+    always_run: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    branches:
+    - release-1.23
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220221-c13e827224-master
+        command:
+        # generic runner script, handles DIND, bazelrc for caching, etc.
+        - runner.sh
+        env:
+        - name: KUBERNETES_VERSION
+          value: "v1.21.2"
+        - name: KIND_E2E
+          value: "true"
+        args:
+        - make
+        - test-e2e
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.1
+      - image: golang:1.17.6
         command:
         - make
         args:
@@ -24,7 +24,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.1
+      - image: golang:1.17.6
         command:
         - make
         args:
@@ -38,7 +38,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.17.1
+      - image: golang:1.17.6
         command:
         - make
         args:


### PR DESCRIPTION
- address https://github.com/advisories/GHSA-vc3p-29h2-gpcp
- branch 1.23