### PR TITLE
Testgrid config upload job uses gcloud-in-go

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -420,7 +420,7 @@ postsubmits:
     spec:
       serviceAccountName: testgrid-config-updater
       containers:
-      - image: gcr.io/k8s-staging-test-infra/bazelbuild:v20210930-b6c4097796-test-infra
+      - image: gcr.io/k8s-staging-test-infra/gcloud-in-go:v20211210-cf89952124
         command:
         - ./testgrid/config-upload.sh
         resources:


### PR DESCRIPTION
it's now triggered by go instead of bazel

/cc @chases2 
prioritize reviewing #25564 has similar effect of fixing this job, current PR is faster though