### PR TITLE
Kubebuilder: add 1-23-3 e2e PR test

### DIFF
--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -19,7 +19,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
       testgrid-tab-name: kubebuilder
-  - name: pull-kubebuilder-e2e-k8s-1-23-4
+  - name: pull-kubebuilder-e2e-k8s-1-23-3
     decorate: true
     always_run: true
     optional: true
@@ -37,7 +37,7 @@ presubmits:
         - ./test_e2e.sh
         env:
         - name: KIND_K8S_VERSION
-          value: "v1.23.4"
+          value: "v1.23.3"
         resources:
           requests:
             cpu: 4000m
@@ -45,7 +45,7 @@ presubmits:
           privileged: true
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
-      testgrid-tab-name: kubebuilder-e2e-1-23-4
+      testgrid-tab-name: kubebuilder-e2e-1-23-3
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"

--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -19,6 +19,36 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
       testgrid-tab-name: kubebuilder
+  - name: pull-kubebuilder-e2e-k8s-1-23-4
+    decorate: true
+    always_run: true
+    optional: true
+    path_alias: sigs.k8s.io/kubebuilder
+    branches:
+    - ^master$
+    - ^feature/plugins-.+$
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220307-7fa60e9872-master
+        command:
+        # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
+        - runner.sh
+        # this MUST be a relative directory with "./" or the runner will fail to find the file
+        - ./test_e2e.sh
+        env:
+        - name: KIND_K8S_VERSION
+          value: "v1.23.4"
+        resources:
+          requests:
+            cpu: 4000m
+        securityContext:
+          privileged: true
+    annotations:
+      testgrid-dashboards: sig-api-machinery-kubebuilder
+      testgrid-tab-name: kubebuilder-e2e-1-23-4
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
   - name: pull-kubebuilder-e2e-k8s-1-22-1
     decorate: true
     always_run: true


### PR DESCRIPTION
This PR adds an e2e test for K8s version ~~1.23.4~~ 1.23.3 for the Kubebuilder repo. This test will run on opened PRs to ensure that changes work on the latest version of K8s.

This addresses https://github.com/kubernetes-sigs/kubebuilder/issues/2509