### PR TITLE
disable presubmit till the test is fixed.

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -241,35 +241,3 @@ presubmits:
     annotations:
       testgrid-dashboards: presubmits-node-problem-detector
       testgrid-num-columns-recent: '30'
-  - name: pull-npd-e2e-test
-    branches:
-    - master
-    always_run: true
-    decorate: true
-    path_alias: k8s.io/node-problem-detector
-    labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220307-7fa60e9872-master
-        env:
-        - name: ZONE
-          value: us-central1-a
-        - name: IMAGE_FAMILY
-          value: cos-89-lts
-        - name: IMAGE_PROJECT
-          value: cos-cloud
-        - name: BOSKOS_PROJECT_TYPE
-          value: gce-project
-        command:
-        - runner.sh
-        args:
-        - bash
-        - -c
-        - >-
-          ./test/build.sh install-lib &&
-          SSH_USER=${USER} SSH_KEY=${JENKINS_GCE_SSH_PRIVATE_KEY_FILE} make e2e-test
-    annotations:
-      testgrid-dashboards: presubmits-node-problem-detector
-      testgrid-num-columns-recent: '30'


### PR DESCRIPTION
We need to update the tests based on ginkgo version


It is been deleted from the main test grid as well. https://github.com/kubernetes/test-infra/pull/25542