### PR TITLE
Bump Kueue tests to go1.18

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
       description: "Run kueue unit tests"
     spec:
       containers:
-      - image: golang:1.17
+      - image: golang:1.18
         env:
         - name: GO_TEST_FLAGS
           value: "-race -count 3"
@@ -28,7 +28,7 @@ presubmits:
       description: "Run kueue test-integration"
     spec:
       containers:
-      - image: golang:1.17
+      - image: golang:1.18
         command:
         - make
         args:
@@ -43,7 +43,7 @@ presubmits:
       description: "Run kueue verify checks"
     spec:
       containers:
-      - image: golang:1.17
+      - image: golang:1.18
         command:
         - make
         args:


### PR DESCRIPTION
Followup PR on repo -> https://github.com/kubernetes-sigs/kueue/pull/122

Note:
https://github.com/golangci/golangci-lint/releases/tag/v1.45.0 adds support for go1.18, we are good to go


Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>