### PR TITLE
Added CAPA alerts email

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
@@ -33,6 +33,7 @@ postsubmits:
       annotations:
         # this is the name of some testgrid dashboard to report to.
         testgrid-dashboards: sig-cluster-lifecycle-image-pushes, sig-k8s-infra-gcb
+        testgrid-alert-email: sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io
       decorate: true
       branches:
         - ^main
@@ -336,4 +337,4 @@ periodics:
     # this is the name of some testgrid dashboard to report to.
       testgrid-dashboards: sig-cluster-lifecycle-image-pushes, sig-k8s-infra-gcb
       testgrid-tab-name: cluster-api-provider-aws-push-images-nightly
-      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+      testgrid-alert-email: sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io


### PR DESCRIPTION
Updated the CAPA image publishing jobs to use the CAPA alerts email
address.

Signed-off-by: Richard Case <richard@weave.works>