### PR TITLE
Fix broken Rerun: revert change to gh client `ListTeamMembers`

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -3815,20 +3815,16 @@ func (c *client) RemoveTeamMembershipBySlug(org, teamSlug, user string) error {
 // Deprecated: please use ListTeamMembersBySlug
 func (c *client) ListTeamMembers(org string, id int, role string) ([]TeamMember, error) {
 	c.logger.WithField("methodName", "ListTeamMembers").
-		Warn("method is deprecated, and will result in multiple api calls to achieve result")
+		Warn("method is deprecated, please use ListTeamMembersBySlug")
 	durationLogger := c.log("ListTeamMembers", id, role)
 	defer durationLogger()
 
 	if c.fake {
 		return nil, nil
 	}
-	organization, err := c.GetOrg(org)
-	if err != nil {
-		return nil, err
-	}
-	path := fmt.Sprintf("/organizations/%d/team/%d/members", organization.Id, id)
+	path := fmt.Sprintf("/teams/%d/members", id)
 	var teamMembers []TeamMember
-	err = c.readPaginatedResultsWithValues(
+	err := c.readPaginatedResultsWithValues(
 		path,
 		url.Values{
 			"per_page": []string{"100"},

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -1903,29 +1903,7 @@ func TestEditTeam(t *testing.T) {
 }
 
 func TestListTeamMembers(t *testing.T) {
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			t.Errorf("Bad method: %s", r.Method)
-		}
-
-		var result interface{}
-		switch r.URL.Path {
-		case "/organizations/1/team/1/members":
-			result = []TeamMember{{Login: "foo"}}
-		case "/orgs/orgName":
-			result = Organization{Login: "orgName", Id: 1}
-		default:
-			t.Errorf("Bad request path: %s", r.URL.Path)
-			return
-		}
-
-		b, err := json.Marshal(result)
-		if err != nil {
-			t.Fatalf("Didn't expect error: %v", err)
-		}
-		fmt.Fprint(w, string(b))
-	}))
-
+	ts := simpleTestServer(t, "/teams/1/members", []TeamMember{{Login: "foo"}}, http.StatusOK)
 	defer ts.Close()
 	c := getClient(ts.URL)
 	teamMembers, err := c.ListTeamMembers("orgName", 1, RoleAll)


### PR DESCRIPTION
Rerun isn't working for some tests. This is due to a recent change utilizing the passed in `org` to determine the team members in `ListTeamMembers`. It turns out that the `IsAuthorized` method that Rerun uses doesn't always pass in the org that the team is associated with. Since the `/teams/{team_id}/members` endpoint's sunsetting has been postponed we can go back to using it for now while a long term solution is put in place.

This fixes https://github.com/kubernetes/test-infra/issues/25600