### PR TITLE
Fix janitor for scalability-presubmit project

### DIFF
--- a/scenarios/kubernetes_janitor.py
+++ b/scenarios/kubernetes_janitor.py
@@ -100,7 +100,9 @@ PR_PROJECTS = {
 }
 
 SCALE_PROJECT = {
-    'k8s-presubmit-scale': 3,
+    # cleans up resources older than 12h
+    # for scale presubmit job we need to give jobs enough time to finish.
+    'k8s-presubmit-scale': 12,
 }
 
 def check_predefine_jobs(jobs, ratelimit):


### PR DESCRIPTION
3h is not enough time to run scalability test at 5k scale and it results in cluster being deleted during the test, as in this example:
https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/109067/pull-kubernetes-e2e-gce-scale-performance-manual/1509050502040522752