### PR TITLE
crier: gerrit: use Markdown syntax for job links

### DIFF
--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -66,6 +66,17 @@ const (
 	ErrorState ProwJobState = "error"
 )
 
+// GetAllProwJobStates returns all possible job states.
+func GetAllProwJobStates() []ProwJobState {
+	return []ProwJobState{
+		TriggeredState,
+		PendingState,
+		SuccessState,
+		FailureState,
+		AbortedState,
+		ErrorState}
+}
+
 // ProwJobAgent specifies the controller (such as plank or jenkins-agent) that runs the job.
 type ProwJobAgent string
 

--- a/prow/crier/reporters/gerrit/reporter.go
+++ b/prow/crier/reporters/gerrit/reporter.go
@@ -67,10 +67,26 @@ const (
 	// codeReview is the default gerrit code review label
 	codeReview = client.CodeReview
 	// maxCommentSizeLimit is from
-	// http://gerrit-documentation.storage.googleapis.com/Documentation/3.2.0/config-gerrit.html#change.commentSizeLimit,
-	// if a comment is 16000 chars it's almost not readable any way, let's not
-	// use all of the space, picking 80% as a heuristic number here
-	maxCommentSizeLimit = 14400
+	// http://gerrit-documentation.storage.googleapis.com/Documentation/3.2.0/config-gerrit.html#change.commentSizeLimit, where it says:
+	//
+	//    Maximum allowed size in characters of a regular (non-robot) comment.
+	//    Comments which exceed this size will be rejected. Size computation is
+	//    approximate and may be off by roughly 1%. Common unit suffixes of 'k',
+	//    'm', or 'g' are supported. The value must be positive.
+	//
+	//    The default limit is 16kiB.
+	//
+	// 16KiB = 16*1024 bytes. Note that the size computation is stated as
+	// **approximate** and can be off by about 1%. To be safe, we use 15*1024 or
+	// 93.75% of the default 16KiB limit. This value is lower than the limit by
+	// 6.25% to be 6x below the ~1% margin of error described by the Gerrit
+	// docs.
+	//
+	// Even assuming that the docs have their units wrong (maybe they actually
+	// mean 16KB = 16000, not 16KiB), the new value of (15*1024)/16000 = 0.96,
+	// or to be 4% less than the theoretical maximum, which is still a
+	// conservative figure.
+	maxCommentSizeLimit = 15 * 1024
 )
 
 var (

--- a/prow/crier/reporters/gerrit/reporter.go
+++ b/prow/crier/reporters/gerrit/reporter.go
@@ -657,6 +657,7 @@ func GenerateReport(pjs []*v1.ProwJob, customCommentSizeLimit int) JobReport {
 			report.Success++
 		}
 	}
+	numJobs := len(report.Jobs)
 
 	report.prioritizeFailedJobs()
 
@@ -691,7 +692,7 @@ func GenerateReport(pjs []*v1.ProwJob, customCommentSizeLimit int) JobReport {
 	// from the end, so that we prioritize reporting the names of the failed
 	// jobs (if any), which are at the front of the list.
 	if commentSize < commentSizeLimit {
-		skipped := len(report.Jobs)
+		skipped := numJobs
 		for i, job := range report.Jobs {
 			lineWithURL := job.serialize()
 
@@ -717,11 +718,11 @@ func GenerateReport(pjs []*v1.ProwJob, customCommentSizeLimit int) JobReport {
 		if skipped > 0 {
 			// Note that this makes the comment longer, but since the size limit of
 			// 14400 is conservative, we should be fine.
-			report.Message += errorMessageLine(fmt.Sprintf("Skipped displaying URLs for %d/%d jobs due to reaching gerrit comment size limit", skipped, len(report.Jobs)))
+			report.Message += errorMessageLine(fmt.Sprintf("Skipped displaying URLs for %d/%d jobs due to reaching gerrit comment size limit", skipped, numJobs))
 		}
 	} else {
 		skipped := 0
-		last := len(report.Jobs) - 1
+		last := numJobs - 1
 		for i := range report.Jobs {
 			j := last - i
 
@@ -738,7 +739,7 @@ func GenerateReport(pjs []*v1.ProwJob, customCommentSizeLimit int) JobReport {
 
 		report.Message += strings.Join(jobLines, "")
 
-		report.Message += errorMessageLine(fmt.Sprintf("Skipped displaying %d/%d jobs due to reaching gerrit comment size limit (too many jobs)", skipped, len(report.Jobs)))
+		report.Message += errorMessageLine(fmt.Sprintf("Skipped displaying %d/%d jobs due to reaching gerrit comment size limit (too many jobs)", skipped, numJobs))
 	}
 
 	return report

--- a/prow/crier/reporters/gerrit/reporter_test.go
+++ b/prow/crier/reporters/gerrit/reporter_test.go
@@ -2257,6 +2257,17 @@ func TestGenerateReport(t *testing.T) {
 			wantMessage:      "[NOTE FROM PROW: Skipped displaying 3/3 jobs due to reaching gerrit comment size limit (too many jobs)]",
 		},
 		{
+			name: "too many jobs; only truncate the last job",
+			jobs: []*v1.ProwJob{
+				job("this", "url", v1.SuccessState),
+				job("that", "hey", v1.FailureState),
+				job("some", "other", v1.SuccessState),
+			},
+			commentSizeLimit: 127 + 60,
+			wantHeader:       "Prow Status: 2 out of 3 pjs passed! 👉 Comment `/retest` to rerun only failed tests (if any), or `/test all` to rerun all tests\n",
+			wantMessage:      "❌ that FAILURE\n✔️ some SUCCESS\n[NOTE FROM PROW: Skipped displaying 1/3 jobs due to reaching gerrit comment size limit (too many jobs)]",
+		},
+		{
 			// Check cases where the job could legitimately not have its URL
 			// field set (because the job did not even get scheduled).
 			name: "missing URLs",

--- a/prow/crier/reporters/gerrit/reporter_test.go
+++ b/prow/crier/reporters/gerrit/reporter_test.go
@@ -2228,9 +2228,12 @@ func TestGenerateReport(t *testing.T) {
 				job("that", "hey", v1.FailureState),
 				job("some", "other", v1.SuccessState),
 			},
-			// 127 is the length of the Header.
-			// 61 is the comment size room we give for the Message part.
-			commentSizeLimit: 127 + 61,
+			// 130 is the length of the Header.
+			// 154 is the comment size room we give for the Message part. Note
+			// that it should be 1 char more than what we have in the
+			// wantMessage part, because we always return comments *under* the
+			// commentSizeLimit.
+			commentSizeLimit: 130 + 154,
 			wantHeader:       "Prow Status: 2 out of 3 pjs passed! 👉 Comment `/retest` to rerun only failed tests (if any), or `/test all` to rerun all tests\n",
 			wantMessage:      "❌ that FAILURE\n✔️ some SUCCESS\n✔️ this SUCCESS\n[NOTE FROM PROW: Skipped displaying URLs for 3/3 jobs due to reaching gerrit comment size limit]",
 		},
@@ -2241,7 +2244,7 @@ func TestGenerateReport(t *testing.T) {
 				job("that", "hey", v1.FailureState),
 				job("some", "other", v1.SuccessState),
 			},
-			commentSizeLimit: 130 + 67,
+			commentSizeLimit: 130 + 161,
 			wantHeader:       "Prow Status: 2 out of 3 pjs passed! 👉 Comment `/retest` to rerun only failed tests (if any), or `/test all` to rerun all tests\n",
 			wantMessage:      "❌ [that](hey) FAILURE\n✔️ some SUCCESS\n✔️ this SUCCESS\n[NOTE FROM PROW: Skipped displaying URLs for 2/3 jobs due to reaching gerrit comment size limit]",
 		},
@@ -2263,7 +2266,7 @@ func TestGenerateReport(t *testing.T) {
 				job("that", "hey", v1.FailureState),
 				job("some", "other", v1.SuccessState),
 			},
-			commentSizeLimit: 127 + 60,
+			commentSizeLimit: 130 + 150,
 			wantHeader:       "Prow Status: 2 out of 3 pjs passed! 👉 Comment `/retest` to rerun only failed tests (if any), or `/test all` to rerun all tests\n",
 			wantMessage:      "❌ that FAILURE\n✔️ some SUCCESS\n[NOTE FROM PROW: Skipped displaying 1/3 jobs due to reaching gerrit comment size limit (too many jobs)]",
 		},
@@ -2283,15 +2286,10 @@ func TestGenerateReport(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			gotReport := GenerateReport(tc.jobs, tc.commentSizeLimit)
-
 			if want, got := tc.wantHeader, gotReport.Header; want != got {
-				fmt.Printf("Header size: %d\n", len(gotReport.Header))
-				fmt.Printf("Message size: %d\n", len(gotReport.Message))
 				t.Fatalf("Header mismatch. Want:\n%s,\ngot: \n%s", want, got)
 			}
 			if want, got := tc.wantMessage, gotReport.Message; want != got {
-				fmt.Printf("Header size: %d\n", len(gotReport.Header))
-				fmt.Printf("Message size: %d\n", len(gotReport.Message))
 				t.Fatalf("Message mismatch. Want:\n%s\ngot: \n%s", want, got)
 			}
 		})

--- a/prow/crier/reporters/gerrit/reporter_test.go
+++ b/prow/crier/reporters/gerrit/reporter_test.go
@@ -2241,7 +2241,7 @@ func TestGenerateReport(t *testing.T) {
 				job("that", "hey", v1.FailureState),
 				job("some", "other", v1.SuccessState),
 			},
-			commentSizeLimit: 127 + 67,
+			commentSizeLimit: 130 + 67,
 			wantHeader:       "Prow Status: 2 out of 3 pjs passed! 👉 Comment `/retest` to rerun only failed tests (if any), or `/test all` to rerun all tests\n",
 			wantMessage:      "❌ [that](hey) FAILURE\n✔️ some SUCCESS\n✔️ this SUCCESS\n[NOTE FROM PROW: Skipped displaying URLs for 2/3 jobs due to reaching gerrit comment size limit]",
 		},
@@ -2285,9 +2285,13 @@ func TestGenerateReport(t *testing.T) {
 			gotReport := GenerateReport(tc.jobs, tc.commentSizeLimit)
 
 			if want, got := tc.wantHeader, gotReport.Header; want != got {
+				fmt.Printf("Header size: %d\n", len(gotReport.Header))
+				fmt.Printf("Message size: %d\n", len(gotReport.Message))
 				t.Fatalf("Header mismatch. Want:\n%s,\ngot: \n%s", want, got)
 			}
 			if want, got := tc.wantMessage, gotReport.Message; want != got {
+				fmt.Printf("Header size: %d\n", len(gotReport.Header))
+				fmt.Printf("Message size: %d\n", len(gotReport.Message))
 				t.Fatalf("Message mismatch. Want:\n%s\ngot: \n%s", want, got)
 			}
 		})


### PR DESCRIPTION
This adds Markdown styled job URL links. Please see the individual commit messages for more details about the design choices made (e.g., we use regexes now for parsing comments).

/cc @chaodaiG @cjwagner
/assign @mpherman2 