### PR TITLE
sig-node: fix containerd configuration

### DIFF
--- a/jobs/e2e_node/containerd/config.toml
+++ b/jobs/e2e_node/containerd/config.toml
@@ -1,5 +1,3 @@
-version = 2
-
 # Kubernetes doesn't use containerd restart manager.
 disabled_plugins = ["restart"]
 
@@ -24,5 +22,5 @@ disabled_plugins = ["restart"]
 
 # Enable registry.k8s.io as the primary mirror for k8s.gcr.io
 # See: https://github.com/kubernetes/k8s.io/issues/3411
-[plugins."io.containerd.grpc.v1.cri".registry.mirrors."k8s.gcr.io"]
+[plugins.cri.registry.mirrors."k8s.gcr.io"]
   endpoint = ["https://registry.k8s.io", "https://k8s.gcr.io",]


### PR DESCRIPTION
Followup of:
  - https://github.com/kubernetes/test-infra/pull/25739

Revert to version 1 of containerd API and add compatible configuration for
registry.k8s.io as primary mirror of k8s.gcr.io

See: https://github.com/containerd/cri/blob/release/1.2/docs/registry.md

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>