### PR TITLE
move kind jobs to cncf cluster to avoid contention

### DIFF
--- a/config/jobs/kubernetes/sig-scheduling/sig-scheduling-config.yaml
+++ b/config/jobs/kubernetes/sig-scheduling/sig-scheduling-config.yaml
@@ -1,6 +1,7 @@
 periodics:
 - interval: 6h
   name: ci-kubernetes-kind-scheduling-multizone-serial
+  cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
     timeout: 200m # allow plenty of time for a serial conformance run
@@ -34,9 +35,12 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          cpu: 4
+          memory: 9Gi
         requests:
-          memory: "9000Mi"
-          cpu: 4000m
+          cpu: 4
+          memory: 9Gi
   annotations:
     testgrid-dashboards: sig-scheduling
     testgrid-tab-name: sig-scheduling-kind, multizone


### PR DESCRIPTION

Jobs are failing on the old google cluster https://testgrid.k8s.io/sig-scheduling#sig-scheduling-kind,%20multizone

Other jobs were migrated already showing more stability

https://github.com/kubernetes/test-infra/pull/25531
https://github.com/kubernetes/test-infra/pull/25527