### PR TITLE
Add CRI-O serial test SSH key placeholder

### DIFF
--- a/jobs/e2e_node/crio/crio_cgrpv2_serial.ign
+++ b/jobs/e2e_node/crio/crio_cgrpv2_serial.ign
@@ -5,6 +5,13 @@
   "storage": {
     "files": [
       {
+        "path": "/etc/ssh-key-secret/ssh-public",
+        "contents": {
+          "source": "data:text/plain;base64,GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
+        },
+        "mode": 420
+      },
+      {
         "path": "/etc/zincati/config.d/90-disable-auto-updates.toml",
         "contents": {
           "source": "data:,%5Bupdates%5D%0Aenabled%20%3D%20false%0A"

--- a/jobs/e2e_node/crio/crio_serial.ign
+++ b/jobs/e2e_node/crio/crio_serial.ign
@@ -10,6 +10,13 @@
   "storage": {
     "files": [
       {
+        "path": "/etc/ssh-key-secret/ssh-public",
+        "contents": {
+          "source": "data:text/plain;base64,GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
+        },
+        "mode": 420
+      },
+      {
         "path": "/etc/zincati/config.d/90-disable-auto-updates.toml",
         "contents": {
           "source": "data:,%5Bupdates%5D%0Aenabled%20%3D%20false%0A"


### PR DESCRIPTION
The placeholder `GCE_SSH_PUBLIC_KEY_FILE_CONTENT` will be replaced
during the test bootstrap in k/k with the right base64 encoded content
of the public SSH key. This way we can pass the right key into the
custom virtual machine image.

Refers to https://github.com/kubernetes/test-infra/issues/24798
Required for https://github.com/kubernetes/kubernetes/pull/108909

cc @ehashman @mrunalp @harche @ameukam 