### PR TITLE
Stop gating bazel tests on test-infra

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -1,9 +1,12 @@
 presubmits:
   kubernetes/test-infra:
+  # pull-test-infra-bazel is deprecated, leave it here just in case. Will be
+  # completely removed once bazel footprint is removed from test-infra
   - name: pull-test-infra-bazel
     branches:
     - master
-    always_run: true
+    always_run: false
+    optional: true
     decorate: true
     labels:
       preset-service-account: "true"


### PR DESCRIPTION
It has been two weeks since prow is not built from bazel, so far no major regressions were observed. Stop gating on bazel as they are not really used in meaningful ways in this repo any more

Thanks a lot for folks who have helped out in this space, especially @BenTheElder for their guidance and direct contributions!

/hold
will wait to merge on Monday