### PR TITLE
Update image builder usages to go instead of bazel

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -41,9 +41,9 @@ postsubmits:
     spec:
       serviceAccountName: pusher
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-bazel:v20210128-v0.6-11-gf1c6399
+      - image: gcr.io/k8s-staging-test-infra/image-builder:v20211014-7ca1952a94
         command:
-        - images/builder/ci-runner.sh
+        - /run.sh
         args:
         - --scratch-bucket=gs://k8s-testimages-scratch
         - --project=k8s-prow
@@ -62,9 +62,9 @@ postsubmits:
     spec:
       serviceAccountName: deployer # TODO(fejta): should be pusher
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-bazel:v20210128-v0.6-11-gf1c6399
+      - image: gcr.io/k8s-staging-test-infra/image-builder:v20211014-7ca1952a94
         command:
-        - images/builder/ci-runner.sh
+        - /run.sh
         args:
         - --scratch-bucket=gs://k8s-testimages-scratch
         - --project=k8s-testimages
@@ -83,9 +83,9 @@ postsubmits:
     spec:
       serviceAccountName: deployer # TODO(fejta): should be pusher
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-bazel:v20210128-v0.6-11-gf1c6399
+      - image: gcr.io/k8s-staging-test-infra/image-builder:v20211014-7ca1952a94
         command:
-        - images/builder/ci-runner.sh
+        - /run.sh
         args:
         - --scratch-bucket=gs://k8s-testimages-scratch
         - --project=k8s-testimages
@@ -104,9 +104,9 @@ postsubmits:
     spec:
       serviceAccountName: pusher
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-bazel:v20210128-v0.6-11-gf1c6399
+      - image: gcr.io/k8s-staging-test-infra/image-builder:v20211014-7ca1952a94
         command:
-        - images/builder/ci-runner.sh
+        - /run.sh
         args:
         - --scratch-bucket=gs://k8s-testimages-scratch
         - --project=k8s-prow
@@ -255,9 +255,9 @@ postsubmits:
     spec:
       serviceAccountName: deployer # TODO(fejta): should be pusher
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-bazel:v20210128-v0.6-11-gf1c6399
+      - image: gcr.io/k8s-staging-test-infra/image-builder:v20211014-7ca1952a94
         command:
-        - images/builder/ci-runner.sh
+        - /run.sh
         args:
         - --scratch-bucket=gs://k8s-testimages-scratch
         - --project=k8s-testimages
@@ -279,9 +279,9 @@ postsubmits:
     spec:
       serviceAccountName: deployer # TODO(fejta): should be pusher
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-bazel:v20210128-v0.6-11-gf1c6399
+      - image: gcr.io/k8s-staging-test-infra/image-builder:v20211014-7ca1952a94
         command:
-        - images/builder/ci-runner.sh
+        - /run.sh
         args:
         - --scratch-bucket=gs://k8s-testimages-scratch
         - --project=k8s-testimages
@@ -302,9 +302,9 @@ postsubmits:
     spec:
       serviceAccountName: deployer # TODO(fejta): should be pusher
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-bazel:v20210128-v0.6-11-gf1c6399
+      - image: gcr.io/k8s-staging-test-infra/image-builder:v20211014-7ca1952a94
         command:
-        - images/builder/ci-runner.sh
+        - /run.sh
         args:
         - --scratch-bucket=gs://k8s-testimages-scratch
         - --project=k8s-testimages
@@ -326,9 +326,9 @@ postsubmits:
     spec:
       serviceAccountName: deployer # TODO(fejta): should be pusher
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-bazel:v20210128-v0.6-11-gf1c6399
+      - image: gcr.io/k8s-staging-test-infra/image-builder:v20211014-7ca1952a94
         command:
-        - images/builder/ci-runner.sh
+        - /run.sh
         args:
         - --scratch-bucket=gs://k8s-testimages-scratch
         - --project=k8s-testimages
@@ -350,9 +350,9 @@ postsubmits:
     spec:
       serviceAccountName: deployer # TODO(fejta): should be pusher
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-bazel:v20210128-v0.6-11-gf1c6399
+      - image: gcr.io/k8s-staging-test-infra/image-builder:v20211014-7ca1952a94
         command:
-        - images/builder/ci-runner.sh
+        - /run.sh
         args:
         - --scratch-bucket=gs://k8s-testimages-scratch
         - --project=k8s-testimages
@@ -374,9 +374,9 @@ postsubmits:
     spec:
       serviceAccountName: deployer # TODO(fejta): should be pusher
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-bazel:v20210128-v0.6-11-gf1c6399
+      - image: gcr.io/k8s-staging-test-infra/image-builder:v20211014-7ca1952a94
         command:
-        - images/builder/ci-runner.sh
+        - /run.sh
         args:
         - --scratch-bucket=gs://k8s-testimages-scratch
         - --project=k8s-testimages

--- a/images/builder/Makefile
+++ b/images/builder/Makefile
@@ -15,9 +15,9 @@
 EXTRA_ARG =
 
 push-prod:
-	bazel run //images/builder -- $(EXTRA_ARG) --project=k8s-testimages --scratch-bucket=gs://k8s-testimages-scratch images/builder
+	go run ./images/builder $(EXTRA_ARG) --project=k8s-testimages --scratch-bucket=gs://k8s-testimages-scratch images/builder
 
 push:
-	bazel run //images/builder -- $(EXTRA_ARG) --allow-dirty images/builder
+	go run ./images/builder $(EXTRA_ARG) --allow-dirty images/builder
 
 .PHONY: push push-prod help

--- a/images/builder/README.md
+++ b/images/builder/README.md
@@ -36,7 +36,7 @@ beyond `_GIT_TAG`.
 ## Usage
 
 ```shell
-bazel run //images/builder -- [options] path/to/build-directory/
+go run ./images/builder [options] path/to/build-directory/
 ```
 
 - `--allow-dirty`: If true, allow pushing dirty builds.

--- a/images/builder/ci-runner.sh
+++ b/images/builder/ci-runner.sh
@@ -17,10 +17,13 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}/../..")" && pwd -P)"
+cd "${ROOT_DIR}"
+
 if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]];then
   echo "Activating service account..."
   gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
 fi
 
 echo "Executing builder, sending logs to ${ARTIFACTS}..."
-bazel run //images/builder -- --log-dir="${ARTIFACTS}" "$@"
+go run ./images/builder --log-dir="${ARTIFACTS}" "$@"

--- a/images/builder/main.go
+++ b/images/builder/main.go
@@ -378,12 +378,6 @@ func parseFlags() options {
 func main() {
 	o := parseFlags()
 
-	if bazelWorkspace := os.Getenv("BUILD_WORKSPACE_DIRECTORY"); bazelWorkspace != "" {
-		if err := os.Chdir(bazelWorkspace); err != nil {
-			log.Fatalf("Failed to chdir to bazel workspace (%s): %v", bazelWorkspace, err)
-		}
-	}
-
 	if o.buildDir == "" {
 		o.buildDir = o.configDir
 	}


### PR DESCRIPTION
Images pushed by sig-release already uses image-builder image, which was built with go build and docker build. Also update test-infra image pushing jobs to use image-builder image instead of bazel image.

/cc @cjwagner @BenTheElder 