### PR TITLE
Hook: Jira plugin does not update PR links when the title changes

### DIFF
--- a/prow/jira/jira.go
+++ b/prow/jira/jira.go
@@ -36,7 +36,7 @@ type Client interface {
 	GetIssue(id string) (*jira.Issue, error)
 	GetRemoteLinks(id string) ([]jira.RemoteLink, error)
 	AddRemoteLink(id string, link *jira.RemoteLink) error
-	RemoveRemoteLink(id string, link *jira.RemoteLink) error
+	UpdateRemoteLink(id string, link *jira.RemoteLink) error
 	ListProjects() (*jira.ProjectList, error)
 	JiraClient() *jira.Client
 	JiraURL() string
@@ -191,9 +191,9 @@ func (jc *client) AddRemoteLink(id string, link *jira.RemoteLink) error {
 	return nil
 }
 
-func (jc *client) RemoveRemoteLink(id string, link *jira.RemoteLink) error {
+func (jc *client) UpdateRemoteLink(id string, link *jira.RemoteLink) error {
 	internalLinkId := fmt.Sprint(link.ID)
-	req, err := jc.upstream.NewRequest("DELETE", "rest/api/2/issue/"+id+"/remotelink/"+internalLinkId, nil)
+	req, err := jc.upstream.NewRequest("PUT", "rest/api/2/issue/"+id+"/remotelink/"+internalLinkId, link)
 	if err != nil {
 		return fmt.Errorf("failed to construct request: %w", err)
 	}
@@ -202,7 +202,7 @@ func (jc *client) RemoveRemoteLink(id string, link *jira.RemoteLink) error {
 		defer resp.Body.Close()
 	}
 	if err != nil {
-		return fmt.Errorf("failed to remove link: %w", JiraError(resp, err))
+		return fmt.Errorf("failed to update link: %w", JiraError(resp, err))
 	}
 
 	return nil

--- a/prow/jira/jira.go
+++ b/prow/jira/jira.go
@@ -36,6 +36,7 @@ type Client interface {
 	GetIssue(id string) (*jira.Issue, error)
 	GetRemoteLinks(id string) ([]jira.RemoteLink, error)
 	AddRemoteLink(id string, link *jira.RemoteLink) error
+	RemoveRemoteLink(id string, link *jira.RemoteLink) error
 	ListProjects() (*jira.ProjectList, error)
 	JiraClient() *jira.Client
 	JiraURL() string
@@ -185,6 +186,23 @@ func (jc *client) AddRemoteLink(id string, link *jira.RemoteLink) error {
 	}
 	if err != nil {
 		return fmt.Errorf("failed to add link: %w", JiraError(resp, err))
+	}
+
+	return nil
+}
+
+func (jc *client) RemoveRemoteLink(id string, link *jira.RemoteLink) error {
+	internalLinkId := fmt.Sprint(link.ID)
+	req, err := jc.upstream.NewRequest("DELETE", "rest/api/2/issue/"+id+"/remotelink/"+internalLinkId, nil)
+	if err != nil {
+		return fmt.Errorf("failed to construct request: %w", err)
+	}
+	resp, err := jc.upstream.Do(req, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return fmt.Errorf("failed to remove link: %w", JiraError(resp, err))
 	}
 
 	return nil

--- a/prow/jira/jira.go
+++ b/prow/jira/jira.go
@@ -201,10 +201,13 @@ func (jc *client) UpdateRemoteLink(id string, link *jira.RemoteLink) error {
 	if resp != nil {
 		defer resp.Body.Close()
 	}
-	if err != nil {
+	if err != nil || resp.StatusCode != http.StatusNoContent {
+		// Trace at least the status code if we got no errors but response is still not valid
+		if err == nil {
+			err = fmt.Errorf("expected status code %d but got %d instead", http.StatusNoContent, resp.StatusCode)
+		}
 		return fmt.Errorf("failed to update link: %w", JiraError(resp, err))
 	}
-
 	return nil
 }
 

--- a/prow/jira/jira.go
+++ b/prow/jira/jira.go
@@ -201,12 +201,11 @@ func (jc *client) UpdateRemoteLink(id string, link *jira.RemoteLink) error {
 	if resp != nil {
 		defer resp.Body.Close()
 	}
-	if err != nil || resp.StatusCode != http.StatusNoContent {
-		// Trace at least the status code if we got no errors but response is still not valid
-		if err == nil {
-			err = fmt.Errorf("expected status code %d but got %d instead", http.StatusNoContent, resp.StatusCode)
-		}
+	if err != nil {
 		return fmt.Errorf("failed to update link: %w", JiraError(resp, err))
+	}
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("failed to update link: expected status code %d but got %d instead", http.StatusNoContent, resp.StatusCode)
 	}
 	return nil
 }

--- a/prow/plugins/jira/jira.go
+++ b/prow/plugins/jira/jira.go
@@ -275,7 +275,7 @@ func upsertGitHubLinkToIssue(log *logrus.Entry, issueID string, jc jiraclient.Cl
 		url = url[:idx]
 	}
 
-	newTitle := fmt.Sprintf("%s#%d: %s", e.Repo.FullName, e.Number, e.IssueTitle)
+	title := fmt.Sprintf("%s#%d: %s", e.Repo.FullName, e.Number, e.IssueTitle)
 	var existingLink *jira.RemoteLink
 
 	// Check if the same link exists already. We consider two links to be the same if the have the same URL.
@@ -283,19 +283,19 @@ func upsertGitHubLinkToIssue(log *logrus.Entry, issueID string, jc jiraclient.Cl
 	// has to be updated (perform an upsert)
 	for _, link := range links {
 		if link.Object.URL == url {
-			if newTitle == link.Object.Title {
+			if title == link.Object.Title {
 				return nil
-			} else {
-				existingLink = &link
-				break
 			}
+			link := link
+			existingLink = &link
+			break
 		}
 	}
 
 	link := &jira.RemoteLink{
 		Object: &jira.RemoteLinkObject{
 			URL:   url,
-			Title: newTitle,
+			Title: title,
 			Icon: &jira.RemoteLinkIcon{
 				Url16x16: "https://github.com/favicon.ico",
 				Title:    "GitHub",

--- a/prow/plugins/jira/jira_test.go
+++ b/prow/plugins/jira/jira_test.go
@@ -134,14 +134,14 @@ func (f *fakeJiraClient) AddRemoteLink(id string, link *jira.RemoteLink) error {
 	return nil
 }
 
-func (f *fakeJiraClient) RemoveRemoteLink(id string, link *jira.RemoteLink) error {
+func (f *fakeJiraClient) UpdateRemoteLink(id string, link *jira.RemoteLink) error {
 	if _, err := f.GetIssue(id); err != nil {
 		return err
 	}
 	if _, found := f.existingLinks[id]; !found {
 		return jiraclient.NewNotFoundError(fmt.Errorf("Link for issue %s not found", id))
 	}
-	delete(f.existingLinks, id)
+	f.newLinks = append(f.newLinks, *link)
 	return nil
 }
 


### PR DESCRIPTION
**Abstract**
Once the link between the PR and its related Jira card is set for the first time, the plugin is unable to update it if something like the title changes.

**Description**
This is what happens: the Jira issue did not reference the PR until the first retitle, then I issued the command `/retitle` and the CI component reacted by retitling the PR and linking the it to the issue I referenced (as part of the new title). Unfortunately the steps are not consequential, so I ended up finding the old title in the issue. From that moment on any new `/retitle` would have not affected the link between the Jira issue and the PR because the system is not able to update an already set link.