### PR TITLE
Use 1 ginko runner for serial/slow jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -8,11 +8,14 @@ presets:
     value: "-kubetest.use-ci-artifacts"
   - name: WINDOWS
     value: "true"
+  - name: AZURE_NODE_MACHINE_TYPE
+    value: "Standard_D4s_v3"
+- labels:
+    preset-capz-windows-parallel: "true"
+  env:
   # Windows isn't really conformance, we typically run at 4 to keep the time reasonable (~45 mins)
   - name: CONFORMANCE_NODES
     value: "4"
-  - name: AZURE_NODE_MACHINE_TYPE
-    value: "Standard_D4s_v3"
 - labels:
     preset-capz-windows-2019: "true"
   env:
@@ -33,6 +36,8 @@ presets:
   env:
   - name: KUBETEST_WINDOWS_CONFIG
     value: "upstream-windows-serial-slow.yaml"
+  - name: CONFORMANCE_NODES
+    value: "1"
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-aks-engine-azure-disk-windows-containerd
@@ -174,6 +179,7 @@ periodics:
     preset-capz-windows-common-main: "true"
     preset-capz-windows-2019: "true"
     preset-capz-containerd-latest: "true"
+    preset-capz-windows-parallel: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -242,6 +248,7 @@ periodics:
     preset-capz-windows-common-main: "true"
     preset-capz-windows-2022: "true"
     preset-capz-containerd-latest: "true"
+    preset-capz-windows-parallel: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -597,6 +604,7 @@ periodics:
     preset-azure-cred-only: "true"
     preset-capz-windows-common-main: "true"
     preset-capz-windows-2019: "true"
+    preset-capz-windows-parallel: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure


### PR DESCRIPTION
During refactor in https://github.com/kubernetes/test-infra/pull/25604, we dropped the explicit ginkgo nodes setting of 1 for the serial slow jobs. This is causing tests to not run in parallel and flakes to occur.

/sig windows