### PR TITLE
Enable the possibility of changing fixed 30s timeout in ghproxy

### DIFF
--- a/ghproxy/ghproxy_test.go
+++ b/ghproxy/ghproxy_test.go
@@ -45,6 +45,7 @@ func TestDiskCachePruning(t *testing.T) {
 		maxConcurrency:      25,
 		pushGatewayInterval: time.Minute,
 		upstreamParsed:      &url.URL{},
+		timeout:             30,
 	}
 
 	now := time.Now()


### PR DESCRIPTION
This commit allows changing fixed 30s timeout to a different value. Paged queries via v4 API
are treaded as continuous request and increasing timeout allows to throttle them more effectively.

Signed-off-by: Jakub Guzik <jguzik@redhat.com>