### PR TITLE
Add stress test presubmit for cli-utils

### DIFF
--- a/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
+++ b/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
@@ -45,3 +45,27 @@ presubmits:
       testgrid-dashboards: sig-cli-misc
       testgrid-tab-name: cli-utils-presubmit-master-e2e
       description: cli-utils presubmit e2e tests on master branch
+  - name: cli-utils-presubmit-master-stress
+    decorate: true
+    always_run: true
+    path_alias: sigs.k8s.io/cli-utils
+    branches:
+    - ^master$
+    - ^release-.*$
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220404-0178a71d18-master
+        command:
+        - runner.sh
+        - make
+        - test-stress
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+    annotations:
+      testgrid-dashboards: sig-cli-misc
+      testgrid-tab-name: cli-utils-presubmit-master-stress
+      description: cli-utils presubmit stress tests on master branch


### PR DESCRIPTION
cli-utils stress tests runs in kind and applies & destroys 1k namespaces, each with a config map and custom resource.