### PR TITLE
Bump bom canay build to image promoter at HEAD

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -66,7 +66,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-promoter
       containers:
-      - image: gcr.io/k8s-staging-artifact-promoter/kpromo:v20220331-v3.3.0-158-ge03464e
+      - image: gcr.io/k8s-staging-artifact-promoter/kpromo:v20220402-v3.3.0-160-gc6d7a2b
         command:
         - /kpromo
         args:


### PR DESCRIPTION
This PR bumps the image promoter version used in the k8s canary
builds to the latest image in staging to test the latest code.

/assign @cpanato 

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>