### PR TITLE
Turn pjutil.Filter into interface

### DIFF
--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -423,9 +423,9 @@ func (c *Controller) processChange(logger logrus.FieldLogger, instance string, c
 		// Automatically trigger the Prow jobs if the revision is new and the
 		// change is not in WorkInProgress.
 		if revision.Created.Time.After(lastUpdate) && !change.WorkInProgress {
-			filters = append(filters, pjutil.TestAllFilter())
+			filters = append(filters, pjutil.NewTestAllFilter())
 		}
-		toTrigger, err := pjutil.FilterPresubmits(pjutil.AggregateFilter(filters), listChangedFiles(change), change.Branch, presubmits, logger)
+		toTrigger, err := pjutil.FilterPresubmits(pjutil.NewAggregateFilter(filters), listChangedFiles(change), change.Branch, presubmits, logger)
 		if err != nil {
 			return fmt.Errorf("filter presubmits: %w", err)
 		}

--- a/prow/gerrit/adapter/trigger.go
+++ b/prow/gerrit/adapter/trigger.go
@@ -67,7 +67,7 @@ func messageFilter(messages []string, failingContexts, allContexts sets.String, 
 		// If the Gerrit Change changed from draft to active state, trigger all
 		// presubmit Prow jobs.
 		if strings.HasSuffix(message, client.ReadyForReviewMessageFixed) || strings.HasSuffix(message, client.ReadyForReviewMessageCustomizable) {
-			filters = append(filters, pjutil.TestAllFilter())
+			filters = append(filters, pjutil.NewTestAllFilter())
 			continue
 		}
 
@@ -79,5 +79,5 @@ func messageFilter(messages []string, failingContexts, allContexts sets.String, 
 		filters = append(filters, filter)
 	}
 
-	return pjutil.AggregateFilter(filters)
+	return pjutil.NewAggregateFilter(filters)
 }

--- a/prow/gerrit/adapter/trigger_test.go
+++ b/prow/gerrit/adapter/trigger_test.go
@@ -351,7 +351,7 @@ func TestMessageFilter(t *testing.T) {
 					check.job = fixed[0]
 					logger := logrus.WithField("case", tc.name).WithField("job", check.job.Name)
 					filt := messageFilter(tc.messages, tc.failed, tc.all, logger)
-					shouldRun, forcedToRun, defaultBehavior := filt(check.job)
+					shouldRun, forcedToRun, defaultBehavior := filt.ShouldRun(check.job)
 					if got, want := shouldRun, check.shouldRun; got != want {
 						t.Errorf("shouldRun: got %t, want %t", got, want)
 					}

--- a/prow/pjutil/filter.go
+++ b/prow/pjutil/filter.go
@@ -19,6 +19,7 @@ package pjutil
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 
@@ -46,16 +47,16 @@ func AvailablePresubmits(changes config.ChangedFilesProvider, org, repo, branch 
 	optionalJobTriggerCommands := sets.NewString()
 	requiredJobsTriggerCommands := sets.NewString()
 
-	runWithTestAll, err := FilterPresubmits(TestAllFilter(), changes, branch, presubmits, logger)
+	runWithTestAll, err := FilterPresubmits(NewTestAllFilter(), changes, branch, presubmits, logger)
 	if err != nil {
 		return runWithTestAllNames, optionalJobTriggerCommands, requiredJobsTriggerCommands, err
 	}
 
 	var triggerFilters []Filter
 	for _, ps := range presubmits {
-		triggerFilters = append(triggerFilters, CommandFilter(ps.RerunCommand))
+		triggerFilters = append(triggerFilters, NewCommandFilter(ps.RerunCommand))
 	}
-	runWithTrigger, err := FilterPresubmits(AggregateFilter(triggerFilters), changes, branch, presubmits, logger)
+	runWithTrigger, err := FilterPresubmits(NewAggregateFilter(triggerFilters), changes, branch, presubmits, logger)
 	if err != nil {
 		return runWithTestAllNames, optionalJobTriggerCommands, requiredJobsTriggerCommands, err
 	}
@@ -80,35 +81,94 @@ func AvailablePresubmits(changes config.ChangedFilesProvider, org, repo, branch 
 //  - we know that the presubmit is forced to run
 //  - what the default behavior should be if the presubmit
 //    runs conditionally and does not match trigger conditions
-type Filter func(p config.Presubmit) (shouldRun bool, forcedToRun bool, defaultBehavior bool)
+type Filter interface {
+	ShouldRun(p config.Presubmit) (shouldRun bool, forcedToRun bool, defaultBehavior bool)
+	Name() string
+}
+
+// ArbitraryFilter is a lazy filter that can be used ad hoc when consumer
+// doesn't want to declare a new struct. One of the usage is in unit test.
+type ArbitraryFilter struct {
+	override func(p config.Presubmit) (shouldRun bool, forcedToRun bool, defaultBehavior bool)
+	name     string
+}
+
+func NewArbitraryFilter(override func(p config.Presubmit) (shouldRun bool, forcedToRun bool, defaultBehavior bool), name string) *ArbitraryFilter {
+	return &ArbitraryFilter{override: override, name: name}
+}
+
+func (af *ArbitraryFilter) ShouldRun(p config.Presubmit) (shouldRun bool, forcedToRun bool, defaultBehavior bool) {
+	return af.override(p)
+}
+
+func (af *ArbitraryFilter) Name() string {
+	return af.name
+}
 
 // CommandFilter builds a filter for `/test foo`
-func CommandFilter(body string) Filter {
-	return func(p config.Presubmit) (bool, bool, bool) {
-		return p.TriggerMatches(body), p.TriggerMatches(body), true
+type CommandFilter struct {
+	body string
+}
+
+func NewCommandFilter(body string) *CommandFilter {
+	return &CommandFilter{body: body}
+}
+
+func (cf *CommandFilter) ShouldRun(p config.Presubmit) (bool, bool, bool) {
+	return p.TriggerMatches(cf.body), p.TriggerMatches(cf.body), true
+}
+
+func (cf *CommandFilter) Name() string {
+	// Arbitrarily grabbing the first 50 chars for debugging purpose
+	end := 50
+	if len(cf.body) < 50 {
+		end = len(cf.body)
 	}
+	return "command-filter: " + cf.body[:end]
 }
 
 // TestAllFilter builds a filter for the automatic behavior of `/test all`.
 // Jobs that explicitly match `/test all` in their trigger regex will be
 // handled by a commandFilter for the comment in question.
-func TestAllFilter() Filter {
-	return func(p config.Presubmit) (bool, bool, bool) {
-		return !p.NeedsExplicitTrigger(), false, false
-	}
+type TestAllFilter struct{}
+
+func NewTestAllFilter() *TestAllFilter {
+	return &TestAllFilter{}
+}
+
+func (tf *TestAllFilter) ShouldRun(p config.Presubmit) (bool, bool, bool) {
+	return !p.NeedsExplicitTrigger(), false, false
+}
+
+func (tf *TestAllFilter) Name() string {
+	return "test-all-filter"
 }
 
 // AggregateFilter builds a filter that evaluates the child filters in order
 // and returns the first match
-func AggregateFilter(filters []Filter) Filter {
-	return func(presubmit config.Presubmit) (bool, bool, bool) {
-		for _, filter := range filters {
-			if shouldRun, forced, defaults := filter(presubmit); shouldRun {
-				return shouldRun, forced, defaults
-			}
+type AggregateFilter struct {
+	filters []Filter
+}
+
+func NewAggregateFilter(filters []Filter) *AggregateFilter {
+	return &AggregateFilter{filters: filters}
+}
+
+func (nf *AggregateFilter) ShouldRun(p config.Presubmit) (bool, bool, bool) {
+	for _, filter := range nf.filters {
+		if shouldRun, forced, defaults := filter.ShouldRun(p); shouldRun {
+			return shouldRun, forced, defaults
 		}
-		return false, false, false
 	}
+	return false, false, false
+}
+
+func (nf *AggregateFilter) Name() string {
+	var names []string
+	for _, filter := range nf.filters {
+		names = append(names, filter.Name())
+	}
+	return strings.Join(names, "::")
 }
 
 // FilterPresubmits determines which presubmits should run by evaluating the user-provided filter.
@@ -118,7 +178,7 @@ func FilterPresubmits(filter Filter, changes config.ChangedFilesProvider, branch
 	var namesToTrigger []string
 	var noMatch, shouldnotRun int
 	for _, presubmit := range presubmits {
-		matches, forced, defaults := filter(presubmit)
+		matches, forced, defaults := filter.ShouldRun(presubmit)
 		if !matches {
 			noMatch++
 			continue
@@ -140,25 +200,52 @@ func FilterPresubmits(filter Filter, changes config.ChangedFilesProvider, branch
 		"total-count":          len(presubmits),
 		"to-trigger-count":     len(toTrigger),
 		"no-match-count":       noMatch,
-		"should-not-run-count": shouldnotRun}).Debug("Filtered complete.")
+		"should-not-run-count": shouldnotRun,
+		"filters":              filter.Name()}).Debug("Filtered complete.")
 	return toTrigger, nil
 }
 
 // RetestFilter builds a filter for `/retest`
-func RetestFilter(failedContexts, allContexts sets.String) Filter {
-	return func(p config.Presubmit) (bool, bool, bool) {
-		failed := failedContexts.Has(p.Context)
-		return failed || (!p.NeedsExplicitTrigger() && !allContexts.Has(p.Context)), false, failed
+type RetestFilter struct {
+	failedContexts, allContexts sets.String
+}
+
+func NewRetestFilter(failedContexts, allContexts sets.String) *RetestFilter {
+	return &RetestFilter{
+		failedContexts: failedContexts,
+		allContexts:    allContexts,
 	}
 }
 
-func RetestRequiredFilter(failedContext, allContexts sets.String) Filter {
-	return func(ps config.Presubmit) (bool, bool, bool) {
-		if ps.Optional {
-			return false, false, false
-		}
-		return RetestFilter(failedContext, allContexts)(ps)
+func (rf *RetestFilter) ShouldRun(p config.Presubmit) (bool, bool, bool) {
+	failed := rf.failedContexts.Has(p.Context)
+	return failed || (!p.NeedsExplicitTrigger() && !rf.allContexts.Has(p.Context)), false, failed
+}
+
+func (rf *RetestFilter) Name() string {
+	return "retest-filter"
+}
+
+type RetestRequiredFilter struct {
+	failedContexts, allContexts sets.String
+}
+
+func NewRetestRequiredFilter(failedContexts, allContexts sets.String) *RetestRequiredFilter {
+	return &RetestRequiredFilter{
+		failedContexts: failedContexts,
+		allContexts:    allContexts,
 	}
+}
+
+func (rrf *RetestRequiredFilter) ShouldRun(ps config.Presubmit) (bool, bool, bool) {
+	if ps.Optional {
+		return false, false, false
+	}
+	return NewRetestFilter(rrf.failedContexts, rrf.allContexts).ShouldRun(ps)
+}
+
+func (rrf *RetestRequiredFilter) Name() string {
+	return "retest-required-filter"
 }
 
 type contextGetter func() (sets.String, sets.String, error)
@@ -172,14 +259,14 @@ func PresubmitFilter(honorOkToTest bool, contextGetter contextGetter, body strin
 	// as they have precedence -- filters that override the false default should
 	// match before others. We order filters by amount of specificity.
 	var filters []Filter
-	filters = append(filters, CommandFilter(body))
+	filters = append(filters, NewCommandFilter(body))
 	if RetestRe.MatchString(body) {
 		logger.Info("Using retest filter.")
 		failedContexts, allContexts, err := contextGetter()
 		if err != nil {
 			return nil, err
 		}
-		filters = append(filters, RetestFilter(failedContexts, allContexts))
+		filters = append(filters, NewRetestFilter(failedContexts, allContexts))
 	}
 	if RetestRequiredRe.MatchString(body) {
 		logger.Info("Using retest-required filter")
@@ -187,11 +274,11 @@ func PresubmitFilter(honorOkToTest bool, contextGetter contextGetter, body strin
 		if err != nil {
 			return nil, err
 		}
-		filters = append(filters, RetestRequiredFilter(failedContexts, allContexts))
+		filters = append(filters, NewRetestRequiredFilter(failedContexts, allContexts))
 	}
 	if (honorOkToTest && OkToTestRe.MatchString(body)) || TestAllRe.MatchString(body) {
 		logger.Debug("Using test-all filter.")
-		filters = append(filters, TestAllFilter())
+		filters = append(filters, NewTestAllFilter())
 	}
-	return AggregateFilter(filters), nil
+	return NewAggregateFilter(filters), nil
 }

--- a/prow/pjutil/filter_test.go
+++ b/prow/pjutil/filter_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/github"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/util/diff"
@@ -97,9 +98,9 @@ func TestTestAllFilter(t *testing.T) {
 			if err := config.SetPresubmitRegexes(testCase.presubmits); err != nil {
 				t.Fatalf("%s: could not set presubmit regexes: %v", testCase.name, err)
 			}
-			filter := TestAllFilter()
+			filter := NewTestAllFilter()
 			for i, presubmit := range testCase.presubmits {
-				actualFiltered, actualForced, actualDefault := filter(presubmit)
+				actualFiltered, actualForced, actualDefault := filter.ShouldRun(presubmit)
 				expectedFiltered, expectedForced, expectedDefault := testCase.expected[i][0], testCase.expected[i][1], testCase.expected[i][2]
 				if actualFiltered != expectedFiltered {
 					t.Errorf("%s: filter did not evaluate correctly, expected %v but got %v for %v", testCase.name, expectedFiltered, actualFiltered, presubmit.Name)
@@ -117,10 +118,11 @@ func TestTestAllFilter(t *testing.T) {
 
 func TestCommandFilter(t *testing.T) {
 	var testCases = []struct {
-		name       string
-		body       string
-		presubmits []config.Presubmit
-		expected   [][]bool
+		name         string
+		body         string
+		presubmits   []config.Presubmit
+		expected     [][]bool
+		expectedName string
 	}{
 		{
 			name: "command filter matches jobs whose triggers match the body",
@@ -141,7 +143,25 @@ func TestCommandFilter(t *testing.T) {
 					RerunCommand: "/test other-trigger",
 				},
 			},
-			expected: [][]bool{{true, true, true}, {false, false, true}},
+			expected:     [][]bool{{true, true, true}, {false, false, true}},
+			expectedName: "command-filter: /test trigger",
+		},
+		{
+			name: "truncate-name",
+			body: `/test trigger
+fill in random content so that it exceeds the limit of 50 chars`,
+			presubmits: []config.Presubmit{
+				{
+					JobBase: config.JobBase{
+						Name: "trigger",
+					},
+					Trigger:      `(?m)^/test (?:.*? )?trigger(?: .*?)?$`,
+					RerunCommand: "/test trigger",
+				},
+			},
+			expected: [][]bool{{true, true, true}},
+			expectedName: `command-filter: /test trigger
+fill in random content so that it ex`,
 		},
 	}
 
@@ -153,9 +173,9 @@ func TestCommandFilter(t *testing.T) {
 			if err := config.SetPresubmitRegexes(testCase.presubmits); err != nil {
 				t.Fatalf("%s: could not set presubmit regexes: %v", testCase.name, err)
 			}
-			filter := CommandFilter(testCase.body)
+			filter := NewCommandFilter(testCase.body)
 			for i, presubmit := range testCase.presubmits {
-				actualFiltered, actualForced, actualDefault := filter(presubmit)
+				actualFiltered, actualForced, actualDefault := filter.ShouldRun(presubmit)
 				expectedFiltered, expectedForced, expectedDefault := testCase.expected[i][0], testCase.expected[i][1], testCase.expected[i][2]
 				if actualFiltered != expectedFiltered {
 					t.Errorf("%s: filter did not evaluate correctly, expected %v but got %v for %v", testCase.name, expectedFiltered, actualFiltered, presubmit.Name)
@@ -166,6 +186,9 @@ func TestCommandFilter(t *testing.T) {
 				if actualDefault != expectedDefault {
 					t.Errorf("%s: filter did not determine default correctly, expected %v but got %v for %v", testCase.name, expectedDefault, actualDefault, presubmit.Name)
 				}
+			}
+			if diff := cmp.Diff(testCase.expectedName, filter.Name()); diff != "" {
+				t.Errorf("Name mismatch. Want(-), got(+):\n%s", diff)
 			}
 		})
 	}
@@ -191,8 +214,10 @@ func TestFilterPresubmits(t *testing.T) {
 	}{
 		{
 			name: "nothing matches, nothing to run or skip",
-			filter: func(p config.Presubmit) (shouldRun bool, forcedToRun bool, defaultBehavior bool) {
-				return false, false, false
+			filter: &ArbitraryFilter{
+				override: func(p config.Presubmit) (shouldRun bool, forcedToRun bool, defaultBehavior bool) {
+					return false, false, false
+				},
 			},
 			presubmits: []config.Presubmit{{
 				JobBase:  config.JobBase{Name: "ignored"},
@@ -207,8 +232,10 @@ func TestFilterPresubmits(t *testing.T) {
 		},
 		{
 			name: "everything matches and is forced to run, nothing to skip",
-			filter: func(p config.Presubmit) (shouldRun bool, forcedToRun bool, defaultBehavior bool) {
-				return true, true, true
+			filter: &ArbitraryFilter{
+				override: func(p config.Presubmit) (shouldRun bool, forcedToRun bool, defaultBehavior bool) {
+					return true, true, true
+				},
 			},
 			presubmits: []config.Presubmit{{
 				JobBase:  config.JobBase{Name: "should-trigger"},
@@ -229,8 +256,10 @@ func TestFilterPresubmits(t *testing.T) {
 		},
 		{
 			name: "error detecting if something should run, nothing to run or skip",
-			filter: func(p config.Presubmit) (shouldRun bool, forcedToRun bool, defaultBehavior bool) {
-				return true, false, false
+			filter: &ArbitraryFilter{
+				override: func(p config.Presubmit) (shouldRun bool, forcedToRun bool, defaultBehavior bool) {
+					return true, false, false
+				},
 			},
 			presubmits: []config.Presubmit{{
 				JobBase:             config.JobBase{Name: "errors"},
@@ -246,8 +275,10 @@ func TestFilterPresubmits(t *testing.T) {
 		},
 		{
 			name: "error detecting if something should run, nothing to skip",
-			filter: func(p config.Presubmit) (shouldRun bool, forcedToRun bool, defaultBehavior bool) {
-				return true, false, false
+			filter: &ArbitraryFilter{
+				override: func(p config.Presubmit) (shouldRun bool, forcedToRun bool, defaultBehavior bool) {
+					return true, false, false
+				},
 			},
 			presubmits: []config.Presubmit{{
 				JobBase:             config.JobBase{Name: "errors"},
@@ -263,8 +294,10 @@ func TestFilterPresubmits(t *testing.T) {
 		},
 		{
 			name: "some things match and are forced to run, nothing to skip",
-			filter: func(p config.Presubmit) (shouldRun bool, forcedToRun bool, defaultBehavior bool) {
-				return p.Name == "should-trigger", true, true
+			filter: &ArbitraryFilter{
+				override: func(p config.Presubmit) (shouldRun bool, forcedToRun bool, defaultBehavior bool) {
+					return p.Name == "should-trigger", true, true
+				},
 			},
 			presubmits: []config.Presubmit{{
 				JobBase:  config.JobBase{Name: "should-trigger"},
@@ -282,8 +315,10 @@ func TestFilterPresubmits(t *testing.T) {
 		},
 		{
 			name: "everything matches and some things are forced to run, others should be skipped",
-			filter: func(p config.Presubmit) (shouldRun bool, forcedToRun bool, defaultBehavior bool) {
-				return true, p.Name == "should-trigger", p.Name == "should-trigger"
+			filter: &ArbitraryFilter{
+				override: func(p config.Presubmit) (shouldRun bool, forcedToRun bool, defaultBehavior bool) {
+					return true, p.Name == "should-trigger", p.Name == "should-trigger"
+				},
 			},
 			presubmits: []config.Presubmit{{
 				JobBase:  config.JobBase{Name: "should-trigger"},
@@ -310,8 +345,10 @@ func TestFilterPresubmits(t *testing.T) {
 		},
 		{
 			name: "everything matches and some that are forces to run supercede some that are skipped due to shared contexts",
-			filter: func(p config.Presubmit) (shouldRun bool, forcedToRun bool, defaultBehavior bool) {
-				return true, p.Name == "should-trigger", p.Name == "should-trigger"
+			filter: &ArbitraryFilter{
+				override: func(p config.Presubmit) (shouldRun bool, forcedToRun bool, defaultBehavior bool) {
+					return true, p.Name == "should-trigger", p.Name == "should-trigger"
+				},
 			},
 			presubmits: []config.Presubmit{{
 				JobBase:  config.JobBase{Name: "should-trigger"},
@@ -949,7 +986,7 @@ func TestPresubmitFilter(t *testing.T) {
 				t.Errorf("%s: expected no error creating the filter, but got one: %v", testCase.name, err)
 			}
 			for i, presubmit := range testCase.presubmits {
-				actualFiltered, actualForced, actualDefault := filter(presubmit)
+				actualFiltered, actualForced, actualDefault := filter.ShouldRun(presubmit)
 				expectedFiltered, expectedForced, expectedDefault := testCase.expected[i][0], testCase.expected[i][1], testCase.expected[i][2]
 				if actualFiltered != expectedFiltered {
 					t.Errorf("%s: filter did not evaluate correctly, expected %v but got %v for %v", testCase.name, expectedFiltered, actualFiltered, presubmit.Name)

--- a/prow/plugins/trigger/generic-comment_test.go
+++ b/prow/plugins/trigger/generic-comment_test.go
@@ -1464,9 +1464,9 @@ func TestRetestFilter(t *testing.T) {
 			if err := config.SetPresubmitRegexes(testCase.presubmits); err != nil {
 				t.Fatalf("%s: could not set presubmit regexes: %v", testCase.name, err)
 			}
-			filter := pjutil.RetestFilter(testCase.failedContexts, testCase.allContexts)
+			filter := pjutil.NewRetestFilter(testCase.failedContexts, testCase.allContexts)
 			for i, presubmit := range testCase.presubmits {
-				actualFiltered, actualForced, actualDefault := filter(presubmit)
+				actualFiltered, actualForced, actualDefault := filter.ShouldRun(presubmit)
 				expectedFiltered, expectedForced, expectedDefault := testCase.expected[i][0], testCase.expected[i][1], testCase.expected[i][2]
 				if actualFiltered != expectedFiltered {
 					t.Errorf("%s: filter did not evaluate correctly, expected %v but got %v for %v", testCase.name, expectedFiltered, actualFiltered, presubmit.Name)

--- a/prow/plugins/trigger/pull-request.go
+++ b/prow/plugins/trigger/pull-request.go
@@ -351,7 +351,7 @@ func buildAllButDrafts(c Client, pr *github.PullRequest, eventGUID string, baseS
 func buildAll(c Client, pr *github.PullRequest, eventGUID string, baseSHA string, presubmits []config.Presubmit) error {
 	org, repo, number, branch := pr.Base.Repo.Owner.Login, pr.Base.Repo.Name, pr.Number, pr.Base.Ref
 	changes := config.NewGitHubDeferredChangedFilesProvider(c.GitHubClient, org, repo, number)
-	toTest, err := pjutil.FilterPresubmits(pjutil.TestAllFilter(), changes, branch, presubmits, c.Logger)
+	toTest, err := pjutil.FilterPresubmits(pjutil.NewTestAllFilter(), changes, branch, presubmits, c.Logger)
 	if err != nil {
 		return err
 	}

--- a/prow/statusreconciler/controller.go
+++ b/prow/statusreconciler/controller.go
@@ -244,9 +244,9 @@ func (c *Controller) triggerNewPresubmits(addedPresubmits map[string][]config.Pr
 			// we want to appropriately trigger and skip from the set of identified presubmits that were
 			// added. we know all of the presubmits we are filtering need to be forced to run, so we can
 			// enforce that with a custom filter
-			filter := func(p config.Presubmit) (shouldRun bool, forcedToRun bool, defaultBehavior bool) {
+			filter := pjutil.NewArbitraryFilter(func(p config.Presubmit) (shouldRun bool, forcedToRun bool, defaultBehavior bool) {
 				return true, false, true
-			}
+			}, "inline-filter")
 			org, repo, number, branch := pr.Base.Repo.Owner.Login, pr.Base.Repo.Name, pr.Number, pr.Base.Ref
 			changes := config.NewGitHubDeferredChangedFilesProvider(c.githubClient, org, repo, number)
 			logger := log.WithFields(logrus.Fields{"org": org, "repo": repo, "number": number, "branch": branch})


### PR DESCRIPTION
These filter functions iterated inside a for loop without any identity attached to logger, makes it hard to debug. Converting it to an interface and add a Name() function so that we know why jobs were triggered