### PR TITLE
azure: capz in-tree tests need IN_TREE_CLOUDPROVIDER=true

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/azure/generate.sh
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/generate.sh
@@ -288,6 +288,8 @@ $(generate_presubmit_annotations ${branch_name} pull-kubernetes-e2e-capz-azure-f
           value: /home/prow/go/src/sigs.k8s.io/cluster-api-provider-azure/test/e2e/data/kubetest/conformance-fast.yaml
         - name: CONFORMANCE_NODES
           value: "25"
+        - name: IN_TREE_CLOUDPROVIDER
+          value: "true"
 $(generate_presubmit_annotations ${branch_name} pull-kubernetes-e2e-capz-conformance)
   - name: pull-kubernetes-e2e-capz-ha-control-plane
     decorate: true
@@ -328,6 +330,8 @@ $(generate_presubmit_annotations ${branch_name} pull-kubernetes-e2e-capz-conform
           value: "1"
         - name: CONFORMANCE_CONTROL_PLANE_MACHINE_COUNT
           value: "3"
+        - name: IN_TREE_CLOUDPROVIDER
+          value: "true"
 $(generate_presubmit_annotations ${branch_name} pull-kubernetes-e2e-capz-ha-control-plane)
 periodics:
 - interval: 3h
@@ -357,6 +361,8 @@ periodics:
         value: "${kubernetes_version}"
       - name: CONFORMANCE_WORKER_MACHINE_COUNT
         value: "2"
+      - name: IN_TREE_CLOUDPROVIDER
+        value: "true"
       securityContext:
         privileged: true
       resources:
@@ -609,6 +615,8 @@ EOF
         value: "latest"
       - name: CONFORMANCE_WORKER_MACHINE_COUNT
         value: "2"
+      - name: IN_TREE_CLOUDPROVIDER
+        value: "true"
       securityContext:
         privileged: true
       resources:

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.20.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.20.yaml
@@ -223,6 +223,8 @@ presubmits:
           value: /home/prow/go/src/sigs.k8s.io/cluster-api-provider-azure/test/e2e/data/kubetest/conformance-fast.yaml
         - name: CONFORMANCE_NODES
           value: "25"
+        - name: IN_TREE_CLOUDPROVIDER
+          value: "true"
 
   - name: pull-kubernetes-e2e-capz-ha-control-plane
     decorate: true
@@ -263,6 +265,8 @@ presubmits:
           value: "1"
         - name: CONFORMANCE_CONTROL_PLANE_MACHINE_COUNT
           value: "3"
+        - name: IN_TREE_CLOUDPROVIDER
+          value: "true"
 
 periodics:
 - interval: 3h
@@ -292,6 +296,8 @@ periodics:
         value: "latest-1.20"
       - name: CONFORMANCE_WORKER_MACHINE_COUNT
         value: "2"
+      - name: IN_TREE_CLOUDPROVIDER
+        value: "true"
       securityContext:
         privileged: true
       resources:

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.21.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.21.yaml
@@ -223,6 +223,8 @@ presubmits:
           value: /home/prow/go/src/sigs.k8s.io/cluster-api-provider-azure/test/e2e/data/kubetest/conformance-fast.yaml
         - name: CONFORMANCE_NODES
           value: "25"
+        - name: IN_TREE_CLOUDPROVIDER
+          value: "true"
 
   - name: pull-kubernetes-e2e-capz-ha-control-plane
     decorate: true
@@ -263,6 +265,8 @@ presubmits:
           value: "1"
         - name: CONFORMANCE_CONTROL_PLANE_MACHINE_COUNT
           value: "3"
+        - name: IN_TREE_CLOUDPROVIDER
+          value: "true"
 
 periodics:
 - interval: 3h
@@ -292,6 +296,8 @@ periodics:
         value: "latest-1.21"
       - name: CONFORMANCE_WORKER_MACHINE_COUNT
         value: "2"
+      - name: IN_TREE_CLOUDPROVIDER
+        value: "true"
       securityContext:
         privileged: true
       resources:

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.22.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.22.yaml
@@ -223,6 +223,8 @@ presubmits:
           value: /home/prow/go/src/sigs.k8s.io/cluster-api-provider-azure/test/e2e/data/kubetest/conformance-fast.yaml
         - name: CONFORMANCE_NODES
           value: "25"
+        - name: IN_TREE_CLOUDPROVIDER
+          value: "true"
 
   - name: pull-kubernetes-e2e-capz-ha-control-plane
     decorate: true
@@ -263,6 +265,8 @@ presubmits:
           value: "1"
         - name: CONFORMANCE_CONTROL_PLANE_MACHINE_COUNT
           value: "3"
+        - name: IN_TREE_CLOUDPROVIDER
+          value: "true"
 
 periodics:
 - interval: 3h
@@ -292,6 +296,8 @@ periodics:
         value: "latest-1.22"
       - name: CONFORMANCE_WORKER_MACHINE_COUNT
         value: "2"
+      - name: IN_TREE_CLOUDPROVIDER
+        value: "true"
       securityContext:
         privileged: true
       resources:

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.23.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.23.yaml
@@ -223,6 +223,8 @@ presubmits:
           value: /home/prow/go/src/sigs.k8s.io/cluster-api-provider-azure/test/e2e/data/kubetest/conformance-fast.yaml
         - name: CONFORMANCE_NODES
           value: "25"
+        - name: IN_TREE_CLOUDPROVIDER
+          value: "true"
 
   - name: pull-kubernetes-e2e-capz-ha-control-plane
     decorate: true
@@ -263,6 +265,8 @@ presubmits:
           value: "1"
         - name: CONFORMANCE_CONTROL_PLANE_MACHINE_COUNT
           value: "3"
+        - name: IN_TREE_CLOUDPROVIDER
+          value: "true"
 
 periodics:
 - interval: 3h
@@ -292,6 +296,8 @@ periodics:
         value: "latest-1.23"
       - name: CONFORMANCE_WORKER_MACHINE_COUNT
         value: "2"
+      - name: IN_TREE_CLOUDPROVIDER
+        value: "true"
       securityContext:
         privileged: true
       resources:

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
@@ -244,6 +244,8 @@ presubmits:
           value: /home/prow/go/src/sigs.k8s.io/cluster-api-provider-azure/test/e2e/data/kubetest/conformance-fast.yaml
         - name: CONFORMANCE_NODES
           value: "25"
+        - name: IN_TREE_CLOUDPROVIDER
+          value: "true"
     annotations:
       testgrid-dashboards: provider-azure-presubmit
       testgrid-tab-name: pull-kubernetes-e2e-capz-conformance
@@ -289,6 +291,8 @@ presubmits:
           value: "1"
         - name: CONFORMANCE_CONTROL_PLANE_MACHINE_COUNT
           value: "3"
+        - name: IN_TREE_CLOUDPROVIDER
+          value: "true"
     annotations:
       testgrid-dashboards: provider-azure-presubmit
       testgrid-tab-name: pull-kubernetes-e2e-capz-ha-control-plane
@@ -322,6 +326,8 @@ periodics:
         value: "latest"
       - name: CONFORMANCE_WORKER_MACHINE_COUNT
         value: "2"
+      - name: IN_TREE_CLOUDPROVIDER
+        value: "true"
       securityContext:
         privileged: true
       resources:
@@ -571,6 +577,8 @@ periodics:
         value: "latest"
       - name: CONFORMANCE_WORKER_MACHINE_COUNT
         value: "2"
+      - name: IN_TREE_CLOUDPROVIDER
+        value: "true"
       securityContext:
         privileged: true
       resources:


### PR DESCRIPTION
https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1994 will change the capz test templates so that "out-of-tree" cloud-provider is the default.

This PR updates the in-tree test specs that use capz to use the new `IN_TREE_CLOUDPROVIDER=true` env var so that the tests continue to run against capz clusters running the in-tree cloud-provider-azure.