### PR TITLE
Set detect-local-node-cidr testgrid tab name

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
@@ -675,6 +675,6 @@ periodics:
           memory: 9Gi
   annotations:
     testgrid-dashboards: sig-network-kind
-    testgrid-tab-name: sig-network-kind
+    testgrid-tab-name: sig-network-kind, detect-local-node-cidr
     description: Runs network tests using KIND against latest kubernetes master with a kubernetes-in-docker cluster and kube-proxy detectLocalMode=NodeCIDR
     testgrid-alert-email: antonio.ojea.garcia@gmail.com, widaly@microsoft.com


### PR DESCRIPTION
Add "detect-local-node-cidr" testgrid-tab-name for experimental
CI job ci-kubernetes-kind-network-detect-local-node-cidr so it
shows up in the testgrid dashboard.

Followup from https://github.com/kubernetes/test-infra/pull/25606#discussion_r830905406

I can see that the test is running, but it's listed under the tab "sig-network-kind", which isn't very descriptive: 
<img width="622" alt="image" src="https://user-images.githubusercontent.com/2948394/159305733-a68f06bd-def8-4041-b4e7-58bc31b5c431.png">
