### PR TITLE
Add a ProwJob queue functionality to plank

### DIFF
--- a/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
@@ -519,9 +519,20 @@ spec:
               job:
                 description: Job is the name of the job
                 type: string
+              job_queue_name:
+                description: JobQueueName is an optional field with name of a queue
+                  defining max concurrency. When several jobs from the same queue
+                  try to run at the same time, the number of them that is actually
+                  started is limited by JobQueueConcurrencies (part of Plank's config).
+                  If this field is left undefined inifinite concurrency is assumed.
+                  This behaviour may be superseded by MaxConcurrency field, if it
+                  is set to a constraining value.
+                type: string
               max_concurrency:
                 description: MaxConcurrency restricts the total number of instances
-                  of this job that can run in parallel at once
+                  of this job that can run in parallel at once. This is a separate
+                  mechanism to JobQueueName and the lowest max concurrency is selected
+                  from these two.
                 minimum: 0
                 type: integer
               namespace:

--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -155,7 +155,9 @@ type ProwJobSpec struct {
 	// trigger this job on their pull request
 	RerunCommand string `json:"rerun_command,omitempty"`
 	// MaxConcurrency restricts the total number of instances
-	// of this job that can run in parallel at once
+	// of this job that can run in parallel at once. This is
+	// a separate mechanism to JobQueueName and the lowest max
+	// concurrency is selected from these two.
 	// +kubebuilder:validation:Minimum=0
 	MaxConcurrency int `json:"max_concurrency,omitempty"`
 	// ErrorOnEviction indicates that the ProwJob should be completed and given
@@ -196,6 +198,15 @@ type ProwJobSpec struct {
 	// ProwJobDefault holds configuration options provided as defaults
 	// in the Prow config
 	ProwJobDefault *ProwJobDefault `json:"prowjob_defaults,omitempty"`
+
+	// JobQueueName is an optional field with name of a queue defining
+	// max concurrency. When several jobs from the same queue try to run
+	// at the same time, the number of them that is actually started is
+	// limited by JobQueueConcurrencies (part of Plank's config). If
+	// this field is left undefined inifinite concurrency is assumed.
+	// This behaviour may be superseded by MaxConcurrency field, if it
+	// is set to a constraining value.
+	JobQueueName string `json:"job_queue_name,omitempty"`
 }
 
 type GitHubTeamSlug struct {

--- a/prow/config/inrepoconfig.go
+++ b/prow/config/inrepoconfig.go
@@ -228,10 +228,10 @@ func DefaultAndValidateProwYAML(c *Config, p *ProwYAML, identifier string) error
 	if err := defaultPostsubmits(p.Postsubmits, p.Presets, c, identifier); err != nil {
 		return err
 	}
-	if err := validatePresubmits(append(p.Presubmits, c.PresubmitsStatic[identifier]...), c.PodNamespace); err != nil {
+	if err := c.validatePresubmits(append(p.Presubmits, c.PresubmitsStatic[identifier]...)); err != nil {
 		return err
 	}
-	if err := validatePostsubmits(append(p.Postsubmits, c.PostsubmitsStatic[identifier]...), c.PodNamespace); err != nil {
+	if err := c.validatePostsubmits(append(p.Postsubmits, c.PostsubmitsStatic[identifier]...)); err != nil {
 		return err
 	}
 

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -128,6 +128,10 @@ type JobBase struct {
 	// ProwJobDefault holds configuration options provided as defaults
 	// in the Prow config
 	ProwJobDefault *prowapi.ProwJobDefault `json:"prowjob_defaults,omitempty"`
+	// Name of the job queue specifying maximum concurrency, omission implies no limit.
+	// Works in parallel with MaxConcurrency and the limit is selected from the
+	// minimal setting of those two fields.
+	JobQueueName string `json:"job_queue_name,omitempty"`
 
 	UtilityConfig
 }

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -963,6 +963,14 @@ plank:
                 # sidecar is the pull spec used for the sidecar utility
                 sidecar: ' '
 
+    # JobQueueConcurrencies is an optional field used to define job queue max concurrency.
+    # Each job can be assigned to a specific queue which has its own max concurrency,
+    # independent from the job's name. An example use case would be easier
+    # scheduling of jobs using boskos resources. This mechanism is separate from
+    # ProwJob's MaxConcurrency setting.
+    job_queue_capacities:
+        "": 0
+
     # JobURLPrefixConfig is the host and path prefix under which job details
     # will be viewable. Use `org/repo`, `org` or `*`as key and an url as value
     job_url_prefix_config:

--- a/prow/pjutil/pjutil.go
+++ b/prow/pjutil/pjutil.go
@@ -212,6 +212,7 @@ func specFromJobBase(jb config.JobBase) prowapi.ProwJobSpec {
 		RerunAuthConfig: jb.RerunAuthConfig,
 		Hidden:          jb.Hidden,
 		ProwJobDefault:  jb.ProwJobDefault,
+		JobQueueName:    jb.JobQueueName,
 	}
 }
 

--- a/prow/plank/controller_test.go
+++ b/prow/plank/controller_test.go
@@ -60,7 +60,7 @@ const (
 	podUnscheduledTimeout = time.Minute * 5
 )
 
-func newFakeConfigAgent(t *testing.T, maxConcurrency int) *fca {
+func newFakeConfigAgent(t *testing.T, maxConcurrency int, queueConcurrencies map[string]int) *fca {
 	presubmits := []config.Presubmit{
 		{
 			JobBase: config.JobBase{
@@ -97,6 +97,7 @@ func newFakeConfigAgent(t *testing.T, maxConcurrency int) *fca {
 						MaxConcurrency: maxConcurrency,
 						MaxGoroutines:  20,
 					},
+					JobQueueConcurrencies: queueConcurrencies,
 					PodPendingTimeout:     &metav1.Duration{Duration: podPendingTimeout},
 					PodRunningTimeout:     &metav1.Duration{Duration: podRunningTimeout},
 					PodUnscheduledTimeout: &metav1.Duration{Duration: podUnscheduledTimeout},
@@ -758,7 +759,7 @@ func TestSyncTriggeredJobs(t *testing.T) {
 				pjClient:     fakeProwJobClient,
 				buildClients: buildClients,
 				log:          logrus.NewEntry(logrus.StandardLogger()),
-				config:       newFakeConfigAgent(t, tc.MaxConcurrency).Config,
+				config:       newFakeConfigAgent(t, tc.MaxConcurrency, nil).Config,
 				totURL:       totServ.URL,
 				clock:        fakeClock,
 			}
@@ -1543,7 +1544,7 @@ func TestSyncPendingJob(t *testing.T) {
 				pjClient:     fakeProwJobClient,
 				buildClients: buildClients,
 				log:          logrus.NewEntry(logrus.StandardLogger()),
-				config:       newFakeConfigAgent(t, 0).Config,
+				config:       newFakeConfigAgent(t, 0, nil).Config,
 				totURL:       totServ.URL,
 				clock:        clock.RealClock{},
 			}
@@ -1620,7 +1621,7 @@ func TestPeriodic(t *testing.T) {
 		pjClient:     fakeProwJobClient,
 		buildClients: buildClients,
 		log:          log,
-		config:       newFakeConfigAgent(t, 0).Config,
+		config:       newFakeConfigAgent(t, 0, nil).Config,
 		totURL:       totServ.URL,
 		clock:        clock.RealClock{},
 	}
@@ -1854,7 +1855,7 @@ func TestMaxConcurrencyWithNewlyTriggeredJobs(t *testing.T) {
 				&indexingClient{
 					Client:     fakeProwJobClient,
 					indexFuncs: map[string]ctrlruntimeclient.IndexerFunc{prowJobIndexName: prowJobIndexer("prowjobs")},
-				}, nil, newFakeConfigAgent(t, 0).Config, nil, "")
+				}, nil, newFakeConfigAgent(t, 0, nil).Config, nil, "")
 			r.buildClients = buildClients
 			for _, job := range test.PJs {
 				request := reconcile.Request{NamespacedName: types.NamespacedName{
@@ -1878,11 +1879,17 @@ func TestMaxConcurrencyWithNewlyTriggeredJobs(t *testing.T) {
 }
 
 func TestMaxConcurency(t *testing.T) {
+	type pendingJob struct {
+		Duplicates int
+		JobQueue   string
+	}
+
 	type testCase struct {
-		Name             string
-		ProwJob          prowapi.ProwJob
-		ExistingProwJobs []prowapi.ProwJob
-		PendingJobs      map[string]int
+		Name                  string
+		JobQueueConcurrencies map[string]int
+		ProwJob               prowapi.ProwJob
+		ExistingProwJobs      []prowapi.ProwJob
+		PendingJobs           map[string]pendingJob
 
 		ExpectedResult bool
 	}
@@ -1898,8 +1905,10 @@ func TestMaxConcurency(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.Now()},
 				Spec: prowapi.ProwJobSpec{
 					MaxConcurrency: 10,
-					Job:            "my-pj"}},
-			PendingJobs:    map[string]int{"my-pj": 10},
+					Job:            "my-pj",
+				},
+			},
+			PendingJobs:    map[string]pendingJob{"my-pj": {Duplicates: 10}},
 			ExpectedResult: false,
 		},
 		{
@@ -1910,7 +1919,8 @@ func TestMaxConcurency(t *testing.T) {
 				},
 				Spec: prowapi.ProwJobSpec{
 					MaxConcurrency: 10,
-					Job:            "my-pj"},
+					Job:            "my-pj",
+				},
 			},
 			ExistingProwJobs: []prowapi.ProwJob{
 				{
@@ -1918,9 +1928,10 @@ func TestMaxConcurency(t *testing.T) {
 					Spec:       prowapi.ProwJobSpec{Agent: prowapi.KubernetesAgent, Job: "my-pj"},
 					Status: prowapi.ProwJobStatus{
 						State: prowapi.TriggeredState,
-					}},
+					},
+				},
 			},
-			PendingJobs:    map[string]int{"my-pj": 9},
+			PendingJobs:    map[string]pendingJob{"my-pj": {Duplicates: 9}},
 			ExpectedResult: false,
 		},
 		{
@@ -1931,16 +1942,18 @@ func TestMaxConcurency(t *testing.T) {
 				},
 				Spec: prowapi.ProwJobSpec{
 					MaxConcurrency: 10,
-					Job:            "my-pj"},
+					Job:            "my-pj",
+				},
 			},
 			ExistingProwJobs: []prowapi.ProwJob{
 				{
 					Spec: prowapi.ProwJobSpec{Job: "my-pj"},
 					Status: prowapi.ProwJobStatus{
 						State: prowapi.TriggeredState,
-					}},
+					},
+				},
 			},
-			PendingJobs:    map[string]int{"my-pj": 10},
+			PendingJobs:    map[string]pendingJob{"my-pj": {Duplicates: 10}},
 			ExpectedResult: false,
 		},
 		{
@@ -1948,7 +1961,8 @@ func TestMaxConcurency(t *testing.T) {
 			ProwJob: prowapi.ProwJob{
 				Spec: prowapi.ProwJobSpec{
 					MaxConcurrency: 1,
-					Job:            "my-pj"},
+					Job:            "my-pj",
+				},
 			},
 			ExistingProwJobs: []prowapi.ProwJob{
 				{
@@ -1958,7 +1972,8 @@ func TestMaxConcurency(t *testing.T) {
 					Spec: prowapi.ProwJobSpec{Job: "my-pj"},
 					Status: prowapi.ProwJobStatus{
 						State: prowapi.TriggeredState,
-					}},
+					},
+				},
 			},
 			ExpectedResult: true,
 		},
@@ -1970,25 +1985,46 @@ func TestMaxConcurency(t *testing.T) {
 				},
 				Spec: prowapi.ProwJobSpec{
 					MaxConcurrency: 2,
-					Job:            "my-pj"},
+					Job:            "my-pj",
+				},
 			},
 			ExistingProwJobs: []prowapi.ProwJob{
 				{
 					Spec: prowapi.ProwJobSpec{Job: "my-pj"},
 					Status: prowapi.ProwJobStatus{
 						CompletionTime: &[]metav1.Time{{}}[0],
-					}},
+					},
+				},
 			},
-			PendingJobs:    map[string]int{"my-pj": 1},
+			PendingJobs:    map[string]pendingJob{"my-pj": {Duplicates: 1}},
 			ExpectedResult: true,
+		},
+		{
+			Name:                  "Job queue concurency 0 always runs",
+			ProwJob:               prowapi.ProwJob{Spec: prowapi.ProwJobSpec{JobQueueName: "queue"}},
+			JobQueueConcurrencies: map[string]int{"queue": 0},
+			ExpectedResult:        true,
+		},
+		{
+			Name: "Num pending within max concurrency but exceeds job queue concurrency",
+			ProwJob: prowapi.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.Now()},
+				Spec: prowapi.ProwJobSpec{
+					MaxConcurrency: 100,
+					Job:            "my-pj",
+					JobQueueName:   "queue",
+				},
+			},
+			JobQueueConcurrencies: map[string]int{"queue": 10},
+			PendingJobs:           map[string]pendingJob{"my-pj": {Duplicates: 10, JobQueue: "queue"}},
+			ExpectedResult:        false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-
 			if tc.PendingJobs == nil {
-				tc.PendingJobs = map[string]int{}
+				tc.PendingJobs = map[string]pendingJob{}
 			}
 			buildClients := map[string]ctrlruntimeclient.Client{}
 			logrus.SetLevel(logrus.DebugLevel)
@@ -1998,16 +2034,17 @@ func TestMaxConcurency(t *testing.T) {
 				tc.ExistingProwJobs[i].Namespace = "prowjobs"
 				prowJobs = append(prowJobs, &tc.ExistingProwJobs[i])
 			}
-			for jobName, numJobsToCreate := range tc.PendingJobs {
-				for i := 0; i < numJobsToCreate; i++ {
+			for jobName, jobsToCreateParams := range tc.PendingJobs {
+				for i := 0; i < jobsToCreateParams.Duplicates; i++ {
 					prowJobs = append(prowJobs, &prowapi.ProwJob{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      fmt.Sprintf("%s-%d", jobName, i),
 							Namespace: "prowjobs",
 						},
 						Spec: prowapi.ProwJobSpec{
-							Agent: prowapi.KubernetesAgent,
-							Job:   jobName,
+							Agent:        prowapi.KubernetesAgent,
+							Job:          jobName,
+							JobQueueName: jobsToCreateParams.JobQueue,
 						},
 						Status: prowapi.ProwJobStatus{
 							State: prowapi.PendingState,
@@ -2022,7 +2059,7 @@ func TestMaxConcurency(t *testing.T) {
 				},
 				buildClients: buildClients,
 				log:          logrus.NewEntry(logrus.StandardLogger()),
-				config:       newFakeConfigAgent(t, 0).Config,
+				config:       newFakeConfigAgent(t, 0, tc.JobQueueConcurrencies).Config,
 				clock:        clock.RealClock{},
 			}
 			// We filter ourselves out via the UID, so make sure its not the empty string


### PR DESCRIPTION
Allow jobs to be aggregated in a queue that secures concurrent execution. This can be especially useful when coupled with boskos pools. Fixes https://github.com/kubernetes/test-infra/issues/21996.