### PR TITLE
Set default flake attempt to 1 (not 2)

### DIFF
--- a/kubetest/conformance/conformance.go
+++ b/kubetest/conformance/conformance.go
@@ -62,7 +62,7 @@ func (d *Deployer) BuildTester(o *e2e.BuildTesterOptions) (e2e.Tester, error) {
 	t.Seed = 1436380640
 	t.GinkgoParallel = 10
 	t.Kubeconfig = d.kubecfg
-	t.FlakeAttempts = 2
+	t.FlakeAttempts = 1
 	t.NumNodes = 4
 	t.SystemdServices = []string{"docker", "kubelet"}
 	t.ReportDir = reportdir


### PR DESCRIPTION
Looks like a vestige from way long back! ( see https://github.com/kubernetes/kubernetes/issues/68091 for context )

Signed-off-by: Davanum Srinivas <davanum@gmail.com>