### PR TITLE
config/prow: set branch restrictions for 1.24 code freeze

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -638,6 +638,32 @@ tide:
     - needs-rebase
   - repos:
     - kubernetes/kubernetes
+    excludedBranches:
+    - master
+    - release-1.24
+    labels:
+    - lgtm
+    - approved
+    - "cncf-cla: yes"
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/blocked-paths
+    - do-not-merge/cherry-pick-not-approved
+    - do-not-merge/contains-merge-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-commit-message
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/needs-kind
+    - do-not-merge/needs-sig
+    - do-not-merge/release-note-label-needed
+    - do-not-merge/work-in-progress
+    - needs-rebase
+  - repos:
+    - kubernetes/kubernetes
+    milestone: v1.24
+    includedBranches:
+    - master
+    - release-1.24
     labels:
     - lgtm
     - approved


### PR DESCRIPTION
The Kubernetes 1.24 Code Freeze is scheduled to start at 01:00 UTC Wednesday 30th March 2022

/hold
The hold should ONLY be cancelled by the Release Team Leads when the 1.24 Release Team is ready around the Code Freeze deadline

/cc @jimangel 
/cc @kubernetes/release-team-leads @kubernetes/release-engineering