### PR TITLE
Kustomize required statuses + Go 1.18

### DIFF
--- a/config/jobs/kubernetes-sigs/kustomize/OWNERS
+++ b/config/jobs/kubernetes-sigs/kustomize/OWNERS
@@ -1,14 +1,15 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- liujingfang1
-- monopole
+- knverey
+- natasha41575
+- mengqiy
 - mortent
-- pwittrock
-- seans3
+- phanimarupaka
+
 approvers:
-- liujingfang1
-- monopole
+- knverey
+- natasha41575
+- mengqiy
 - mortent
-- pwittrock
-- seans3
+- phanimarupaka

--- a/config/jobs/kubernetes-sigs/kustomize/kustomize-presubmit-master.yaml
+++ b/config/jobs/kubernetes-sigs/kustomize/kustomize-presubmit-master.yaml
@@ -8,7 +8,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: golang:1.16
+      - image: golang:1.18
         command:
         - make
         args:

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -548,6 +548,13 @@ branch-protection:
           required_status_checks:
             contexts:
             - Kubespray CI Pipeline
+        kustomize:
+          required_status_checks:
+            contexts:
+              - Lint
+              - Test Linux
+              - Test MacOS
+              - Test Windows
         metrics-server:
           branches:
             gh-pages:


### PR DESCRIPTION
* Updates the presubmit job to use Go 1.18
* Requires all of Kustomize's CI statuses (currently only the presubmit job and the CLA check are required)

/cc @natasha41575 

I determined the names by trying to make the same update in the UI (which gets reset):

![image](https://user-images.githubusercontent.com/4789493/161832592-8c48fc94-9222-4f48-a544-973f1745b357.png)
