### PR TITLE
Introduce backoff time to throttling algorithm

### DIFF
--- a/ghproxy/ghproxy.go
+++ b/ghproxy/ghproxy.go
@@ -99,10 +99,11 @@ type options struct {
 	upstream       string
 	upstreamParsed *url.URL
 
-	maxConcurrency              int
-	requestThrottlingTime       uint
-	requestThrottlingTimeV4     uint
-	requestThrottlingTimeForGET uint
+	maxConcurrency               int
+	requestThrottlingTime        uint
+	requestThrottlingTimeV4      uint
+	requestThrottlingTimeForGET  uint
+	requestThrottlingBackoffTime uint
 
 	// pushGateway fields are used to configure pushing prometheus metrics.
 	pushGateway         string
@@ -147,6 +148,7 @@ func flagOptions() *options {
 	flag.UintVar(&o.requestThrottlingTime, "throttling-time-ms", 0, "Additional throttling mechanism which imposes time spacing between outgoing requests. Counted per organization. Has to be set together with --get-throttling-time-ms.")
 	flag.UintVar(&o.requestThrottlingTimeV4, "throttling-time-v4-ms", 0, "Additional throttling mechanism which imposes time spacing between outgoing requests. Counted per organization. Overrides --throttling-time-ms setting for API v4.")
 	flag.UintVar(&o.requestThrottlingTimeForGET, "get-throttling-time-ms", 0, "Additional throttling mechanism which imposes time spacing between outgoing GET requests. Counted per organization. Has to be set together with --throttling-time-ms.")
+	flag.UintVar(&o.requestThrottlingBackoffTime, "throttling-backoff-time", 30, "Backoff time for throttling mechanism. When a queue is longer than the given time, algorithm is temporarily disabled. Default is 30 seconds.")
 	flag.StringVar(&o.pushGateway, "push-gateway", "", "If specified, push prometheus metrics to this endpoint.")
 	flag.DurationVar(&o.pushGatewayInterval, "push-gateway-interval", time.Minute, "Interval at which prometheus metrics are pushed.")
 	flag.StringVar(&o.logLevel, "log-level", "debug", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
@@ -196,7 +198,7 @@ func main() {
 
 func proxy(o *options, upstreamTransport http.RoundTripper, diskCachePruneInterval time.Duration) http.Handler {
 	var cache http.RoundTripper
-	throttlingTimes := ghcache.NewRequestThrottlingTimes(o.requestThrottlingTime, o.requestThrottlingTimeV4, o.requestThrottlingTimeForGET)
+	throttlingTimes := ghcache.NewRequestThrottlingTimes(o.requestThrottlingTime, o.requestThrottlingTimeV4, o.requestThrottlingTimeForGET, o.requestThrottlingBackoffTime)
 	if o.redisAddress != "" {
 		cache = ghcache.NewRedisCache(apptokenequalizer.New(upstreamTransport), o.redisAddress, o.maxConcurrency, throttlingTimes)
 	} else if o.dir == "" {


### PR DESCRIPTION
This commit introduces backoff time to the additional throttling algorithm.
When there is an issue with gh api access, an algorithm that was supposed to work
locally (in timespan of around 10-60 seconds per queue) is co-responsible for forming
a massive queue of messages, scheduled to be handled in the future. This is unwanted
behavior. When there is an external problem and the bigger queue forms, the algorithm will be
temporarily disabled. User can choose the value and therefore indirectly steer a length of the queue.

Signed-off-by: Jakub Guzik <jguzik@redhat.com>