### PR TITLE
Remove bazel related instructions from testgrid related READMEs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,4 +109,10 @@ verify-boilerplate:
 .PHONY: verify-yamllint
 verify-yamllint:
 	hack/make-rules/verify/yamllint.sh
+.PHONY: update-proto
+update-proto:
+	hack/make-rules/update/proto.sh
+.PHONY: verify-proto
+verify-proto:
+	hack/make-rules/verify/proto.sh
 #################################################################################

--- a/config/testgrids/README.md
+++ b/config/testgrids/README.md
@@ -21,7 +21,7 @@ directory (including a new one, if desired):
      or create a new `dashboard` and assign the testgroup to the dashboard.
      * The testgroup name from a dashboard tab should match the name from a testgroup
      * Note that a testgroup can be within multiple dashboards.
-1.   Test your new config (`bazel test //config/tests/...`)
+1.   Test your new config (`go test ./config/tests`)
 
 
 NOTE: If you're adding a periodic or postsubmit and don't want to specially configure your test
@@ -31,7 +31,7 @@ need to be added to a dashboard further down.
 
 ## Testing
 
-Run `bazel test //config/tests/...` to ensure these configurations are valid.
+Run `go test //config/tests` to ensure these configurations are valid.
 
 This finds common problems such as malformed yaml, a tab referring to a
 non-existent test group, a test group never appearing on any tab, etc. It also enforces some

--- a/hack/make-rules/update/proto.sh
+++ b/hack/make-rules/update/proto.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"
+cd $REPO_ROOT
+
+GRPC="plugins=grpc"
+IMPORT_MAP="Mtestgrid/config/config.proto=k8s.io/test-infra/testgrid/config,Mtestgrid/summary/summary.proto=k8s.io/test-infra/testgrid/summary,Mtestgrid/cmd/summarizer/response/types.proto=k8s.io/test-infra/testgrid/cmd/summarizer/response"
+BOILERPLATE_FILE="hack/boilerplate/boilerplate.generated.go.txt"
+
+echo "Install proto generating tools."
+# Install protoc
+if [[ ! -f "_bin/protoc/bin/protoc" ]]; then
+  mkdir -p _bin/protoc
+  PROTOC_ZIP=protoc-3.15.5-linux-x86_64.zip
+  if [[ "$(uname)" == Darwin ]]; then
+    PROTOC_ZIP=protoc-3.15.5-osx-x86_64.zip
+  fi
+  curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.15.5/$PROTOC_ZIP
+  unzip -o $PROTOC_ZIP -d _bin/protoc bin/protoc
+  unzip -o $PROTOC_ZIP -d _bin/protoc 'include/*'
+  rm -f $PROTOC_ZIP
+fi
+
+echo "Ensuring go version."
+source ./hack/build/setup-go.sh
+
+cd "hack/tools"
+PROTOC_GEN_GO="${REPO_ROOT}/_bin/protoc-gen-go"
+go build -o "${PROTOC_GEN_GO}" github.com/golang/protobuf/protoc-gen-go
+cd "${REPO_ROOT}"
+
+genproto() {
+  dir=$(dirname "$1")
+  base=$(basename "$1")
+  out=${REPO_ROOT}/$dir/${base%.proto}.pb.go
+  rm -f "$out" # mac will complain otherwise
+  export PATH="${REPO_ROOT}/_bin/protoc/include/google/protobuf;${REPO_ROOT}/_bin;$PATH"
+  ./_bin/protoc/bin/protoc "--plugin=${PROTOC_GEN_GO}" "--proto_path=${dir}" "--proto_path=${REPO_ROOT}" "--go_out=${GRPC},${IMPORT_MAP}:$REPO_ROOT/$dir" "$1"
+  tmp=$(mktemp)
+  mv "$out" "$tmp"
+  cat "$boiler" "$tmp" > "$out"
+}
+
+echo -n "Generating protos: " >&2
+for p in $(find . \
+  -not '(' -path './vendor' -prune ')' \
+  -not '(' -path './node_modules' -prune ')' \
+  -not '(' -path './_bin' -prune ')' \
+  -name '*.proto'); do
+  echo "Generating for: $p"
+  echo -n "$p "
+  genproto "$p"
+done
+echo

--- a/hack/make-rules/verify/proto.sh
+++ b/hack/make-rules/verify/proto.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"
+cd $REPO_ROOT
+
+# place to stick temp binaries
+BINDIR="${REPO_ROOT}/_bin"
+if [[ ! -d "${BINDIR}" ]]; then
+  mkdir "${BINDIR}"
+fi
+
+DIFFROOT="${REPO_ROOT}"
+TMP_DIFFROOT="$(TMPDIR="${BINDIR}" mktemp -d "${BINDIR}/verify-proto.XXXXX")"
+
+mkdir -p "${TMP_DIFFROOT}/testgrid"
+cp -a "${DIFFROOT}"/testgrid "${TMP_DIFFROOT}/"
+
+"${REPO_ROOT}/hack/make-rules/update/proto.sh"
+
+echo "diffing ${DIFFROOT} against freshly generated proto"
+ret=0
+diff -Naupr "${DIFFROOT}/testgrid" "${TMP_DIFFROOT}/testgrid" || ret=$?
+# Restore so that verify proto doesn't modify workspace
+cp -a "${TMP_DIFFROOT}"/testgrid "${DIFFROOT}"/
+
+# Clean up
+rm -rf "${TMP_DIFFROOT}"
+
+if [[ ${ret} -eq 0 ]]; then
+  echo "${DIFFROOT} up to date."
+  exit 0
+fi
+echo "ERROR: out of date proto files. Fix with make update-proto" >&2
+exit 1

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/bazelbuild/buildtools v0.0.0-20211007154642-8dd79e56e98e
 	github.com/client9/misspell v0.3.4
 	github.com/go-bindata/go-bindata/v3 v3.1.3
+	github.com/golang/protobuf v1.5.2
 	github.com/golangci/golangci-lint v1.43.0
 	github.com/google/ko v0.9.4-0.20220213235838-0187841b1641
 	github.com/sethvargo/gcs-cacher v0.1.3

--- a/hack/tools/tools.go
+++ b/hack/tools/tools.go
@@ -35,6 +35,9 @@ import (
 	_ "k8s.io/code-generator/cmd/lister-gen"
 	_ "sigs.k8s.io/controller-tools/cmd/controller-gen"
 
+	// proto generator
+	_ "github.com/golang/protobuf/protoc-gen-go"
+
 	// test runner
 	_ "gotest.tools/gotestsum"
 

--- a/testgrid/build_test_update.md
+++ b/testgrid/build_test_update.md
@@ -18,7 +18,7 @@ merged.
 
 You can convert a yaml file to the config proto with:
 ```
-bazel run //testgrid/cmd/configurator -- \
+go run ./testgrid/cmd/configurator \
   --yaml=testgrid/config.yaml \
   --print-text \
   --oneshot \
@@ -36,15 +36,15 @@ Cloud Storage (GCS) location, and read from there.
 If you modify a .proto file, you'll also need to generate and check in the
 .pb.go files.
 
-Run `bazel run //hack:update-protos` to generate, and `bazel run //hack:verify-protos.sh`
+Run `make update-protos` to generate, and `make run verify-protos`
 to verify.
 
 ## Testing
 
-Run `bazel test //testgrid/...` to run all unit tests in TestGrid. Note that this does not validate
-the [testgrid.k8s.io config]; those tests are in `bazel test //config/tests/testgrids/...`
+Run `go test ./testgrid` to run all unit tests in TestGrid. Note that this does not validate
+the [testgrid.k8s.io config]; those tests are in `go test ./config/tests/testgrids`
 
-Run `bazel test //...` for repository-wide testing, such as ensuring that
+Run `make test` for repository-wide testing, such as ensuring that
 every job in our CI system appears somewhere in testgrid, etc.
 
 [`config.proto`]: ./config/config.proto

--- a/testgrid/cmd/transfigure/README.md
+++ b/testgrid/cmd/transfigure/README.md
@@ -42,7 +42,7 @@ and delete the `gen-config.yaml` file that Transfigure has been maintaining.
 
 The `gcr.io/k8s-prow/transfigure` image is built and published automatically by [`post-test-infra-push-prow`](https://github.com/kubernetes/test-infra/blob/9a939de10fa72af415eb1e628345b7d16c1f0be0/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml#L118-L143) with the rest of the Prow components.
 
-You can build the image locally and use it in Docker with `bazel run //testgrid/cmd/transfigure`. Publish to a remote repository after building with `docker push` or build and push all Prow images at once with [`prow/push.sh`](/prow/push.sh).
+You can build the image locally and use it in Docker. Publish to a remote repository after building with `docker push` or build and push all Prow images at once with [`prow/push.sh`](/prow/push.sh).
 
 [testgrid.k8s.io]: (https://testgrid.k8s.io/)
 [Config Merger]: /testgrid/merging.md

--- a/testgrid/config.md
+++ b/testgrid/config.md
@@ -185,7 +185,7 @@ dashboard_groups:
 
 ## Testing your configuration
 
-Run [`bazel test //config/tests/testgrids/..`](/config/tests/testgrids) to ensure the configuration is valid.
+Run [`go test ./config/tests/testgrids`](/config/tests/testgrids) to ensure the configuration is valid.
 
 ## Advanced configuration
 


### PR DESCRIPTION
Also by the way added update-proto. Noticed that this script had been used by testgrid only in the past, which seems to have been migrated to https://github.com/GoogleCloudPlatform/testgrid/tree/master/pb/summary. Adding it any ways to ensure no regression, can remove later on