### PR TITLE
update conformance test job for capg release 0.4 branches

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-0-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-0-4.yaml
@@ -129,7 +129,7 @@ presubmits:
       path_alias: "sigs.k8s.io/image-builder"
     - org: kubernetes
       repo: kubernetes
-      base_ref: master
+      base_ref: release-1.21
       path_alias: k8s.io/kubernetes
     spec:
       containers:
@@ -140,7 +140,6 @@ presubmits:
           command:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"
-            - "--use-ci-artifacts"
           # we need privileged mode in order to do docker in docker
           securityContext:
             privileged: true


### PR DESCRIPTION
the main branch will not work anymore on the release-0.4 because that is not supported anymore for the old releases. however we still push patches from capi/capg

this might be deprecated soon as well

need this change for https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/549

/assign @dims 