### PR TITLE
switch ci-kubernetes-e2e-ubuntu-gce-containerd to use new registry

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -480,6 +480,7 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    preset-use-new-registry: "true"
   spec:
     containers:
       - args:


### PR DESCRIPTION
https://testgrid.k8s.io/google-gce#pull-kubernetes-e2e-gce-ubuntu-containerd&width=20 seems to be doing fine with `preset-use-new-registry` (set in https://github.com/kubernetes/test-infra/pull/25608)

So let's add a bit more here. Switch the corresponding CI job to the new registry endpoint too

Signed-off-by: Davanum Srinivas <davanum@gmail.com>