### PR TITLE
Clean up old snapshot by boskos resources

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-cleanup.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-cleanup.yaml
@@ -11,6 +11,10 @@ periodics:
     repo: perf-tests
     base_ref: master
     path_alias: k8s.io/perf-tests
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
   annotations:
     testgrid-dashboards: sig-scalability-experiments
     testgrid-tab-name: snapshots-cleanup
@@ -21,16 +25,17 @@ periodics:
       - runner.sh
       - /workspace/scenarios/execute.py
       args:
-      - $(GOPATH)/src/k8s.io/perf-tests/clusterloader2/clean-up-old-snapshots.sh
+      - $(GOPATH)/src/k8s.io/perf-tests/clusterloader2/clean-up-old-snapshots-boskos.sh
       # Command (list|delete)
       - delete
-      # Comma-separated list of projects to process
-      # It should match projects list for type: scalability-project in prow/cluster/boskos-resources.yaml
-      - k8s-e2e-gce-scalability-1-1,k8s-e2e-gce-scalability-1-2,k8s-e2e-gci-gce-scale-1-4,k8s-e2e-gci-gce-scale-1-5,k8s-jenkins-gci-scalability,k8s-jenkins-gci-scalability-2,k8s-jenkins-kubemark,k8s-jenkins-scalability-2,k8s-jenkins-scalability-3,k8s-jenkins-scalability-4,k8s-jenkins-scalability-5
       # Comma-separated list of snapshot prefixes to delete
       - ci-kubernetes-e2e-gci-gce-scalability
       # Delete snapshots older than x days
       - "30"
+      # Comma-separated list of boskos pools to process
+      - scalability-project
+      # File with boskos resource definitions
+      - $(GOPATH)/src/k8s.io/test-infra/config/prow/cluster/build/boskos-resources/boskos-resources.yaml
 
 - name: ci-kubernetes-scalability-cleanup-golang-builds-canary
   cluster: k8s-infra-prow-build


### PR DESCRIPTION
This replaces the old behaviour of using only GCP Project IDs. It uses script introduced in https://github.com/kubernetes/perf-tests/pull/2028.

/assign @jprzychodzen 