### PR TITLE
Add sig-k8s-infra-gcb testgrid group to post-kueue-push-images

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-kueue.yaml
+++ b/config/jobs/image-pushing/k8s-staging-kueue.yaml
@@ -3,7 +3,7 @@ postsubmits:
     - name: post-kueue-push-images
       cluster: k8s-infra-prow-build-trusted
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling, sig-k8s-infra-gcb
       decorate: true
       branches:
         - ^master$


### PR DESCRIPTION
Omitted from previous PR, which breaks unit test