### PR TITLE
migrate kind jobs to k8s-infra-prow-build

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -50,6 +50,7 @@ presubmits:
           privileged: true
   # mimic pull-kubernetes-e2e-kind, but using kind built in this PR
   - name: pull-kind-e2e-kubernetes
+    cluster: k8s-infra-prow-build
     always_run: true
     labels:
       preset-dind-enabled: "true"
@@ -86,13 +87,17 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: "4"
+            memory: 9000Mi
           requests:
-            memory: "9000Mi"
-            cpu: 7400m
+            cpu: "4"
+            memory: 9000Mi
   # conformance test against kubernetes master branch with `kind`, skipping
   # serial tests so it runs in ~20m
   # GA-only variant
   - name: pull-kind-conformance-parallel-ga-only
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -125,16 +130,17 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: "4"
+            memory: 9000Mi
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            cpu: "4"
+            memory: 9000Mi
   # conformance test against kubernetes master branch with `kind`, skipping
   # serial tests so it runs in ~20m
   # IPv6 enabled variant
   - name: pull-kind-conformance-parallel-ipv6
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -171,16 +177,17 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: "4"
+            memory: 9000Mi
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            cpu: "4"
+            memory: 9000Mi
   # conformance test against kubernetes master branch with `kind`, skipping
   # serial tests so it runs in ~20m
   # Dual Stack enabled variant
   - name: pull-kind-conformance-parallel-dual-stack-ipv4-ipv6
+    cluster: k8s-infra-prow-build
     always_run: false
     optional: true
     labels:
@@ -218,13 +225,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: "4"
+            memory: 9000Mi
           requests:
-            # TODO(BenTheElder): adjust these everywhere
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            cpu: "4"
+            memory: 9000Mi
   # mimic pull-kubernetes-e2e-kind, but using kind built in this PR
   - always_run: true
     decorate: true
@@ -240,6 +246,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     name: pull-kind-e2e-kubernetes-1-23
+    cluster: k8s-infra-prow-build
     path_alias: sigs.k8s.io/kind
     spec:
       containers:
@@ -281,6 +288,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     name: pull-kind-e2e-kubernetes-1-22
+    cluster: k8s-infra-prow-build
     path_alias: sigs.k8s.io/kind
     spec:
       containers:
@@ -322,6 +330,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     name: pull-kind-e2e-kubernetes-1-21
+    cluster: k8s-infra-prow-build
     path_alias: sigs.k8s.io/kind
     spec:
       containers:
@@ -363,6 +372,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     name: pull-kind-e2e-kubernetes-1-20
+    cluster: k8s-infra-prow-build
     path_alias: sigs.k8s.io/kind
     spec:
       containers:
@@ -404,6 +414,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     name: pull-kind-e2e-kubernetes-1-19
+    cluster: k8s-infra-prow-build
     path_alias: sigs.k8s.io/kind
     spec:
       containers:

--- a/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-kind-dual-canary
+    cluster: k8s-infra-prow-build
     optional: true
     always_run: false
     skip_report: false
@@ -37,19 +38,19 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 4
+            memory: 9Gi
           requests:
-            # TODO(BenTheElder): adjust these everywhere
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "4000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            cpu: 4
+            memory: 9Gi
     annotations:
       testgrid-dashboards: sig-network-kind
       testgrid-tab-name: pr-sig-network-kind, dual
       description: Runs tests against a Dual Stack Kubernetes in Docker cluster
       testgrid-alert-email: antonio.ojea.garcia@gmail.com
   - name: pull-kubernetes-e2e-kind-ipvs-dual-canary
+    cluster: k8s-infra-prow-build
     optional: true
     always_run: false
     skip_report: false
@@ -88,13 +89,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 4
+            memory: 9Gi
           requests:
-            # TODO(BenTheElder): adjust these everywhere
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "4000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            cpu: 4
+            memory: 9Gi
     annotations:
       testgrid-dashboards: sig-network-kind
       testgrid-tab-name: pr-sig-network-kind, ipvs, dual
@@ -102,6 +102,7 @@ presubmits:
       testgrid-alert-email: antonio.ojea.garcia@gmail.com
   # network test against kubernetes master branch with `kind` multizone cluster
   - name: pull-kubernetes-e2e-kind-multizone
+    cluster: k8s-infra-prow-build
     optional: true
     always_run: false
     skip_report: false
@@ -137,9 +138,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 4
+            memory: 9Gi
           requests:
-            memory: "9000Mi"
-            cpu: 4000m
+            cpu: 4
+            memory: 9Gi
     annotations:
       testgrid-dashboards: sig-network-kind
       testgrid-tab-name: pr-sig-network-kind, multizone
@@ -150,6 +154,7 @@ periodics:
 # network test against kubernetes master branch with `kind`
 - interval: 6h
   name: ci-kubernetes-kind-network
+  cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
@@ -182,12 +187,12 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          cpu: 4
+          memory: 9Gi
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "4000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          cpu: 4
+          memory: 9Gi
   annotations:
     testgrid-dashboards: sig-network-kind, sig-testing-kind
     testgrid-tab-name: sig-network-kind, master
@@ -197,6 +202,7 @@ periodics:
 # network test against kubernetes master branch with `kind` ipv6
 - interval: 6h
   name: ci-kubernetes-kind-network-ipv6
+  cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
@@ -235,12 +241,12 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          cpu: 4
+          memory: 9Gi
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "4000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          cpu: 4
+          memory: 9Gi
   annotations:
     testgrid-dashboards: sig-network-kind, sig-testing-kind
     testgrid-tab-name: sig-network-kind, IPv6, master
@@ -250,6 +256,7 @@ periodics:
 # network test against kubernetes master branch with `kind` dual stack
 - interval: 6h
   name: ci-kubernetes-kind-network-dual
+  cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
@@ -290,12 +297,12 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          cpu: 4
+          memory: 9Gi
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "4000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          cpu: 4
+          memory: 9Gi
   annotations:
     testgrid-dashboards: sig-network-kind, sig-testing-kind
     testgrid-tab-name: sig-network-kind, dual, master
@@ -305,6 +312,7 @@ periodics:
 # network test against kubernetes master branch with `kind`
 - interval: 6h
   name: ci-kubernetes-kind-network-ipvs
+  cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
@@ -339,12 +347,12 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          cpu: 4
+          memory: 9Gi
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "4000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          cpu: 4
+          memory: 9Gi
   annotations:
     testgrid-dashboards: sig-network-kind, sig-testing-kind
     testgrid-tab-name: sig-network-kind, ipvs, master
@@ -354,6 +362,7 @@ periodics:
 # network test against kubernetes master branch with `kind` ipv6
 - interval: 6h
   name: ci-kubernetes-kind-network-ipvs-ipv6
+  cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
@@ -394,12 +403,12 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          cpu: 4
+          memory: 9Gi
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "4000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          cpu: 4
+          memory: 9Gi
   annotations:
     testgrid-dashboards: sig-network-kind, sig-testing-kind
     testgrid-tab-name: sig-network-kind, ipvs, IPv6, master
@@ -409,6 +418,7 @@ periodics:
 # network test against kubernetes master branch with `kind` dual stack
 - interval: 6h
   name: ci-kubernetes-kind-network-ipvs-dual
+  cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
@@ -451,12 +461,12 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          cpu: 4
+          memory: 9Gi
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "4000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          cpu: 4
+          memory: 9Gi
   annotations:
     testgrid-dashboards: sig-network-kind, sig-testing-kind
     testgrid-tab-name: sig-network-kind, ipvs, dual, master
@@ -467,6 +477,7 @@ periodics:
 # serial tests so it runs in ~20m
 - interval: 6h
   name: ci-kubernetes-kind-network-parallel
+  cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
@@ -500,12 +511,12 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          cpu: 4
+          memory: 9Gi
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "4000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          cpu: 4
+          memory: 9Gi
   annotations:
     testgrid-dashboards: sig-network-kind, sig-testing-kind
     testgrid-tab-name: sig-network-kind, master [non-serial]
@@ -515,6 +526,7 @@ periodics:
 # network test against kubernetes master branch with `kind` ipv6
 - interval: 6h
   name: ci-kubernetes-kind-network-parallel-ipv6
+  cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
@@ -554,12 +566,12 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          cpu: 4
+          memory: 9Gi
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "4000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          cpu: 4
+          memory: 9Gi
   annotations:
     testgrid-dashboards: sig-network-kind, sig-testing-kind
     testgrid-tab-name: sig-network-kind, IPv6, master [non-serial]
@@ -568,6 +580,7 @@ periodics:
     testgrid-num-columns-recent: '3'
 - interval: 6h
   name: ci-kubernetes-kind-multizone
+  cluster: k8s-infra-prow-build
   decorate: true
   labels:
     preset-service-account: "true"
@@ -601,9 +614,12 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          cpu: 4
+          memory: 9Gi
         requests:
-          memory: "9000Mi"
-          cpu: 4000m
+          cpu: 4
+          memory: 9Gi
   annotations:
     testgrid-dashboards: sig-network-kind
     testgrid-tab-name: sig-network-kind, multizone

--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -2,6 +2,7 @@ presubmits:
   kubernetes/kubernetes:
   # conformance test using image against kubernetes master branch with `kind`
   - name: pull-kubernetes-conformance-image-test
+    cluster: k8s-infra-prow-build
     skip_branches:
     - release-\d+\.\d+ # per-release settings
     always_run: false
@@ -34,18 +35,19 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: "4"
+            memory: 9000Mi
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            cpu: "4"
+            memory: 9000Mi
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: sig-testing-misc
       description: Runs conformance tests using kind and the conformance image
 
   - name: pull-kubernetes-conformance-kind-ipv6-parallel
+    cluster: k8s-infra-prow-build
     decorate: true
     path_alias: k8s.io/kubernetes
     skip_branches:
@@ -81,12 +83,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: "4"
+            memory: 9000Mi
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            cpu: "4"
+            memory: 9000Mi
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: sig-testing-kind
@@ -98,6 +100,7 @@ periodics:
 # conformance test using image against kubernetes master branch with `kind`
 - interval: 1h
   name: ci-kubernetes-conformance-image-test
+  cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
@@ -123,12 +126,12 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          cpu: "4"
+          memory: 9000Mi
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "9000Mi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          cpu: "4"
+          memory: 9000Mi
   # conformance test using image against kubernetes 1.14 branch with `kind`
   annotations:
     testgrid-dashboards: conformance-all, conformance-kind, sig-testing-kind
@@ -169,11 +172,11 @@ periodics:
         privileged: true
       resources:
         limits:
-          memory: 12Gi
-          cpu: 7
+          cpu: "4"
+          memory: 9000Mi
         requests:
-          memory: 12Gi
-          cpu: 7
+          cpu: "4"
+          memory: 9000Mi
   annotations:
     testgrid-num-failures-to-alert: '2'
     testgrid-alert-stale-results-hours: '48'

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -199,6 +199,7 @@ presubmits:
       testgrid-create-test-group: 'true'
 
   - name: pull-kubernetes-conformance-kind-ga-only
+    cluster: k8s-infra-prow-build
     optional: true
     always_run: false
     decorate: true
@@ -239,6 +240,7 @@ presubmits:
       testgrid-dashboards: sig-testing-kind
 
   - name: pull-kubernetes-conformance-kind-ga-only-parallel
+    cluster: k8s-infra-prow-build
     always_run: true
     decorate: true
     skip_branches:
@@ -279,4 +281,3 @@ presubmits:
       testgrid-alert-stale-results-hours: '24'
       testgrid-create-test-group: 'true'
       testgrid-dashboards: sig-testing-kind
-    cluster: k8s-infra-prow-build


### PR DESCRIPTION
I copied from https://github.com/kubernetes/test-infra/commit/005e7aa687f4ef02f6c17c4d2be4649389c37283 I don't know if this is the right way

Kind jobs are being flaky lately, golang 1.18 increased memory consumption, I don't have any strng evidence, but just experience told us that suddenly flakiness on these jobs without clear explanation or correlation on the test came from resource problems.

Moving jobs to the cncf infra and setting limits to avoid problems with noisy neighbours