### PR TITLE
use go install instead of go get

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
@@ -44,7 +44,7 @@ periodics:
         REPO_ROOT=$GOPATH/src/k8s.io/cloud-provider-gcp;
         cd;
         export GO111MODULE=on;
-        go get sigs.k8s.io/kubetest2@latest;
-        go get sigs.k8s.io/kubetest2/kubetest2-gce@latest;
-        go get sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
+        go install sigs.k8s.io/kubetest2@latest;
+        go install sigs.k8s.io/kubetest2/kubetest2-gce@latest;
+        go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
         kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo -- --test-package-version=v1.23.0 --focus-regex='\[Conformance\]'

--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -76,7 +76,7 @@ presubmits:
           REPO_ROOT=$(git rev-parse --show-toplevel);
           cd;
           export GO111MODULE=on;
-          go get sigs.k8s.io/kubetest2@latest;
-          go get sigs.k8s.io/kubetest2/kubetest2-gce@latest;
-          go get sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
+          go install sigs.k8s.io/kubetest2@latest;
+          go install sigs.k8s.io/kubetest2/kubetest2-gce@latest;
+          go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
           kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo -- --test-package-version=v1.23.0 --parallel=30 --test-args='--minStartupPods=8 --container-runtime=containerd' --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
@@ -82,9 +82,9 @@ periodics:
         REPO_ROOT=$GOPATH/src/k8s.io/kubernetes;
         cd;
         export GO111MODULE=on;
-        go get sigs.k8s.io/kubetest2@latest;
-        go get sigs.k8s.io/kubetest2/kubetest2-gce@latest;
-        go get sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
+        go install sigs.k8s.io/kubetest2@latest;
+        go install sigs.k8s.io/kubetest2/kubetest2-gce@latest;
+        go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
         kubetest2 gce -v 2 \;
           --repo-root $REPO_ROOT \;
           --legacy-mode \;


### PR DESCRIPTION
Fix for [#108989 ](https://github.com/kubernetes/kubernetes/issues/108989)

'go get' is no longer supported outside a module. so use 'go install'.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>