### PR TITLE
Update OpenShift testgrid definitions (with fix)

### DIFF
--- a/config/testgrids/openshift/assisted-installer.yaml
+++ b/config/testgrids/openshift/assisted-installer.yaml
@@ -82,33 +82,6 @@ dashboards:
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
-  - name: periodic-ci-openshift-release-master-nightly-4.7-e2e-metal-assisted
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.7-e2e-metal-assisted
-    base_options: width=10
-    open_test_template:
-      url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
-    file_bug_template:
-      options:
-      - key: classification
-        value: Red Hat
-      - key: product
-        value: OpenShift Container Platform
-      - key: cf_internal_whiteboard
-        value: buildcop
-      - key: short_desc
-        value: 'test: <test-name>'
-      - key: cf_environment
-        value: 'test: <test-name>'
-      - key: comment
-        value: 'test: <test-name> failed, see job: <test-url>'
-      url: https://bugzilla.redhat.com/enter_bug.cgi
-    open_bug_template:
-      url: https://github.com/openshift/origin/issues/
-    results_url_template:
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: https://github.com/openshift/origin/search
-    code_search_url_template:
-      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
   - name: periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-assisted
     test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-assisted
     base_options: width=10

--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.11-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.11-informing.yaml
@@ -640,6 +640,33 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
+    name: periodic-ci-openshift-multiarch-master-nightly-4.11-upgrade-from-stable-4.10-ocp-e2e-aws-arm64
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: periodic-ci-openshift-multiarch-master-nightly-4.11-upgrade-from-stable-4.10-ocp-e2e-aws-arm64
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: classification
+        value: Red Hat
+      - key: product
+        value: OpenShift Container Platform
+      - key: cf_internal_whiteboard
+        value: buildcop
+      - key: short_desc
+        value: 'test: <test-name>'
+      - key: cf_environment
+        value: 'test: <test-name>'
+      - key: comment
+        value: 'test: <test-name> failed, see job: <link>'
+      url: https://bugzilla.redhat.com/enter_bug.cgi
     name: periodic-ci-openshift-release-master-ci-4.11-e2e-aws
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
@@ -4541,6 +4568,9 @@ test_groups:
   name: periodic-ci-openshift-multiarch-master-nightly-4.11-upgrade-from-nightly-4.10-ocp-remote-libvirt-ppc64le
 - gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-multiarch-master-nightly-4.11-upgrade-from-nightly-4.10-ocp-remote-libvirt-s390x
   name: periodic-ci-openshift-multiarch-master-nightly-4.11-upgrade-from-nightly-4.10-ocp-remote-libvirt-s390x
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-multiarch-master-nightly-4.11-upgrade-from-stable-4.10-ocp-e2e-aws-arm64
+  name: periodic-ci-openshift-multiarch-master-nightly-4.11-upgrade-from-stable-4.10-ocp-e2e-aws-arm64
 - days_of_results: 60
   gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.11-e2e-aws
   name: periodic-ci-openshift-release-master-ci-4.11-e2e-aws

--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.7-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.7-informing.yaml
@@ -1207,33 +1207,6 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.7-e2e-metal-assisted
-    open_bug_template:
-      url: https://github.com/openshift/origin/issues/
-    open_test_template:
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    results_url_template:
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.7-e2e-metal-assisted
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
-    code_search_path: https://github.com/openshift/origin/search
-    code_search_url_template:
-      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
-    file_bug_template:
-      options:
-      - key: classification
-        value: Red Hat
-      - key: product
-        value: OpenShift Container Platform
-      - key: cf_internal_whiteboard
-        value: buildcop
-      - key: short_desc
-        value: 'test: <test-name>'
-      - key: cf_environment
-        value: 'test: <test-name>'
-      - key: comment
-        value: 'test: <test-name> failed, see job: <link>'
-      url: https://bugzilla.redhat.com/enter_bug.cgi
     name: periodic-ci-openshift-release-master-nightly-4.7-e2e-metal-ipi-compact
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
@@ -2393,8 +2366,6 @@ test_groups:
 - days_of_results: 60
   gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.7-e2e-gcp-rt
   name: periodic-ci-openshift-release-master-nightly-4.7-e2e-gcp-rt
-- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.7-e2e-metal-assisted
-  name: periodic-ci-openshift-release-master-nightly-4.7-e2e-metal-assisted
 - gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.7-e2e-metal-ipi-compact
   name: periodic-ci-openshift-release-master-nightly-4.7-e2e-metal-ipi-compact
 - gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.7-e2e-metal-ipi-ovn-dualstack


### PR DESCRIPTION
Builds on https://github.com/kubernetes/test-infra/pull/25521, should fix the following error in the presubmits:
```
 could not write config: 1 error occurred:
	* could not find the referenced (TestGroup) periodic-ci-openshift-release-master-nightly-4.7-e2e-metal-assisted 
```

Example: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/test-infra/25521/pull-test-infra-unit-test/1500862880398970880#1:build-log.txt%3A593