### PR TITLE
add preset-use-new-registry label

### DIFF
--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -1,18 +1,3 @@
-presets:
-- labels:
-    preset-use-new-registry: "true"
-  env:
-  - name: KUBE_TEST_REPO_LIST
-    value: https://raw.githubusercontent.com/kubernetes/test-infra/master/config/jobs/kubernetes/sig-cloud-provider/gcp/registry/default.yaml
-  - name: KUBE_DOCKER_REGISTRY
-    value: registry.k8s.io
-  - name: KUBE_ADDON_REGISTRY
-    value: registry.k8s.io
-  - name: TEST_ETCD_DOCKER_REPOSITORY
-    value: registry.k8s.io/etcd
-  - name: CONTAINERD_INFRA_CONTAINER
-    value: registry.k8s.io/pause:3.6
-
 periodics:
 - interval: 12h
   name: ci-kubernetes-e2e-gce-gci-serial-sig-cli

--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -150,6 +150,7 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    preset-use-new-registry: "true"
   spec:
     containers:
     - args:

--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -1,3 +1,18 @@
+presets:
+- labels:
+    preset-use-new-registry: "true"
+  env:
+  - name: KUBE_TEST_REPO_LIST
+    value: https://raw.githubusercontent.com/kubernetes/test-infra/master/config/jobs/kubernetes/sig-cloud-provider/gcp/registry/default.yaml
+  - name: KUBE_DOCKER_REGISTRY
+    value: registry.k8s.io
+  - name: KUBE_ADDON_REGISTRY
+    value: registry.k8s.io
+  - name: TEST_ETCD_DOCKER_REPOSITORY
+    value: registry.k8s.io/etcd
+  - name: CONTAINERD_INFRA_CONTAINER
+    value: registry.k8s.io/pause:3.6
+
 periodics:
 - interval: 12h
   name: ci-kubernetes-e2e-gce-gci-serial-sig-cli

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -1,6 +1,7 @@
 presets:
 - labels:
     preset-pull-kubernetes-e2e: "true"
+    preset-use-new-registry: "true"
   env:
   - name: KUBE_GCS_UPDATE_LATEST
     value: "n"
@@ -441,6 +442,7 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    preset-use-new-registry: "true"
   spec:
     containers:
     - args:
@@ -559,6 +561,7 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    preset-use-new-registry: "true"
   spec:
     containers:
     - args:
@@ -684,6 +687,7 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    preset-use-new-registry: "true"
   spec:
     containers:
     - args:

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -1,7 +1,6 @@
 presets:
 - labels:
     preset-pull-kubernetes-e2e: "true"
-    preset-use-new-registry: "true"
   env:
   - name: KUBE_GCS_UPDATE_LATEST
     value: "n"

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -10,20 +10,6 @@ presets:
     value: cos-cloud
   - name: NODE_ACCELERATORS
     value: type=nvidia-tesla-k80,count=2
-- labels:
-    preset-use-new-registry: "true"
-  env:
-  - name: KUBE_TEST_REPO_LIST
-    value: https://raw.githubusercontent.com/kubernetes/test-infra/master/config/jobs/kubernetes/sig-cloud-provider/gcp/registry/default.yaml
-  - name: KUBE_DOCKER_REGISTRY
-    value: registry.k8s.io
-  - name: KUBE_ADDON_REGISTRY
-    value: registry.k8s.io
-  - name: TEST_ETCD_DOCKER_REPOSITORY
-    value: registry.k8s.io/etcd
-  - name: CONTAINERD_INFRA_CONTAINER
-    value: registry.k8s.io/pause:3.6
-
 
 periodics:
 - name: ci-kubernetes-e2e-gce-device-plugin-gpu

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -1,7 +1,6 @@
 presets:
 - labels:
     preset-ci-gce-device-plugin-gpu: "true"
-    preset-use-new-registry: "true"
   env:
   # Note: The GCE Node image used may have a dependency on the nvidia-driver-installer image defined in https://github.com/kubernetes/kubernetes/blob/master/test/e2e/testing-manifests/scheduling/nvidia-driver-installer.yaml
   # If updating the image defined here, the cos-gpu-installer image may need to updated to support the corresponding COS image.
@@ -11,6 +10,20 @@ presets:
     value: cos-cloud
   - name: NODE_ACCELERATORS
     value: type=nvidia-tesla-k80,count=2
+- labels:
+    preset-use-new-registry: "true"
+  env:
+  - name: KUBE_TEST_REPO_LIST
+    value: https://raw.githubusercontent.com/kubernetes/test-infra/master/config/jobs/kubernetes/sig-cloud-provider/gcp/registry/default.yaml
+  - name: KUBE_DOCKER_REGISTRY
+    value: registry.k8s.io
+  - name: KUBE_ADDON_REGISTRY
+    value: registry.k8s.io
+  - name: TEST_ETCD_DOCKER_REPOSITORY
+    value: registry.k8s.io/etcd
+  - name: CONTAINERD_INFRA_CONTAINER
+    value: registry.k8s.io/pause:3.6
+
 
 periodics:
 - name: ci-kubernetes-e2e-gce-device-plugin-gpu

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -1,6 +1,7 @@
 presets:
 - labels:
     preset-ci-gce-device-plugin-gpu: "true"
+    preset-use-new-registry: "true"
   env:
   # Note: The GCE Node image used may have a dependency on the nvidia-driver-installer image defined in https://github.com/kubernetes/kubernetes/blob/master/test/e2e/testing-manifests/scheduling/nvidia-driver-installer.yaml
   # If updating the image defined here, the cos-gpu-installer image may need to updated to support the corresponding COS image.
@@ -19,6 +20,7 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
     preset-ci-gce-device-plugin-gpu: "true"
+    preset-use-new-registry: "true"
   annotations:
     fork-per-release: "true"
     fork-per-release-replacements: "--extract=ci/latest-fast -> --extract=ci/latest-{{.Version}}"

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -1,3 +1,18 @@
+presets:
+- labels:
+    preset-use-new-registry: "true"
+  env:
+  - name: KUBE_TEST_REPO_LIST
+    value: https://raw.githubusercontent.com/kubernetes/test-infra/master/config/jobs/kubernetes/sig-cloud-provider/gcp/registry/default.yaml
+  - name: KUBE_DOCKER_REGISTRY
+    value: registry.k8s.io
+  - name: KUBE_ADDON_REGISTRY
+    value: registry.k8s.io
+  - name: TEST_ETCD_DOCKER_REPOSITORY
+    value: registry.k8s.io/etcd
+  - name: CONTAINERD_INFRA_CONTAINER
+    value: registry.k8s.io/pause:3.6
+
 presubmits:
   # Note, these jobs need to generally stage results to a GCE bucket.
   # We currently have three, ingress, network-policies , and ipvs...

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -1,18 +1,3 @@
-presets:
-- labels:
-    preset-use-new-registry: "true"
-  env:
-  - name: KUBE_TEST_REPO_LIST
-    value: https://raw.githubusercontent.com/kubernetes/test-infra/master/config/jobs/kubernetes/sig-cloud-provider/gcp/registry/default.yaml
-  - name: KUBE_DOCKER_REGISTRY
-    value: registry.k8s.io
-  - name: KUBE_ADDON_REGISTRY
-    value: registry.k8s.io
-  - name: TEST_ETCD_DOCKER_REPOSITORY
-    value: registry.k8s.io/etcd
-  - name: CONTAINERD_INFRA_CONTAINER
-    value: registry.k8s.io/pause:3.6
-
 presubmits:
   # Note, these jobs need to generally stage results to a GCE bucket.
   # We currently have three, ingress, network-policies , and ipvs...

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -28,6 +28,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-pull-kubernetes-e2e: "true"
       preset-pull-kubernetes-e2e-gce: "true"
+      preset-use-new-registry: "true"
     spec:
       containers:
       - command:


### PR DESCRIPTION
This pr is to assist [k8s-sigs/oci-procy issue 29](https://github.com/kubernetes-sigs/oci-proxy/issues/29): adding a `preset-use-new-registry` label to a batch of jobs to see if they're images are being pulled from the new registry.

There are 6 jobs affected in this pr, all part of sig-release-master-blocking:
- gce-cos-master-alpha-features
- gce-cos-master-default
- gce-cos-master-reboot
- gce-device-plugin-gpu-master
- gci-gce-ingress
- skew-cluster-latest-kubectl-stable1-gce

They were chosen using the following criteria:
- had a recent, successful testgrid run.
- the resulting artifacts of the job includes the file `images-containerd.log`
- the job is not kind based (we determined by making sure `kind-version.txt` was not in the artifacts, and `kind` was not in the  description in the job's prow config)
- the job is not CAPI-based (determined by making sure capi and capa not included in prow config description)
- the job had `--scenario=kubernetes_e2e`included in its prow config args.
