### PR TITLE
Embed config.go file in hook instead of load them at run time

### DIFF
--- a/pkg/genyaml/README.md
+++ b/pkg/genyaml/README.md
@@ -157,7 +157,7 @@ config := &example.Configuration{
 }
 
 // Initialize a CommentMap instance from the `config.go` source file:
-cm, err := genyaml.NewCommentMap("config.go")
+cm, err := genyaml.NewCommentMap(nil, "config.go")
 
 // Generate a commented YAML snippet:
 yamlSnippet, err := cm.GenYaml(config)

--- a/pkg/genyaml/genyaml.go
+++ b/pkg/genyaml/genyaml.go
@@ -95,20 +95,40 @@ type CommentMap struct {
 	sync.RWMutex
 }
 
-// NewCommentMap is the constructor for CommentMap accepting a variadic number of paths.
-func NewCommentMap(paths ...string) (*CommentMap, error) {
+// NewCommentMap is the constructor for CommentMap accepting a variadic number
+// of path and raw files contents.
+func NewCommentMap(rawFiles map[string][]byte, paths ...string) (*CommentMap, error) {
 	cm := &CommentMap{
 		comments: make(map[string]map[string]Comment),
 	}
 
-	packageFiles := map[string][]string{}
+	// Group files in dir assuming they are from the same package, this
+	// technically doesn't hold true all the time, but is the best effort to
+	// ensure that generated yamls are from the same package.
+	type group struct {
+		paths       []string
+		rawContents map[string][]byte
+	}
+
+	packageFiles := map[string]*group{}
 	for _, path := range paths {
 		dir := filepath.Dir(path)
-		packageFiles[dir] = append(packageFiles[dir], path)
+		if _, ok := packageFiles[dir]; !ok {
+			packageFiles[dir] = &group{}
+		}
+		packageFiles[dir].paths = append(packageFiles[dir].paths, path)
+	}
+
+	for path, content := range rawFiles {
+		dir := filepath.Dir(path)
+		if _, ok := packageFiles[dir]; !ok {
+			packageFiles[dir] = &group{}
+		}
+		packageFiles[dir].rawContents = map[string][]byte{path: content}
 	}
 
 	for pkg, files := range packageFiles {
-		if err := cm.addPackage(files); err != nil {
+		if err := cm.addPackage(files.paths, files.rawContents); err != nil {
 			return nil, fmt.Errorf("failed to add files in %s: %w", pkg, err)
 		}
 	}
@@ -159,8 +179,9 @@ func jsonToYaml(j []byte) ([]byte, error) {
 	return yaml3.Marshal(jsonObj)
 }
 
-// astFrom takes a path to a Go file and returns the abstract syntax tree (AST) for that file.
-func astFrom(paths []string) (*doc.Package, error) {
+// astFrom takes paths of Go files, or the content of Go files,
+// returns the abstract syntax tree (AST) for that file.
+func astFrom(paths []string, rawFiles map[string][]byte) (*doc.Package, error) {
 	fset := token.NewFileSet()
 	m := make(map[string]*ast.File)
 
@@ -170,6 +191,13 @@ func astFrom(paths []string) (*doc.Package, error) {
 			return nil, fmt.Errorf("unable to parse file to AST from path %s: %w", file, err)
 		}
 		m[file] = f
+	}
+	for fn, content := range rawFiles {
+		f, err := parser.ParseFile(fset, fn, content, parser.ParseComments)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse file to AST from raw content %s: %w", fn, err)
+		}
+		m[fn] = f
 	}
 
 	// Copied from the go doc command: https://github.com/golang/go/blob/fc116b69e2004c159d0f2563c6e91ac75a79f872/src/go/doc/doc.go#L203
@@ -287,8 +315,8 @@ func getType(typ interface{}) string {
 }
 
 // genDocMap extracts the name of the field as it should appear in YAML format and returns the resultant string.
-func (cm *CommentMap) genDocMap(packageFiles []string) error {
-	pkg, err := astFrom(packageFiles)
+func (cm *CommentMap) genDocMap(packageFiles []string, rawFiles map[string][]byte) error {
+	pkg, err := astFrom(packageFiles, rawFiles)
 	if err != nil {
 		return fmt.Errorf("unable to generate AST documentation map: %w", err)
 	}
@@ -412,11 +440,11 @@ func (cm *CommentMap) PrintComments() {
 }
 
 // addPackage allow for adding to the CommentMap via a list of paths to go files in the same package
-func (cm *CommentMap) addPackage(paths []string) error {
+func (cm *CommentMap) addPackage(paths []string, rawFiles map[string][]byte) error {
 	cm.Lock()
 	defer cm.Unlock()
 
-	err := cm.genDocMap(paths)
+	err := cm.genDocMap(paths, rawFiles)
 	if err != nil {
 		return err
 	}

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -7594,7 +7594,7 @@ func TestGenYamlDocs(t *testing.T) {
 	}
 	inputFiles = append(inputFiles, prowapiInputFiles...)
 
-	commentMap, err := genyaml.NewCommentMap(inputFiles...)
+	commentMap, err := genyaml.NewCommentMap(nil, inputFiles...)
 	if err != nil {
 		t.Fatalf("failed to construct commentMap: %v", err)
 	}

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -18,6 +18,7 @@ package plugins
 
 import (
 	"context"
+	_ "embed"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -61,7 +62,12 @@ var (
 	reviewEventHandlers        = map[string]ReviewEventHandler{}
 	reviewCommentEventHandlers = map[string]ReviewCommentEventHandler{}
 	statusEventHandlers        = map[string]StatusEventHandler{}
-	CommentMap, _              = genyaml.NewCommentMap()
+	// CommentMap is used by many plugins for printing help messages defined in
+	// config.go.
+	CommentMap, _ = genyaml.NewCommentMap(nil)
+
+	//go:embed config.go
+	embededConfigGoFileContent []byte
 )
 
 func init() {
@@ -72,7 +78,8 @@ func init() {
 	if version.Name != "hook" {
 		return
 	}
-	if cm, err := genyaml.NewCommentMap("prow/plugins/config.go"); err == nil {
+
+	if cm, err := genyaml.NewCommentMap(map[string][]byte{"prow/plugins/config.go": embededConfigGoFileContent}); err == nil {
 		CommentMap = cm
 	} else {
 		logrus.WithError(err).Error("Failed to initialize commentMap")

--- a/prow/plugins/plugins_test.go
+++ b/prow/plugins/plugins_test.go
@@ -30,6 +30,12 @@ import (
 	"k8s.io/test-infra/pkg/genyaml"
 )
 
+func TestEnsureEmbed(t *testing.T) {
+	if len(embededConfigGoFileContent) == 0 {
+		t.Error("EmbededConfigGoFileContent is empty.")
+	}
+}
+
 func TestHasSelfApproval(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -231,7 +237,7 @@ func TestGenYamlDocs(t *testing.T) {
 		t.Fatalf("filepath.Glob: %v", err)
 	}
 
-	commentMap, err := genyaml.NewCommentMap(inputFiles...)
+	commentMap, err := genyaml.NewCommentMap(nil, inputFiles...)
 	if err != nil {
 		t.Fatalf("failed to construct commentMap: %v", err)
 	}


### PR DESCRIPTION
Expecting a Go file to be present next to the binary file of hook is not a safe assumption, embedding them so that there is no floating deps.

The loading logic invokes `os.Readfile` from `parser` package as of Go1.18 https://cs.opensource.google/go/go/+/refs/tags/go1.18:src/go/parser/interface.go;l=42;drc=refs%2Ftags%2Fgo1.18, so passing in embedded filesystem doesn't work. Luckily raw content is supported at https://cs.opensource.google/go/go/+/refs/tags/go1.18:src/go/parser/interface.go;l=26;drc=refs%2Ftags%2Fgo1.18