### PR TITLE
chore: Skip running tests for doc changes

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-v2-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-v2-config.yaml
@@ -28,6 +28,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-unit-mainv2
     decorate: true
+    skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     always_run: true
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
@@ -51,6 +52,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-sanity-mainv2
     decorate: true
+    skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     always_run: true
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
@@ -79,6 +81,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-integration-mainv2
     decorate: true
+    skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     always_run: true
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
@@ -107,6 +110,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-single-az-mainv2
     decorate: true
+    skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     decoration_config:
       timeout: 3h
     always_run: true
@@ -161,6 +165,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-multi-az-mainv2
     decorate: true
+    skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     decoration_config:
       timeout: 3h
     always_run: true
@@ -216,6 +221,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-migration-mainv2
     decorate: true
+    skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     decoration_config:
       timeout: 3h
     always_run: true
@@ -272,6 +278,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-migration-windows-mainv2
     decorate: true
+    skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     decoration_config:
       timeout: 3h
     always_run: true
@@ -392,6 +399,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-windows-build-mainv2
     decorate: true
+    skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     always_run: true
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:

--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-v2-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-v2-config.yaml
@@ -29,7 +29,6 @@ presubmits:
   - name: pull-azuredisk-csi-driver-unit-mainv2
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-    always_run: true
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
     - main_v2
@@ -53,7 +52,6 @@ presubmits:
   - name: pull-azuredisk-csi-driver-sanity-mainv2
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-    always_run: true
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
     - main_v2
@@ -82,7 +80,6 @@ presubmits:
   - name: pull-azuredisk-csi-driver-integration-mainv2
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-    always_run: true
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
     - main_v2
@@ -113,7 +110,6 @@ presubmits:
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     decoration_config:
       timeout: 3h
-    always_run: true
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
     - main_v2
@@ -168,7 +164,6 @@ presubmits:
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     decoration_config:
       timeout: 3h
-    always_run: true
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
     - main_v2
@@ -224,7 +219,6 @@ presubmits:
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     decoration_config:
       timeout: 3h
-    always_run: true
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
     - main_v2
@@ -281,7 +275,6 @@ presubmits:
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     decoration_config:
       timeout: 3h
-    always_run: true
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
     - main_v2
@@ -400,7 +393,6 @@ presubmits:
   - name: pull-azuredisk-csi-driver-windows-build-mainv2
     decorate: true
     skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-    always_run: true
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     branches:
     - main_v2


### PR DESCRIPTION
Skip the test runs on main_v2 branch of azuredisk CSI driver when there's only doc changes in the PR