### PR TITLE
kubernetes-sigs/descheduler: do not self-approve PRs of approvers

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -71,6 +71,7 @@ approve:
   - kubernetes-sigs/cluster-api-provider-aws
   - kubernetes-sigs/cluster-api-provider-azure
   - kubernetes-sigs/cluster-api-provider-vsphere
+  - kubernetes-sigs/descheduler
   require_self_approval: true
   ignore_review_state: true
 - repos:


### PR DESCRIPTION
Following discussion in https://github.com/kubernetes/test-infra/issues/12693 the goal is to avoid getting PRs of authors who are approvers getting self-approved.

cc @damemi 