### PR TITLE
Remove sig-node-critical tab

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.23.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.23.yaml
@@ -166,7 +166,7 @@ periodics:
 - annotations:
     fork-per-release-periodic-interval: 2h 6h 24h
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
-    testgrid-dashboards: sig-node-critical, sig-release-job-config-errors
+    testgrid-dashboards: sig-node-release-blocking, sig-release-job-config-errors
     testgrid-tab-name: node-kubelet-1.23-kubetest2
   cluster: k8s-infra-prow-build
   decorate: true

--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -2,7 +2,6 @@ dashboard_groups:
 - name: sig-node
   dashboard_names:
     - sig-node-release-blocking # This is a replica of sig-node jobs that are release blocking.
-    - sig-node-critical # This dashboard contains jobs that sig-node has deemed critical to the greater operation of the sig. They should always be green.
     - sig-node-kubelet
     - sig-node-containerd
     - sig-node-cri-o
@@ -18,10 +17,6 @@ dashboard_groups:
 
 dashboards:
 - name: sig-node-release-blocking # Tabs included in this group are defined in the jobs that are included.
-- name: sig-node-critical
-  dashboard_tab:
-    - name: containerd-NodeConformance
-      test_group_name: ci-containerd-node-e2e
 
 - name: sig-node-cadvisor
 - name: sig-node-kubelet


### PR DESCRIPTION
We had previously said we were going to remove this dashboard as it only has 2 jobs, neither of which is critical.

Moving the release-blocking job to the correct node tab.

/cc @SergeyKanzhelev 