### PR TITLE
Improve CRI-O serial ignition

### DIFF
--- a/jobs/e2e_node/crio/crio_cgrpv2_serial.ign
+++ b/jobs/e2e_node/crio/crio_cgrpv2_serial.ign
@@ -16,17 +16,17 @@
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Copy authorized keys\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c '/usr/bin/mkdir -p /home/prow/.ssh && /usr/bin/cat /etc/ssh-key-secret/ssh-public >> /home/prow/.ssh/authorized_keys'\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Copy authorized keys\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c '/usr/bin/mkdir -m 0700 -p /home/prow/.ssh && /usr/bin/cat /etc/ssh-key-secret/ssh-public >> /home/prow/.ssh/authorized_keys && chown -R prow:prow /home/prow/.ssh && chmod 0600 /home/prow/.ssh/authorized_keys'\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "authorized-key.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install dbus-tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/rpm-ostree install --apply-live --allow-inactive dbus-tools\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install dbus-tools.\nBefore=crio-install.service\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/rpm-ostree install --apply-live --allow-inactive dbus-tools\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "dbus-tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /usr/local/crio-nodee2e-installer.sh  https://raw.githubusercontent.com/cri-o/cri-o/74583d26406963ba150004f343bc36c16a861164/scripts/node_e2e_installer'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /usr/local/crio-nodee2e-installer.sh  https://raw.githubusercontent.com/cri-o/cri-o/74583d26406963ba150004f343bc36c16a861164/scripts/node_e2e_installer'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }
@@ -36,7 +36,8 @@
     "users": [
       {
         "name": "prow",
-        "system": true
+        "system": true,
+        "groups": ["sudo"]
       }
     ]
   }

--- a/jobs/e2e_node/crio/crio_serial.ign
+++ b/jobs/e2e_node/crio/crio_serial.ign
@@ -21,17 +21,17 @@
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Copy authorized keys\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c '/usr/bin/mkdir -p /home/prow/.ssh && /usr/bin/cat /etc/ssh-key-secret/ssh-public >> /home/prow/.ssh/authorized_keys'\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Copy authorized keys\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c '/usr/bin/mkdir -m 0700 -p /home/prow/.ssh && /usr/bin/cat /etc/ssh-key-secret/ssh-public >> /home/prow/.ssh/authorized_keys && chown -R prow:prow /home/prow/.ssh && chmod 0600 /home/prow/.ssh/authorized_keys'\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "authorized-key.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install dbus-tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/rpm-ostree install --apply-live --allow-inactive dbus-tools\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install dbus-tools.\nBefore=crio-install.service\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/rpm-ostree install --apply-live --allow-inactive dbus-tools\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "dbus-tools-install.service"
       },
       {
-        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /usr/local/crio-nodee2e-installer.sh  https://raw.githubusercontent.com/cri-o/cri-o/74583d26406963ba150004f343bc36c16a861164/scripts/node_e2e_installer'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /usr/local/crio-nodee2e-installer.sh  https://raw.githubusercontent.com/cri-o/cri-o/74583d26406963ba150004f343bc36c16a861164/scripts/node_e2e_installer'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "crio-install.service"
       }
@@ -41,7 +41,8 @@
     "users": [
       {
         "name": "prow",
-        "system": true
+        "system": true,
+        "groups": ["sudo"]
       }
     ]
   }


### PR DESCRIPTION
This patch contains a bunch of fixes for the serial CRI-O tests by
modifying its ignition:

- Fix the permissions for the ssh keys when copying them into the prow
  user directory.
- Allow prow user to run sudo
- Wait for DNS to be available when running the dbus and CRI-O systemd
  units.

Related to https://github.com/kubernetes/test-infra/issues/24798