### PR TITLE
Use n1-standard-4 machines for CRI-O serial tests

### DIFF
--- a/jobs/e2e_node/crio/latest/image-config-cgrpv1-serial.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-cgrpv1-serial.yaml
@@ -2,5 +2,5 @@ images:
   fedora:
     image_family: fedora-coreos-stable
     project: fedora-coreos-cloud
-    machine: n1-standard-2
+    machine: n1-standard-4
     metadata: "user-data</workspace/test-infra/jobs/e2e_node/crio/crio_serial.ign"

--- a/jobs/e2e_node/crio/latest/image-config-cgrpv2-serial.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-cgrpv2-serial.yaml
@@ -2,5 +2,5 @@ images:
   fedora:
     image_family: fedora-coreos-stable
     project: fedora-coreos-cloud
-    machine: n1-standard-2
+    machine: n1-standard-4
     metadata: "user-data</workspace/test-infra/jobs/e2e_node/crio/crio_cgrpv2_serial.ign"


### PR DESCRIPTION
There is a single slow flaking test which seems to timeout because of
low resources. To improve the usability, we now utilize a better test
machine.

```
E2eNode Suite: [sig-node] Density [Serial] [Slow] create a sequence of pods latency/resource should be within limit when create 10 pods with 50 background pods expand_less	4m3s
{ Failure test/e2e_node/density_test.go:250
Unexpected error:
    <*errors.errorString | 0xc0012fc9a0>: {
        s: "too high pod startup latency 50th percentile: 6.018745539s",
    }
    too high pod startup latency 50th percentile: 6.018745539s
occurred
test/e2e_node/density_test.go:590}
```

cc @harche @mrunalp @ehashman 