### PR TITLE
[cloud provider azure] Skip in-tree testcases for some jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -602,7 +602,7 @@ periodics:
       - name: KUBERNETES_VERSION
         value: 1.23.5
       - name: GINKGO_ARGS
-        value: --ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --test.parallel=4 --report-dir=/logs/artifacts --disable-log-dump=true
+        value: --ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|In-tree.Volumes --test.parallel=4 --report-dir=/logs/artifacts --disable-log-dump=true
       - name: CONTROL_PLANE_MACHINE_COUNT
         value: "3"
   annotations:


### PR DESCRIPTION
Jobs with CAPZ deploy out-of-tree clusters so in-tree testcases
are not suitable.

Signed-off-by: Zhecheng Li <zhechengli@microsoft.com>