### PR TITLE
remove pull-kubernetes-conformance-kind-ipv6-parallel job

### DIFF
--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -45,55 +45,6 @@ presubmits:
       testgrid-dashboards: sig-testing-misc
       description: Runs conformance tests using kind and the conformance image
 
-  - name: pull-kubernetes-conformance-kind-ipv6-parallel
-    decorate: true
-    path_alias: k8s.io/kubernetes
-    skip_branches:
-    - release-\d+\.\d+ # per-release settings
-    always_run: false
-    skip_report: false
-    max_concurrency: 8
-    optional: true
-    run_if_changed: '^test/'
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/krte:v20220221-c13e827224-master
-        env:
-        # enable IPV6 in bootstrap image
-        - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
-          value: "true"
-        # tell kind CI script to use ipv6
-        - name: "IP_FAMILY"
-          value: "ipv6"
-        # skip serial tests and run with --ginkgo-parallel
-        - name: "PARALLEL"
-          value: "true"
-        command:
-          - wrapper.sh
-          - bash
-          - -c
-          - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: sig-testing-kind
-      description: Use kind to run e2e tests (+Conformance, -Serial) against a latest kubernetes master IPv6 cluster created with sigs.k8s.io/kind
-      testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com
-      testgrid-num-failures-to-alert: "15"
-
 periodics:
 # conformance test using image against kubernetes master branch with `kind`
 - interval: 1h


### PR DESCRIPTION
It served well, but since we already have `pull-kubernetes-e2e-kind-ipv6` running in each presubmit better have only one 