### PR TITLE
fixing node-kubelet-containerd-performance-test job

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -1299,7 +1299,7 @@ periodics:
           - --gcp-project-type=node-e2e-project
           - --gcp-zone=us-west1-b
           - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/perf-image-config.yaml
-          - '--node-test-args=--feature-gates=LocalStorageCapacityIsolation=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+          - '--node-test-args=--feature-gates=LocalStorageCapacityIsolation=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}" --server-start-timeout=420s'
           - --node-tests=true
           - --provider=gce
           - --test_args=--nodes=1

--- a/jobs/e2e_node/perf-image-config.yaml
+++ b/jobs/e2e_node/perf-image-config.yaml
@@ -10,6 +10,7 @@ images:
   ubuntu:
     image: ubuntu-gke-2004-1-20-v20210401 # docker 19.03.8 / containerd 1.4.3
     project: ubuntu-os-gke-cloud
+    machine: n1-standard-16
     metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"
     tests:
       - 'Node Performance Testing'


### PR DESCRIPTION
Signed-off-by: Naman <namanlakhwani@gmail.com>

related issue: #25430 
Job status: https://k8s-testgrid.appspot.com/sig-node-containerd#node-kubelet-containerd-performance-test

### Proposed changes

- changes done in `jobs/e2e_node/perf-image-config.yaml` - added `machine: n1-standard-16` for ubnutu which was removed [here](https://github.com/kubernetes/test-infra/pull/25385/files#diff-418885af5c07fb6f3d66bc02eb9a767271f4b8f4ed9af21f05c02000f1b4e661L13) and as a result we are getting following [logs](https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-containerd-performance-test/1509717064682573824/build-log.txt)

```
ensure environment has enough CPU + Memory to run
Skipping Node Performance Tests due to lack of CPU. Required {{15 0} {<nil>} 15 DecimalSI} is less than capacity {{1 0} {<nil>} 1 DecimalSI}.
```

- changes done in `config/jobs/kubernetes/sig-node/containerd.yaml` - added `--server-start-timeout=420s` in the `node-args` as it is mentioned in the old [job](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-node/node-kubelet.yaml#L136)

cc: @adisky @SergeyKanzhelev @ehashman 
Thanks!