### PR TITLE
deck: create a URL in a structured way

### DIFF
--- a/prow/cmd/deck/job_history.go
+++ b/prow/cmd/deck/job_history.go
@@ -105,7 +105,12 @@ type jobHistoryTemplate struct {
 }
 
 func (bucket blobStorageBucket) readObject(ctx context.Context, key string) ([]byte, error) {
-	rc, err := bucket.Opener.Reader(ctx, fmt.Sprintf("%s://%s/%s", bucket.storageProvider, bucket.name, key))
+	u := url.URL{
+		Scheme:      bucket.storageProvider,
+		Host:        bucket.name,
+		Path:        key,
+	}
+	rc, err := bucket.Opener.Reader(ctx, u.String())
 	if err != nil {
 		return nil, fmt.Errorf("creating reader for object %s: %w", key, err)
 	}


### PR DESCRIPTION
Print-formatting to create a URL is not a robust mechanism. We are very
clear about the scheme, "host" and path we need for this URL, so we
should create it in a structured manner.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>