### PR TITLE
releng: update kubekins/krte to Go 1.18

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.17.8
+    GO_VERSION: 1.18
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
@@ -9,7 +9,7 @@ variants:
     UPGRADE_DOCKER: 'true'
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.18rc1
+    GO_VERSION: 1.18
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
@@ -22,7 +22,7 @@ variants:
     KIND_VERSION: 0.10.0
   master:
     CONFIG: master
-    GO_VERSION: 1.17.8
+    GO_VERSION: 1.18
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
Update kubekins/krte to Go 1.18 

xref https://github.com/kubernetes/release/issues/2307

/assign @saschagrunert @xmudrii @puerco @palnabarun @justaugustus @BenTheElder
cc https://github.com/orgs/kubernetes/teams/release-engineering