### PR TITLE
Fix CRI-O serial presubmit jobs by adjusting skipped tests

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -787,7 +787,7 @@ presubmits:
         - --node-tests=true
         - --provider=gce
           #TODO: NodeFeature:DevicePluginProbe tests are failing and being investigated in https://issues.k8s.io/106635
-        - --test_args=--nodes=1 --focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[Feature:Eviction\]|\[NodeFeature:DevicePluginProbe\]"
+        - --test_args=--nodes=1 --focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]|\[NodeFeature:DevicePluginProbe\]"
         - --timeout=420m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/crio/latest/image-config-cgrpv1-serial.yaml
         resources:
@@ -830,7 +830,7 @@ presubmits:
         - --node-tests=true
         - --provider=gce
           #TODO: NodeFeature:DevicePluginProbe tests are failing and being investigated in https://issues.k8s.io/106635
-        - --test_args=--nodes=1 --focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[Feature:Eviction\]|\[NodeFeature:DevicePluginProbe\]"
+        - --test_args=--nodes=1 --focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]|\[NodeFeature:DevicePluginProbe\]"
         - --timeout=420m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/crio/latest/image-config-cgrpv2-serial.yaml
         resources:


### PR DESCRIPTION
The eviction tests are running under `NodeFeature:Eviction` rather than just `Feature:Eviction`.

cc @ehashman @mrunalp @harche 

Referring to https://github.com/kubernetes/kubernetes/pull/108909