### PR TITLE
azure: use latest supported k8s version for capz ccm PR test

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -238,6 +238,8 @@ presubmits:
               value: "standard"
             - name: CONTROL_PLANE_MACHINE_COUNT
               value: "3"
+            - name: KUBERNETES_VERSION
+              value: 1.23.5
     annotations:
       testgrid-dashboards: provider-azure-cloud-provider-azure
       testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-capz


### PR DESCRIPTION
This PR adds an explicit `KUBERNETES_VERSION` input to the capz + out-of-tree PR tests we run for cloud-provider-azure. By convention we should always use the latest bits of k8s for these tests as those are the most likely foundations required to best validate forward-moving progress in the cloud-provider-azure repo.