### PR TITLE
Add environment variable to inject SSH key during CRI-O serial tests

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -797,6 +797,9 @@ presubmits:
           requests:
             cpu: 4
             memory: 6Gi
+        env:
+        - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
+          value: "1"
   - name: pull-kubernetes-node-kubelet-serial-crio-cgroupv2
     cluster: k8s-infra-prow-build
     skip_branches:
@@ -840,6 +843,9 @@ presubmits:
           requests:
             cpu: 4
             memory: 6Gi
+        env:
+        - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
+          value: "1"
   - name: pull-kubernetes-node-crio-e2e
     cluster: k8s-infra-prow-build
     skip_branches:


### PR DESCRIPTION
We now use a dedicated environment variable `IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE` to be able to inject the SSH public key into the igntion file for the CRI-O serial tests.

Required for https://github.com/kubernetes/kubernetes/pull/108909

cc @ehashman @mrunalp @harche 