### PR TITLE
add missing maintainers_friendly_name

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -431,6 +431,7 @@ repo_milestone:
     # curl -H "Authorization: token <token>" "https://api.github.com/orgs/<org-name>/teams?page=N"
     maintainers_id: 2460384
     maintainers_team: milestone-maintainers
+    maintainers_friendly_name: Milestone Maintainers Team
   kubernetes-sigs/controller-runtime:
     maintainers_id: 2785806
     maintainers_team: controller-runtime-maintainers


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/109308#issuecomment-1088665833:

> @danwinship: You must be a member of the [kubernetes/milestone-maintainers](https://github.com/orgs/kubernetes/teams/milestone-maintainers/members) GitHub team to set the milestone. If you believe you should be able to issue the /milestone command, please contact your and have them propose you as an additional delegate for this responsibility.

"... please contact your and have them ..."