### PR TITLE
Enforce restart when prow can access a build cluster that failed before

### DIFF
--- a/prow/cmd/prow-controller-manager/main.go
+++ b/prow/cmd/prow-controller-manager/main.go
@@ -153,6 +153,12 @@ func main() {
 	}
 
 	buildManagers, err := o.kubernetes.BuildClusterManagers(o.dryRun,
+		// The watch apimachinery doesn't support restarts, so just exit the
+		// binary if a build cluster can be connected later .
+		func() {
+			logrus.Info("Build cluster that failed to connect initially now worked, exiting to trigger a restart.")
+			interrupts.Terminate()
+		},
 		func(o *manager.Options) {
 			o.Namespace = cfg().PodNamespace
 		},

--- a/prow/cmd/sinker/main.go
+++ b/prow/cmd/sinker/main.go
@@ -141,6 +141,12 @@ func main() {
 	}
 
 	buildManagers, err := o.kubernetes.BuildClusterManagers(o.dryRun,
+		// The watch apimachinery doesn't support restarts, so just exit the
+		// binary if a build cluster can be connected later .
+		func() {
+			logrus.Info("Build cluster that failed to connect initially now worked, exiting to trigger a restart.")
+			interrupts.Terminate()
+		},
 		func(o *manager.Options) {
 			o.Namespace = cfg().PodNamespace
 		},

--- a/prow/flagutil/kubernetes_cluster_clients.go
+++ b/prow/flagutil/kubernetes_cluster_clients.go
@@ -340,7 +340,7 @@ var clientCreationFailures = prometheus.NewCounterVec(prometheus.CounterOpts{
 // BuildClusterManagers returns a manager per buildCluster.
 // Per default, LeaderElection and the metrics listener are disabled, as we assume
 // that there is another manager for ProwJobs that handles that.
-func (o *KubernetesOptions) BuildClusterManagers(dryRun bool, opts ...func(*manager.Options)) (map[string]manager.Manager, error) {
+func (o *KubernetesOptions) BuildClusterManagers(dryRun bool, callBack func(), opts ...func(*manager.Options)) (map[string]manager.Manager, error) {
 	if err := o.resolve(dryRun); err != nil {
 		return nil, err
 	}
@@ -362,21 +362,7 @@ func (o *KubernetesOptions) BuildClusterManagers(dryRun bool, opts ...func(*mana
 	for buildCluserName, buildClusterConfig := range o.clusterConfigs {
 		go func(name string, config rest.Config) {
 			defer threads.Done()
-			var mgr manager.Manager
-			var err error
-			// Try up to 4 times to create the manager. Total time trying: ~31s
-			delay := time.Second
-			tries := 4
-			for try := 0; try < tries; try++ {
-				mgr, err = manager.New(&config, options)
-				if err == nil {
-					break
-				}
-				if try+1 < tries {
-					time.Sleep(delay)
-					delay = delay * 5
-				}
-			}
+			mgr, err := manager.New(&config, options)
 			lock.Lock()
 			defer lock.Unlock()
 			if err != nil {
@@ -388,7 +374,33 @@ func (o *KubernetesOptions) BuildClusterManagers(dryRun bool, opts ...func(*mana
 		}(buildCluserName, buildClusterConfig)
 	}
 	threads.Wait()
-	return res, utilerrors.NewAggregate(errs)
+
+	aggregatedErr := utilerrors.NewAggregate(errs)
+
+	if aggregatedErr == nil {
+		// Retry the build clusters that failed to be connected initially, execute
+		// callback function when they become reachable later on.
+		// This is useful where a build cluster is not reachable transiently, for
+		// example API server upgrade caused connection problem.
+		go func() {
+			for {
+				for buildCluserName, buildClusterConfig := range o.clusterConfigs {
+					if _, ok := res[buildCluserName]; ok {
+						continue
+					}
+					if _, err := manager.New(&buildClusterConfig, options); err == nil {
+						logrus.WithField("build-cluster", buildCluserName).Info("Build cluster that failed to connect initially now worked.")
+						callBack()
+					}
+				}
+				// Sleep arbitrarily amount of time
+				time.Sleep(5 * time.Second)
+			}
+		}()
+	} else {
+		logrus.Debug("No error constructing managers for build clusters, skip polling build clusters.")
+	}
+	return res, aggregatedErr
 }
 
 // BuildClusterUncachedRuntimeClients returns ctrlruntimeclients for the build cluster in a non-caching implementation.


### PR DESCRIPTION
This will catch the case where a build cluster is going through master upgrade, which takes ~5 to 10 minutes in cases where I have observed.

/cc @alvaroaleman @cjwagner @mpherman2 