### PR TITLE
[WIP] Larger timeout for cloud-provider-azure push images

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-provider-azure.yaml
+++ b/config/jobs/image-pushing/k8s-staging-provider-azure.yaml
@@ -11,6 +11,8 @@ postsubmits:
         testgrid-dashboards: provider-azure-cloud-provider-azure, sig-k8s-infra-gcb
         testgrid-tab-name: post-cloud-provider-azure-push-images
       decorate: true
+      decoration_config:
+        timeout: 3h
       # this causes the job to only run on the master branch. Remove it if your
       # job makes sense on every branch (unless it's setting a `latest` tag it
       # probably does).


### PR DESCRIPTION
cloud-provider-azure now pushes images for:

ccm:
* linux amd64 arm arm64

cnm:
* linux amd64 arm arm64
* windows amd64 2004 1809 20h2 ltsc2022

Signed-off-by: Zhecheng Li <zhechengli@microsoft.com>