### PR TITLE
Also wait for node pool operations

### DIFF
--- a/kubetest/gke.go
+++ b/kubetest/gke.go
@@ -902,7 +902,7 @@ func (g *gkeDeployer) Down() error {
 
 	operationNameBytes, err := control.Output(exec.Command(
 		"gcloud", g.containerArgs("operations", "list", "--project="+g.project,
-			g.location, "--format=value(name)", fmt.Sprintf("--filter=(status=RUNNING AND targetLink ~ /clusters/%s$)", g.cluster))...))
+			g.location, "--format=value(name)", fmt.Sprintf("--filter=(status=RUNNING AND (targetLink ~ /clusters/%s$ OR targetLink ~ /clusters/%s/))", g.cluster, g.cluster))...))
 	if err != nil {
 		return fmt.Errorf("failed to list RUNNING operations for cluster %s: %w", g.cluster, err)
 	}


### PR DESCRIPTION
Examples of targetLink:
* locations/us-central1/clusters/cluster-name
* locations/us-central1/clusters/cluster-name/nodePools/node-pool1

The goal is to catch the second case as well.

/hold let me validate this manually

/assign @wojtek-t 