### PR TITLE
Enable `testfreeze` plugin for k/k

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -843,6 +843,7 @@ plugins:
     - size
     - skip
     - slackevents
+    - testfreeze
     - transfer-issue
     - trick-or-treat
     - trigger


### PR DESCRIPTION
As follow-up of https://github.com/kubernetes/test-infra/pull/25535, we now enable the testfreeze plugin in test-infra.
