### PR TITLE
Fix spelling typo in comment of get_jq.sh

### DIFF
--- a/metrics/get_jq.sh
+++ b/metrics/get_jq.sh
@@ -42,7 +42,7 @@ download() {
 mkdir -p "${JQ_DIR}"
 # linux64 is used by CI, making sure that this is used in CI as well
 download jq-linux64
-# ensure that `_bin/jq-1.5/jq` is compitable with host, so that python3 test
+# ensure that `_bin/jq-1.5/jq` is compatible with host, so that python3 test
 # won't fail locally
 if [[ "$(uname)" == Darwin ]]; then
     download jq-osx-amd64


### PR DESCRIPTION
The spelling typo causes failures when verifying spelling checks.

For example:
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/1948/pull-project-infra-check-testgrid-config/1500931020109647872

Signed-off-by: Brian Carey <bcarey@redhat.com>