### PR TITLE
Make Crier gracefully terminate when interrupted.

### DIFF
--- a/prow/interrupts/interrupts.go
+++ b/prow/interrupts/interrupts.go
@@ -120,7 +120,7 @@ func WaitForGracefulShutdown() {
 	}
 }
 
-// Context returns a context that stays is cancelled when an interrupt hits.
+// Context returns a context that is cancelled when an interrupt hits.
 // Using this context is a weak guarantee that your work will finish before
 // process exit as callers cannot signal that they are finished. Prefer to use
 // Run().


### PR DESCRIPTION
I also looked through the reporters' code to audit their termination mode. Most of the reporter code is run on worker threads via the manager, but there are a few additional go routines started during reporter initialization to manage things like PR lock map pruning, and Gerrit config and auth updates.
I don't think it is worth instrumenting these with contexts to allow them to gracefully terminate. It wouldn't be hard and I'm willing to do so if others think we should, but my reasoning is that these threads only exist to asynchronously maintain resources used by the worker threads and we don't need to wait for them to finish, only the worker threads need to finish. Ignoring graceful termination for these other threads is simpler (and technically a hair faster).

/assign @chaodaiG 