### PR TITLE
capz: remove windows dockershim main presubmit job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -99,39 +99,6 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-e2e-optional-main
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-  - name: pull-cluster-api-provider-azure-e2e-windows-dockershim
-    path_alias: "sigs.k8s.io/cluster-api-provider-azure"
-    optional: false
-    decorate: true
-    # please see: https://play.golang.org/p/JJSVylVPd53 for more insights
-    run_if_changed: (^[^d].*$)|(^d$)|(^.[^o].*$)|(^do$)|(^..[^c].*$)|(^doc$)|(^...[^s].*$)|(^docs$)|(^....[^/].*$)|(^[^d][^o][^c][^s]/.*$)
-    max_concurrency: 5
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-      preset-azure-cred-only: "true"
-      preset-azure-anonymous-pull: "true"
-    branches:
-    - ^main$
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220307-7fa60e9872-1.23
-        command:
-          - runner.sh
-        args:
-          - ./scripts/ci-e2e.sh
-        env:
-          - name: GINKGO_FOCUS
-            value: ".*Windows.*dockershim.*"
-          - name: GINKGO_SKIP
-            value: ""
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-    annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-      testgrid-tab-name: capz-pr-e2e-windows-dockershim-main
-      testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-e2e-exp
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false


### PR DESCRIPTION
This PR updates the capz main presubmit test definitions to remove the distinct windows-dockershim test job.

This job runs as part of the `[OPTIONAL]` set of tests, so we're already getting this optional functional signal when we run that set of jobs.