### PR TITLE
set owners on the experiment folder

### DIFF
--- a/experiment/OWNERS
+++ b/experiment/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+- aojea
+approvers:
+- aojea


### PR DESCRIPTION
I've just found this sweat spot and is being successfully used for network jobs that use kind, without having to add knobs to kind itself

https://github.com/kubernetes/test-infra/blob/master/experiment/kind-multizone-e2e.sh

Since top approvers use to be busy I'd like to add myself as approver here so we can move forward faster, per example

https://github.com/kubernetes/test-infra/pull/25606