### PR TITLE
Update to trigger build & push of cs-fetch-repos image

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-infra-tools.yaml
+++ b/config/jobs/image-pushing/k8s-staging-infra-tools.yaml
@@ -86,7 +86,7 @@ postsubmits:
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-k8s-infra-k8sio, sig-k8s-infra-gcb
-        description: Builds the cs-fetch-repos image which creates a git repository configuration file for indexing by codesearch (aka Hound).
+        description: Builds the cs-fetch-repos image that creates a git repository configuration file for indexing by codesearch (aka Hound).
       decorate: true
       run_if_changed: "^images/codesearch/cs-fetch-repos/"
       branches:


### PR DESCRIPTION
Part of issue: https://github.com/kubernetes/k8s.io/issues/2182

Just a minor update to trigger the build & push of `cs-fetch-repos` docker image.

cc: @ameukam