### PR TITLE
Gerrit: stop posting message for inrepoconfig error

### DIFF
--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -44,8 +44,7 @@ import (
 )
 
 const (
-	inRepoConfigRetries       = 2
-	inRepoConfigFailedMessage = "Unable to get InRepoConfig Presubmits. This is likely due to merge conflict. Please rebase to trigger presubmits."
+	inRepoConfigRetries = 2
 )
 
 var gerritMetrics = struct {
@@ -409,10 +408,6 @@ func (c *Controller) processChange(logger logrus.FieldLogger, instance string, c
 			}
 		}
 		if err != nil {
-			// Leave message to let user know that we did not get Presubmits
-			if err := c.gc.SetReview(instance, change.ID, change.CurrentRevision, inRepoConfigFailedMessage, nil); err != nil {
-				return err
-			}
 			return fmt.Errorf("failed to get inRepoConfig for Presubmits: %w", err)
 		}
 		presubmits = append(presubmits, c.config().PresubmitsStatic[cloneURI.String()]...)


### PR DESCRIPTION
This gets fired on PR that has merge conflict every minute, and very spammy, will need to think about how to handle it better