### PR TITLE
Make gerrit inRepoConfig use mergeIfNecessary by default

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -52,6 +52,7 @@ import (
 
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	gerrit "k8s.io/test-infra/prow/gerrit/client"
+	"k8s.io/test-infra/prow/git/types"
 	"k8s.io/test-infra/prow/git/v2"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/kube"
@@ -2304,9 +2305,9 @@ func parseProwConfig(c *Config) error {
 	}
 
 	for name, method := range c.Tide.MergeType {
-		if method != github.MergeMerge &&
-			method != github.MergeRebase &&
-			method != github.MergeSquash {
+		if method != types.MergeMerge &&
+			method != types.MergeRebase &&
+			method != types.MergeSquash {
 			return fmt.Errorf("merge type %q for %s is not a valid type", method, name)
 		}
 	}

--- a/prow/config/inrepoconfig.go
+++ b/prow/config/inrepoconfig.go
@@ -30,8 +30,8 @@ import (
 	"github.com/sirupsen/logrus"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
+	"k8s.io/test-infra/prow/git/types"
 	"k8s.io/test-infra/prow/git/v2"
-	"k8s.io/test-infra/prow/github"
 	"sigs.k8s.io/yaml"
 )
 
@@ -109,9 +109,9 @@ func prowYAMLGetter(
 
 	// TODO(mpherman): This is to hopefully mittigate issue with gerrit merges. Need to come up with a solution that checks
 	// each CLs merge strategy as they can differ. ifNecessary is just the gerrit default
-	var mergeMethod github.PullRequestMergeType
+	var mergeMethod types.PullRequestMergeType
 	if c.Gerrit.DeckURL != "" {
-		mergeMethod = github.MergeIfNecessary
+		mergeMethod = types.MergeIfNecessary
 	} else {
 		mergeMethod = c.Tide.MergeMethod(orgRepo)
 	}

--- a/prow/config/inrepoconfig.go
+++ b/prow/config/inrepoconfig.go
@@ -110,7 +110,7 @@ func prowYAMLGetter(
 	// TODO(mpherman): This is to hopefully mittigate issue with gerrit merges. Need to come up with a solution that checks
 	// each CLs merge strategy as they can differ. ifNecessary is just the gerrit default
 	var mergeMethod types.PullRequestMergeType
-	if c.Gerrit.DeckURL != "" {
+	if c.Gerrit.OrgReposConfig != nil {
 		mergeMethod = types.MergeIfNecessary
 	} else {
 		mergeMethod = c.Tide.MergeMethod(orgRepo)

--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -28,8 +28,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/git/types"
 	"k8s.io/test-infra/prow/git/v2"
-	"k8s.io/test-infra/prow/github"
 )
 
 // TideQueries is a TideQuery slice.
@@ -92,7 +92,7 @@ type Tide struct {
 
 	// A key/value pair of an org/repo as the key and merge method to override
 	// the default method of merge. Valid options are squash, rebase, and merge.
-	MergeType map[string]github.PullRequestMergeType `json:"merge_method,omitempty"`
+	MergeType map[string]types.PullRequestMergeType `json:"merge_method,omitempty"`
 
 	// A key/value pair of an org/repo as the key and Go template to override
 	// the default merge commit title and/or message. Template is passed the
@@ -226,14 +226,14 @@ func (t *Tide) BatchSizeLimit(repo OrgRepo) int {
 
 // MergeMethod returns the merge method to use for a repo. The default of merge is
 // returned when not overridden.
-func (t *Tide) MergeMethod(repo OrgRepo) github.PullRequestMergeType {
+func (t *Tide) MergeMethod(repo OrgRepo) types.PullRequestMergeType {
 	v, ok := t.MergeType[repo.String()]
 	if !ok {
 		if ov, found := t.MergeType[repo.Org]; found {
 			return ov
 		}
 
-		return github.MergeMerge
+		return types.MergeMerge
 	}
 
 	return v

--- a/prow/config/tide_test.go
+++ b/prow/config/tide_test.go
@@ -26,8 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilpointer "k8s.io/utils/pointer"
 
+	"k8s.io/test-infra/prow/git/types"
 	"k8s.io/test-infra/prow/git/v2"
-	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/labels"
 )
 
@@ -175,37 +175,37 @@ func TestOrgExceptionsAndRepos(t *testing.T) {
 
 func TestMergeMethod(t *testing.T) {
 	ti := &Tide{
-		MergeType: map[string]github.PullRequestMergeType{
-			"kubernetes/kops":             github.MergeRebase,
-			"kubernetes-helm":             github.MergeSquash,
-			"kubernetes-helm/chartmuseum": github.MergeMerge,
+		MergeType: map[string]types.PullRequestMergeType{
+			"kubernetes/kops":             types.MergeRebase,
+			"kubernetes-helm":             types.MergeSquash,
+			"kubernetes-helm/chartmuseum": types.MergeMerge,
 		},
 	}
 
 	var testcases = []struct {
 		org      string
 		repo     string
-		expected github.PullRequestMergeType
+		expected types.PullRequestMergeType
 	}{
 		{
 			"kubernetes",
 			"kubernetes",
-			github.MergeMerge,
+			types.MergeMerge,
 		},
 		{
 			"kubernetes",
 			"kops",
-			github.MergeRebase,
+			types.MergeRebase,
 		},
 		{
 			"kubernetes-helm",
 			"monocular",
-			github.MergeSquash,
+			types.MergeSquash,
 		},
 		{
 			"kubernetes-helm",
 			"chartmuseum",
-			github.MergeMerge,
+			types.MergeMerge,
 		},
 	}
 

--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	prowgithub "k8s.io/test-infra/prow/github"
+	git "k8s.io/test-infra/prow/git/types"
 )
 
 const github = "github.com"
@@ -369,17 +369,17 @@ func (r *Repo) CheckoutNewBranch(branch string) error {
 // Merge attempts to merge commitlike into the current branch. It returns true
 // if the merge completes. It returns an error if the abort fails.
 func (r *Repo) Merge(commitlike string) (bool, error) {
-	return r.MergeWithStrategy(commitlike, prowgithub.MergeMerge)
+	return r.MergeWithStrategy(commitlike, git.MergeMerge)
 }
 
 // MergeWithStrategy attempts to merge commitlike into the current branch given the merge strategy.
 // It returns true if the merge completes. It returns an error if the abort fails.
-func (r *Repo) MergeWithStrategy(commitlike string, mergeStrategy prowgithub.PullRequestMergeType) (bool, error) {
+func (r *Repo) MergeWithStrategy(commitlike string, mergeStrategy git.PullRequestMergeType) (bool, error) {
 	r.logger.WithField("commitlike", commitlike).Info("Merging.")
 	switch mergeStrategy {
-	case prowgithub.MergeMerge:
+	case git.MergeMerge:
 		return r.mergeWithMergeStrategyMerge(commitlike)
-	case prowgithub.MergeSquash:
+	case git.MergeSquash:
 		return r.mergeWithMergeStrategySquash(commitlike)
 	default:
 		return false, fmt.Errorf("merge strategy %q is not supported", mergeStrategy)
@@ -426,7 +426,7 @@ func (r *Repo) mergeWithMergeStrategySquash(commitlike string) (bool, error) {
 // MergeAndCheckout merges the provided headSHAs in order onto baseSHA using the provided strategy.
 // If no headSHAs are provided, it will only checkout the baseSHA and return.
 // Only the `merge` and `squash` strategies are supported.
-func (r *Repo) MergeAndCheckout(baseSHA string, mergeStrategy prowgithub.PullRequestMergeType, headSHAs ...string) error {
+func (r *Repo) MergeAndCheckout(baseSHA string, mergeStrategy git.PullRequestMergeType, headSHAs ...string) error {
 	if baseSHA == "" {
 		return errors.New("baseSHA must be set")
 	}

--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	git "k8s.io/test-infra/prow/git/types"
+	"k8s.io/test-infra/prow/git/types"
 )
 
 const github = "github.com"
@@ -369,17 +369,17 @@ func (r *Repo) CheckoutNewBranch(branch string) error {
 // Merge attempts to merge commitlike into the current branch. It returns true
 // if the merge completes. It returns an error if the abort fails.
 func (r *Repo) Merge(commitlike string) (bool, error) {
-	return r.MergeWithStrategy(commitlike, git.MergeMerge)
+	return r.MergeWithStrategy(commitlike, types.MergeMerge)
 }
 
 // MergeWithStrategy attempts to merge commitlike into the current branch given the merge strategy.
 // It returns true if the merge completes. It returns an error if the abort fails.
-func (r *Repo) MergeWithStrategy(commitlike string, mergeStrategy git.PullRequestMergeType) (bool, error) {
+func (r *Repo) MergeWithStrategy(commitlike string, mergeStrategy types.PullRequestMergeType) (bool, error) {
 	r.logger.WithField("commitlike", commitlike).Info("Merging.")
 	switch mergeStrategy {
-	case git.MergeMerge:
+	case types.MergeMerge:
 		return r.mergeWithMergeStrategyMerge(commitlike)
-	case git.MergeSquash:
+	case types.MergeSquash:
 		return r.mergeWithMergeStrategySquash(commitlike)
 	default:
 		return false, fmt.Errorf("merge strategy %q is not supported", mergeStrategy)
@@ -426,7 +426,7 @@ func (r *Repo) mergeWithMergeStrategySquash(commitlike string) (bool, error) {
 // MergeAndCheckout merges the provided headSHAs in order onto baseSHA using the provided strategy.
 // If no headSHAs are provided, it will only checkout the baseSHA and return.
 // Only the `merge` and `squash` strategies are supported.
-func (r *Repo) MergeAndCheckout(baseSHA string, mergeStrategy git.PullRequestMergeType, headSHAs ...string) error {
+func (r *Repo) MergeAndCheckout(baseSHA string, mergeStrategy types.PullRequestMergeType, headSHAs ...string) error {
 	if baseSHA == "" {
 		return errors.New("baseSHA must be set")
 	}

--- a/prow/git/git_test.go
+++ b/prow/git/git_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/test-infra/prow/git/localgit"
-	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/git/types"
 )
 
 var defaultBranch = localgit.DefaultBranch("")
@@ -300,7 +300,7 @@ func testMergeAndCheckout(clients localgit.Clients, t *testing.T) {
 		name          string
 		setBaseSHA    bool
 		prBranches    []string
-		mergeStrategy github.PullRequestMergeType
+		mergeStrategy types.PullRequestMergeType
 		err           string
 	}{
 		{
@@ -317,7 +317,7 @@ func testMergeAndCheckout(clients localgit.Clients, t *testing.T) {
 			name:          "Merge strategy rebase, error",
 			setBaseSHA:    true,
 			prBranches:    []string{"my-pr-branch"},
-			mergeStrategy: github.MergeRebase,
+			mergeStrategy: types.MergeRebase,
 			err:           "merge strategy \"rebase\" is not supported",
 		},
 		{
@@ -328,25 +328,25 @@ func testMergeAndCheckout(clients localgit.Clients, t *testing.T) {
 			name:          "Merge succeeds with one head and merge strategy",
 			setBaseSHA:    true,
 			prBranches:    []string{"my-pr-branch"},
-			mergeStrategy: github.MergeMerge,
+			mergeStrategy: types.MergeMerge,
 		},
 		{
 			name:          "Merge succeeds with multiple heads and merge strategy",
 			setBaseSHA:    true,
 			prBranches:    []string{"my-pr-branch", "my-other-pr-branch"},
-			mergeStrategy: github.MergeMerge,
+			mergeStrategy: types.MergeMerge,
 		},
 		{
 			name:          "Merge succeeds with one head and squash strategy",
 			setBaseSHA:    true,
 			prBranches:    []string{"my-pr-branch"},
-			mergeStrategy: github.MergeSquash,
+			mergeStrategy: types.MergeSquash,
 		},
 		{
 			name:          "Merge succeeds with multiple heads and squash stragey",
 			setBaseSHA:    true,
 			prBranches:    []string{"my-pr-branch", "my-other-pr-branch"},
-			mergeStrategy: github.MergeSquash,
+			mergeStrategy: types.MergeSquash,
 		},
 	}
 

--- a/prow/git/types/types.go
+++ b/prow/git/types/types.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package git stores types used by all git clients
+package types
+
+// PullRequestMergeType enumerates the types of merges the GitHub API can
+// perform
+// https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button
+type PullRequestMergeType string
+
+// Possible types of merges for the GitHub merge API
+const (
+	MergeMerge       PullRequestMergeType = "merge"
+	MergeRebase      PullRequestMergeType = "rebase"
+	MergeSquash      PullRequestMergeType = "squash"
+	MergeIfNecessary PullRequestMergeType = "ifNecessary"
+)

--- a/prow/git/types/types.go
+++ b/prow/git/types/types.go
@@ -14,12 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package git stores types used by all git clients
+// Package types stores types used by all git clients
 package types
 
-// PullRequestMergeType enumerates the types of merges the GitHub API can
-// perform
-// https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button
+// PullRequestMergeType enumerates the types of merges used by Prow for either Github or Gerrit API
 type PullRequestMergeType string
 
 // Possible types of merges for the GitHub merge API

--- a/prow/git/v2/adapter.go
+++ b/prow/git/v2/adapter.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"k8s.io/test-infra/prow/git"
-	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/git/types"
 )
 
 func OrgRepo(full string) (string, string, error) {
@@ -59,11 +59,11 @@ type repoClientAdapter struct {
 }
 
 func (a *repoClientAdapter) MergeAndCheckout(baseSHA string, mergeStrategy string, headSHAs ...string) error {
-	return a.Repo.MergeAndCheckout(baseSHA, github.PullRequestMergeType(mergeStrategy), headSHAs...)
+	return a.Repo.MergeAndCheckout(baseSHA, types.PullRequestMergeType(mergeStrategy), headSHAs...)
 }
 
 func (a *repoClientAdapter) MergeWithStrategy(commitlike, mergeStrategy string, opts ...MergeOpt) (bool, error) {
-	return a.Repo.MergeWithStrategy(commitlike, github.PullRequestMergeType(mergeStrategy))
+	return a.Repo.MergeWithStrategy(commitlike, types.PullRequestMergeType(mergeStrategy))
 }
 
 func (a *repoClientAdapter) Clone(from string) error {

--- a/prow/git/v2/interactor.go
+++ b/prow/git/v2/interactor.go
@@ -207,14 +207,14 @@ func (i *interactor) MergeWithStrategy(commitlike, mergeStrategy string, opts ..
 		return i.mergeMerge(commitlike, opts...)
 	case "squash":
 		return i.squashMerge(commitlike)
+	case "ifNecessary":
+		return i.mergeIfNecessary(commitlike, opts...)
 	default:
 		return false, fmt.Errorf("merge strategy %q is not supported", mergeStrategy)
 	}
 }
 
-func (i *interactor) mergeMerge(commitlike string, opts ...MergeOpt) (bool, error) {
-	args := []string{"merge", "--no-ff", "--no-stat"}
-
+func (i *interactor) mergeHelper(args []string, commitlike string, opts ...MergeOpt) (bool, error) {
 	if len(opts) == 0 {
 		args = append(args, []string{"-m", "merge"}...)
 	} else {
@@ -234,6 +234,16 @@ func (i *interactor) mergeMerge(commitlike string, opts ...MergeOpt) (bool, erro
 		return false, fmt.Errorf("error aborting merge of %q: %w %v", commitlike, err, string(out))
 	}
 	return false, nil
+}
+
+func (i *interactor) mergeMerge(commitlike string, opts ...MergeOpt) (bool, error) {
+	args := []string{"merge", "--no-ff", "--no-stat"}
+	return i.mergeHelper(args, commitlike, opts...)
+}
+
+func (i *interactor) mergeIfNecessary(commitlike string, opts ...MergeOpt) (bool, error) {
+	args := []string{"merge", "--ff", "--no-stat"}
+	return i.mergeHelper(args, commitlike, opts...)
 }
 
 func (i *interactor) squashMerge(commitlike string) (bool, error) {

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -85,9 +85,10 @@ type PullRequestMergeType string
 
 // Possible types of merges for the GitHub merge API
 const (
-	MergeMerge  PullRequestMergeType = "merge"
-	MergeRebase PullRequestMergeType = "rebase"
-	MergeSquash PullRequestMergeType = "squash"
+	MergeMerge       PullRequestMergeType = "merge"
+	MergeRebase      PullRequestMergeType = "rebase"
+	MergeSquash      PullRequestMergeType = "squash"
+	MergeIfNecessary PullRequestMergeType = "ifNecessary"
 )
 
 func unmarshalClientError(b []byte) error {

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -78,19 +78,6 @@ const (
 	stateCannotBeChangedMessagePrefix = "state cannot be changed."
 )
 
-// PullRequestMergeType enumerates the types of merges the GitHub API can
-// perform
-// https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button
-type PullRequestMergeType string
-
-// Possible types of merges for the GitHub merge API
-const (
-	MergeMerge       PullRequestMergeType = "merge"
-	MergeRebase      PullRequestMergeType = "rebase"
-	MergeSquash      PullRequestMergeType = "squash"
-	MergeIfNecessary PullRequestMergeType = "ifNecessary"
-)
-
 func unmarshalClientError(b []byte) error {
 	var errors []error
 	clientError := ClientError{}

--- a/prow/plugins/merge-method-comment/merge-method-comment.go
+++ b/prow/plugins/merge-method-comment/merge-method-comment.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/git/types"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
@@ -94,13 +95,13 @@ func needsComment(c config.Tide, pe github.PullRequestEvent) (bool, string) {
 	comment := fmt.Sprintf("This PR has multiple commits, and the default merge method is: %s.\n", method)
 
 	switch {
-	case method == github.MergeSquash && c.MergeLabel != "":
+	case method == types.MergeSquash && c.MergeLabel != "":
 		comment = fmt.Sprintf("%sYou can request commits to be merged using the label: %s", comment, c.MergeLabel)
-	case method == github.MergeSquash && c.MergeLabel == "":
+	case method == types.MergeSquash && c.MergeLabel == "":
 		comment = comment + "Commits will be squashed, as no merge labels are defined"
-	case method == github.MergeMerge && c.SquashLabel != "":
+	case method == types.MergeMerge && c.SquashLabel != "":
 		comment = fmt.Sprintf("%sYou can request commits to be squashed using the label: %s", comment, c.SquashLabel)
-	case method == github.MergeMerge && c.SquashLabel == "":
+	case method == types.MergeMerge && c.SquashLabel == "":
 		comment = comment + "Commits will be merged, as no squash labels are defined"
 	}
 

--- a/prow/plugins/merge-method-comment/merge-method-comment_test.go
+++ b/prow/plugins/merge-method-comment/merge-method-comment_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/git/types"
 	"k8s.io/test-infra/prow/github"
 )
 
@@ -94,7 +95,7 @@ func TestHandlePR(t *testing.T) {
 		name               string
 		client             *ghc
 		event              github.PullRequestEvent
-		defaultMergeMethod github.PullRequestMergeType
+		defaultMergeMethod types.PullRequestMergeType
 		squashLabel        string
 		mergeLabel         string
 		err                error
@@ -108,7 +109,7 @@ func TestHandlePR(t *testing.T) {
 				PullRequest: singleCommitPR,
 			},
 			squashLabel:        "squash-label",
-			defaultMergeMethod: github.MergeSquash,
+			defaultMergeMethod: types.MergeSquash,
 		},
 		{
 			name:   "multiple commits, merge by-default, squash label configured",
@@ -117,7 +118,7 @@ func TestHandlePR(t *testing.T) {
 				Action:      github.PullRequestActionOpened,
 				PullRequest: multipleCommitsPR,
 			},
-			defaultMergeMethod: github.MergeMerge,
+			defaultMergeMethod: types.MergeMerge,
 			squashLabel:        "squash-label",
 			comments: []github.IssueComment{
 				{
@@ -132,7 +133,7 @@ func TestHandlePR(t *testing.T) {
 				Action:      github.PullRequestActionOpened,
 				PullRequest: multipleCommitsPR,
 			},
-			defaultMergeMethod: github.MergeMerge,
+			defaultMergeMethod: types.MergeMerge,
 			comments: []github.IssueComment{
 				{
 					Body: "Commits will be merged, as no squash labels are defined",
@@ -146,7 +147,7 @@ func TestHandlePR(t *testing.T) {
 				Action:      github.PullRequestActionOpened,
 				PullRequest: multipleCommitsPR,
 			},
-			defaultMergeMethod: github.MergeSquash,
+			defaultMergeMethod: types.MergeSquash,
 			mergeLabel:         "merge-label",
 			comments: []github.IssueComment{
 				{
@@ -161,7 +162,7 @@ func TestHandlePR(t *testing.T) {
 				Action:      github.PullRequestActionOpened,
 				PullRequest: multipleCommitsPR,
 			},
-			defaultMergeMethod: github.MergeSquash,
+			defaultMergeMethod: types.MergeSquash,
 			comments: []github.IssueComment{
 				{
 					Body: "Commits will be squashed, as no merge labels are defined",
@@ -176,7 +177,7 @@ func TestHandlePR(t *testing.T) {
 						{
 							User: github.User{Login: "k8s-bot"},
 							Body: fmt.Sprintf("This PR has multiple commits, and the default merge method is: %s.\n%s",
-								github.MergeMerge,
+								types.MergeMerge,
 								"Commits will be merged, as no squash labels are defined"),
 						},
 					},
@@ -186,7 +187,7 @@ func TestHandlePR(t *testing.T) {
 				Action:      github.PullRequestActionOpened,
 				PullRequest: multipleCommitsPR,
 			},
-			defaultMergeMethod: github.MergeMerge,
+			defaultMergeMethod: types.MergeMerge,
 			comments: []github.IssueComment{
 				{
 					Body: "Commits will be merged, as no squash labels are defined",
@@ -198,7 +199,7 @@ func TestHandlePR(t *testing.T) {
 			client: &ghc{
 				listCommentsErr: fmt.Errorf("cannot list comments"),
 			},
-			defaultMergeMethod: github.MergeMerge,
+			defaultMergeMethod: types.MergeMerge,
 			event: github.PullRequestEvent{
 				Action:      github.PullRequestActionOpened,
 				PullRequest: multipleCommitsPR,
@@ -210,7 +211,7 @@ func TestHandlePR(t *testing.T) {
 			client: &ghc{
 				createCommentErr: fmt.Errorf("cannot create comment"),
 			},
-			defaultMergeMethod: github.MergeMerge,
+			defaultMergeMethod: types.MergeMerge,
 			event: github.PullRequestEvent{
 				Action:      github.PullRequestActionSynchronize,
 				PullRequest: multipleCommitsPR,
@@ -224,7 +225,7 @@ func TestHandlePR(t *testing.T) {
 				Action:      github.PullRequestActionSynchronize,
 				PullRequest: multipleCommitsPR,
 			},
-			defaultMergeMethod: github.MergeMerge,
+			defaultMergeMethod: types.MergeMerge,
 			comments: []github.IssueComment{
 				{
 					Body: "Commits will be merged, as no squash labels are defined",
@@ -238,7 +239,7 @@ func TestHandlePR(t *testing.T) {
 				Action:      github.PullRequestActionReopened,
 				PullRequest: multipleCommitsPR,
 			},
-			defaultMergeMethod: github.MergeMerge,
+			defaultMergeMethod: types.MergeMerge,
 			comments: []github.IssueComment{
 				{
 					Body: "Commits will be merged, as no squash labels are defined",
@@ -252,7 +253,7 @@ func TestHandlePR(t *testing.T) {
 				Action:      github.PullRequestActionEdited,
 				PullRequest: multipleCommitsPR,
 			},
-			defaultMergeMethod: github.MergeMerge,
+			defaultMergeMethod: types.MergeMerge,
 			comments: []github.IssueComment{
 				{
 					Body: "Commits will be merged, as no squash labels are defined",
@@ -266,7 +267,7 @@ func TestHandlePR(t *testing.T) {
 				Action:      github.PullRequestActionReviewRequested,
 				PullRequest: multipleCommitsPR,
 			},
-			defaultMergeMethod: github.MergeMerge,
+			defaultMergeMethod: types.MergeMerge,
 		},
 	}
 
@@ -281,7 +282,7 @@ func TestHandlePR(t *testing.T) {
 
 			c.event.Number = 101
 			config := config.Tide{
-				MergeType: map[string]github.PullRequestMergeType{
+				MergeType: map[string]types.PullRequestMergeType{
 					"kubernetes/kubernetes": c.defaultMergeMethod,
 				},
 				SquashLabel: c.squashLabel,

--- a/prow/plugins/verify-owners/verify-owners.go
+++ b/prow/plugins/verify-owners/verify-owners.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/git/types"
 	"k8s.io/test-infra/prow/git/v2"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/labels"
@@ -266,7 +267,7 @@ func handle(ghc githubClient, gc git.ClientFactory, roc repoownersClient, log *l
 	if err := r.Config("commit.gpgsign", "false"); err != nil {
 		log.WithError(err).Errorf("Cannot set gpgsign=false in gitconfig: %v", err)
 	}
-	if err := r.MergeAndCheckout(pr.Base.Ref, string(github.MergeMerge), pr.Head.SHA); err != nil {
+	if err := r.MergeAndCheckout(pr.Base.Ref, string(types.MergeMerge), pr.Head.SHA); err != nil {
 		return err
 	}
 	// If OWNERS_ALIASES file exists, get all aliases.


### PR DESCRIPTION
This is a bit of a messy solution, but figuring out the Merge Strategy for each CL is going to be a larger endeavor and we want gerrit users to have a more reasonable default. 

/assign @chaodai @listx 