### PR TITLE
Fix a bug for the IsAuthorized function when configuring the rerun auth config with team slugs

### DIFF
--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -258,13 +258,9 @@ func (rac *RerunAuthConfig) IsAuthorized(org, user string, cli prowgithub.RerunC
 		}
 	}
 	for _, ghts := range rac.GitHubTeamSlugs {
-		team, err := cli.GetTeamBySlug(ghts.Slug, ghts.Org)
+		member, err := cli.TeamBySlugHasMember(ghts.Org, ghts.Slug, user)
 		if err != nil {
-			return false, fmt.Errorf("GitHub failed to fetch team with slug %s and org %s: %w", ghts.Slug, ghts.Org, err)
-		}
-		member, err := cli.TeamHasMember(org, team.ID, user)
-		if err != nil {
-			return false, fmt.Errorf("GitHub failed to fetch members of team %v: %w", team, err)
+			return false, fmt.Errorf("GitHub failed to check if team with slug %s has member %s: %w", ghts.Slug, user, err)
 		}
 		if member {
 			return true, nil

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -239,8 +239,8 @@ type MilestoneClient interface {
 
 // RerunClient interface for job rerun access check related API actions
 type RerunClient interface {
+	TeamBySlugHasMember(org string, teamSlug string, memberLogin string) (bool, error)
 	TeamHasMember(org string, teamID int, memberLogin string) (bool, error)
-	GetTeamBySlug(slug string, org string) (*Team, error)
 	IsCollaborator(org, repo, user string) (bool, error)
 	IsMember(org, user string) (bool, error)
 	GetIssueLabels(org, repo string, number int) ([]Label, error)


### PR DESCRIPTION
The config update in https://github.com/GoogleCloudPlatform/oss-test-infra/pull/1514/files did not work. 

The reason seems to be the check here is using `ghts.Org` for `GetTeamBySlug` but `org` for `TeamHasMember`. This PR will fix it and use `TeamBySlugHasMember` function to simplify the check.