### PR TITLE
chore: add optional presubmit for akeyless provider with secrets-store-csi

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -537,6 +537,44 @@ presubmits:
       testgrid-tab-name: pr-secrets-store-csi-driver-e2e-provider-k8s-1-23-0
       description: "Run e2e test with e2e-provider for Secrets Store CSI driver in Kubernetes 1.23.0"
       testgrid-num-columns-recent: '30'
+  - name: pull-secrets-store-csi-driver-e2e-akeyless
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    always_run: false
+    optional: true
+    path_alias: sigs.k8s.io/secrets-store-csi-driver
+    branches:
+    - ^main$
+    - ^release-*
+    labels:
+      # this is required because we want to run kind in docker
+      preset-dind-enabled: "true"
+      # this is required to make CNI installation to succeed for kind
+      preset-kind-volume-mounts: "true"
+      # Sets up the akeyless parameters used for testing
+      preset-akeyless-secrets-store-creds: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220323-55ba9f6da3-master
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - >-
+            make e2e-bootstrap e2e-helm-deploy e2e-akeyless
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: "4"
+            memory: "4Gi"
+    annotations:
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
+      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-akeyless
+      description: "Run e2e test with akeyless provider for Secrets Store CSI driver."
+      testgrid-num-columns-recent: '30'
 
   # release jobs
   - name: release-secrets-store-csi-driver-e2e-aws

--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-presets.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-presets.yaml
@@ -17,3 +17,11 @@ presets:
       secretKeyRef:
         name: azure-secrets-store-cred
         key: tenantid
+- labels:
+    preset-akeyless-secrets-store-creds: "true"
+  env:
+  - name: AKEYLESS_ACCESS_KEY
+    valueFrom:
+      secretKeyRef:
+        name: akeyless-test-cred
+        key: credentials


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

- Adds an optional presubmit job to validate akeyless provider with secrets-store-csi-driver.
- The credentials will be available in the test pod env var `AKEYLESS_ACCESS_KEY`

After this PR is merged, tests can be manually triggered in PRs with `/test pull-secrets-store-csi-driver-e2e-akeyless`

/assign @tam7t
 
/cc @d-goro 
to validate if the env var they need for tests is in the required format