### PR TITLE
add pull-k8sio-dns-validate-config job

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/k8sio-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/k8sio-presubmit.yaml
@@ -206,3 +206,17 @@ presubmits:
       - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
         command:
         - ./hack/verify.sh
+  - name: pull-k8sio-dns-validate-config
+    run_if_changed: "^dns/"
+    annotations:
+      testgrid-dashboards: sig-k8s-infra-k8sio
+      testgrid-tab-name: pull-k8sio-dns-validate-config
+    decorate: true
+    spec:
+      containers:
+        - image: registry.k8s.io/infra-tools/octodns:v20220319-97d14a558
+          command:
+            - bash
+          args:
+            - -c
+            - "cd dns && make validate-config"

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-dns.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-dns.yaml
@@ -23,7 +23,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-dns-updater
       containers:
-      - image: k8s.gcr.io/infra-tools/octodns:v20200616-67ce585
+      - image: registry.k8s.io/infra-tools/octodns:v20220319-97d14a558
         command:
         - bash
         args:
@@ -56,7 +56,7 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-dns-updater
     containers:
-    - image: k8s.gcr.io/infra-tools/octodns:v20200616-67ce585
+    - image: registry.k8s.io/infra-tools/octodns:v20220319-97d14a558
       command:
       - bash
       args:


### PR DESCRIPTION
This PR is for testing the dns configs part of presubmit

code has been added to validate config via https://github.com/kubernetes/k8s.io/pull/3339

Sample run:
```shell
% go run ./prow/cmd/phaino ./foo.yaml 
INFO[0000] Reading...                                    path=./foo.yaml
INFO[0000] Converting job into docker run command...     job=pull-k8sio-dns-validate-config
fallback to GOPATH: /Users/manjunath/go
: "docker" "run" "--rm=true" \
 "--name=phaino-443-1" \
 "--entrypoint=bash" \
 "-w" \
 "/home/prow/go/src/github.com/kubernetes/k8s.io" \
 "-v" \
 "/Users/manjunath/k8s_ws/src/k8s.io/k8s.io:/home/prow/go/src/github.com/kubernetes/k8s.io" \
 "-e" \
 "GOPROXY=https://proxy.golang.org" \
 "--label=prow.k8s.io/refs.repo=k8s.io" \
 "--label=prow.k8s.io/type=presubmit" \
 "--label=created-by-prow=true" \
 "--label=prow.k8s.io/context=pull-k8sio-dns-validate-config" \
 "--label=prow.k8s.io/job=pull-k8sio-dns-validate-config" \
 "--label=prow.k8s.io/refs.base_ref=main" \
 "--label=prow.k8s.io/refs.org=kubernetes" \
 "--label=prow.k8s.io/refs.pull=3547" \
 "--label=phaino=true" \
 "k8s.gcr.io/infra-tools/octodns:v20220319-97d14a558" \
 "-c" \
 "cd dns && make validate-config" 
INFO[0000] Starting job...                               job=pull-k8sio-dns-validate-config
INFO[0000] Waiting for job to finish...                  container=phaino-443-1 job=pull-k8sio-dns-validate-config
Unable to find image 'k8s.gcr.io/infra-tools/octodns:v20220319-97d14a558' locally
v20220319-97d14a558: Pulling from infra-tools/octodns
89d9c30c1d48: Already exists 
910c49c00810: Already exists 
a9cac48f48d9: Already exists 
6a8710d4fefc: Already exists 
94bfe828ec5b: Already exists 
dee83271f337: Pull complete 
44bfdb81e60a: Pull complete 
55281d1b4a54: Pull complete 
0e3e8dd1d904: Pull complete 
09d79a5ad60f: Pull complete 
Digest: sha256:c02b5f933e3600b9d815759df797f21303d920d58c26b4820f3ee256b194b6a7
Status: Downloaded newer image for k8s.gcr.io/infra-tools/octodns:v20220319-97d14a558
source ./lib.sh; \
precook_zone_configs /tmp/octodns.BHFDHd canary.k8s.io. canary.kubernetes.io. canary.x-k8s.io. canary.k8s-e2e.com. canary.k8s.dev. canary.kubernetes.dev. k8s.io. kubernetes.io. x-k8s.io. k8s-e2e.com. k8s.dev. kubernetes.dev.; \
precook_octodns_config_validate octodns-config.yaml /tmp/octodns.BHFDHd /tmp/octodns.DdahDd;
/home/prow/go/src/github.com/kubernetes/k8s.io/dns/check-zone.sh -c /tmp/octodns.BHFDHd -v -o /tmp/octodns.DdahDd \
        canary.k8s.io. canary.kubernetes.io. canary.x-k8s.io. canary.k8s-e2e.com. canary.k8s.dev. canary.kubernetes.dev. k8s.io. kubernetes.io. x-k8s.io. k8s-e2e.com. k8s.dev. kubernetes.dev.
Checking that the GCP dns servers for (canary.k8s.io. canary.kubernetes.io. canary.x-k8s.io. canary.k8s-e2e.com. canary.k8s.dev. canary.kubernetes.dev. k8s.io. kubernetes.io. x-k8s.io. k8s-e2e.com. k8s.dev. kubernetes.dev.) serve up everything in our octodns config
2022-03-24T10:23:55  [139943007108424] INFO  Manager __init__: config_file=/tmp/octodns.DdahDd
2022-03-24T10:23:55  [139943007108424] INFO  Manager __init__:   max_workers=1
2022-03-24T10:23:55  [139943007108424] INFO  Manager __init__:   max_workers=False
2022-03-24T10:23:55  [139943007108424] INFO  YamlProvider[config] populate:   found 52 records, exists=False
2022-03-24T10:23:56  [139943007108424] INFO  YamlProvider[config] populate:   found 99 records, exists=False
2022-03-24T10:23:56  [139943007108424] INFO  YamlProvider[config] populate:   found 0 records, exists=False
2022-03-24T10:23:56  [139943007108424] INFO  YamlProvider[config] populate:   found 2 records, exists=False
2022-03-24T10:23:56  [139943007108424] INFO  YamlProvider[config] populate:   found 2 records, exists=False
2022-03-24T10:23:56  [139943007108424] INFO  YamlProvider[config] populate:   found 3 records, exists=False
2022-03-24T10:23:56  [139943007108424] INFO  YamlProvider[config] populate:   found 53 records, exists=False
2022-03-24T10:23:56  [139943007108424] INFO  YamlProvider[config] populate:   found 102 records, exists=False
2022-03-24T10:23:56  [139943007108424] INFO  YamlProvider[config] populate:   found 1 records, exists=False
2022-03-24T10:23:56  [139943007108424] INFO  YamlProvider[config] populate:   found 3 records, exists=False
2022-03-24T10:23:56  [139943007108424] INFO  YamlProvider[config] populate:   found 3 records, exists=False
2022-03-24T10:23:56  [139943007108424] INFO  YamlProvider[config] populate:   found 4 records, exists=False
***PASS***
INFO[0025] PASS: 61778f6a-ab5c-11ec-b0b8-acde48001122    duration=25.155176604s job=pull-k8sio-dns-validate-config
INFO[0025] SUCCESS                                      
INFO[0025] Press Ctrl + c to exit.                      
^CINFO[0065] Received signal.                              signal=interrupt
INFO[0065] Interrupt received.                          
INFO[0065] All workers gracefully terminated, exiting.  
```

And also updated the octodns to latest image: `k8s.gcr.io/infra-tools/octodns:v20220319-97d14a558`