### PR TITLE
Roll up typescript with Go

### DIFF
--- a/hack/prowimagebuilder/main.go
+++ b/hack/prowimagebuilder/main.go
@@ -320,7 +320,7 @@ func main() {
 							// Don't call wg.Done() as we are not done yet
 							continue
 						}
-						errChan <- fmt.Errorf("building image for %s failed: %v", id.Dir, err)
+						errChan <- fmt.Errorf("building image for %s failed: %w", id.Dir, err)
 					}
 					doneChan <- id
 				case <-ctx.Done():

--- a/hack/ts-rollup/main.go
+++ b/hack/ts-rollup/main.go
@@ -1,0 +1,232 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"sync"
+
+	"context"
+
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	defaultOutputDir = "_output/js"
+
+	rimraf = "node_modules/rimraf/bin.js"
+	tsc    = "node_modules/typescript/bin/tsc"
+	rollup = "node_modules/rollup/dist/bin/rollup"
+	terser = "node_modules/terser/bin/terser"
+
+	defaultRollupConfig = "rollup.config.js"
+	defaultTerserConfig = "hack/ts.rollup_bundle.min.minify_options.json"
+
+	defaultWorkersCount = 5
+)
+
+var (
+	rootDir string
+)
+
+func rootDirWithGit() {
+	// Best effort
+	out, err := runCmd(nil, "git", "rev-parse", "--show-toplevel")
+	if err != nil {
+		logrus.WithError(err).Warn("Failed getting git root dir")
+	}
+	rootDir = out
+}
+
+type options struct {
+	packages    string
+	workers     int
+	cleanupOnly bool
+}
+
+type packagesInfo struct {
+	Packages []packageInfo `yaml:"packages"`
+}
+
+type packageInfo struct {
+	Dir        string `yaml:"dir"`
+	Entrypoint string `yaml:"entrypoint"`
+	Dst        string `yaml:"dst"`
+}
+
+func loadPackagesInfo(f string) (*packagesInfo, error) {
+	b, err := ioutil.ReadFile(f)
+	if err != nil {
+		return nil, fmt.Errorf("reading file %q: %w", f, err)
+	}
+	var res packagesInfo
+	return &res, yaml.Unmarshal(b, &res)
+}
+
+// Mock for unit testing purpose
+var runCmdInDirFunc = runCmdInDir
+
+func runCmdInDir(dir string, additionalEnv []string, cmd string, args ...string) (string, error) {
+	command := exec.Command(cmd, args...)
+	if dir != "" {
+		command.Dir = dir
+	}
+	command.Env = append(os.Environ(), additionalEnv...)
+	stdOut, err := command.StdoutPipe()
+	if err != nil {
+		return "", err
+	}
+	stdErr, err := command.StderrPipe()
+	if err != nil {
+		return "", err
+	}
+	if err := command.Start(); err != nil {
+		return "", err
+	}
+	scanner := bufio.NewScanner(stdOut)
+	var allOut string
+	for scanner.Scan() {
+		out := scanner.Text()
+		allOut = allOut + out
+		logrus.WithField("cmd", command.Args).Info(out)
+	}
+	allErr, _ := io.ReadAll(stdErr)
+	err = command.Wait()
+	// Print error only when command failed
+	if err != nil && len(allErr) > 0 {
+		logrus.WithField("cmd", command.Args).Error(string(allErr))
+	}
+	return strings.TrimSpace(allOut), err
+}
+
+func runCmd(additionalEnv []string, cmd string, args ...string) (string, error) {
+	return runCmdInDirFunc(rootDir, additionalEnv, cmd, args...)
+}
+
+func rollupOne(pi *packageInfo, cleanupOnly bool) error {
+	entrypointFileBasename := strings.TrimSuffix(path.Base(pi.Entrypoint), ".ts")
+	// Intermediate output files, stored under `_output` dir
+	jsOutputFile := path.Join(defaultOutputDir, pi.Dir, entrypointFileBasename+".js")
+	bundleOutputDir := path.Join(defaultOutputDir, pi.Dir)
+	rollupOutputFile := path.Join(bundleOutputDir, "bundle.js")
+	// terserOutputFile is the minified bundle, which is placed next to all
+	// other static files in the source tree
+	terserOutputFile := path.Join(pi.Dir, pi.Dst)
+	if cleanupOnly {
+		return os.Remove(terserOutputFile)
+	}
+	if _, err := runCmd(nil, rimraf, "dist"); err != nil {
+		return fmt.Errorf("running rimraf: %w", err)
+	}
+	if _, err := runCmd(nil, tsc, "-p", path.Join(pi.Dir, "tsconfig.json"), "--outDir", defaultOutputDir); err != nil {
+		return fmt.Errorf("running tsc: %w", err)
+	}
+	if _, err := runCmd(nil, rollup, "--environment", fmt.Sprintf("ROLLUP_OUT_FILE:%s,ROLLUP_ENTRYPOINT:%s", rollupOutputFile, jsOutputFile), "-c", defaultRollupConfig, "--preserveSymlinks"); err != nil {
+		return fmt.Errorf("running rollup: %w", err)
+	}
+	if _, err := runCmd(nil, terser, rollupOutputFile, "--output", terserOutputFile, "--config-file", defaultTerserConfig); err != nil {
+		return fmt.Errorf("running terser: %w", err)
+	}
+	return nil
+}
+
+func main() {
+	var o options
+	flag.StringVar(&o.packages, "packages", "", "Yaml file contains list of packages to be rolled up.")
+	flag.IntVar(&o.workers, "workers", defaultWorkersCount, "Number of workers in parallel.")
+	flag.BoolVar(&o.cleanupOnly, "cleanup-only", false, "Indicate cleanup only.")
+	flag.StringVar(&rootDir, "root-dir", "", "Root dir of this repo, where everything happens.")
+	flag.Parse()
+
+	if rootDir == "" {
+		rootDirWithGit()
+	}
+	if rootDir == "" {
+		logrus.Error("Unable to determine root dir, please pass in --root-dir.")
+		os.Exit(1)
+	}
+
+	pis, err := loadPackagesInfo(o.packages)
+	if err != nil {
+		logrus.WithError(err).WithField("packages", o.packages).Error("Failed loading")
+		os.Exit(1)
+	}
+
+	var wg sync.WaitGroup
+	packageChan := make(chan packageInfo, 10)
+	errChan := make(chan error, len(pis.Packages))
+	doneChan := make(chan packageInfo, len(pis.Packages))
+	// Start workers
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	for i := 0; i < o.workers; i++ {
+		go func(ctx context.Context, packageChan chan packageInfo, errChan chan error, doneChan chan packageInfo) {
+			for {
+				select {
+				case pi := <-packageChan:
+					err := rollupOne(&pi, o.cleanupOnly)
+					if err != nil {
+						errChan <- fmt.Errorf("building image for %s failed: %v", pi.Entrypoint, err)
+					}
+					doneChan <- pi
+				case <-ctx.Done():
+					return
+				}
+			}
+		}(ctx, packageChan, errChan, doneChan)
+	}
+
+	for _, pi := range pis.Packages {
+		pi := pi
+		wg.Add(1)
+		packageChan <- pi
+	}
+
+	go func(ctx context.Context, wg *sync.WaitGroup, doneChan chan packageInfo) {
+		var done int
+		for {
+			select {
+			case pi := <-doneChan:
+				done++
+				logrus.WithFields(logrus.Fields{"entrypoint": pi.Entrypoint, "done": done, "total": len(pis.Packages)}).Info("Done with package.")
+				wg.Done()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}(ctx, &wg, doneChan)
+
+	wg.Wait()
+	for {
+		select {
+		case err := <-errChan:
+			logrus.WithError(err).Error("Failed.")
+			os.Exit(1)
+		default:
+			return
+		}
+	}
+}

--- a/prow/cmd/deck/.ts-packages
+++ b/prow/cmd/deck/.ts-packages
@@ -1,17 +1,52 @@
-prow/spyglass/lenses/restcoverage/restcoverage.ts->script_bundle.min.js
-prow/spyglass/lenses/podinfo/podinfo.ts->script_bundle.min.js
-prow/spyglass/lenses/metadata/metadata.ts->script_bundle.min.js
-prow/spyglass/lenses/links/links.ts->script_bundle.min.js
-prow/spyglass/lenses/junit/lens.ts->script_bundle.min.js
-prow/spyglass/lenses/html/html.ts->script_bundle.min.js
-prow/spyglass/lenses/coverage/coverage.ts->script_bundle.min.js
-prow/spyglass/lenses/buildlog/buildlog.ts->script_bundle.min.js
-prow/cmd/deck/static/spyglass/spyglass.ts->../spyglass_bundle.min.js
-prow/cmd/deck/static/spyglass/lens.ts->../spyglass_lens_bundle.min.js
-prow/cmd/deck/static/command-help/command-help.ts->../command_help_bundle.min.js
-prow/cmd/deck/static/tide-history/tide-history.ts->../tide_history_bundle.min.js
-prow/cmd/deck/static/tide/tide.ts->../tide_bundle.min.js
-prow/cmd/deck/static/pr/pr.ts->../pr_bundle.min.js
-prow/cmd/deck/static/plugin-help/plugin-help.ts->../plugin_help_bundle.min.js
-prow/cmd/deck/static/prow/prow.ts->../prow_bundle.min.js
-prow/cmd/deck/static/job-history/job-history.ts->../job_history_bundle.min.js
+packages:
+- dir: prow/spyglass/lenses/restcoverage
+  entrypoint: restcoverage.ts
+  dst: script_bundle.min.js
+- dir: prow/spyglass/lenses/podinfo
+  entrypoint: podinfo.ts
+  dst: script_bundle.min.js
+- dir: prow/spyglass/lenses/metadata
+  entrypoint: metadata.ts
+  dst: script_bundle.min.js
+- dir: prow/spyglass/lenses/links
+  entrypoint: links.ts
+  dst: script_bundle.min.js
+- dir: prow/spyglass/lenses/junit
+  entrypoint: lens.ts
+  dst: script_bundle.min.js
+- dir: prow/spyglass/lenses/html
+  entrypoint: html.ts
+  dst: script_bundle.min.js
+- dir: prow/spyglass/lenses/coverage
+  entrypoint: coverage.ts
+  dst: script_bundle.min.js
+- dir: prow/spyglass/lenses/buildlog
+  entrypoint: buildlog.ts
+  dst: script_bundle.min.js
+- dir: prow/cmd/deck/static/spyglass
+  entrypoint: spyglass.ts
+  dst: ../spyglass_bundle.min.js
+- dir: prow/cmd/deck/static/spyglass
+  entrypoint: lens.ts
+  dst: ../spyglass_lens_bundle.min.js
+- dir: prow/cmd/deck/static/command-help
+  entrypoint: command-help.ts
+  dst: ../command_help_bundle.min.js
+- dir: prow/cmd/deck/static/tide-history
+  entrypoint: tide-history.ts
+  dst: ../tide_history_bundle.min.js
+- dir: prow/cmd/deck/static/tide
+  entrypoint: tide.ts
+  dst: ../tide_bundle.min.js
+- dir: prow/cmd/deck/static/pr
+  entrypoint: pr.ts
+  dst: ../pr_bundle.min.js
+- dir: prow/cmd/deck/static/plugin-help
+  entrypoint: plugin-help.ts
+  dst: ../plugin_help_bundle.min.js
+- dir: prow/cmd/deck/static/prow
+  entrypoint: prow.ts
+  dst: ../prow_bundle.min.js
+- dir: prow/cmd/deck/static/job-history
+  entrypoint: job-history.ts
+  dst: ../job_history_bundle.min.js


### PR DESCRIPTION
Following #25556 , another attempt to stabilize ts rollup speed

- easier to maintain than bash
- can do things in parallel

only use it for deck at this point, will use ii for other things if apply

/cc @cjwagner @BenTheElder 