### PR TITLE
Tide does not watch for kubeconfig change

### DIFF
--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -176,15 +176,6 @@ func main() {
 		}
 	})
 
-	// The watch apimachinery doesn't support restarts, so just exit the binary if a kubeconfig changes
-	// to make the kubelet restart us.
-	if err := o.kubernetes.AddKubeconfigChangeCallback(func() {
-		logrus.Info("Kubeconfig changed, exiting to trigger a restart")
-		interrupts.Terminate()
-	}); err != nil {
-		logrus.WithError(err).Fatal("Failed to register kubeconfig change callback")
-	}
-
 	controllerMux := http.NewServeMux()
 	controllerMux.Handle("/", c)
 	controllerMux.Handle("/history", c.History)


### PR DESCRIPTION
 Tide does not watch for kubeconfig change

Tide does not access build clusters at all, it's confusing to watch kubeconfig changes in tide

/cc @alvaroaleman 