### PR TITLE
Add a new periodic job to test CAPA e2e with ClusterClass

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-clusterclass.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-clusterclass.yaml
@@ -1,0 +1,44 @@
+periodics:
+- name: periodic-cluster-api-provider-aws-e2e-clusterclass
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  interval: 12h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-aws
+    base_ref: main
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220404-0178a71d18-master
+      command:
+        - "runner.sh"
+        - "./scripts/ci-e2e.sh"
+      env:
+      - name: BOSKOS_HOST
+        value: "boskos.test-pods.svc.cluster.local"
+      - name: AWS_REGION
+        value: "us-west-2"
+      # Parallelize tests
+      - name: GINKGO_ARGS
+        value: "-nodes 20"
+      - name: E2E_FOCUS
+        value: "\\[ClusterClass\\]"
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 2
+          memory: "9Gi"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+    testgrid-tab-name: periodic-e2e-main-clusterclass
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "2"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
@@ -28,7 +28,7 @@ periodics:
         value: "us-west-2"
       # Parallelize tests
       - name: GINKGO_ARGS
-        value: "-nodes 20"
+        value: "-nodes 20 --ginkgo.skip=\\[ClusterClass\\]"
       securityContext:
         privileged: true
       resources:


### PR DESCRIPTION
This PR adds a new periodic prow jobs to test CAPA e2e with ClusterClass. 

Reference: https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/3346