### PR TITLE
Use prow labels to re-use configuration across Windows jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -1,3 +1,38 @@
+presets:
+- labels:
+    preset-capz-windows-common-main: "true"
+  env:
+  - name: "KUBERNETES_VERSION"
+    value: "latest"
+  - name: E2E_ARGS
+    value: "-kubetest.use-ci-artifacts"
+  - name: WINDOWS
+    value: "true"
+  # Windows isn't really conformance, we typically run at 4 to keep the time reasonable (~45 mins)
+  - name: CONFORMANCE_NODES
+    value: "4"
+  - name: AZURE_NODE_MACHINE_TYPE
+    value: "Standard_D4s_v3"
+- labels:
+    preset-capz-windows-2019: "true"
+  env:
+  - name: WINDOWS_FLAVOR
+    value: "containerd"
+- labels:
+    preset-capz-windows-2022: "true"
+  env:
+  - name: WINDOWS_FLAVOR
+    value: "containerd-2022"
+- labels:
+    preset-capz-containerd-latest: "true"
+  env:
+  - name: WINDOWS_CONTAINERD_URL
+    value: "https://github.com/containerd/containerd/releases/download/v1.6.1/containerd-1.6.1-windows-amd64.tar.gz"
+- labels:
+    preset-capz-serial-slow: "true"
+  env:
+  - name: KUBETEST_WINDOWS_CONFIG
+    value: "upstream-windows-serial-slow.yaml"
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-aks-engine-azure-disk-windows-containerd
@@ -136,6 +171,9 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
+    preset-capz-windows-common-main: "true"
+    preset-capz-windows-2019: "true"
+    preset-capz-containerd-latest: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -147,20 +185,6 @@ periodics:
         command:
           - "runner.sh"
           - "./scripts/ci-conformance.sh"
-        env:
-          - name: E2E_ARGS
-            value: "-kubetest.use-ci-artifacts"
-          - name: WINDOWS
-            value: "true"
-          # Windows isn't really conformance, we typically run at 4 to keep the time reasonable (~45 mins)
-          - name: CONFORMANCE_NODES
-            value: "4"
-          - name: "KUBERNETES_VERSION"
-            value: "latest"
-          - name: WINDOWS_FLAVOR
-            value: "containerd"
-          - name: AZURE_NODE_MACHINE_TYPE
-            value: "Standard_D4s_v3"
         securityContext:
           privileged: true
         resources:
@@ -181,6 +205,10 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
+    preset-capz-windows-common-main: "true"
+    preset-capz-windows-2019: "true"
+    preset-capz-containerd-latest: "true"
+    preset-capz-serial-slow: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -192,19 +220,6 @@ periodics:
         command:
           - "runner.sh"
           - "./scripts/ci-conformance.sh"
-        env:
-          - name: E2E_ARGS
-            value: "-kubetest.use-ci-artifacts"
-          - name: WINDOWS
-            value: "true"
-          - name: CONFORMANCE_NODES
-            value: "1"
-          - name: "KUBERNETES_VERSION"
-            value: "latest"
-          - name: WINDOWS_FLAVOR
-            value: "containerd"
-          - name: KUBETEST_WINDOWS_CONFIG
-            value: "upstream-windows-serial-slow.yaml"
         securityContext:
           privileged: true
         resources:
@@ -224,6 +239,9 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
+    preset-capz-windows-common-main: "true"
+    preset-capz-windows-2022: "true"
+    preset-capz-containerd-latest: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -235,20 +253,6 @@ periodics:
         command:
           - "runner.sh"
           - "./scripts/ci-conformance.sh"
-        env:
-          - name: E2E_ARGS
-            value: "-kubetest.use-ci-artifacts"
-          - name: WINDOWS
-            value: "true"
-          # Windows isn't really conformance, we typically run at 4 to keep the time reasonable (~45 mins)
-          - name: CONFORMANCE_NODES
-            value: "4"
-          - name: "KUBERNETES_VERSION"
-            value: "latest"
-          - name: WINDOWS_FLAVOR
-            value: "containerd-2022"
-          - name: AZURE_NODE_MACHINE_TYPE
-            value: "Standard_D4s_v3"
         securityContext:
           privileged: true
         resources:
@@ -268,6 +272,10 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
+    preset-capz-windows-common-main: "true"
+    preset-capz-windows-2022: "true"
+    preset-capz-containerd-latest: "true"
+    preset-capz-serial-slow: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -279,19 +287,6 @@ periodics:
         command:
           - "runner.sh"
           - "./scripts/ci-conformance.sh"
-        env:
-          - name: E2E_ARGS
-            value: "-kubetest.use-ci-artifacts"
-          - name: WINDOWS
-            value: "true"
-          - name: CONFORMANCE_NODES
-            value: "1"
-          - name: "KUBERNETES_VERSION"
-            value: "latest"
-          - name: WINDOWS_FLAVOR
-            value: "containerd-2022"
-          - name: KUBETEST_WINDOWS_CONFIG
-            value: "upstream-windows-serial-slow.yaml"
         securityContext:
           privileged: true
         resources:
@@ -600,6 +595,8 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-cred-only: "true"
+    preset-capz-windows-common-main: "true"
+    preset-capz-windows-2019: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -612,21 +609,8 @@ periodics:
           - "runner.sh"
           - "./scripts/ci-conformance.sh"
         env:
-          - name: E2E_ARGS
-            value: "-kubetest.use-ci-artifacts"
-          - name: WINDOWS
-            value: "true"
-          # Windows isn't really conformance, we typically run at 4 to keep the time reasonable (~45 mins)
-          - name: CONFORMANCE_NODES
-            value: "4"
-          - name: "KUBERNETES_VERSION"
-            value: "latest"
-          - name: WINDOWS_FLAVOR
-            value: "containerd"
           - name: WINDOWS_CONTAINERD_URL
             value: "https://github.com/kubernetes-sigs/sig-windows-tools/releases/download/windows-containerd-nightly/windows-containerd.tar.gz"
-          - name: AZURE_NODE_MACHINE_TYPE
-            value: "Standard_D4s_v3"
         securityContext:
           privileged: true
         resources:


### PR DESCRIPTION
Use prow labels to re-use configuration across Windows jobs and updates containerd to 1.6.1 for capz windows jobs

/sig windows

/assign @marosset @oprinmarius