### PR TITLE
Add preset-use-new-registry label to generated tests generator

### DIFF
--- a/releng/generate_tests.py
+++ b/releng/generate_tests.py
@@ -40,6 +40,7 @@ PROW_CONFIG_TEMPLATE = """
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
+      preset-use-new-registry: "true"
     name:
     spec:
       containers:


### PR DESCRIPTION
Ensures tests that will be generated next will use registry.k8s.io

Related: https://github.com/kubernetes-sigs/oci-proxy/issues/29