### PR TITLE
SELinux: turn off label separation instead of relabelling

### DIFF
--- a/config/mkpj.sh
+++ b/config/mkpj.sh
@@ -33,4 +33,10 @@ config="${root}/config/prow/config.yaml"
 job_config_path="${root}/config/jobs"
 
 docker pull gcr.io/k8s-prow/mkpj 1>&2 || true
-docker run -i --rm --user "$(id -u):$(id -g)" -v "${root}:${root}:z" gcr.io/k8s-prow/mkpj "--config-path=${config}" "--job-config-path=${job_config_path}" "$@"
+docker run \
+       -i --rm \
+       --user "$(id -u):$(id -g)" \
+       -v "${root}:${root}" \
+       --security-opt="label=disable" \
+       gcr.io/k8s-prow/mkpj \
+       "--config-path=${config}" "--job-config-path=${job_config_path}" "$@"

--- a/hack/make-rules/verify/yamllint.sh
+++ b/hack/make-rules/verify/yamllint.sh
@@ -33,7 +33,8 @@ LINT_COMMAND=("yamllint" "-c" "config/jobs/.yamllint.conf" "config/jobs" "config
 
 "${DOCKER[@]}" run \
     --rm -i \
-    -v "${REPO_ROOT:?}:${REPO_ROOT:?}:z" -w "${REPO_ROOT}" \
+    -v "${REPO_ROOT:?}:${REPO_ROOT:?}" -w "${REPO_ROOT}" \
+    --security-opt="label=disable" \
     "quay.io/kubermatic/yamllint:0.1" \
     "${LINT_COMMAND[@]}"
 

--- a/hack/run-in-node-container.sh
+++ b/hack/run-in-node-container.sh
@@ -45,6 +45,7 @@ fi
     --user $(id -u):$(id -g) \
     -e HOME=/tmp \
     -v "${REPO_ROOT:?}:${REPO_ROOT:?}" -w "${REPO_ROOT}" \
+    --security-opt="label=disable" \
     "${NODE_IMAGE}" \
     "$@"
 if [[ -n "${NO_DOCKER:-}" ]]; then

--- a/hack/run-in-python-container.sh
+++ b/hack/run-in-python-container.sh
@@ -29,5 +29,6 @@ docker run \
     -e HOME=/tmp \
     -e PYTHONPATH='' \
     -v "${REPO_ROOT:?}:${REPO_ROOT:?}" -w "${REPO_ROOT}" \
+    --security-opt="label=disable" \
     "${PY_IMAGE}" \
     bash -c 'source ./hack/make-rules/py-test/activate-python_venv.sh && $0 $@' "$@"


### PR DESCRIPTION
In several places, we run a container with the local repo directory bind-mounted as a volume. However, without relabelling the directory contents, selinux will disallow access.

Since relabelling directories (using `:z` or `:Z`) on the host OS could have unforseen consequences - e.g. preventing something on the host OS from accessing the directory - it's arguably safer to just turn off label  separation using `--security-opt="label=disable"`.

See docs like:
https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label
https://docs.docker.com/engine/reference/run/
https://docs.podman.io/en/latest/markdown/podman-run.1.html

On systems without selinux enforcing, this won't have any affect.

See the individual commits for details, but the changes can be tested with:

```
$ make verify-tslint       # uses run-in-node-container
$ make verify-boilerplate  # uses run-in-python-container
$ make verify-yamllint     # uses yamllint
$ ./config/mkpj.sh --help
```