### PR TITLE
Promote PROMETHEUS_SCRAPE_MASTER_KUBELETS

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -315,13 +315,15 @@ presets:
 - labels:
     preset-e2e-scalability-presubmits: "true"
   env:
+  - name: PROMETHEUS_SCRAPE_MASTER_KUBELETS
+    value: true
 
 - labels:
     preset-e2e-scalability-periodics: "true"
   env:
+  - name: PROMETHEUS_SCRAPE_MASTER_KUBELETS
+    value: true
 
 - labels:
     preset-e2e-scalability-periodics-master: "true"
   env:
-  - name: PROMETHEUS_SCRAPE_MASTER_KUBELETS
-    value: true


### PR DESCRIPTION
It has been added in master perf-dash (https://github.com/kubernetes/perf-tests/pull/1995), it's no-op in older versions.

Let's promote PROMETHEUS_SCRAPE_MASTER_KUBELETS to presubmits.