### PR TITLE
Revert "Revert "Tide: Consider PRs that are being serially retested for batches""

### DIFF
--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/test-infra/prow/git/v2"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/io"
+	"k8s.io/test-infra/prow/kube"
 	"k8s.io/test-infra/prow/pjutil"
 	"k8s.io/test-infra/prow/tide/blockers"
 	"k8s.io/test-infra/prow/tide/history"
@@ -79,6 +80,7 @@ type Controller struct {
 	prowJobClient      ctrlruntimeclient.Client
 	gc                 git.ClientFactory
 	usesGitHubAppsAuth bool
+	pickNewBatch       func(sp subpool, candidates []PullRequest, maxBatchSize int) ([]PullRequest, error)
 
 	sc *statusController
 
@@ -319,6 +321,7 @@ func newSyncController(
 		config:             cfg,
 		gc:                 gc,
 		usesGitHubAppsAuth: usesGitHubAppsAuth,
+		pickNewBatch:       pickNewBatch(gc, cfg),
 		sc:                 sc,
 		changedFiles: &changedFilesAgent{
 			ghc:             ghcSync,
@@ -1062,46 +1065,48 @@ func prNumbers(prs []PullRequest) []int {
 	return nums
 }
 
-func (c *Controller) pickNewBatch(sp subpool, candidates []PullRequest, maxBatchSize int) ([]PullRequest, error) {
-	var res []PullRequest
-	r, err := c.gc.ClientFor(sp.org, sp.repo)
-	if err != nil {
-		return nil, err
-	}
-	defer r.Clean()
-	if err := r.Config("user.name", "prow"); err != nil {
-		return nil, err
-	}
-	if err := r.Config("user.email", "prow@localhost"); err != nil {
-		return nil, err
-	}
-	if err := r.Config("commit.gpgsign", "false"); err != nil {
-		sp.log.Warningf("Cannot set gpgsign=false in gitconfig: %v", err)
-	}
-	if err := r.Checkout(sp.sha); err != nil {
-		return nil, err
-	}
-
-	for _, pr := range candidates {
-		mergeMethod, err := prMergeMethod(c.config().Tide, &pr)
+func pickNewBatch(gc git.ClientFactory, cfg config.Getter) func(sp subpool, candidates []PullRequest, maxBatchSize int) ([]PullRequest, error) {
+	return func(sp subpool, candidates []PullRequest, maxBatchSize int) ([]PullRequest, error) {
+		var res []PullRequest
+		r, err := gc.ClientFor(sp.org, sp.repo)
 		if err != nil {
-			sp.log.WithFields(pr.logFields()).Warnf("Failed to get merge method for PR, will skip: %v.", err)
-			continue
-		}
-		if ok, err := r.MergeWithStrategy(string(pr.HeadRefOID), string(mergeMethod)); err != nil {
-			// we failed to abort the merge and our git client is
-			// in a bad state; it must be cleaned before we try again
 			return nil, err
-		} else if ok {
-			res = append(res, pr)
-			// TODO: Make this configurable per subpool.
-			if maxBatchSize > 0 && len(res) >= maxBatchSize {
-				break
+		}
+		defer r.Clean()
+		if err := r.Config("user.name", "prow"); err != nil {
+			return nil, err
+		}
+		if err := r.Config("user.email", "prow@localhost"); err != nil {
+			return nil, err
+		}
+		if err := r.Config("commit.gpgsign", "false"); err != nil {
+			sp.log.Warningf("Cannot set gpgsign=false in gitconfig: %v", err)
+		}
+		if err := r.Checkout(sp.sha); err != nil {
+			return nil, err
+		}
+
+		for _, pr := range candidates {
+			mergeMethod, err := prMergeMethod(cfg().Tide, &pr)
+			if err != nil {
+				sp.log.WithFields(pr.logFields()).Warnf("Failed to get merge method for PR, will skip: %v.", err)
+				continue
+			}
+			if ok, err := r.MergeWithStrategy(string(pr.HeadRefOID), string(mergeMethod)); err != nil {
+				// we failed to abort the merge and our git client is
+				// in a bad state; it must be cleaned before we try again
+				return nil, err
+			} else if ok {
+				res = append(res, pr)
+				// TODO: Make this configurable per subpool.
+				if maxBatchSize > 0 && len(res) >= maxBatchSize {
+					break
+				}
 			}
 		}
-	}
 
-	return res, nil
+		return res, nil
+	}
 }
 
 type newBatchFunc func(sp subpool, candidates []PullRequest, maxBatchSize int) ([]PullRequest, error)
@@ -1118,7 +1123,7 @@ func (c *Controller) pickBatch(sp subpool, cc map[int]contextChecker, newBatchFu
 
 	var candidates []PullRequest
 	for _, pr := range sp.prs {
-		if isPassingTests(sp.log, c.ghc, pr, cc[int(pr.Number)]) {
+		if c.isBatchCandidateEligible(sp.log, &pr, cc[int(pr.Number)]) {
 			candidates = append(candidates, pr)
 		}
 	}
@@ -1149,6 +1154,71 @@ func (c *Controller) pickBatch(sp subpool, cc map[int]contextChecker, newBatchFu
 	}
 
 	return res, presubmits, nil
+}
+
+// isBatchCandidateEligible determines batch retesting eligibility. It allows PRs where all mandatory contexts
+// are either passing or pending. Pending ones are only allowed if we find a ProwJob that corresponds to them
+// and was created by Tide, as that allows us to infer that this job passed in the past.
+// We look at the actively running ProwJob rather than a previous successful one, because the latter might
+// already be garbage collected.
+func (c *Controller) isBatchCandidateEligible(log *logrus.Entry, candidate *PullRequest, cc contextChecker) bool {
+	candidateHeadContexts, err := headContexts(log, c.ghc, candidate)
+	if err != nil {
+		log.WithError(err).WithFields(candidate.logFields()).Debug("failed to get headContexts for batch candidate, ignoring.")
+		return false
+	}
+	var contextNames []string
+	for _, headContext := range candidateHeadContexts {
+		contextNames = append(contextNames, string(headContext.Context))
+	}
+
+	if len(cc.MissingRequiredContexts(contextNames)) > 0 {
+		return false
+	}
+
+	for _, headContext := range candidateHeadContexts {
+		if headContext.State == githubql.StatusStateSuccess {
+			continue
+		}
+		if headContext.State != githubql.StatusStatePending && !cc.IsOptional(string(headContext.Context)) {
+			return false
+		}
+
+		pjLabels := createdByTideLabels()
+		pjLabels[kube.ProwJobTypeLabel] = string(prowapi.PresubmitJob)
+		pjLabels[kube.OrgLabel] = string(candidate.Repository.Owner.Login)
+		pjLabels[kube.RepoLabel] = string(candidate.Repository.Name)
+		pjLabels[kube.BaseRefLabel] = string(candidate.BaseRef.Name)
+		pjLabels[kube.PullLabel] = string(strconv.Itoa(int(candidate.Number)))
+		pjLabels[kube.ContextAnnotation] = string(headContext.Context)
+
+		var pjs prowapi.ProwJobList
+		if err := c.prowJobClient.List(c.ctx,
+			&pjs,
+			ctrlruntimeclient.InNamespace(c.config().ProwJobNamespace),
+			ctrlruntimeclient.MatchingLabels(pjLabels),
+		); err != nil {
+			log.WithError(err).Debug("failed to list prowjobs for PR, ignoring")
+			return false
+		}
+
+		if prowJobListHasProwJobWithMatchingHeadSHA(&pjs, string(candidate.HeadRefOID)) {
+			continue
+		}
+
+		return false
+	}
+
+	return true
+}
+
+func prowJobListHasProwJobWithMatchingHeadSHA(pjs *prowapi.ProwJobList, headSHA string) bool {
+	for _, pj := range pjs.Items {
+		if pj.Spec.Refs != nil && len(pj.Spec.Refs.Pulls) == 1 && pj.Spec.Refs.Pulls[0].SHA == headSHA {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Controller) prepareMergeDetails(commitTemplates config.TideMergeCommitTemplate, pr PullRequest, mergeMethod github.PullRequestMergeType) github.MergeDetails {
@@ -1416,6 +1486,12 @@ func (c *Controller) trigger(sp subpool, presubmits []config.Presubmit, prs []Pu
 		pj.Namespace = c.config().ProwJobNamespace
 		log := c.logger.WithFields(pjutil.ProwJobFields(&pj))
 		start := time.Now()
+		if pj.Labels == nil {
+			pj.Labels = map[string]string{}
+		}
+		for k, v := range createdByTideLabels() {
+			pj.Labels[k] = v
+		}
 		if err := c.prowJobClient.Create(c.ctx, &pj); err != nil {
 			log.WithField("duration", time.Since(start).String()).Debug("Failed to create ProwJob on the cluster.")
 			return fmt.Errorf("failed to create a ProwJob for job: %q, PRs: %v: %w", spec.Job, prNumbers(prs), err)
@@ -1423,6 +1499,10 @@ func (c *Controller) trigger(sp subpool, presubmits []config.Presubmit, prs []Pu
 		log.WithField("duration", time.Since(start).String()).Debug("Created ProwJob on the cluster.")
 	}
 	return nil
+}
+
+func createdByTideLabels() map[string]string {
+	return map[string]string{"created-by-tide": "true"}
 }
 
 func (c *Controller) nonFailedBatchForJobAndRefsExists(jobName string, refs *prowapi.Refs) bool {

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -1177,10 +1177,10 @@ func (c *Controller) isBatchCandidateEligible(log *logrus.Entry, candidate *Pull
 	}
 
 	for _, headContext := range candidateHeadContexts {
-		if headContext.State == githubql.StatusStateSuccess {
+		if headContext.Context == statusContext || cc.IsOptional(string(headContext.Context)) || headContext.State == githubql.StatusStateSuccess {
 			continue
 		}
-		if headContext.State != githubql.StatusStatePending && !cc.IsOptional(string(headContext.Context)) {
+		if headContext.State != githubql.StatusStatePending {
 			return false
 		}
 

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -54,8 +54,14 @@ import (
 	"k8s.io/test-infra/prow/git/localgit"
 	"k8s.io/test-infra/prow/git/v2"
 	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/kube"
 	"k8s.io/test-infra/prow/tide/history"
 )
+
+func init() {
+	// Debugging tests without this isn't fun
+	logrus.SetLevel(logrus.DebugLevel)
+}
 
 var defaultBranch = localgit.DefaultBranch("")
 
@@ -1109,9 +1115,10 @@ func testPickBatch(clients localgit.Clients, t *testing.T) {
 		},
 	})
 	c := &Controller{
-		logger: logrus.WithField("component", "tide"),
-		gc:     gc,
-		config: ca.Config,
+		logger:       logrus.WithField("component", "tide"),
+		gc:           gc,
+		config:       ca.Config,
+		pickNewBatch: pickNewBatch(gc, ca.Config),
 	}
 	prs, presubmits, err := c.pickBatch(sp, map[int]contextChecker{
 		0: &config.TideContextPolicy{},
@@ -4735,6 +4742,243 @@ func TestSetTideStatusSuccess(t *testing.T) {
 
 			if ghc.setStatus != tc.expectApiCall {
 				t.Errorf("expected CreateStatusApiCall: %t, got CreateStatusApiCall: %t", tc.expectApiCall, ghc.setStatus)
+			}
+		})
+	}
+}
+
+// TestBatchPickingConsidersPRThatIsCurrentlyBeingSeriallyRetested verifies the following sequence of events:
+// 1. Tide creates a serial retest run for a passing PR
+// 2. The status contexts on the PR get updated to pending
+// 3. A second PR becomes eligible
+// 4. Tide creates a batch of the first and the second PR
+func TestBatchPickingConsidersPRThatIsCurrentlyBeingSeriallyRetested(t *testing.T) {
+	t.Parallel()
+	configGetter := func() *config.Config {
+		return &config.Config{
+			ProwConfig: config.ProwConfig{Tide: config.Tide{
+				Queries:       config.TideQueries{{}},
+				MaxGoroutines: 1,
+			}},
+			JobConfig: config.JobConfig{PresubmitsStatic: map[string][]config.Presubmit{
+				"/": {{AlwaysRun: true, Reporter: config.Reporter{Context: "mandatory-job"}}},
+			}},
+		}
+	}
+	ghc := &fgc{}
+	mmc := newMergeChecker(configGetter, ghc)
+	mgr := newFakeManager()
+	log := logrus.WithField("test", t.Name())
+	history, err := history.New(1, nil, "")
+	if err != nil {
+		t.Fatalf("failed to construct history: %v", err)
+	}
+	c, err := newSyncController(
+		context.Background(), log, ghc, mgr, configGetter, nil, &statusController{}, history, mmc, false,
+	)
+	if err != nil {
+		t.Fatalf("failed to construct sync controller: %v", err)
+	}
+	c.pickNewBatch = func(sp subpool, candidates []PullRequest, maxBatchSize int) ([]PullRequest, error) {
+		return candidates, nil
+	}
+
+	// Add a successful PR to github
+	initialPR := PullRequest{}
+	initialPR.Commits.Nodes = append(initialPR.Commits.Nodes, struct{ Commit Commit }{
+		Commit: Commit{Status: CommitStatus{Contexts: []Context{{
+			Context: githubql.String("mandatory-job"),
+			State:   githubql.StatusStateSuccess,
+		}}}},
+	})
+	ghc.prs = map[string][]PullRequest{"": {initialPR}}
+
+	// sync, this creates a new serial retest prowjob
+	if err := c.Sync(); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	// Ensure there is actually the retest job
+	var pjs prowapi.ProwJobList
+	if err := c.prowJobClient.List(c.ctx, &pjs); err != nil {
+		t.Fatalf("failed to list prowjobs: %v", err)
+	}
+	if n := len(pjs.Items); n != 1 {
+		t.Fatalf("expected a prowjob to be created, but client had %d items", n)
+	}
+
+	// Update the context on the PR to pending just like crier would
+	initialPR.Commits.Nodes[0].Commit.Status.Contexts[0].State = githubql.StatusStatePending
+
+	// Add a second PR that also needs retesting to GitHub
+	secondPR := PullRequest{Number: githubql.Int(1)}
+	secondPR.Commits.Nodes = append(secondPR.Commits.Nodes, struct{ Commit Commit }{
+		Commit: Commit{Status: CommitStatus{Contexts: []Context{{
+			Context: githubql.String("mandatory-job"),
+			State:   githubql.StatusStateSuccess,
+		}}}},
+	})
+	ghc.prs[""] = append(ghc.prs[""], secondPR)
+
+	// sync again
+	if err := c.Sync(); err != nil {
+		t.Fatalf("failed to sync: %v", err)
+	}
+
+	// verify we have a batch prowjob
+	if err := c.prowJobClient.List(c.ctx, &pjs); err != nil {
+		t.Fatalf("failed to list prowjobs: %v", err)
+	}
+	for _, pj := range pjs.Items {
+		if pj.Spec.Type == prowapi.BatchJob {
+			return
+		}
+	}
+
+	t.Errorf("expected to find a batch prwjob, but wasn't the case. ProwJobs: %+v", pjs.Items)
+}
+
+func TestIsBatchCandidateEligible(t *testing.T) {
+	t.Parallel()
+
+	const (
+		requiredContextName = "required-context"
+		optionalContextName = "optional-context"
+	)
+
+	tcs := []struct {
+		name          string
+		pjManipulator func(**prowapi.ProwJob)
+		prManipulator func(*PullRequest)
+
+		expected bool
+	}{
+		{
+			name:     "Is eligible",
+			expected: true,
+		},
+		{
+			name: "Successful context doesn't require prowjob",
+			prManipulator: func(pr *PullRequest) {
+				pr.Commits.Nodes[0].Commit.Status.Contexts[0].State = githubql.StatusStateSuccess
+			},
+			pjManipulator: func(pj **prowapi.ProwJob) { *pj = nil },
+			expected:      true,
+		},
+		{
+			name: "Optional failed context is ignored",
+			prManipulator: func(pr *PullRequest) {
+				pr.Commits.Nodes[0].Commit.Status.Contexts = append(pr.Commits.Nodes[0].Commit.Status.Contexts, Context{
+					Context: githubql.String(optionalContextName),
+					State:   githubql.StatusStateFailure,
+				})
+			},
+		},
+		{
+			name:          "Has missing required context, not eligible",
+			prManipulator: func(pr *PullRequest) { pr.Commits.Nodes[0].Commit.Status.Contexts = nil },
+		},
+		{
+			name: "Has failed context, not eligible",
+			prManipulator: func(pr *PullRequest) {
+				pr.Commits.Nodes[0].Commit.Status.Contexts[0].State = githubql.StatusStateFailure
+			},
+		},
+		{
+			name: "Has error context, not eligible",
+			prManipulator: func(pr *PullRequest) {
+				pr.Commits.Nodes[0].Commit.Status.Contexts[0].State = githubql.StatusStateError
+			},
+		},
+		{
+			name:          "No prowjob, not eligible",
+			pjManipulator: func(pj **prowapi.ProwJob) { *pj = nil },
+		},
+		{
+			name:          "Pj doesn't have created by tide label, not eligible",
+			pjManipulator: func(pj **prowapi.ProwJob) { (*pj).Labels["created-by-tide"] = "wrong" },
+		},
+		{
+			name:          "Pj doesn't have presubmit label, not eligible",
+			pjManipulator: func(pj **prowapi.ProwJob) { (*pj).Labels[kube.ProwJobTypeLabel] = "wrong" },
+		},
+		{
+			name:          "PJ doesn't have org label, not eligible",
+			pjManipulator: func(pj **prowapi.ProwJob) { (*pj).Labels[kube.OrgLabel] = "wrong" },
+		},
+		{
+			name:          "PJ doesn't have repo label, not eligible",
+			pjManipulator: func(pj **prowapi.ProwJob) { (*pj).Labels[kube.RepoLabel] = "wrong" },
+		},
+		{
+			name:          "Pj doesn't have baseref label, not eligible",
+			pjManipulator: func(pj **prowapi.ProwJob) { (*pj).Labels[kube.BaseRefLabel] = "wrong" },
+		},
+		{
+			name:          "Pj doesn't have pull label, not eligible",
+			pjManipulator: func(pj **prowapi.ProwJob) { (*pj).Labels[kube.PullLabel] = "wrong" },
+		},
+		{
+			name:          "pj doesn't have context label, not eligible",
+			pjManipulator: func(pj **prowapi.ProwJob) { (*pj).Labels[kube.ContextAnnotation] = "wrong" },
+		},
+		{
+			name:          "Pj is for wrong headref, not eligible",
+			pjManipulator: func(pj **prowapi.ProwJob) { (*pj).Spec.Refs.Pulls[0].SHA = "wrong" },
+		},
+	}
+
+	newPR := func() PullRequest {
+		pr := PullRequest{}
+		pr.Commits.Nodes = append(pr.Commits.Nodes, struct{ Commit Commit }{Commit: Commit{Status: CommitStatus{Contexts: []Context{
+			{Context: githubql.String(requiredContextName), State: githubql.StatusStatePending},
+		}}}})
+		return pr
+	}
+	newProwJob := func() *prowapi.ProwJob {
+		return &prowapi.ProwJob{
+			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+				"created-by-tide":      "true",
+				kube.ProwJobTypeLabel:  "presubmit",
+				kube.OrgLabel:          "",
+				kube.RepoLabel:         "",
+				kube.BaseRefLabel:      "",
+				kube.PullLabel:         "0",
+				kube.ContextAnnotation: requiredContextName,
+			}},
+			Spec: prowapi.ProwJobSpec{Refs: &prowapi.Refs{Pulls: []prowapi.Pull{{}}}},
+		}
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			pj := newProwJob()
+			pr := newPR()
+
+			if tc.prManipulator != nil {
+				tc.prManipulator(&pr)
+			}
+			if tc.pjManipulator != nil {
+				tc.pjManipulator(&pj)
+			}
+
+			var initObjects []runtime.Object
+			if pj != nil {
+				initObjects = append(initObjects, pj)
+			}
+
+			c := &Controller{
+				config:        func() *config.Config { return &config.Config{} },
+				ctx:           context.Background(),
+				prowJobClient: fakectrlruntimeclient.NewFakeClient(initObjects...),
+			}
+
+			cc := &config.TideContextPolicy{
+				RequiredContexts: []string{requiredContextName},
+				OptionalContexts: []string{optionalContextName},
+			}
+
+			if actual := c.isBatchCandidateEligible(logrus.WithField("tc", tc.name), &pr, cc); actual != tc.expected {
+				t.Errorf("expected result %t, got %t", tc.expected, actual)
 			}
 		})
 	}


### PR DESCRIPTION
This re-adds the aforementioned change. The second commit fixes what was wrong with it:
* It didn't ignore tides own status context
* It didn't ignore optional contexts (both the production code and the test for this were incorrect)

It also updates the test for `isPassingTests` to check if everything that is allowed there is also allowed by the new `isBatchCandidateEligible` which is why I am confident that this is correct now.

/cc @chaodaiG 
