### PR TITLE
update override plugin to use new bySlug methods

### DIFF
--- a/prow/plugins/override/override_test.go
+++ b/prow/plugins/override/override_test.go
@@ -252,8 +252,8 @@ func (c *fakeClient) ListTeams(org string) ([]github.Team, error) {
 	return []github.Team{}, nil
 }
 
-func (c *fakeClient) ListTeamMembers(org string, id int, role string) ([]github.TeamMember, error) {
-	if id == 1 {
+func (c *fakeClient) ListTeamMembersBySlug(org, teamSlug, role string) ([]github.TeamMember, error) {
+	if teamSlug == "team-foo" {
 		return []github.TeamMember{
 			{Login: "user1"},
 			{Login: "user2"},
@@ -1163,11 +1163,11 @@ func TestValidateGitHubTeamSlugs(t *testing.T) {
 	githubTeams := []github.Team{
 		{
 			ID:   2,
-			Slug: "team-foo",
+			Slug: "team-bar",
 		},
 		{
 			ID:   3,
-			Slug: "team-bar",
+			Slug: "team-baz",
 		},
 	}
 
@@ -1187,7 +1187,7 @@ func TestValidateGitHubTeamSlugs(t *testing.T) {
 		{
 			name: "no errors for valid team slugs",
 			teamSlugs: map[string][]string{
-				repoRef: {"team-foo", "team-bar"},
+				repoRef: {"team-bar", "team-baz"},
 			},
 		},
 	}


### PR DESCRIPTION
Now that the new ...bySlug replacements are in place for the gh client's TeamClient, we can use them in the override plugin to eliminate the multiple api call methods that use the id instead.

part of issue: https://github.com/kubernetes/test-infra/issues/25457