### PR TITLE
skip the tests for now as the CI tests are passing manually

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -100,7 +100,9 @@ presubmits:
   - name: pull-npd-e2e-kubernetes-gce-gci
     branches:
     - master
-    always_run: true
+    always_run: false
+    optional: true
+    skip_report: true
     decorate: true
     path_alias: k8s.io/node-problem-detector
     labels:
@@ -136,7 +138,9 @@ presubmits:
   - name: pull-npd-e2e-kubernetes-gce-gci-custom-flags
     branches:
     - master
-    always_run: true
+    always_run: false
+    optional: true
+    skip_report: true
     decorate: true
     path_alias: k8s.io/node-problem-detector
     labels:
@@ -172,7 +176,9 @@ presubmits:
   - name: pull-npd-e2e-kubernetes-gce-ubuntu
     branches:
     - master
-    always_run: true
+    always_run: false
+    optional: true
+    skip_report: true
     decorate: true
     path_alias: k8s.io/node-problem-detector
     labels:
@@ -208,7 +214,9 @@ presubmits:
   - name: pull-npd-e2e-kubernetes-gce-ubuntu-custom-flags
     branches:
     - master
-    always_run: true
+    always_run: false
+    optional: true
+    skip_report: true
     decorate: true
     path_alias: k8s.io/node-problem-detector
     labels:


### PR DESCRIPTION
Skipping the tests for now in presubmits as the ci tests are passing which would still help in debugging 

https://testgrid.k8s.io/sig-node-node-problem-detector#ci-npd-e2e-kubernetes-gce-ubuntu