### PR TITLE
add canary job to test the kpromo with signatures in the bom repo

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -50,6 +50,36 @@ postsubmits:
       testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
       testgrid-num-failures-to-alert: '2'
 
+  kubernetes-sigs/bom:
+  # This job is a canary job to test the k-promo and the image promotion with signatures
+  # it will promote the image to another bucket in the same gcp project
+  # TODO: update the service account to one that is inside the staging-bom project
+  - name: post-bom-image-promo-canary
+    cluster: k8s-infra-prow-build-trusted
+    decorate: true
+    run_if_changed: 'canary/((images/.*/images\.yaml)|(manifests/.*/promoter-manifest\.yaml))'
+    # Never run more than 1 job at a time. This is because we don't want to run
+    # into a case where an older manifest PR merge gets run last (after a newer
+    # one).
+    max_concurrency: 1
+    branches:
+    - ^main$
+    spec:
+      serviceAccountName: k8s-infra-gcr-promoter
+      containers:
+      - image: gcr.io/k8s-staging-artifact-promoter/kpromo:v20220331-v3.3.0-158-ge03464e
+        command:
+        - /kpromo
+        args:
+        - cip
+        - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes-sigs/bom/canary
+        - --signer-account=test-signer@ulabs-cloud-tests.iam.gserviceaccount.com
+        - --confirm
+    annotations:
+      testgrid-dashboards: sig-release-releng-informing
+      testgrid-alert-email: release-managers+alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '2'
+
 periodics:
 - interval: 1h
   cluster: k8s-infra-prow-build-trusted


### PR DESCRIPTION
- add canary job to test the kpromo with signatures in the bom repo
this will make us to test the kpromo and signatures in a specific repo

/assign @puerco @justaugustus
cc @kubernetes/release-engineering 