### PR TITLE
kubernetes-csi: move distributed deployment testing to 1.23

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-manual-job-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-manual-job-config.yaml
@@ -3,9 +3,6 @@
 presubmits:
   kubernetes-csi/csi-driver-host-path:
   - name: pull-kubernetes-csi-csi-driver-host-distributed-on-kubernetes-1-21
-    # Will only work on branches with https://github.com/kubernetes-csi/csi-driver-host-path/pull/248 merged.
-    # That was merged into master and we don't maintain any older branches, so always
-    # running it is fine.
     always_run: true
     optional: true
     decorate: true
@@ -56,14 +53,13 @@ presubmits:
 
 periodics:
 - interval: 6h
-  # 1.21 is used because the distributed deployment also
-  # uses capacity tracking which is enabled by default in
-  # Kubernetes 1.21.
+  # 1.23 is used because it is the (currently) latest stable
+  # release.
   #
   # This job is meant to detect regressions in upcoming releases
   # that slipped through pre-merge testing, so we have to use canary
   # images.
-  name: ci-kubernetes-csi-canary-distributed-on-kubernetes-1-21
+  name: ci-kubernetes-csi-canary-distributed-on-kubernetes-1-23
   decorate: true
   extra_refs:
   - org: kubernetes-csi
@@ -76,7 +72,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   annotations:
     testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: distributed-on-1-21
+    testgrid-tab-name: distributed-on-1-23
     testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
     description: periodic Kubernetes-CSI job for distributed provisioning on Kubernetes master, with CSIStorageCapacity
   spec:
@@ -89,7 +85,7 @@ periodics:
       - ./.prow.sh
       env:
       - name: CSI_PROW_KUBERNETES_VERSION
-        value: "1.21.0"
+        value: "1.23.0"
       - name: CSI_PROW_USE_BAZEL
         value: "false"
       - name: CSI_SNAPSHOTTER_VERSION

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-manual-job-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-manual-job-config.yaml
@@ -2,7 +2,7 @@
 
 presubmits:
   kubernetes-csi/external-provisioner:
-  - name: pull-kubernetes-csi-external-provisioner-distributed-on-kubernetes-1-21
+  - name: pull-kubernetes-csi-external-provisioner-distributed-on-kubernetes-1-23
     always_run: true
     optional: false
     decorate: true
@@ -26,7 +26,7 @@ presubmits:
         - ./.prow.sh
         env:
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.21.0"
+          value: "1.23.0"
         - name: CSI_PROW_USE_BAZEL
           value: "true"
         - name: CSI_PROW_DRIVER_VERSION


### PR DESCRIPTION
Kubernetes 1.21 will soon fall out of support, using the latest stable release
is better.

/cc @jsafrane 