### PR TITLE
Add yq to kubekins-e2e

### DIFF
--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -70,6 +70,11 @@ RUN wget -q "https://storage.googleapis.com/golang/${GO_TARBALL}" && \
     tar xzf "${GO_TARBALL}" -C /usr/local && \
     rm "${GO_TARBALL}"
 
+# install yq
+ARG YQ_VERSION
+RUN wget -q "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
+    -O /usr/local/bin/yq && chmod +x /usr/local/bin/yq
+
 # install bazel
 ARG BAZEL_VERSION_ARG
 ENV BAZEL_VERSION=${BAZEL_VERSION_ARG}

--- a/images/kubekins-e2e/cloudbuild.yaml
+++ b/images/kubekins-e2e/cloudbuild.yaml
@@ -26,6 +26,7 @@ steps:
     - --build-arg=UPGRADE_DOCKER_ARG=$_UPGRADE_DOCKER
     - --build-arg=KIND_VERSION=$_KIND_VERSION
     - --build-arg=KUBETEST2_VERSION=$_KUBETEST2_VERSION
+    - --build-arg=YQ_VERSION=$_YQ_VERSION
     - -f
     - images/kubekins-e2e/Dockerfile
     - .
@@ -47,6 +48,7 @@ substitutions:
   _UPGRADE_DOCKER: 'false'
   _KIND_VERSION: ''
   _KUBETEST2_VERSION: ''
+  _YQ_VERSION: v4.23.1
 options:
   substitution_option: ALLOW_LOOSE
 images:


### PR DESCRIPTION
We use [yq](https://github.com/mikefarah/yq) in increasing number of scripts. Instead of installing it manually each time via `go install ...` it'd be more useful to have this available within the container context.

/cc @jprzychodzen 