### PR TITLE
Replace test-infra build health badge with continuous test job

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # test-infra
 
 [![GoDoc](https://godoc.org/github.com/kubernetes/test-infra?status.svg)](https://godoc.org/github.com/kubernetes/test-infra)
-[![Build status](https://prow.k8s.io/badge.svg?jobs=post-test-infra-bazel)](https://testgrid.k8s.io/sig-testing-misc#post-bazel)
+[![Build status](https://prow.k8s.io/badge.svg?jobs=ci-test-infra-continuous-test](https://testgrid.k8s.io/sig-testing-misc#continuous)
 
 This repository contains tools and configuration files for the testing and
 automation needs of the Kubernetes project.

--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -1,32 +1,4 @@
 periodics:
-- name: ci-test-infra-bazel
-  decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
-  interval: 1h
-  labels:
-    preset-service-account: "true"
-    preset-bazel-scratch-dir: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:v20210806-38e1be0-test-infra
-      command:
-      - hack/bazel.sh
-      args:
-      - test
-      - --config=ci
-      - --nobuild_tests_only
-      - //...
-      env:
-      - name: BAZEL_FETCH_PLEASE
-        value: //...
-  annotations:
-    testgrid-dashboards: sig-testing-misc
-    testgrid-tab-name: ci-bazel
-    description: Runs bazel test //... on the test-infra repo every hour
-
 - name: ci-test-infra-continuous-test
   decorate: true
   extra_refs:

--- a/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
@@ -1,26 +1,39 @@
 postsubmits:
   kubernetes/test-infra:
-  - name: post-test-infra-bazel
+  - name: post-test-infra-test-all
     branches:
     - master
     decorate: true
     labels:
       preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:v20210806-38e1be0-test-infra
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220307-7fa60e9872-test-infra
         command:
-        - hack/bazel.sh
+        - runner.sh
         args:
+        - make
         - test
-        - --config=ci
-        - --nobuild_tests_only
-        - //...
+        - verify
         env:
-        - name: BAZEL_FETCH_PLEASE
-          value: //...
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            # This job is very CPU intensive as building prow images in
+            # parallel
+            cpu: "14"
+      tolerations:
+      - key: "highcpu"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+      nodeSelector:
+        highcpu: "true"
     annotations:
       testgrid-dashboards: sig-testing-misc
-      testgrid-tab-name: post-bazel
-      description: Runs bazel test //... on the test-infra repo on each commit
+      testgrid-tab-name: post-test-all
+      description: Runs 'make test verify' on the test-infra repo on each commit

--- a/prow/cmd/tot/main_test.go
+++ b/prow/cmd/tot/main_test.go
@@ -193,11 +193,11 @@ func TestGetURL(t *testing.T) {
 		{
 			name: "fallback bucket - postsubmit",
 
-			jobName: "ci-test-infra-bazel",
+			jobName: "post-test-infra-test-all",
 			c:       c,
 			bucket:  "https://storage.googleapis.com/kubernetes-jenkins",
 
-			expected: "https://storage.googleapis.com/kubernetes-jenkins/logs/ci-test-infra-bazel/latest-build.txt",
+			expected: "https://storage.googleapis.com/kubernetes-jenkins/logs/post-test-infra-test-all/latest-build.txt",
 		},
 		{
 			name: "fallback bucket - periodic",


### PR DESCRIPTION
The build health of this repo was indicated by post-test-infra-bazel, which is no longer relevant, replace it with new continuous test

/cc @cjwagner @BenTheElder 