### PR TITLE
sig-node: use registry.k8s.io for containerd-related jobs

### DIFF
--- a/jobs/e2e_node/containerd/config.toml
+++ b/jobs/e2e_node/containerd/config.toml
@@ -1,3 +1,5 @@
+version = 2
+
 # Kubernetes doesn't use containerd restart manager.
 disabled_plugins = ["restart"]
 
@@ -19,3 +21,8 @@ disabled_plugins = ["restart"]
 # Runtime handler used for runtime class test.
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler]
   runtime_type = "io.containerd.runc.v2"
+
+# Enable registry.k8s.io as the primary mirror for k8s.gcr.io
+# See: https://github.com/kubernetes/k8s.io/issues/3411
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."k8s.gcr.io"]
+  endpoint = ["https://registry.k8s.io", "https://k8s.gcr.io",]


### PR DESCRIPTION
Related:
  - https://github.com/kubernetes/k8s.io/issues/3411

Ensure containerd configuration for e2e tests use registry.k8s.io for
image pulling.

See: https://github.com/containerd/containerd/blob/main/docs/cri/registry.md#configure-registry-endpoint.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>