### PR TITLE
Allow buildlog to configure a highlighting service

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -57,6 +57,10 @@ deck:
     - lens:
         name: buildlog
         config:
+          #highlighter:
+          #  endpoint: http://localhost:1234, http://some-service[.namespace.svc.cluster.local]
+          #  pin: true
+          #  auto: false
           highlight_regexes:
           - Automatic merge failed
           - cannot convert.+to type

--- a/prow/cmd/deck/job_history.go
+++ b/prow/cmd/deck/job_history.go
@@ -106,9 +106,9 @@ type jobHistoryTemplate struct {
 
 func (bucket blobStorageBucket) readObject(ctx context.Context, key string) ([]byte, error) {
 	u := url.URL{
-		Scheme:      bucket.storageProvider,
-		Host:        bucket.name,
-		Path:        key,
+		Scheme: bucket.storageProvider,
+		Host:   bucket.name,
+		Path:   key,
 	}
 	rc, err := bucket.Opener.Reader(ctx, u.String())
 	if err != nil {

--- a/prow/spyglass/lenses/buildlog/template.html
+++ b/prow/spyglass/lenses/buildlog/template.html
@@ -6,6 +6,7 @@
 <div>
 {{range $log := .LogViews}}
   <div>
+    {{if .CanAnalyze}}<button class="analyze-button" data-artifact="{{$log.ArtifactName}}" title="Highlight interesting lines identified by prow">Analyze</button>{{end}}
     <button class="show-all-button" data-artifact="{{$log.ArtifactName}}">Show all hidden lines</button>
     {{if .ShowRawLog}}<a href="{{$log.ArtifactLink}}" style="padding-left:15px;">Raw {{$log.ArtifactName}}<i class="material-icons" style="padding-left: 3px;">open_in_new</i></a>{{end}}
     <div class="loglines{{if .CanSave}} savable{{end}}" id="{{$log.ArtifactName}}-content">


### PR DESCRIPTION
Optionally allows configuring the `buildlog` lens to use a highlighting service.

Does nothing by default, but if configured logs get an "analyze" button at the top of the log. When clicked, it will then send the URL to the service. The service should respond with any lights that should be highlighted, and the lens selects these lines.

An additional option is to configure the lens to automatically request this analysis before loading the log and/or save the highlighted line for the next load.
