### PR TITLE
deps: Bump testgrid to v0.0.123

### DIFF
--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -290,27 +290,6 @@ func TestConfig(t *testing.T) {
 			} else {
 				testgroupMap[dashboardtab.TestGroupName]++
 			}
-
-			if dashboardtab.AlertOptions != nil && (dashboardtab.AlertOptions.AlertStaleResultsHours != 0 || dashboardtab.AlertOptions.NumFailuresToAlert != 0) {
-				for _, testgroup := range cfg.TestGroups {
-					// Disallow alert options in tab but not group.
-					// Disallow different alert options in tab vs. group.
-					if testgroup.Name == dashboardtab.TestGroupName {
-						if testgroup.AlertStaleResultsHours == 0 {
-							t.Errorf("Cannot define alert_stale_results_hours in DashboardTab %v and not TestGroup %v.", dashboardtab.Name, dashboardtab.TestGroupName)
-						}
-						if testgroup.NumFailuresToAlert == 0 {
-							t.Errorf("Cannot define num_failures_to_alert in DashboardTab %v and not TestGroup %v.", dashboardtab.Name, dashboardtab.TestGroupName)
-						}
-						if testgroup.AlertStaleResultsHours != dashboardtab.AlertOptions.AlertStaleResultsHours {
-							t.Errorf("alert_stale_results_hours for DashboardTab %v must match TestGroup %v.", dashboardtab.Name, dashboardtab.TestGroupName)
-						}
-						if testgroup.NumFailuresToAlert != dashboardtab.AlertOptions.NumFailuresToAlert {
-							t.Errorf("num_failures_to_alert for DashboardTab %v must match TestGroup %v.", dashboardtab.Name, dashboardtab.TestGroupName)
-						}
-					}
-				}
-			}
 		}
 	}
 
@@ -588,6 +567,9 @@ func TestNoEmpyMailToAddresses(t *testing.T) {
 		for _, dashboardtab := range dashboard.DashboardTab {
 			intro := fmt.Sprintf("dashboard_tab %v/%v", dashboard.Name, dashboardtab.Name)
 			if dashboardtab.AlertOptions != nil {
+				if dashboardtab.AlertOptions.AlertMailToAddresses == "" {
+					continue
+				}
 				mails := strings.Split(dashboardtab.AlertOptions.AlertMailToAddresses, ",")
 				for _, m := range mails {
 					_, err := mail.ParseAddress(m)

--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -168,10 +168,6 @@ func TestConfig(t *testing.T) {
 				t.Error("IsExternal must be true")
 			}
 
-			if !testgroup.UseKubernetesClient {
-				t.Error("UseKubernetesClient must be true")
-			}
-
 			for hIdx, header := range testgroup.ColumnHeader {
 				if header.ConfigurationValue == "" {
 					t.Errorf("Column Header %d is empty", hIdx)

--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -130,7 +130,7 @@ func TestMain(m *testing.M) {
 	}
 
 	var err error
-	cfg, err = config.Read(*protoPath, context.Background(), nil)
+	cfg, err = config.Read(context.Background(), *protoPath, nil)
 	if err != nil {
 		fmt.Printf("Could not load config: %v\n", err)
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -25,13 +25,13 @@ replace (
 
 require (
 	cloud.google.com/go v0.81.0
-	cloud.google.com/go/pubsub v1.4.0
+	cloud.google.com/go/pubsub v1.9.1
 	cloud.google.com/go/storage v1.12.0
 	github.com/Azure/azure-sdk-for-go v42.3.0+incompatible
 	github.com/Azure/azure-storage-blob-go v0.8.0
 	github.com/Azure/go-autorest/autorest v0.11.18
 	github.com/Azure/go-autorest/autorest/adal v0.9.13
-	github.com/GoogleCloudPlatform/testgrid v0.0.68
+	github.com/GoogleCloudPlatform/testgrid v0.0.123
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/andygrunwald/go-gerrit v0.0.0-20210709065208-9d38b0be0268
 	github.com/andygrunwald/go-jira v1.14.0
@@ -59,7 +59,7 @@ require (
 	github.com/google/gofuzz v1.2.1-0.20210504230335-f78f29fc09ea
 	github.com/google/uuid v1.2.0
 	github.com/gorilla/csrf v1.6.2
-	github.com/gorilla/mux v1.7.4
+	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/securecookie v1.1.1
 	github.com/gorilla/sessions v1.2.0
 	github.com/gregjones/httpcache v0.0.0-20190212212710-3befbb6ad0cc

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 bazil.org/fuse v0.0.0-20160811212531-371fbbdaa898/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=
 bazil.org/fuse v0.0.0-20180421153158-65cc252bf669/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=
+bitbucket.org/creachadair/stringset v0.0.9 h1:L4vld9nzPt90UZNrXjNelTshD74ps4P5NGs3Iq6yN3o=
+bitbucket.org/creachadair/stringset v0.0.9/go.mod h1:t+4WcQ4+PXTa8aQdNKe40ZP6iwesoMFWAxPGd3UGjyY=
 cloud.google.com/go v0.25.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.30.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
@@ -152,8 +154,9 @@ github.com/GoogleCloudPlatform/cloudsql-proxy v0.0.0-20191009163259-e802c2cb94ae
 github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20190822182118-27a4ced34534/go.mod h1:iroGtC8B3tQiqtds1l+mgk/BBOrxbqjH+eUfFQYRc14=
 github.com/GoogleCloudPlatform/testgrid v0.0.1-alpha.3/go.mod h1:f96W2HYy3tiBNV5zbbRc+NczwYHgG1PHXMQfoEWv680=
 github.com/GoogleCloudPlatform/testgrid v0.0.7/go.mod h1:lmtHGBL0M/MLbu1tR9BWV7FGZ1FEFIdPqmJiHNCL7y8=
-github.com/GoogleCloudPlatform/testgrid v0.0.68 h1:qs3/BQpz3j3qsgnfjV8aVBfPopkGxp/TnWjjiboUVf8=
 github.com/GoogleCloudPlatform/testgrid v0.0.68/go.mod h1:SIRhudHYGiAUqMwKorBp2Kb5yJKhMq/nEMzFpYlKHVk=
+github.com/GoogleCloudPlatform/testgrid v0.0.123 h1:S5LE2LjkPsUlyt7blkIgwajiUfgFzv5s17+TkyKDfnI=
+github.com/GoogleCloudPlatform/testgrid v0.0.123/go.mod h1:4Ojwl21NNySkM1rG8hT9K2bugPX9fIrc2hC+GHegLR8=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
@@ -340,6 +343,7 @@ github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfc
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/creachadair/staticfile v0.1.3/go.mod h1:a3qySzCIXEprDGxk6tSxSI+dBBdLzqeBOMhZ+o2d3pM=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -762,8 +766,9 @@ github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
-github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.1.3/go.mod h1:8KCfur6+4Mqcc6S0FEfKuN15Vl5MgXW92AE8ovaJD0w=
@@ -1685,6 +1690,7 @@ golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1830,6 +1836,7 @@ golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.5 h1:ouewzE6p+/VEB31YYnTbEJdi8pFqKp4P4n85vwo3DHA=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -1947,6 +1954,7 @@ google.golang.org/genproto v0.0.0-20200921151605-7abf4a1a14d5/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201201144952-b05cb90ed32e/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20201209185603-f92720507ed4/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201210142538-e3217bee35cc/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201214200347-8c77b98c765d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210222152913-aa3ee6e6a81c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
@@ -2084,6 +2092,7 @@ k8s.io/api v0.17.2/go.mod h1:BS9fjjLc4CMuqfSO8vgbHPKMt5+SF0ET6u/RVDihTo4=
 k8s.io/api v0.17.3/go.mod h1:YZ0OTkuw7ipbe305fMpIdf3GLXZKRigjtZaV5gzC2J0=
 k8s.io/api v0.17.4/go.mod h1:5qxx6vjmwUVG2nHQTKGlLts8Tbok8PzHl4vHtVFuZCA=
 k8s.io/api v0.17.6/go.mod h1:1jKVwkj0UZ4huak/yRt3MFfU5wc32+B41SkNN5HhyFg=
+k8s.io/api v0.19.13/go.mod h1:xNpkpfCFYnVjbmKqIInsBPqUROkHefMc42rUA92XkdU=
 k8s.io/api v0.21.1/go.mod h1:FstGROTmsSHBarKc8bylzXih8BLNYTiS3TZcsoEDg2s=
 k8s.io/api v0.21.3/go.mod h1:hUgeYHUbBp23Ue4qdX9tR8/ANi/g3ehylAqDn9NWVOg=
 k8s.io/api v0.22.2 h1:M8ZzAD0V6725Fjg53fKeTJxGsJvRbk4TEm/fexHMtfw=
@@ -2111,6 +2120,7 @@ k8s.io/apimachinery v0.17.3/go.mod h1:gxLnyZcGNdZTCLnq3fgzyg2A5BVCHTNDFrw8AmuJ+0
 k8s.io/apimachinery v0.17.4/go.mod h1:gxLnyZcGNdZTCLnq3fgzyg2A5BVCHTNDFrw8AmuJ+0g=
 k8s.io/apimachinery v0.17.6/go.mod h1:Lg8zZ5iC/O8UjCqW6DNhcQG2m4TdjF9kwG3891OWbbA=
 k8s.io/apimachinery v0.18.5/go.mod h1:OaXp26zu/5J7p0f92ASynJa1pZo06YlV9fG7BoWbCko=
+k8s.io/apimachinery v0.19.13/go.mod h1:RMyblyny2ZcDQ/oVE+lC31u7XTHUaSXEK2IhgtwGxfc=
 k8s.io/apimachinery v0.21.1/go.mod h1:jbreFvJo3ov9rj7eWT7+sYiRx+qZuCYXwWT1bcDswPY=
 k8s.io/apimachinery v0.21.3/go.mod h1:H/IM+5vH9kZRNJ4l3x/fXP/5bOPJaVP/guptnZPeCFI=
 k8s.io/apimachinery v0.22.2 h1:ejz6y/zNma8clPVfNDLnPbleBo6MpoFy/HBiBqCouVk=
@@ -2184,6 +2194,7 @@ k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c/go.mod h1:GRQhZsXIAJ1xR0C
 k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
 k8s.io/kube-openapi v0.0.0-20200410145947-bcb3869e6f29/go.mod h1:F+5wygcW0wmRTnM3cOgIqGivxkwSWIWT5YdsDbeAOaU=
 k8s.io/kube-openapi v0.0.0-20200410163147-594e756bea31/go.mod h1:1TqjTSzOxsLGIKfj0lK8EeCP7K1iUG65v09OM0/WG5E=
+k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6/go.mod h1:UuqjUnNftUyPE5H64/qeyjQoUZhGpeFDVdxjTeEVN2o=
 k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7/go.mod h1:wXW5VT87nVfh/iLV8FpR2uDvrFyomxbtb1KivDbvPTE=
 k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e h1:KLHHjkdQFomZy8+06csTWZ0m1343QqxZhR2LJ1OxCYM=
 k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e/go.mod h1:vHXdDvt9+2spS2Rx9ql3I8tycm3H9FDfdUoIuKCefvw=
@@ -2274,6 +2285,7 @@ sigs.k8s.io/structured-merge-diff v1.0.1/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8AP
 sigs.k8s.io/structured-merge-diff/v2 v2.0.1/go.mod h1:Wb7vfKAodbKgf6tn1Kl0VvGj7mRH6DGaRcixXEJXTsE=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
+sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.0/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.2 h1:Hr/htKFmJEbtMgS/UD0N+gtgctAqz81t3nu+sPzynno=

--- a/hack/make-rules/verify/yamllint.sh
+++ b/hack/make-rules/verify/yamllint.sh
@@ -33,7 +33,7 @@ LINT_COMMAND=("yamllint" "-c" "config/jobs/.yamllint.conf" "config/jobs" "config
 
 "${DOCKER[@]}" run \
     --rm -i \
-    -v "${REPO_ROOT:?}:${REPO_ROOT:?}" -w "${REPO_ROOT}" \
+    -v "${REPO_ROOT:?}:${REPO_ROOT:?}:z" -w "${REPO_ROOT}" \
     "quay.io/kubermatic/yamllint:0.1" \
     "${LINT_COMMAND[@]}"
 

--- a/pkg/benchmarkjunit/parse.go
+++ b/pkg/benchmarkjunit/parse.go
@@ -71,12 +71,12 @@ func recordLogText(s *junit.Suite, text string) {
 
 	switch {
 	case result.Failure != nil:
-		*result.Failure = text
+		result.Failure.Value = text
 		// Also add failure text to "categorized_fail" property for TestGrid.
 		result.SetProperty("categorized_fail", text)
 
 	case result.Skipped != nil:
-		*result.Skipped = text
+		result.Skipped.Value = text
 
 	default:
 		result.Output = &text
@@ -167,13 +167,18 @@ func parse(raw []byte) (*junit.Suites, error) {
 				suite.Results = append(suite.Results, junit.Result{
 					ClassName: path.Base(suite.Name),
 					Name:      match[2],
-					Skipped:   &emptyText,
+					Skipped: &junit.Skipped{
+						Value: emptyText,
+					},
 				})
 			} else if match[1] == "FAIL" {
 				suite.Results = append(suite.Results, junit.Result{
 					ClassName: path.Base(suite.Name),
 					Name:      match[2],
-					Failure:   &emptyText,
+					Failure: &junit.Failure{
+						Type:  "failure",
+						Value: emptyText,
+					},
 				})
 				suite.Failures += 1
 				suite.Tests += 1

--- a/prow/spyglass/lenses/junit/lens.go
+++ b/prow/spyglass/lenses/junit/lens.go
@@ -108,7 +108,7 @@ func (jr JunitResult) Status() testStatus {
 func (jr JunitResult) SkippedReason() string {
 	res := ""
 	if jr.Skipped != nil {
-		res = *jr.Skipped
+		res = jr.Message(-1) // Don't truncate
 	}
 	return res
 }

--- a/prow/spyglass/lenses/junit/lens_test.go
+++ b/prow/spyglass/lenses/junit/lens_test.go
@@ -94,14 +94,30 @@ func (fa *FakeArtifact) ReadAtMost(n int64) ([]byte, error) {
 }
 
 func TestGetJvd(t *testing.T) {
-	emptyFailureMsg := ""
-	failureMsgs := []string{
-		" failure message 0 ",
-		" failure message 1 ",
+	emptySkipped := junit.Skipped{}
+	failures := []junit.Failure{
+		{
+			Type:    "failure",
+			Message: "failure message 0",
+			Value:   " failure value 0 ",
+		},
+		{
+			Type:    "failure",
+			Message: "failure message 1",
+			Value:   " failure value 1 ",
+		},
 	}
-	errorMsgs := []string{
-		" error message 0 ",
-		" error message 1 ",
+	errors := []junit.Errored{
+		{
+			Type:    "error",
+			Message: "error message 0",
+			Value:   " error value 0 ",
+		},
+		{
+			Type:    "error",
+			Message: "error message 1",
+			Value:   " error value 1 ",
+		},
 	}
 
 	tests := []struct {
@@ -116,7 +132,7 @@ func TestGetJvd(t *testing.T) {
 				<testsuites>
 					<testsuite>
 						<testcase classname="fake_class_0" name="fake_test_0">
-							<failure message="Failed" type=""> failure message 0 </failure>
+							<failure message="failure message 0" type="failure"> failure value 0 </failure>
 						</testcase>
 					</testsuite>
 				</testsuites>
@@ -132,7 +148,7 @@ func TestGetJvd(t *testing.T) {
 								junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
-									Failure:   &failureMsgs[0],
+									Failure:   &failures[0],
 								},
 							},
 						},
@@ -149,7 +165,7 @@ func TestGetJvd(t *testing.T) {
 				<testsuites>
 					<testsuite>
 						<testcase classname="fake_class_0" name="fake_test_0">
-							<error message="Error" type=""> error message 0 </error>
+							<error message="error message 0" type="error"> error value 0 </error>
 						</testcase>
 					</testsuite>
 				</testsuites>
@@ -165,7 +181,7 @@ func TestGetJvd(t *testing.T) {
 								junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
-									Errored:   &errorMsgs[0],
+									Errored:   &errors[0],
 								},
 							},
 						},
@@ -231,7 +247,7 @@ func TestGetJvd(t *testing.T) {
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
 									Failure:   nil,
-									Skipped:   &emptyFailureMsg,
+									Skipped:   &emptySkipped,
 								},
 							},
 						},
@@ -247,7 +263,7 @@ func TestGetJvd(t *testing.T) {
 				<testsuites>
 					<testsuite>
 						<testcase classname="fake_class_0" name="fake_test_0">
-							<failure message="Failed" type=""> failure message 0 </failure>
+							<failure message="failure message 0" type="failure"> failure value 0 </failure>
 						</testcase>
 					<testcase classname="fake_class_0" name="fake_test_0">
 							<skipped/>
@@ -266,7 +282,7 @@ func TestGetJvd(t *testing.T) {
 								junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
-									Failure:   &failureMsgs[0],
+									Failure:   &failures[0],
 								},
 							},
 							{
@@ -274,7 +290,7 @@ func TestGetJvd(t *testing.T) {
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
 									Failure:   nil,
-									Skipped:   &emptyFailureMsg,
+									Skipped:   &emptySkipped,
 								},
 							},
 						},
@@ -288,7 +304,7 @@ func TestGetJvd(t *testing.T) {
 								junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
-									Failure:   &failureMsgs[0],
+									Failure:   &failures[0],
 								},
 							},
 							{
@@ -296,7 +312,7 @@ func TestGetJvd(t *testing.T) {
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
 									Failure:   nil,
-									Skipped:   &emptyFailureMsg,
+									Skipped:   &emptySkipped,
 								},
 							},
 						},
@@ -312,7 +328,7 @@ func TestGetJvd(t *testing.T) {
 				<testsuites>
 					<testsuite>
 						<testcase classname="fake_class_0" name="fake_test_0">
-							<failure message="Failed" type=""> failure message 0 </failure>
+							<failure message="failure message 0" type="failure"> failure value 0 </failure>
 						</testcase>
 						<testcase classname="fake_class_1" name="fake_test_0"></testcase>
 					</testsuite>
@@ -342,7 +358,7 @@ func TestGetJvd(t *testing.T) {
 								junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
-									Failure:   &failureMsgs[0],
+									Failure:   &failures[0],
 								},
 							},
 						},
@@ -359,7 +375,7 @@ func TestGetJvd(t *testing.T) {
 				<testsuites>
 					<testsuite>
 						<testcase classname="fake_class_0" name="fake_test_0">
-							<failure message="Failed" type=""> failure message 0 </failure>
+							<failure message="failure message 0" type="failure"> failure value 0 </failure>
 						</testcase>
 					</testsuite>
 				</testsuites>
@@ -395,7 +411,7 @@ func TestGetJvd(t *testing.T) {
 								junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
-									Failure:   &failureMsgs[0],
+									Failure:   &failures[0],
 								},
 							},
 						},
@@ -412,12 +428,12 @@ func TestGetJvd(t *testing.T) {
 				<testsuites>
 					<testsuite>
 						<testcase classname="fake_class_0" name="fake_test_0">
-							<failure message="Failed" type=""> failure message 0 </failure>
+							<failure message="failure message 0" type="failure"> failure value 0 </failure>
 						</testcase>
 					</testsuite>
 					<testsuite>
 						<testcase classname="fake_class_0" name="fake_test_0">
-							<failure message="Failed" type=""> failure message 1 </failure>
+							<failure message="failure message 1" type="failure"> failure value 1 </failure>
 						</testcase>
 					</testsuite>
 				</testsuites>
@@ -433,14 +449,14 @@ func TestGetJvd(t *testing.T) {
 								junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
-									Failure:   &failureMsgs[0],
+									Failure:   &failures[0],
 								},
 							},
 							{
 								junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
-									Failure:   &failureMsgs[1],
+									Failure:   &failures[1],
 								},
 							},
 						},
@@ -538,7 +554,7 @@ func TestGetJvd(t *testing.T) {
 				<testsuites>
 					<testsuite>
 						<testcase classname="fake_class_0" name="fake_test_0">
-							<failure message="Failed" type=""> failure message 0 </failure>
+							<failure message="failure message 0" type="failure"> failure value 0 </failure>
 						</testcase>
 					</testsuite>
 					<testsuite>
@@ -559,7 +575,7 @@ func TestGetJvd(t *testing.T) {
 								junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
-									Failure:   &failureMsgs[0],
+									Failure:   &failures[0],
 								},
 							},
 							{
@@ -584,7 +600,7 @@ func TestGetJvd(t *testing.T) {
 					</testsuite>
 					<testsuite>
 						<testcase classname="fake_class_0" name="fake_test_0">
-							<failure message="Failed" type=""> failure message 0 </failure>
+							<failure message="failure message 0" type="failure"> failure value 0 </failure>
 						</testcase>
 					</testsuite>
 				</testsuites>
@@ -609,7 +625,7 @@ func TestGetJvd(t *testing.T) {
 								junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
-									Failure:   &failureMsgs[0],
+									Failure:   &failures[0],
 								},
 							},
 						},
@@ -624,12 +640,12 @@ func TestGetJvd(t *testing.T) {
 				<testsuites>
 					<testsuite>
 						<testcase classname="fake_class_0" name="fake_test_0">
-							<failure message="Failed" type=""> failure message 0 </failure>
+							<failure message="failure message 0" type="failure"> failure value 0 </failure>
 						</testcase>
 					</testsuite>
 					<testsuite>
 						<testcase classname="fake_class_0" name="fake_test_0">
-							<failure message="Failed" type=""> failure message 1 </failure>
+							<failure message="failure message 1" type="failure"> failure value 1 </failure>
 						</testcase>
 					</testsuite>
 					<testsuite>
@@ -650,14 +666,14 @@ func TestGetJvd(t *testing.T) {
 								junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
-									Failure:   &failureMsgs[0],
+									Failure:   &failures[0],
 								},
 							},
 							{
 								junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
-									Failure:   &failureMsgs[1],
+									Failure:   &failures[1],
 								},
 							},
 							{
@@ -679,7 +695,7 @@ func TestGetJvd(t *testing.T) {
 				<testsuites>
 					<testsuite>
 						<testcase classname="fake_class_0" name="fake_test_0">
-							<failure message="Failed" type=""> failure message 0 </failure>
+							<failure message="failure message 0" type="failure"> failure value 0 </failure>
 						</testcase>
 					</testsuite>
 				</testsuites>
@@ -715,7 +731,7 @@ func TestGetJvd(t *testing.T) {
 								junit.Result{
 									Name:      "fake_test_0",
 									ClassName: "fake_class_0",
-									Failure:   &failureMsgs[0],
+									Failure:   &failures[0],
 								},
 							},
 						},

--- a/testgrid/pkg/configurator/configurator/client.go
+++ b/testgrid/pkg/configurator/configurator/client.go
@@ -122,7 +122,11 @@ func write(ctx context.Context, client *storage.Client, path string, bytes []byt
 	if err = p.SetURL(u); err != nil {
 		return err
 	}
-	return gcs.Upload(ctx, client, p, bytes, worldReadable, cacheControl)
+	_, err = gcs.Upload(ctx, client, p, bytes, worldReadable, cacheControl)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // Ignores what changed for now and recomputes everything

--- a/testgrid/pkg/configurator/prow/prow.go
+++ b/testgrid/pkg/configurator/prow/prow.go
@@ -142,22 +142,6 @@ func (pac *ProwAwareConfigurator) ApplySingleProwjobAnnotations(c *configpb.Conf
 		testGroup.NumColumnsRecent = minPresubmitNumColumnsRecent
 	}
 
-	if srh, ok := j.Annotations[testgridAlertStaleResultsHoursAnnotation]; ok {
-		srhInt, err := strconv.ParseInt(srh, 10, 32)
-		if err != nil {
-			return fmt.Errorf("%s value %q is not a valid integer", testgridAlertStaleResultsHoursAnnotation, srh)
-		}
-		testGroup.AlertStaleResultsHours = int32(srhInt)
-	}
-
-	if nfta, ok := j.Annotations[testgridNumFailuresToAlertAnnotation]; ok {
-		nftaInt, err := strconv.ParseInt(nfta, 10, 32)
-		if err != nil {
-			return fmt.Errorf("%s value %q is not a valid integer", testgridNumFailuresToAlertAnnotation, nfta)
-		}
-		testGroup.NumFailuresToAlert = int32(nftaInt)
-	}
-
 	if dora, ok := j.Annotations[testgridDaysOfResultsAnnotation]; ok {
 		doraInt, err := strconv.ParseInt(dora, 10, 32)
 		if err != nil {
@@ -232,7 +216,24 @@ func (pac *ProwAwareConfigurator) ApplySingleProwjobAnnotations(c *configpb.Conf
 			if firstDashboard {
 				firstDashboard = false
 				if emails, ok := j.Annotations[testgridEmailAnnotation]; ok {
-					dt.AlertOptions = &configpb.DashboardTabAlertOptions{AlertMailToAddresses: emails}
+					initAlertOptions(dt)
+					dt.AlertOptions.AlertMailToAddresses = emails
+				}
+				if srh, ok := j.Annotations[testgridAlertStaleResultsHoursAnnotation]; ok {
+					srhInt, err := strconv.ParseInt(srh, 10, 32)
+					if err != nil {
+						return fmt.Errorf("%s value %q is not a valid integer", testgridAlertStaleResultsHoursAnnotation, srh)
+					}
+					initAlertOptions(dt)
+					dt.AlertOptions.AlertStaleResultsHours = int32(srhInt)
+				}
+				if nfta, ok := j.Annotations[testgridNumFailuresToAlertAnnotation]; ok {
+					nftaInt, err := strconv.ParseInt(nfta, 10, 32)
+					if err != nil {
+						return fmt.Errorf("%s value %q is not a valid integer", testgridNumFailuresToAlertAnnotation, nfta)
+					}
+					initAlertOptions(dt)
+					dt.AlertOptions.NumFailuresToAlert = int32(nftaInt)
 				}
 			}
 			if dc != nil {
@@ -243,6 +244,12 @@ func (pac *ProwAwareConfigurator) ApplySingleProwjobAnnotations(c *configpb.Conf
 	}
 
 	return nil
+}
+
+func initAlertOptions(dt *configpb.DashboardTab) {
+	if dt.AlertOptions == nil {
+		dt.AlertOptions = &configpb.DashboardTabAlertOptions{}
+	}
 }
 
 // sortPeriodics sorts all periodics by name (ascending).

--- a/testgrid/pkg/configurator/prow/prow_test.go
+++ b/testgrid/pkg/configurator/prow/prow_test.go
@@ -348,8 +348,6 @@ func Test_applySingleProwjobAnnotations(t *testing.T) {
 						Name:                   ProwJobName,
 						GcsPrefix:              ProwDefaultGCSPath + "logs/" + ProwJobName,
 						NumColumnsRecent:       13,
-						NumFailuresToAlert:     4,
-						AlertStaleResultsHours: 24,
 						DaysOfResults:          30,
 						ShortTextMetric:        "haunted-house",
 						DisableProwjobAnalysis: true,
@@ -364,7 +362,9 @@ func Test_applySingleProwjobAnnotations(t *testing.T) {
 								Description:   ProwJobDefaultDescription + "\nprowjob_description: spooky scary",
 								TestGroupName: ProwJobName,
 								AlertOptions: &config.DashboardTabAlertOptions{
-									AlertMailToAddresses: "ghost@example.com",
+									AlertMailToAddresses:   "ghost@example.com",
+									NumFailuresToAlert:     4,
+									AlertStaleResultsHours: 24,
 								},
 								CodeSearchUrlTemplate: &config.LinkTemplate{
 									Url: "https://github.com/test/repo/compare/<start-custom-0>...<end-custom-0>",


### PR DESCRIPTION
The last Ginkgo major versino v2 make use of the "message" attribute at
the junit xml to add extra content to fail/error/skip, this has being
fixed at latest testgrid [1]. This change bumps the testgrid dependency to
integrate the fix with spyglass.

[1] https://github.com/GoogleCloudPlatform/testgrid/pull/838