### PR TITLE
[CAPG] Add PR test coverage optional presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-main.yaml
@@ -301,7 +301,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-apidiff-main
   - name: pull-cluster-api-provider-gcp-coverage
-    always_run: true
+    always_run: false
     optional: true
     decorate: true
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-main.yaml
@@ -300,3 +300,31 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-apidiff-main
+  - name: pull-cluster-api-provider-gcp-coverage
+    always_run: true
+    optional: true
+    decorate: true
+    path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200813-1642133-1.18
+        command:
+        - runner.sh
+        - bash
+        args:
+        - -c
+        - |
+          result=0
+          ./scripts/ci-test-coverage.sh || result=$?
+          cd ../test-infra/gopherage
+          GO111MODULE=on go build .
+          find ${ARTIFACTS} -type f -iname 'junit*.xml' -exec rm {} \;
+          ./gopherage filter --exclude-path="zz_generated,generated\.pb\.go"  "${ARTIFACTS}/combined-coverage.out" > "${ARTIFACTS}/filtered.cov" || result=$?
+          ./gopherage junit --threshold 0.05 "${ARTIFACTS}/filtered.cov" > "${ARTIFACTS}/junit_coverage.xml" || result=$?
+          exit $result
+        securityContext:
+        privileged: true
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
+      testgrid-tab-name: pr-coverage
+      testgrid-alert-email: k8s-infra-staging-cluster-api-gcp@kubernetes.io


### PR DESCRIPTION
Add an optional presubmit that generates the test coverage for PR.
Similar to https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-testing/coverage.yaml#L129

related to https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/547