### PR TITLE
Updated the k8s version used in the ci test (e2e) done with prow

### DIFF
--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -37,7 +37,7 @@ presubmits:
         - ./test_e2e.sh
         env:
         - name: KIND_K8S_VERSION
-          value: "v1.23.3"
+          value: "v1.23.5"
         resources:
           requests:
             cpu: 4000m


### PR DESCRIPTION
Consistency needed in the k8s version used in Kubebuilder CLI and k8s version used in the ci test (e2e).
Since https://github.com/kubernetes-sigs/kubebuilder/pull/2575 is merged, I think this change is also needed.