### PR TITLE
Set WINDOWS_USE_HOST_PROCESS_CONTAINERS for pull-kubernetes-e2e-capz-azure-disk-windows

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -687,6 +687,8 @@ presubmits:
               value: "true"
             - name: WINDOWS_FLAVOR
               value: "containerd-2022"
+            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS
+              value: "true"
             - name: NODE_MACHINE_TYPE
               value: "Standard_D4s_v3"
             - name: DISABLE_ZONE


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

Set WINDOWS_USE_HOST_PROCESS_CONTAINERS for pull-kubernetes-e2e-capz-azure-disk-windows so we can run azuredisk-csi-driver validation for Windows in CAPZ clusters.

Related to https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/1201