### PR TITLE
Bump the max size of junit xml(s)

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -43,7 +43,7 @@ sinker:
 
 deck:
   spyglass:
-    size_limit: 100000000 # 100MB
+    size_limit: 200000000 # 200MB
     gcs_browser_prefix: https://gcsweb.k8s.io/gcs/
     testgrid_config: gs://k8s-testgrid/config
     testgrid_root: https://testgrid.k8s.io/


### PR DESCRIPTION
With the json output switch, we end up with larger output for each line,
which in turn has bumped up the size of the junit xml(s). Please see for
example:

https://testgrid.k8s.io/sig-release-master-blocking#integration-master&width=20

We end up with a message in test grid that xml file is too large.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>