### PR TITLE
Bump golang in gcb-docker-gcloud to 1.17.8-alpine

### DIFF
--- a/images/gcb-docker-gcloud/README.md
+++ b/images/gcb-docker-gcloud/README.md
@@ -6,7 +6,7 @@ combination of `docker`, `gcloud`, and `go` all in the same build step
 ## contents
 
 - base:
-  - golang:1.16.2-alpine
+  - golang:1.17.8-alpine
 - languages:
   - `go`
 - tools:

--- a/images/gcb-docker-gcloud/cloudbuild.yaml
+++ b/images/gcb-docker-gcloud/cloudbuild.yaml
@@ -14,7 +14,7 @@ steps:
     - gcr.io/$PROJECT_ID/gcb-docker-gcloud:latest
 substitutions:
   _GIT_TAG: '12345'
-  _GO_VERSION: 1.16.2
+  _GO_VERSION: 1.17.8
 images:
   - 'gcr.io/$PROJECT_ID/gcb-docker-gcloud:$_GIT_TAG'
   - 'gcr.io/$PROJECT_ID/gcb-docker-gcloud:latest'


### PR DESCRIPTION
Signed-off-by: Zhecheng Li <zhechengli@microsoft.com>