### PR TITLE
Prow integration tests: Collect previous logs

### DIFF
--- a/prow/test/integration/cleanup.sh
+++ b/prow/test/integration/cleanup.sh
@@ -29,9 +29,14 @@ function do_kubectl() {
 if [[ -n "${ARTIFACTS:-}" && -d "${ARTIFACTS}" ]]; then
   log_dir="${ARTIFACTS}/prow_pod_logs"
   mkdir -p "${log_dir}"
+
+  # Do not fail the entire script if we can't collect logs for whatever reason
+  set +e
   for app in ${PROW_COMPONENTS}; do
     do_kubectl logs svc/$app >"${log_dir}/${app}.log"
+    do_kubectl logs -p svc/$app >"${log_dir}/${app}-previous.log"
   done
+  set -e
 fi
 
 kind delete cluster --name "${DEFAULT_CLUSTER_NAME}"


### PR DESCRIPTION
This is helpful in cases where a container crashloops