### PR TITLE
Remove branch protection from gh-pages for sig-storage-local-static-provisioner

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -597,6 +597,10 @@ branch-protection:
           restrictions:
             users:
             - k8s-ci-robot
+        sig-storage-local-static-provisioner:
+          branches:
+            gh-pages:
+              protect: false
 
 tide:
   sync_period: 2m


### PR DESCRIPTION
The Helm chart release for sig-storage-local-static-provisioner [failed](https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/issues/289) due to the `gh-pages` branch being protected, this PR follows #24222 that fixed this for Metrics Server end ExternalDNS.