### PR TITLE
correct repo for ci-kubernetes-node-swap-(fedora|ubuntu)-serial

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -130,7 +130,7 @@ periodics:
         args:
           - --root=/go/src
           - "--job=$(JOB_NAME)"
-          - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+          - --repo=k8s.io/kubernetes=master
           - "--service-account=/etc/service-account/service-account.json"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
           - "--timeout=240"
@@ -171,7 +171,7 @@ periodics:
       args:
       - --root=/go/src
       - "--job=$(JOB_NAME)"
-      - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+      - --repo=k8s.io/kubernetes=master
       - "--service-account=/etc/service-account/service-account.json"
       - "--upload=gs://kubernetes-jenkins/pr-logs"
       - "--timeout=240"


### PR DESCRIPTION
fix failures in https://testgrid.k8s.io/sig-node-kubelet#kubelet-gce-e2e-swap-fedora-serial 

```
I0406 08:46:55.079] Call:  git fetch --quiet --tags 'https://github.com/kubernetes/$(REPO_NAME)' '$(PULL_REFS)'
W0406 08:46:55.277] fatal: unable to access 'https://github.com/kubernetes/$(REPO_NAME)/': The requested URL returned error: 400
E0406 08:46:55.278] Command failed
I0406 08:46:55.278] process 78 exited with code 128 after 0.0m
W0406 08:46:55.278] git fetch failed
I0406 08:46:56.792] Call:  git fetch --quiet --tags 'https://github.com/kubernetes/$(REPO_NAME)' '$(PULL_REFS)'
W0406 08:46:56.986] fatal: unable to access 'https://github.com/kubernetes/$(REPO_NAME)/': The requested URL returned error: 400
E0406 08:46:56.987] Command failed
I0406 08:46:56.987] process 81 exited with code 128 after 0.0m
E0406 08:46:56.988] unexpected error
Traceback (most recent call last):
  File "./test-infra/jenkins/bootstrap.py", line 1096, in bootstrap
  File "./test-infra/jenkins/bootstrap.py", line 981, in setup_root
  File "./test-infra/jenkins/bootstrap.py", line 286, in checkout
  File "./test-infra/jenkins/bootstrap.py", line 1054, in <lambda>
  File "./test-infra/jenkins/bootstrap.py", line 149, in _call

```