### PR TITLE
Bump kubebuilder-presubmits to use go 1.18

### DIFF
--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - ^feature/plugins-.+$
     spec:
       containers:
-      - image: golang:1.17
+      - image: golang:1.18
         command:
         - ./test.sh
         resources:


### PR DESCRIPTION
*Description:*
Kubebuilder's master branch is introducing support for Golang 1.18. This PR is changing the `pull-kubebuilder-test` pre-submit job to use `golang:1.18` image instead of the previous version.

*Motivation:*
Kubebuilder Golang 1.18 Support PR https://github.com/kubernetes-sigs/kubebuilder/pull/2561
Kubebuilder Golang 1.18 Issue https://github.com/kubernetes-sigs/kubebuilder/issues/2559