### PR TITLE
Fix verify-boilerplate target

### DIFF
--- a/hack/boilerplate/boilerplate.py.txt
+++ b/hack/boilerplate/boilerplate.py.txt
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/hack/boilerplate/verify_boilerplate.py
+++ b/hack/boilerplate/verify_boilerplate.py
@@ -37,7 +37,7 @@ def get_args():
                         default=rootdir,
                         help="root directory to examine")
 
-    default_boilerplate_dir = os.path.join(rootdir, "verify/boilerplate")
+    default_boilerplate_dir = os.path.join(rootdir, "hack/boilerplate")
     parser.add_argument("--boilerplate-dir", default=default_boilerplate_dir)
 
     parser.add_argument(
@@ -49,8 +49,9 @@ def get_args():
             '_output',
             'third_party',
             'vendor',
-            'verify/boilerplate/test',
+            'hack/boilerplate/test',
             'verify_boilerplate.py',
+            '.python_virtual_env',
         ],
         action='append',
         help='Customize paths to avoid',

--- a/hack/boilerplate/verify_boilerplate.py
+++ b/hack/boilerplate/verify_boilerplate.py
@@ -244,6 +244,8 @@ def main():
             print(line)
         sys.exit(1)
 
+    print("Verified %d files" % (len(filenames), ))
+
 
 if __name__ == "__main__":
     ARGS = get_args()

--- a/hack/boilerplate/verify_boilerplate.py
+++ b/hack/boilerplate/verify_boilerplate.py
@@ -84,7 +84,7 @@ def is_generated(data):
     return False
 
 
-def file_passes(filename, refs, regexs):  # pylint: disable=too-many-locals
+def file_passes(filename, refs, regexs):  # pylint: disable=too-many-locals,too-many-return-statements,too-many-branches
     try:
         # Pass the encoding parameter to avoid ascii decode error for some
         # platform.
@@ -126,6 +126,7 @@ def file_passes(filename, refs, regexs):  # pylint: disable=too-many-locals
 
     # check if we encounter a 'YEAR' placeholder if the file is generated
     if is_generated(file_data):
+        # pylint: disable=unused-variable
         for i, line in enumerate(data):
             if "Copyright YEAR" in line:
                 return False

--- a/prow/test/integration/test/gerrit_test.go
+++ b/prow/test/integration/test/gerrit_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package integration
 
 import (


### PR DESCRIPTION
Running `make verify-boilerplate` doesn't currently appear to check anything.

The commits in this PR reverts `verify-boilerplate.py` back to the repo-infra version, tweaks it for this repo, adds a message to show that it's actually verifying files, and also fixes the `make -C hack/ test-verify-boilerplate` test.