### PR TITLE
Capz windows presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
@@ -82,9 +82,9 @@ presubmits:
       preset-capz-containerd-latest: "true"
       preset-capz-windows-common-main-pull: "true"
     extra_refs:
-    - org: jsturtevant
+    - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: pr-support-containerd
+      base_ref: main
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
     spec:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -30,7 +30,7 @@ presets:
     preset-capz-containerd-latest: "true"
   env:
   - name: WINDOWS_CONTAINERD_URL
-    value: "https://github.com/containerd/containerd/releases/download/v1.6.1/containerd-1.6.1-windows-amd64.tar.gz"
+    value: "https://github.com/containerd/containerd/releases/download/v1.6.2/containerd-1.6.2-windows-amd64.tar.gz"
 - labels:
     preset-capz-serial-slow: "true"
   env:


### PR DESCRIPTION
Now that https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2193 merged we can use capz for pre-submits.

this also bumps the containerd version to latest release