### PR TITLE
update ingress-nginx deployment for integration tests and fix readme

### DIFF
--- a/prow/test/integration/README.md
+++ b/prow/test/integration/README.md
@@ -16,8 +16,9 @@ This script would [setup](#setup) the environment, [run](#run-test) all the avai
 * [Create a local cluster](setup-cluster.sh) using [kind](https://kind.sigs.k8s.io/).
 * Wait for prow components to be ready.
 
+In order to set up the cluster, run the integration tests, and **not** teardown the cluster after use:
 ```bash
-./prow/test/integration/integration-test.sh setup
+SKIP_TEARDOWN=true ./prow/test/integration/integration-test.sh
 ```
 
 ## Run test
@@ -35,10 +36,10 @@ Optional parameters:
 
 ## Cleanup
 
-Delete the local cluster and the local registry.
+If the local cluster exists, run the tests and then delete the local cluster and the local registry by using:
 
 ```bash
-./prow/test/integration/integration-test.sh teardown
+SKIP_SETUP=true ./prow/test/integration/integration-test.sh
 ```
 
 # Add new integration tests

--- a/prow/test/integration/setup-cluster.sh
+++ b/prow/test/integration/setup-cluster.sh
@@ -97,8 +97,8 @@ data:
 EOF
 
   echo "Install nginx on kind cluster"
-  # Pin the ingress-nginx manifest to 8b99f49d2d9c042355da9e53c2648bd0c049ae52 (Release 0.41.2) on 11/22/2020
-  do-kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/8b99f49d2d9c042355da9e53c2648bd0c049ae52/deploy/static/provider/kind/deploy.yaml
+  # Pin the ingress-nginx manifest to fb72fcd81772fb3eca923897aec2d92fa5bdff41 (Release 1.1.2) on 3/18/2022
+  do-kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/fb72fcd81772fb3eca923897aec2d92fa5bdff41/deploy/static/provider/kind/deploy.yaml
 }
 
 function deploy_prow() {


### PR DESCRIPTION
Version `0.41.2` of `ingress-nginx` doesn't support kubernetes versions `1.22.x` or `1.23.x`. Consequently, these tests would not succeed locally with those versions installed.

Some time ago, the `integration-test.sh` script was updated, and the `setup` and `teardown` args are no longer relevant. I updated the readme to suggest the actual commands for setting up and tearing down the local cluster.