### PR TITLE
Remove bazel jobs from master

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -1,6 +1,9 @@
 presubmits:
   kubernetes/kops:
   - name: pull-kops-bazel-build
+    branches:
+    - release-1.22
+    - release-1.23
     always_run: true
     skip_report: false
     labels:
@@ -26,6 +29,9 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits
       testgrid-tab-name: bazel-build
   - name: pull-kops-bazel-test
+    branches:
+    - release-1.22
+    - release-1.23
     always_run: true
     skip_report: false
     labels:
@@ -255,27 +261,6 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits
       testgrid-tab-name: e2e-1-20
-  - name: pull-kops-verify-bazel
-    branches:
-    - master
-    always_run: true
-    labels:
-      preset-service-account: "true"
-    decorate: true
-    decoration_config:
-      timeout: 10m
-    path_alias: k8s.io/kops
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220404-0178a71d18-experimental
-        command:
-        - runner.sh
-        args:
-        - "make"
-        - "verify-bazel"
-    annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits
-      testgrid-tab-name: verify-bazel
   - name: pull-kops-verify-generated
     always_run: true
     labels:


### PR DESCRIPTION
/cc @johngmyers @justinsb @hakman @rifelpet 

We no longer use bazel on the master branch, so we should remove the tests that would block eventual removal of bazel make targets.