### PR TITLE
releng: Update canary image promotion jobs

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -50,10 +50,10 @@ postsubmits:
       testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
       testgrid-num-failures-to-alert: '2'
 
-  kubernetes-sigs/bom:
-  # This job is a canary job to test the k-promo and the image promotion with signatures
-  # it will promote the image to another bucket in the same gcp project
-  - name: post-bom-image-promo-canary
+  kubernetes-sigs/promo-tools:
+  # This job is a canary job to test promoting the image promoter before
+  # rolling changes out to production instances
+  - name: post-promo-tools-image-promo-canary
     cluster: k8s-infra-prow-build-trusted
     decorate: true
     run_if_changed: 'canary/((images/.*/images\.yaml)|(manifests/.*/promoter-manifest\.yaml))'
@@ -71,7 +71,7 @@ postsubmits:
         - /kpromo
         args:
         - cip
-        - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes-sigs/bom/canary
+        - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes-sigs/promo-tools/canary
         - --confirm
     annotations:
       testgrid-dashboards: sig-release-releng-informing

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -145,6 +145,36 @@ periodics:
       - org: kubernetes
         slug: release-managers
 
+# This job is a canary job to test promoting the image promoter before
+# rolling changes out to production instances
+- interval: 1h
+  cluster: k8s-infra-prow-build-trusted
+  max_concurrency: 1
+  name: ci-promo-tools-image-promo-canary
+  decorate: true
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: promo-tools
+    base_ref: main
+  spec:
+    serviceAccountName: k8s-infra-gcr-promoter
+    containers:
+    - image: gcr.io/k8s-staging-artifact-promoter/kpromo:v20220402-v3.3.0-160-gc6d7a2b
+      command:
+      - /kpromo
+      args:
+      - cip
+      - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes-sigs/promo-tools/canary
+      - --confirm
+  annotations:
+    testgrid-dashboards: sig-release-releng-informing
+    testgrid-alert-email: release-managers+alerts@kubernetes.io
+    testgrid-num-failures-to-alert: '2'
+  rerun_auth_config:
+    github_team_slugs:
+      - org: kubernetes
+        slug: release-managers
+
 - interval: 4h
   cluster: k8s-infra-prow-build-trusted
   max_concurrency: 1

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -66,7 +66,8 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-promoter
       containers:
-      - image: gcr.io/k8s-staging-artifact-promoter/kpromo:v20220402-v3.3.0-160-gc6d7a2b
+      - image: gcr.io/k8s-staging-artifact-promoter/kpromo:latest-canary
+        imagePullPolicy: Always
         command:
         - /kpromo
         args:
@@ -159,7 +160,8 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-gcr-promoter
     containers:
-    - image: gcr.io/k8s-staging-artifact-promoter/kpromo:v20220402-v3.3.0-160-gc6d7a2b
+    - image: gcr.io/k8s-staging-artifact-promoter/kpromo:latest-canary
+      imagePullPolicy: Always
       command:
       - /kpromo
       args:


### PR DESCRIPTION
- releng: Move image promotion canary job to sigs.k8s.io/promo-tools
- releng: Add periodic canary job for image promotion
- releng: Bump images for canary image promo jobs to promo-tools@main

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @cpanato @puerco 
cc: @kubernetes/release-engineering 
ref: https://github.com/kubernetes/k8s.io/pull/3588, https://github.com/kubernetes-sigs/promo-tools/issues/523
