### PR TITLE
Switch on new registry for pull-kubernetes-e2e-gce-ubuntu-containerd

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -10,7 +10,7 @@ presets:
   - name: CREATE_CUSTOM_NETWORK
     value: "true"
 - labels:
-    preset-pull-registry-repo-list: "true"
+    preset-use-new-registry: "true"
   env:
   - name: KUBE_TEST_REPO_LIST
     value: https://raw.githubusercontent.com/kubernetes/test-infra/master/config/jobs/kubernetes/sig-cloud-provider/gcp/registry/default.yaml
@@ -286,67 +286,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-pull-kubernetes-e2e: "true"
       preset-pull-kubernetes-e2e-gce: "true"
-    spec:
-      containers:
-        - args:
-            - --root=/go/src
-            - --repo=k8s.io/kubernetes=$(PULL_REFS)
-            - --repo=k8s.io/release
-            - --upload=gs://kubernetes-jenkins/pr-logs
-            - --timeout=105
-            - --scenario=kubernetes_e2e
-            - --
-            - --build=quick
-            - --cluster=
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0
-            - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
-            - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
-            - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
-            - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
-            - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-2004-focal-v20200423
-            - --env=KUBE_GCE_MASTER_PROJECT=ubuntu-os-cloud
-            - --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu
-            - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2004-focal-v20200423
-            - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
-            - --extract=local
-            - --gcp-master-image=ubuntu
-            - --gcp-node-image=ubuntu
-            - --gcp-zone=us-west1-b
-            - --ginkgo-parallel=30
-            - --provider=gce
-            - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-ubuntu-containerd
-            - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
-            - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
-          image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220307-7fa60e9872-master
-          resources:
-            limits:
-              cpu: 4
-              memory: "14Gi"
-            requests:
-              cpu: 4
-              memory: "14Gi"
-          securityContext:
-            privileged: true
-
-  - name: pull-kubernetes-e2e-gce-registry-sandbox
-    cluster: k8s-infra-prow-build
-    always_run: false
-    skip_report: false
-    skip_branches:
-      - release-\d+\.\d+ # per-release image
-    annotations:
-      fork-per-release: "true"
-      testgrid-alert-stale-results-hours: "24"
-      testgrid-create-test-group: "true"
-      testgrid-num-failures-to-alert: "10"
-      testgrid-dashboards: google-gce
-    labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
-      preset-dind-enabled: "true"
-      preset-pull-kubernetes-e2e: "true"
-      preset-pull-kubernetes-e2e-gce: "true"
-      preset-pull-registry-repo-list: "true"
+      preset-use-new-registry: "true"
     spec:
       containers:
         - args:


### PR DESCRIPTION
- Remove the old CI job used for testing
- better name for the preset
- switch the registry on for all CI runs of pull-kubernetes-e2e-gce-ubuntu-containerd to drive traffic to the new registry.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>