### PR TITLE
releng: Update kpromo to v3.4.0-1

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-1
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.4.0-1
         command:
         - /kpromo
         args:
@@ -34,7 +34,7 @@ presubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-vuln-scanning
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-1
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.4.0-1
         command:
         - /kpromo
         args:
@@ -77,7 +77,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-1
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.4.0-1
         command:
         - /kpromo
         args:

--- a/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.4.0-1
+      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.0-1
         command:
         - /kpromo
         args:
@@ -34,7 +34,7 @@ presubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-vuln-scanning
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.4.0-1
+      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.0-1
         command:
         - /kpromo
         args:
@@ -77,7 +77,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.4.0-1
+      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.0-1
         command:
         - /kpromo
         args:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -13,7 +13,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-promoter
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.4.0-1
+      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.0-1
         command:
         - /kpromo
         args:
@@ -38,7 +38,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-promoter
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.4.0-1
+      - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.0-1
         command:
         - /kpromo
         args:
@@ -92,7 +92,7 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-promoter
     containers:
-    - image: k8s.gcr.io/artifact-promoter/kpromo:v3.4.0-1
+    - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.0-1
       command:
       - /kpromo
       args:
@@ -130,7 +130,7 @@ periodics:
     # https://github.com/kubernetes/k8s.io/pull/695.
     serviceAccountName: k8s-infra-gcr-promoter
     containers:
-    - image: k8s.gcr.io/artifact-promoter/kpromo:v3.4.0-1
+    - image: registry.k8s.io/artifact-promoter/kpromo:v3.4.0-1
       command:
       - /kpromo
       args:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -13,7 +13,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-promoter
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-1
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.4.0-1
         command:
         - /kpromo
         args:
@@ -38,7 +38,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-promoter
       containers:
-      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-1
+      - image: k8s.gcr.io/artifact-promoter/kpromo:v3.4.0-1
         command:
         - /kpromo
         args:
@@ -92,7 +92,7 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-promoter
     containers:
-    - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-1
+    - image: k8s.gcr.io/artifact-promoter/kpromo:v3.4.0-1
       command:
       - /kpromo
       args:
@@ -130,7 +130,7 @@ periodics:
     # https://github.com/kubernetes/k8s.io/pull/695.
     serviceAccountName: k8s-infra-gcr-promoter
     containers:
-    - image: k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-1
+    - image: k8s.gcr.io/artifact-promoter/kpromo:v3.4.0-1
       command:
       - /kpromo
       args:


### PR DESCRIPTION
Image updates for sigs.k8s.io/promo-tools v3.4.0: https://github.com/kubernetes-sigs/promo-tools/releases/tag/v3.4.0 / https://github.com/kubernetes-sigs/promo-tools/issues/523

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @puerco @cpanato @saschagrunert 
cc: @kubernetes/release-engineering 
ref: https://github.com/kubernetes/k8s.io/pull/3601, https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-cip-push-image-cip/1511498664818774016

**NOTE: the prow promotion updates are purposely elided from this PR to give one more opportunity for testing before these changes are live everywhere**