### PR TITLE
Pick batches using correct merge method.

### DIFF
--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -1088,7 +1088,12 @@ func (c *Controller) pickNewBatch(sp subpool, candidates []PullRequest, maxBatch
 	}
 
 	for _, pr := range candidates {
-		if ok, err := r.Merge(string(pr.HeadRefOID)); err != nil {
+		mergeMethod, err := prMergeMethod(c.config().Tide, &pr)
+		if err != nil {
+			sp.log.WithFields(pr.logFields()).Warnf("Failed to get merge method for PR, will skip: %v.", err)
+			continue
+		}
+		if ok, err := r.MergeWithStrategy(string(pr.HeadRefOID), string(mergeMethod)); err != nil {
 			// we failed to abort the merge and our git client is
 			// in a bad state; it must be cleaned before we try again
 			return nil, err


### PR DESCRIPTION
If we don't pick batches using the correct merge method, when we try to load inrepo config or merge the batch using the correct merge method we may encounter a merge conflict.
This doesn't completely solve the problem since inrepo config is not respecting any merge method labels that might exist on the PR currently, but it should mitigate the issue as long as merge method labels are not used which is the majority of cases.
https://github.com/kubernetes/test-infra/blob/db403c7c00a9244965eb4729b4f005ac98161051/prow/config/inrepoconfig.go#L109

/assign @chaodaiG 
/cc @alvaroaleman @howardjohn 