### PR TITLE
Revert "Revert "switch ci-kubernetes-e2e-ubuntu-gce-containerd to use new registry

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -538,6 +538,7 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    preset-use-new-registry: "true"
   spec:
     containers:
       - args:


### PR DESCRIPTION
This reverts commit dd154326d8e63bb9e55d0fad8904e3588067f897.

Let's try https://github.com/kubernetes/test-infra/pull/25616 once again :)

Signed-off-by: Davanum Srinivas <davanum@gmail.com>