### PR TITLE
update milestone, lgtm, and milestonestatus plugins to utilize bySlug methods

### DIFF
--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -683,10 +683,12 @@ func (f *FakeClient) ListTeams(org string) ([]github.Team, error) {
 	return []github.Team{
 		{
 			ID:   0,
+			Slug: "admins",
 			Name: "Admins",
 		},
 		{
 			ID:   42,
+			Slug: "leads",
 			Name: "Leads",
 		},
 	}, nil
@@ -704,6 +706,24 @@ func (f *FakeClient) ListTeamMembers(org string, teamID int, role string) ([]git
 		42: {{Login: "sig-lead"}},
 	}
 	members, ok := teams[teamID]
+	if !ok {
+		return []github.TeamMember{}, nil
+	}
+	return members, nil
+}
+
+// ListTeamMembers return a fake team with a single "sig-lead" GitHub teammember
+func (f *FakeClient) ListTeamMembersBySlug(org, teamSlug, role string) ([]github.TeamMember, error) {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+	if role != github.RoleAll {
+		return nil, fmt.Errorf("unsupported role %v (only all supported)", role)
+	}
+	teams := map[string][]github.TeamMember{
+		"admins": {{Login: "default-sig-lead"}},
+		"leads":  {{Login: "sig-lead"}},
+	}
+	members, ok := teams[teamSlug]
 	if !ok {
 		return []github.TeamMember{}, nil
 	}

--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -477,6 +477,7 @@ type Milestone struct {
 	// You can curl the following endpoint in order to determine the github ID of your team
 	// responsible for maintaining the milestones:
 	// curl -H "Authorization: token <token>" https://api.github.com/orgs/<org-name>/teams
+	// Deprecated: use MaintainersTeam instead
 	MaintainersID           int    `json:"maintainers_id,omitempty"`
 	MaintainersTeam         string `json:"maintainers_team,omitempty"`
 	MaintainersFriendlyName string `json:"maintainers_friendly_name,omitempty"`
@@ -1243,6 +1244,16 @@ func validateTrigger(triggers []Trigger) error {
 	return nil
 }
 
+var warnRepoMilestone time.Time
+
+func validateRepoMilestone(milestones map[string]Milestone) {
+	for _, milestone := range milestones {
+		if milestone.MaintainersID != 0 {
+			logrusutil.ThrottledWarnf(&warnRepoMilestone, time.Hour, "deprecated field: maintainers_id is configured for repo_milestone, maintainers_team should be used instead")
+		}
+	}
+}
+
 func compileRegexpsAndDurations(pc *Configuration) error {
 	cRe, err := regexp.Compile(pc.SigMention.Regexp)
 	if err != nil {
@@ -1327,6 +1338,7 @@ func (c *Configuration) Validate() error {
 	if err := validateTrigger(c.Triggers); err != nil {
 		return err
 	}
+	validateRepoMilestone(c.RepoMilestone)
 
 	return nil
 }

--- a/prow/plugins/lgtm/lgtm.go
+++ b/prow/plugins/lgtm/lgtm.go
@@ -135,7 +135,7 @@ type githubClient interface {
 	GetSingleCommit(org, repo, SHA string) (github.RepositoryCommit, error)
 	IsMember(org, user string) (bool, error)
 	ListTeams(org string) ([]github.Team, error)
-	ListTeamMembers(org string, id int, role string) ([]github.TeamMember, error)
+	ListTeamMembersBySlug(org, teamSlug, role string) ([]github.TeamMember, error)
 	RequestReview(org, repo string, number int, logins []string) error
 }
 
@@ -385,7 +385,7 @@ func stickyLgtm(log *logrus.Entry, gc githubClient, _ *plugins.Configuration, lg
 	}
 	for _, teamInOrg := range teams {
 		if teamInOrg.Name == lgtm.StickyLgtmTeam {
-			members, err := gc.ListTeamMembers(org, teamInOrg.ID, github.RoleAll)
+			members, err := gc.ListTeamMembersBySlug(org, teamInOrg.Slug, github.RoleAll)
 			if err != nil {
 				log.WithError(err).Errorf("Failed to list members in %s:%s.", org, teamInOrg.Name)
 				return false

--- a/prow/plugins/milestone/milestone_test.go
+++ b/prow/plugins/milestone/milestone_test.go
@@ -109,8 +109,7 @@ func TestMilestoneStatus(t *testing.T) {
 		fakeClient.MilestoneMap = milestonesMap
 		fakeClient.Milestone = tc.previousMilestone
 
-		maintainersID := 42
-		maintainersName := "fake-maintainers-team"
+		maintainersTeamName := "leads"
 		e := &github.GenericCommentEvent{
 			Action: github.GenericCommentActionCreated,
 			Body:   tc.body,
@@ -119,10 +118,10 @@ func TestMilestoneStatus(t *testing.T) {
 			User:   github.User{Login: tc.commenter},
 		}
 
-		repoMilestone := map[string]plugins.Milestone{"": {MaintainersID: 0, MaintainersTeam: maintainersName}}
+		repoMilestone := map[string]plugins.Milestone{"": {MaintainersTeam: "admins"}}
 
 		if !tc.noRepoMaintainer {
-			repoMilestone["org/repo"] = plugins.Milestone{MaintainersID: maintainersID, MaintainersTeam: maintainersName}
+			repoMilestone["org/repo"] = plugins.Milestone{MaintainersTeam: maintainersTeamName}
 		}
 
 		if err := handle(fakeClient, logrus.WithField("plugin", pluginName), e, repoMilestone); err != nil {

--- a/prow/plugins/milestonestatus/milestonestatus_test.go
+++ b/prow/plugins/milestonestatus/milestonestatus_test.go
@@ -134,10 +134,10 @@ func TestMilestoneStatus(t *testing.T) {
 			User:   github.User{Login: tc.commenter},
 		}
 
-		repoMilestone := map[string]plugins.Milestone{"": {MaintainersID: 0}}
+		repoMilestone := map[string]plugins.Milestone{"": {MaintainersTeam: "admins"}}
 
 		if !tc.noRepoMaintainer {
-			repoMilestone["org/repo"] = plugins.Milestone{MaintainersID: 42}
+			repoMilestone["org/repo"] = plugins.Milestone{MaintainersTeam: "leads"}
 		}
 
 		if err := handle(fakeClient, logrus.WithField("plugin", pluginName), e, repoMilestone); err != nil {


### PR DESCRIPTION
Now that the new ...bySlug replacements are in place for the gh client's TeamClient, we can use them in the `milestone`, `lgtm`, and `milestonestatus` plugins to eliminate the multiple api call methods that use the id instead.

part of issue: https://github.com/kubernetes/test-infra/issues/25457