### PR TITLE
Switch to go 1.18 for security-profiles-operator presubmits

### DIFF
--- a/config/jobs/kubernetes-sigs/security-profiles-operator/security-profiles-operator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/security-profiles-operator/security-profiles-operator-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
       testgrid-create-test-group: 'true'
     spec:
       containers:
-      - image: golang:1.17
+      - image: golang:1.18
         command:
         - hack/pull-security-profiles-operator-build
 
@@ -20,7 +20,7 @@ presubmits:
       testgrid-create-test-group: 'true'
     spec:
       containers:
-      - image: golang:1.17
+      - image: golang:1.18
         command:
         - hack/pull-security-profiles-operator-verify
 
@@ -32,7 +32,7 @@ presubmits:
       testgrid-create-test-group: 'true'
     spec:
       containers:
-      - image: golang:1.17
+      - image: golang:1.18
         command:
         - hack/pull-security-profiles-operator-test-unit
 


### PR DESCRIPTION
Updating the used go image version for those jobs to stay up-to-date.

/assign @pjbgf 