### PR TITLE
Test-infra: re-enable unit test for prow jobs configs change

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -135,7 +135,7 @@ presubmits:
   - name: pull-test-infra-unit-test
     branches:
     - master
-    skip_if_only_changed: '^config/jobs/'
+    always_run: true
     decorate: true
     labels:
       # Python unit tests run in docker.


### PR DESCRIPTION
Apparently go unit test TestImagePushingJobs tests prow jobs configs change, so adding it back to avoid prow jobs configs change from breaking HEAD