### PR TITLE
Update service account credential helper for 1.21+

### DIFF
--- a/gencred/README.md
+++ b/gencred/README.md
@@ -175,6 +175,8 @@ token, caPEM, err := serviceaccount.CreateClusterServiceAccountCredentials(clien
 
 `token` will contain the **service account access token** and `caPEM` will contain the **server certificate authority**.
 
+This requests a token valid for one week or until the service account is deleted.
+
 ```go
 import "encoding/base64"
 

--- a/gencred/pkg/serviceaccount/BUILD.bazel
+++ b/gencred/pkg/serviceaccount/BUILD.bazel
@@ -7,7 +7,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//gencred/pkg/kubeconfig:go_default_library",
-        "@io_k8s_api//authorization/v1beta1:go_default_library",
+        "@io_k8s_api//authentication/v1:go_default_library",
+        "@io_k8s_api//authorization/v1:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_api//rbac/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
@@ -36,7 +37,8 @@ go_test(
     embed = [":go_default_library"],
     tags = ["manual"],
     deps = [
-        "@io_k8s_api//authorization/v1beta1:go_default_library",
+        "@io_k8s_api//authentication/v1:go_default_library",
+        "@io_k8s_api//authorization/v1:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",

--- a/gencred/pkg/serviceaccount/serviceaccount_test.go
+++ b/gencred/pkg/serviceaccount/serviceaccount_test.go
@@ -19,7 +19,8 @@ package serviceaccount
 import (
 	"testing"
 
-	authorizationv1beta1 "k8s.io/api/authorization/v1beta1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -39,16 +40,14 @@ func TestCreateClusterServiceAccountCredentials(t *testing.T) {
 			createClient: func() kubernetes.Interface {
 				var client kubernetes.Interface = &k8sFake.Clientset{}
 
-				client.(*k8sFake.Clientset).Fake.AddReactor("get", "secrets", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
-					r := &corev1.Secret{
-						TypeMeta: metav1.TypeMeta{},
+				client.(*k8sFake.Clientset).Fake.AddReactor("get", "configmaps", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+					r := &corev1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "secret-abc",
+							Name:      "kube-root-ca.crt",
 							Namespace: corev1.NamespaceDefault,
 						},
-						Data: map[string][]uint8{
-							corev1.ServiceAccountTokenKey:  {1, 2, 3},
-							corev1.ServiceAccountRootCAKey: {1, 2, 3},
+						Data: map[string]string{
+							"ca.crt": "ca",
 						},
 					}
 					return true, r, nil
@@ -66,10 +65,19 @@ func TestCreateClusterServiceAccountCredentials(t *testing.T) {
 				})
 
 				client.(*k8sFake.Clientset).Fake.AddReactor("create", "selfsubjectaccessreviews", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
-					r := &authorizationv1beta1.SelfSubjectAccessReview{
-						Status: authorizationv1beta1.SubjectAccessReviewStatus{
+					r := &authorizationv1.SelfSubjectAccessReview{
+						Status: authorizationv1.SubjectAccessReviewStatus{
 							Allowed: true,
 							Reason:  "I am a test!",
+						},
+					}
+					return true, r, nil
+				})
+
+				client.(*k8sFake.Clientset).Fake.AddReactor("create", "serviceaccounts/token", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+					r := &authenticationv1.TokenRequest{
+						Status: authenticationv1.TokenRequestStatus{
+							Token: "abc",
 						},
 					}
 					return true, r, nil


### PR DESCRIPTION
Use projected tokens (GA since 1.21+) and v1 authorization APIs (required since 1.22+)