### PR TITLE
fix image path for cs-fetch-repos-canary postsubmit

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-infra-tools.yaml
+++ b/config/jobs/image-pushing/k8s-staging-infra-tools.yaml
@@ -101,4 +101,4 @@ postsubmits:
               - --project=k8s-staging-infra-tools
               - --scratch-bucket=gs://k8s-staging-infra-tools-gcb
               - --env-passthrough=PULL_BASE_REF
-              - images/k8s-infra
+              - images/codesearch/cs-fetch-repos


### PR DESCRIPTION
Part of issue: https://github.com/kubernetes/k8s.io/issues/2182

This is a fix for the failing post-submit job ~ https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-k8sio-push-image-cs-fetch-repos-canary/1504388922468208640

cc: @ameukam