### PR TITLE
Remove some aks-engine tests for cloud-provider-azure

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -21,63 +21,6 @@ presubmits:
       testgrid-tab-name: pr-cloud-provider-azure-check
       description: "Run lint check tests for cloud-provider-azure."
       testgrid-num-columns-recent: '30'
-  # pull-cloud-provider-azure-e2e runs kubernetes conformance tests.
-  - name: pull-cloud-provider-azure-e2e
-    skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-    decorate: true
-    decoration_config:
-      timeout: 5h
-    path_alias: sigs.k8s.io/cloud-provider-azure
-    branches:
-    - master
-    labels:
-      preset-service-account: "true"
-      preset-azure-cred: "true"
-      preset-dind-enabled: "true"
-    extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: release-1.23
-      path_alias: k8s.io/kubernetes
-      workdir: true
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220307-7fa60e9872-1.23
-        command:
-        - runner.sh
-        - kubetest
-        args:
-        # Generic e2e test args
-        - --test
-        - --up
-        - --down
-        - --build=quick
-        - --dump=$(ARTIFACTS)
-        # Azure-specific test args
-        - --provider=skeleton
-        - --deployment=aksengine
-        - --aksengine-agentpoolcount=2
-        - --aksengine-admin-username=azureuser
-        - --aksengine-creds=$(AZURE_CREDENTIALS)
-        - --aksengine-orchestratorRelease=1.23
-        - --aksengine-mastervmsize=Standard_DS2_v2
-        - --aksengine-agentvmsize=Standard_D4s_v3
-        - --aksengine-ccm
-        - --aksengine-cnm
-        - --aksengine-deploy-custom-k8s
-        - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
-        - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux.json
-        - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/nightly/aks-engine-nightly-linux-amd64.tar.gz
-        # Specific test args
-        - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\]
-        - --ginkgo-parallel=30
-        securityContext:
-          privileged: true
-    annotations:
-      testgrid-dashboards: provider-azure-cloud-provider-azure
-      testgrid-tab-name: pr-cloud-provider-azure-e2e
-      description: "Run Kubernetes e2e tests for cloud-provider-azure."
-      testgrid-num-columns-recent: '30'
   # pull-cloud-provider-azure-e2e-ccm-vmss-basic-lb runs Azure specific e2e tests with VMSS and basic loadbalancer.
   - name: pull-cloud-provider-azure-e2e-ccm-vmss-basic-lb
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
@@ -137,66 +80,6 @@ presubmits:
       testgrid-dashboards: provider-azure-cloud-provider-azure
       testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-basic-lb
       description: "Runs Azure specific tests (VMSS + basic LB) with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
-      testgrid-num-columns-recent: '30'
-    # pull-cloud-provider-azure-e2e-ccm runs Azure specific e2e tests.
-  - name: pull-cloud-provider-azure-e2e-ccm
-    skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-    decorate: true
-    decoration_config:
-      timeout: 5h
-    path_alias: sigs.k8s.io/cloud-provider-azure
-    branches:
-      - master
-    labels:
-      preset-service-account: "true"
-      preset-azure-cred: "true"
-      preset-dind-enabled: "true"
-    extra_refs:
-      - org: kubernetes
-        repo: kubernetes
-        base_ref: release-1.23
-        path_alias: k8s.io/kubernetes
-        workdir: true
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220307-7fa60e9872-1.23
-          command:
-            - runner.sh
-            - kubetest
-          args:
-            # Generic e2e test args
-            - --test
-            - --up
-            - --down
-            - --build=quick
-            - --dump=$(ARTIFACTS)
-            # Azure-specific test args
-            - --provider=skeleton
-            - --deployment=aksengine
-            - --aksengine-agentpoolcount=2
-            - --aksengine-admin-username=azureuser
-            - --aksengine-creds=$(AZURE_CREDENTIALS)
-            - --aksengine-orchestratorRelease=1.23
-            - --aksengine-mastervmsize=Standard_DS2_v2
-            - --aksengine-agentvmsize=Standard_D4s_v3
-            - --aksengine-ccm
-            - --aksengine-cnm
-            - --aksengine-deploy-custom-k8s
-            - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
-            - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux.json
-            - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/nightly/aks-engine-nightly-linux-amd64.tar.gz
-            # Specific test args
-            - --test-ccm
-            - --ginkgo-parallel=30
-          securityContext:
-            privileged: true
-          env:
-            - name: AZURE_LOADBALANCER_SKU
-              value: "standard"
-    annotations:
-      testgrid-dashboards: provider-azure-cloud-provider-azure
-      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm
-      description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
       testgrid-num-columns-recent: '30'
     # pull-cloud-provider-azure-e2e-ccm-vmss runs Azure specific e2e tests with vmss.
   - name: pull-cloud-provider-azure-e2e-ccm-vmss
@@ -258,10 +141,9 @@ presubmits:
       testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss
       description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
       testgrid-num-columns-recent: '30'
+  # pull-cloud-provider-azure-e2e-capz runs kubernetes conformance tests.
   - name: pull-cloud-provider-azure-e2e-capz
-    always_run: false
-    #skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-    optional: true
+    skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     decorate: true
     decoration_config:
       timeout: 5h
@@ -315,6 +197,7 @@ presubmits:
       testgrid-tab-name: pr-cloud-provider-azure-e2e-capz
       description: "Runs Kubernetes conformance tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
       testgrid-num-columns-recent: '30'
+  # pull-cloud-provider-azure-e2e-ccm-capz runs Azure specific e2e tests.
   - name: pull-cloud-provider-azure-e2e-ccm-capz
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     decorate: true
@@ -383,8 +266,8 @@ presubmits:
       testgrid-num-columns-recent: '30'
 periodics:
 - interval: 24h
-  # cloud-provider-azure-master runs Azure specific tests periodically.
-  name: cloud-provider-azure-master
+  # cloud-provider-azure-master-capz runs Azure specific tests periodically.
+  name: cloud-provider-azure-master-capz
   decorate: true
   decoration_config:
     timeout: 5h
@@ -427,7 +310,7 @@ periodics:
           value: "3"
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
-    testgrid-tab-name: cloud-provider-azure-master
+    testgrid-tab-name: cloud-provider-azure-master-capz
     testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
     description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
 - interval: 24h
@@ -555,8 +438,8 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
     description: "Runs node multiple nodepools autoscaling tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
 - interval: 24h
-  # cloud-provider-azure-conformance runs Kubernetes conformance tests periodically.
-  name: cloud-provider-azure-conformance
+  # cloud-provider-azure-conformance-capz runs Kubernetes conformance tests periodically.
+  name: cloud-provider-azure-conformance-capz
   decorate: true
   decoration_config:
     timeout: 5h
@@ -609,7 +492,7 @@ periodics:
         value: "3"
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
-    testgrid-tab-name: cloud-provider-azure-conformance
+    testgrid-tab-name: cloud-provider-azure-conformance-capz
     testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
     description: "Runs Kubernetes conformance tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
 - interval: 24h

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-0.7.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-0.7.yaml
@@ -20,63 +20,6 @@ presubmits:
         testgrid-tab-name: pr-cloud-provider-azure-check-1-20
         description: "Run lint check tests for cloud-provider-azure release-0.7."
         testgrid-num-columns-recent: '30'
-    # pull-cloud-provider-azure-e2e-1-20 runs kubernetes conformance tests.
-    - name: pull-cloud-provider-azure-e2e-1-20
-      skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-0.7
-      labels:
-        preset-service-account: "true"
-        preset-azure-cred: "true"
-        preset-dind-enabled: "true"
-      extra_refs:
-        - org: kubernetes
-          repo: kubernetes
-          base_ref: release-1.20
-          path_alias: k8s.io/kubernetes
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220307-7fa60e9872-1.20
-            command:
-              - runner.sh
-              - kubetest
-            args:
-              # Generic e2e test args
-              - --test
-              - --up
-              - --down
-              - --build=quick
-              - --dump=$(ARTIFACTS)
-              # Azure-specific test args
-              - --provider=skeleton
-              - --deployment=aksengine
-              - --aksengine-agentpoolcount=2
-              - --aksengine-admin-username=azureuser
-              - --aksengine-creds=$(AZURE_CREDENTIALS)
-              - --aksengine-orchestratorRelease=1.20
-              - --aksengine-mastervmsize=Standard_DS2_v2
-              - --aksengine-agentvmsize=Standard_D4s_v3
-              - --aksengine-ccm
-              - --aksengine-cnm
-              - --aksengine-deploy-custom-k8s
-              - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
-              - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux.json
-              - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/nightly/aks-engine-nightly-linux-amd64.tar.gz
-              # Specific test args
-              - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\]
-              - --ginkgo-parallel=30
-            securityContext:
-              privileged: true
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-20-presubmit
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-1-20
-        description: "Run Kubernetes e2e tests for cloud-provider-azure release-0.7."
-        testgrid-num-columns-recent: '30'
     # pull-cloud-provider-azure-e2e-ccm-vmss-basic-lb-1-20 runs Azure specific e2e tests with VMSS and basic loadbalancer.
     - name: pull-cloud-provider-azure-e2e-ccm-vmss-basic-lb-1-20
       skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
@@ -136,66 +79,6 @@ presubmits:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-20-presubmit
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-basic-lb-1-20
         description: "Runs Azure specific tests (VMSS + basic LB) with cloud-provider-azure release-0.7 (https://github.com/kubernetes-sigs/cloud-provider-azure)."
-        testgrid-num-columns-recent: '30'
-      # pull-cloud-provider-azure-e2e-ccm-1-20
-    - name: pull-cloud-provider-azure-e2e-ccm-1-20
-      skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-0.7
-      labels:
-        preset-service-account: "true"
-        preset-azure-cred: "true"
-        preset-dind-enabled: "true"
-      extra_refs:
-        - org: kubernetes
-          repo: kubernetes
-          base_ref: release-1.20
-          path_alias: k8s.io/kubernetes
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220307-7fa60e9872-1.20
-            command:
-              - runner.sh
-              - kubetest
-            args:
-              # Generic e2e test args
-              - --test
-              - --up
-              - --down
-              - --build=quick
-              - --dump=$(ARTIFACTS)
-              # Azure-specific test args
-              - --provider=skeleton
-              - --deployment=aksengine
-              - --aksengine-agentpoolcount=2
-              - --aksengine-admin-username=azureuser
-              - --aksengine-creds=$(AZURE_CREDENTIALS)
-              - --aksengine-orchestratorRelease=1.20
-              - --aksengine-mastervmsize=Standard_DS2_v2
-              - --aksengine-agentvmsize=Standard_D4s_v3
-              - --aksengine-ccm
-              - --aksengine-cnm
-              - --aksengine-deploy-custom-k8s
-              - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
-              - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux.json
-              - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/nightly/aks-engine-nightly-linux-amd64.tar.gz
-              # Specific test args
-              - --test-ccm
-              - --ginkgo-parallel=30
-            securityContext:
-              privileged: true
-            env:
-              - name: AZURE_LOADBALANCER_SKU
-                value: "standard"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-20-presubmit
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-1-20
-        description: "Runs Azure specific tests with cloud-provider-azure release-0.7 (https://github.com/kubernetes-sigs/cloud-provider-azure)."
         testgrid-num-columns-recent: '30'
       # pull-cloud-provider-azure-e2e-ccm-vmss-1-20
     - name: pull-cloud-provider-azure-e2e-ccm-vmss-1-20
@@ -257,10 +140,9 @@ presubmits:
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-1-20
         description: "Runs Azure specific tests with cloud-provider-azure release-0.7 (https://github.com/kubernetes-sigs/cloud-provider-azure)."
         testgrid-num-columns-recent: '30'
+    # pull-cloud-provider-azure-e2e-capz-1-20 runs kubernetes conformance tests.
     - name: pull-cloud-provider-azure-e2e-capz-1-20
-      always_run: false
-      #skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-      optional: true
+      skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
       decorate: true
       decoration_config:
         timeout: 5h
@@ -316,7 +198,6 @@ presubmits:
         testgrid-num-columns-recent: '30'
     - name: pull-cloud-provider-azure-e2e-ccm-capz-1-20
       skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-      optional: true
       decorate: true
       decoration_config:
         timeout: 3h

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.0.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.0.yaml
@@ -21,63 +21,6 @@ presubmits:
         testgrid-tab-name: pr-cloud-provider-azure-check-1-21
         description: "Run lint check tests for cloud-provider-azure release-1.0."
         testgrid-num-columns-recent: '30'
-    # pull-cloud-provider-azure-e2e-1-21 runs kubernetes conformance tests.
-    - name: pull-cloud-provider-azure-e2e-1-21
-      skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.0
-      labels:
-        preset-service-account: "true"
-        preset-azure-cred: "true"
-        preset-dind-enabled: "true"
-      extra_refs:
-        - org: kubernetes
-          repo: kubernetes
-          base_ref: release-1.21
-          path_alias: k8s.io/kubernetes
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220307-7fa60e9872-1.21
-            command:
-              - runner.sh
-              - kubetest
-            args:
-              # Generic e2e test args
-              - --test
-              - --up
-              - --down
-              - --build=quick
-              - --dump=$(ARTIFACTS)
-              # Azure-specific test args
-              - --provider=skeleton
-              - --deployment=aksengine
-              - --aksengine-agentpoolcount=2
-              - --aksengine-admin-username=azureuser
-              - --aksengine-creds=$(AZURE_CREDENTIALS)
-              - --aksengine-orchestratorRelease=1.21
-              - --aksengine-mastervmsize=Standard_DS2_v2
-              - --aksengine-agentvmsize=Standard_D4s_v3
-              - --aksengine-ccm
-              - --aksengine-cnm
-              - --aksengine-deploy-custom-k8s
-              - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
-              - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux.json
-              - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/nightly/aks-engine-nightly-linux-amd64.tar.gz
-              # Specific test args
-              - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\]
-              - --ginkgo-parallel=30
-            securityContext:
-              privileged: true
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-21-presubmit
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-1-21
-        description: "Run Kubernetes e2e tests for cloud-provider-azure release-1.0."
-        testgrid-num-columns-recent: '30'
     # pull-cloud-provider-azure-e2e-ccm-vmss-basic-lb-1-21 runs Azure specific e2e tests with VMSS and basic loadbalancer.
     - name: pull-cloud-provider-azure-e2e-ccm-vmss-basic-lb-1-21
       skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
@@ -137,66 +80,6 @@ presubmits:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-21-presubmit
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-basic-lb-1-21
         description: "Runs Azure specific tests (VMSS + basic LB) with cloud-provider-azure release-1.0 (https://github.com/kubernetes-sigs/cloud-provider-azure)."
-        testgrid-num-columns-recent: '30'
-      # pull-cloud-provider-azure-e2e-ccm-1-21
-    - name: pull-cloud-provider-azure-e2e-ccm-1-21
-      skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.0
-      labels:
-        preset-service-account: "true"
-        preset-azure-cred: "true"
-        preset-dind-enabled: "true"
-      extra_refs:
-        - org: kubernetes
-          repo: kubernetes
-          base_ref: release-1.21
-          path_alias: k8s.io/kubernetes
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220307-7fa60e9872-1.21
-            command:
-              - runner.sh
-              - kubetest
-            args:
-              # Generic e2e test args
-              - --test
-              - --up
-              - --down
-              - --build=quick
-              - --dump=$(ARTIFACTS)
-              # Azure-specific test args
-              - --provider=skeleton
-              - --deployment=aksengine
-              - --aksengine-agentpoolcount=2
-              - --aksengine-admin-username=azureuser
-              - --aksengine-creds=$(AZURE_CREDENTIALS)
-              - --aksengine-orchestratorRelease=1.21
-              - --aksengine-mastervmsize=Standard_DS2_v2
-              - --aksengine-agentvmsize=Standard_D4s_v3
-              - --aksengine-ccm
-              - --aksengine-cnm
-              - --aksengine-deploy-custom-k8s
-              - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
-              - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux.json
-              - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/nightly/aks-engine-nightly-linux-amd64.tar.gz
-              # Specific test args
-              - --test-ccm
-              - --ginkgo-parallel=30
-            securityContext:
-              privileged: true
-            env:
-              - name: AZURE_LOADBALANCER_SKU
-                value: "standard"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-21-presubmit
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-1-21
-        description: "Runs Azure specific tests with cloud-provider-azure release-1.0 (https://github.com/kubernetes-sigs/cloud-provider-azure)."
         testgrid-num-columns-recent: '30'
       # pull-cloud-provider-azure-e2e-ccm-vmss-1-21
     - name: pull-cloud-provider-azure-e2e-ccm-vmss-1-21
@@ -258,10 +141,9 @@ presubmits:
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-1-21
         description: "Runs Azure specific tests with cloud-provider-azure release-1.0 (https://github.com/kubernetes-sigs/cloud-provider-azure)."
         testgrid-num-columns-recent: '30'
+    # pull-cloud-provider-azure-e2e-capz-1-21 runs kubernetes conformance tests.
     - name: pull-cloud-provider-azure-e2e-capz-1-21
-      always_run: false
-      #skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-      optional: true
+      skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
       decorate: true
       decoration_config:
         timeout: 5h
@@ -317,7 +199,6 @@ presubmits:
         testgrid-num-columns-recent: '30'
     - name: pull-cloud-provider-azure-e2e-ccm-capz-1-21
       skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-      optional: true
       decorate: true
       decoration_config:
         timeout: 3h

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.1.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.1.yaml
@@ -21,63 +21,6 @@ presubmits:
         testgrid-tab-name: pr-cloud-provider-azure-check-1-22
         description: "Run lint check tests for cloud-provider-azure release-1.1."
         testgrid-num-columns-recent: '30'
-    # pull-cloud-provider-azure-e2e-1-22 runs kubernetes conformance tests.
-    - name: pull-cloud-provider-azure-e2e-1-22
-      skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.1
-      labels:
-        preset-service-account: "true"
-        preset-azure-cred: "true"
-        preset-dind-enabled: "true"
-      extra_refs:
-        - org: kubernetes
-          repo: kubernetes
-          base_ref: release-1.22
-          path_alias: k8s.io/kubernetes
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220307-7fa60e9872-1.22
-            command:
-              - runner.sh
-              - kubetest
-            args:
-              # Generic e2e test args
-              - --test
-              - --up
-              - --down
-              - --build=quick
-              - --dump=$(ARTIFACTS)
-              # Azure-specific test args
-              - --provider=skeleton
-              - --deployment=aksengine
-              - --aksengine-agentpoolcount=2
-              - --aksengine-admin-username=azureuser
-              - --aksengine-creds=$(AZURE_CREDENTIALS)
-              - --aksengine-orchestratorRelease=1.22
-              - --aksengine-mastervmsize=Standard_DS2_v2
-              - --aksengine-agentvmsize=Standard_D4s_v3
-              - --aksengine-ccm
-              - --aksengine-cnm
-              - --aksengine-deploy-custom-k8s
-              - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
-              - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux.json
-              - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/nightly/aks-engine-nightly-linux-amd64.tar.gz
-              # Specific test args
-              - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\]
-              - --ginkgo-parallel=30
-            securityContext:
-              privileged: true
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-22-presubmit
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-1-22
-        description: "Run Kubernetes e2e tests for cloud-provider-azure release-1.1."
-        testgrid-num-columns-recent: '30'
     # pull-cloud-provider-azure-e2e-ccm-vmss-basic-lb-1-22 runs Azure specific e2e tests with VMSS and basic loadbalancer.
     - name: pull-cloud-provider-azure-e2e-ccm-vmss-basic-lb-1-22
       skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
@@ -137,66 +80,6 @@ presubmits:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-22-presubmit
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-basic-lb-1-22
         description: "Runs Azure specific tests (VMSS + basic LB) with cloud-provider-azure release-1.1 (https://github.com/kubernetes-sigs/cloud-provider-azure)."
-        testgrid-num-columns-recent: '30'
-      # pull-cloud-provider-azure-e2e-ccm-1-22
-    - name: pull-cloud-provider-azure-e2e-ccm-1-22
-      skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.1
-      labels:
-        preset-service-account: "true"
-        preset-azure-cred: "true"
-        preset-dind-enabled: "true"
-      extra_refs:
-        - org: kubernetes
-          repo: kubernetes
-          base_ref: release-1.22
-          path_alias: k8s.io/kubernetes
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220307-7fa60e9872-1.22
-            command:
-              - runner.sh
-              - kubetest
-            args:
-              # Generic e2e test args
-              - --test
-              - --up
-              - --down
-              - --build=quick
-              - --dump=$(ARTIFACTS)
-              # Azure-specific test args
-              - --provider=skeleton
-              - --deployment=aksengine
-              - --aksengine-agentpoolcount=2
-              - --aksengine-admin-username=azureuser
-              - --aksengine-creds=$(AZURE_CREDENTIALS)
-              - --aksengine-orchestratorRelease=1.22
-              - --aksengine-mastervmsize=Standard_DS2_v2
-              - --aksengine-agentvmsize=Standard_D4s_v3
-              - --aksengine-ccm
-              - --aksengine-cnm
-              - --aksengine-deploy-custom-k8s
-              - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
-              - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux.json
-              - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/nightly/aks-engine-nightly-linux-amd64.tar.gz
-              # Specific test args
-              - --test-ccm
-              - --ginkgo-parallel=30
-            securityContext:
-              privileged: true
-            env:
-              - name: AZURE_LOADBALANCER_SKU
-                value: "standard"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-22-presubmit
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-1-22
-        description: "Runs Azure specific tests with cloud-provider-azure release-1.1 (https://github.com/kubernetes-sigs/cloud-provider-azure)."
         testgrid-num-columns-recent: '30'
       # pull-cloud-provider-azure-e2e-ccm-vmss-1-22
     - name: pull-cloud-provider-azure-e2e-ccm-vmss-1-22
@@ -258,10 +141,9 @@ presubmits:
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-1-22
         description: "Runs Azure specific tests with cloud-provider-azure release-1.1 (https://github.com/kubernetes-sigs/cloud-provider-azure)."
         testgrid-num-columns-recent: '30'
+    # pull-cloud-provider-azure-e2e-capz-1-22 runs kubernetes conformance tests.
     - name: pull-cloud-provider-azure-e2e-capz-1-22
-      always_run: false
-      #skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-      optional: true
+      skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
       decorate: true
       decoration_config:
         timeout: 5h
@@ -317,7 +199,6 @@ presubmits:
         testgrid-num-columns-recent: '30'
     - name: pull-cloud-provider-azure-e2e-ccm-capz-1-22
       skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-      optional: true
       decorate: true
       decoration_config:
         timeout: 3h

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.23.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.23.yaml
@@ -21,63 +21,6 @@ presubmits:
         testgrid-tab-name: pr-cloud-provider-azure-check-1-23
         description: "Run lint check tests for cloud-provider-azure release-1.23."
         testgrid-num-columns-recent: '30'
-    # pull-cloud-provider-azure-e2e-1-23 runs kubernetes conformance tests.
-    - name: pull-cloud-provider-azure-e2e-1-23
-      skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.23
-      labels:
-        preset-service-account: "true"
-        preset-azure-cred: "true"
-        preset-dind-enabled: "true"
-      extra_refs:
-        - org: kubernetes
-          repo: kubernetes
-          base_ref: release-1.23
-          path_alias: k8s.io/kubernetes
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220307-7fa60e9872-1.23
-            command:
-              - runner.sh
-              - kubetest
-            args:
-              # Generic e2e test args
-              - --test
-              - --up
-              - --down
-              - --build=quick
-              - --dump=$(ARTIFACTS)
-              # Azure-specific test args
-              - --provider=skeleton
-              - --deployment=aksengine
-              - --aksengine-agentpoolcount=2
-              - --aksengine-admin-username=azureuser
-              - --aksengine-creds=$(AZURE_CREDENTIALS)
-              - --aksengine-orchestratorRelease=1.23
-              - --aksengine-mastervmsize=Standard_DS2_v2
-              - --aksengine-agentvmsize=Standard_D4s_v3
-              - --aksengine-ccm
-              - --aksengine-cnm
-              - --aksengine-deploy-custom-k8s
-              - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
-              - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux.json
-              - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/nightly/aks-engine-nightly-linux-amd64.tar.gz
-              # Specific test args
-              - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\]
-              - --ginkgo-parallel=30
-            securityContext:
-              privileged: true
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-23-presubmit
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-1-23
-        description: "Run Kubernetes e2e tests for cloud-provider-azure release-1.23."
-        testgrid-num-columns-recent: '30'
     # pull-cloud-provider-azure-e2e-ccm-vmss-basic-lb-1-23 runs Azure specific e2e tests with VMSS and basic loadbalancer.
     - name: pull-cloud-provider-azure-e2e-ccm-vmss-basic-lb-1-23
       skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
@@ -137,66 +80,6 @@ presubmits:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-23-presubmit
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-basic-lb-1-23
         description: "Runs Azure specific tests (VMSS + basic LB) with cloud-provider-azure release-1.23 (https://github.com/kubernetes-sigs/cloud-provider-azure)."
-        testgrid-num-columns-recent: '30'
-      # pull-cloud-provider-azure-e2e-ccm-1-23
-    - name: pull-cloud-provider-azure-e2e-ccm-1-23
-      skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.23
-      labels:
-        preset-service-account: "true"
-        preset-azure-cred: "true"
-        preset-dind-enabled: "true"
-      extra_refs:
-        - org: kubernetes
-          repo: kubernetes
-          base_ref: release-1.23
-          path_alias: k8s.io/kubernetes
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220307-7fa60e9872-1.23
-            command:
-              - runner.sh
-              - kubetest
-            args:
-              # Generic e2e test args
-              - --test
-              - --up
-              - --down
-              - --build=quick
-              - --dump=$(ARTIFACTS)
-              # Azure-specific test args
-              - --provider=skeleton
-              - --deployment=aksengine
-              - --aksengine-agentpoolcount=2
-              - --aksengine-admin-username=azureuser
-              - --aksengine-creds=$(AZURE_CREDENTIALS)
-              - --aksengine-orchestratorRelease=1.23
-              - --aksengine-mastervmsize=Standard_DS2_v2
-              - --aksengine-agentvmsize=Standard_D4s_v3
-              - --aksengine-ccm
-              - --aksengine-cnm
-              - --aksengine-deploy-custom-k8s
-              - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
-              - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux.json
-              - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/nightly/aks-engine-nightly-linux-amd64.tar.gz
-              # Specific test args
-              - --test-ccm
-              - --ginkgo-parallel=30
-            securityContext:
-              privileged: true
-            env:
-              - name: AZURE_LOADBALANCER_SKU
-                value: "standard"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-23-presubmit
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-1-23
-        description: "Runs Azure specific tests with cloud-provider-azure release-1.23 (https://github.com/kubernetes-sigs/cloud-provider-azure)."
         testgrid-num-columns-recent: '30'
       # pull-cloud-provider-azure-e2e-ccm-vmss-1-23
     - name: pull-cloud-provider-azure-e2e-ccm-vmss-1-23
@@ -258,10 +141,9 @@ presubmits:
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-1-23
         description: "Runs Azure specific tests with cloud-provider-azure release-1.23 (https://github.com/kubernetes-sigs/cloud-provider-azure)."
         testgrid-num-columns-recent: '30'
+    # pull-cloud-provider-azure-e2e-capz-1-23 runs kubernetes conformance tests.
     - name: pull-cloud-provider-azure-e2e-capz-1-23
-      always_run: false
-      #skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-      optional: true
+      skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
       decorate: true
       decoration_config:
         timeout: 5h
@@ -315,9 +197,9 @@ presubmits:
         testgrid-tab-name: pr-cloud-provider-azure-e2e-capz-1-23
         description: "Runs Kubernetes conformance tests with cloud-provider-azure release-1.23 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
         testgrid-num-columns-recent: '30'
+    # pull-cloud-provider-azure-e2e-ccm-1-23
     - name: pull-cloud-provider-azure-e2e-ccm-capz-1-23
       skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-      optional: true
       decorate: true
       decoration_config:
         timeout: 3h


### PR DESCRIPTION
* Use capz e2e and e2e ccm tests, remove aks-engine ones for master and
  all releases
* Rename daily conformance and cloud-provider-azure specific tests

Signed-off-by: Zhecheng Li <zhechengli@microsoft.com>