### PR TITLE
Enable cherrypicker for cluster-api-provider-openstack

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1303,6 +1303,12 @@ external_plugins:
     - issue_comment
     - pull_request
     endpoint: http://cherrypicker
+  kubernetes-sigs/cluster-api-provider-openstack:
+  - name: cherrypicker
+    events:
+    - issue_comment
+    - pull_request
+    endpoint: http://cherrypicker
   kubernetes-sigs/controller-tools:
   - name: cherrypicker
     events:


### PR DESCRIPTION
This PR enables the cherrypicker plugin for https://github.com/kubernetes-sigs/cluster-api-provider-openstack
