### PR TITLE
Revert "switch ci-kubernetes-e2e-ubuntu-gce-containerd to use new registry"

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -480,7 +480,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
-    preset-use-new-registry: "true"
   spec:
     containers:
       - args:


### PR DESCRIPTION
Hit a speed bump! https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-ubuntu-gce-containerd/1503513345318195200

Looks like the pull jobs work because we build the artifacts, here in this job we pull prebuilt artifacts and we run into issues. need to think about this scenario a bit.

This reverts commit 4dba3fb3d054e6aabbcda0c4e11c9176aa09190e.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>