### PR TITLE
Set ci-kubernetes-verify-master serial typecheck

### DIFF
--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -130,6 +130,10 @@ periodics:
         value: master
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
+      # Consider removing after https://github.com/golang/go/issues/49035 is solved
+      # See https://github.com/kubernetes/kubernetes/pull/108618
+      - name: TYPECHECK_SERIAL
+        value: "true"
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true


### PR DESCRIPTION
This PR sets the verify job to run verify-typecheck serially to cut down on memory usage.

Fixes https://github.com/kubernetes/kubernetes/issues/107702

Requires https://github.com/kubernetes/kubernetes/pull/108618

cc @kubernetes/ci-signal 

/kind flake
/sig testing
/hold