### PR TITLE
[bugzilla] Add the token path to the secret agent

### DIFF
--- a/prow/flagutil/bugzilla.go
+++ b/prow/flagutil/bugzilla.go
@@ -80,6 +80,9 @@ func (o *BugzillaOptions) BugzillaClient() (bugzilla.Client, error) {
 		}
 		generator = &generatorFunc
 	} else {
+		if err := secret.Add(o.ApiKeyPath); err != nil {
+			return nil, fmt.Errorf("failed to add Bugzilla token to secret agent: %w", err)
+		}
 		generatorFunc := secret.GetTokenGenerator(o.ApiKeyPath)
 		generator = &generatorFunc
 	}


### PR DESCRIPTION
/cc @alvaroaleman 

It seems that in the Bugzilla options the API token generator was return an empty token because we don't pass the token path into the secret agent. Therefore we ended up not passing the required `Headers` to the request.

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>