### PR TITLE
add periodic-k8sio-deploy-app-codesearch job

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-apps-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-apps-periodics.yaml
@@ -18,8 +18,8 @@ periodics:
         command:
           - ./apps/codesearch/deploy.sh
     annotations:
-      testgrid-create-test-group: 'true'
       testgrid-dashboards: sig-k8s-infra-apps
+      testgrid-tab-name: periodic-deploy-codesearch
       testgrid-description: 'runs https://git.k8s.io/k8s.io/apps/codesearch/deploy.sh daily in kubernetes/k8s.io/apps/codesearch'
       testgrid-alert-email: k8s-infra-rbac-codesearch@kubernetes.io, k8s-infra-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '2'

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-apps-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-apps-periodics.yaml
@@ -11,15 +11,16 @@ periodics:
       - aborted
       - error
       report_template: 'Deploying codesearch: {{.Status.State}}. <{{.Status.URL}}|Spyglass> | <https://testgrid.k8s.io/sig-k8s-infra-apps#deploy-codesearch|Testgrid> | <https://prow.k8s.io/?job={{.Spec.Job}}|Deck>'
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: sig-k8s-infra-apps
+    testgrid-tab-name: periodic-deploy-codesearch
+    testgrid-description: 'runs https://git.k8s.io/k8s.io/apps/codesearch/deploy.sh daily in kubernetes/k8s.io/apps/codesearch'
+    testgrid-alert-email: k8s-infra-rbac-codesearch@kubernetes.io, k8s-infra-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: '2'
   spec:
     serviceAccountName: prow-deployer
     containers:
       - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
         command:
           - ./apps/codesearch/deploy.sh
-    annotations:
-      testgrid-dashboards: sig-k8s-infra-apps
-      testgrid-tab-name: periodic-deploy-codesearch
-      testgrid-description: 'runs https://git.k8s.io/k8s.io/apps/codesearch/deploy.sh daily in kubernetes/k8s.io/apps/codesearch'
-      testgrid-alert-email: k8s-infra-rbac-codesearch@kubernetes.io, k8s-infra-alerts@kubernetes.io
-      testgrid-num-failures-to-alert: '2'

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-apps-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-apps-periodics.yaml
@@ -20,7 +20,6 @@ periodics:
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: sig-k8s-infra-apps
-      testgrid-tab-name: periodic-deploy-codesearch
       testgrid-description: 'runs https://git.k8s.io/k8s.io/apps/codesearch/deploy.sh daily in kubernetes/k8s.io/apps/codesearch'
       testgrid-alert-email: k8s-infra-rbac-codesearch@kubernetes.io, k8s-infra-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '2'

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-apps-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-apps-periodics.yaml
@@ -15,7 +15,7 @@ periodics:
     serviceAccountName: prow-deployer
     containers:
       - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
-          command:
+        command:
           - ./apps/codesearch/deploy.sh
     annotations:
       testgrid-create-test-group: 'true'

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-apps-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-apps-periodics.yaml
@@ -1,0 +1,26 @@
+periodics:
+- name: periodic-k8sio-deploy-app-codesearch
+  cluster: k8s-infra-prow-build-trusted
+  interval: 24h
+  decorate: true
+  reporter_config:
+    slack:
+      channel: "k8s-infra-alerts"
+      job_states_to_report:
+      - failure
+      - aborted
+      - error
+      report_template: 'Deploying codesearch: {{.Status.State}}. <{{.Status.URL}}|Spyglass> | <https://testgrid.k8s.io/sig-k8s-infra-apps#deploy-codesearch|Testgrid> | <https://prow.k8s.io/?job={{.Spec.Job}}|Deck>'
+  spec:
+    serviceAccountName: prow-deployer
+    containers:
+      - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
+          command:
+          - ./apps/codesearch/deploy.sh
+    annotations:
+      testgrid-create-test-group: 'true'
+      testgrid-dashboards: sig-k8s-infra-apps
+      testgrid-tab-name: periodic-deploy-codesearch
+      testgrid-description: 'runs https://git.k8s.io/k8s.io/apps/codesearch/deploy.sh daily in kubernetes/k8s.io/apps/codesearch'
+      testgrid-alert-email: k8s-infra-rbac-codesearch@kubernetes.io, k8s-infra-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '2'


### PR DESCRIPTION
## Resolves:
* https://github.com/kubernetes/k8s.io/issues/2182

## Changes:
* Add periodic prow job that triggers rolling upgrade of code search every 24h. This is needed to trigger the daily update of the new search data for the code search tool.

## Reference Links:
* https://github.com/kubernetes/k8s.io/blob/main/apps/codesearch/deployment.yaml#L24-L28 
* https://github.com/kubernetes/k8s.io/blob/main/images/codesearch/cs-fetch-repos/src/fetch-repos.py 
