### PR TITLE
Adjust buckets of github_request_wait_duration_seconds metric

### DIFF
--- a/ghproxy/ghmetrics/ghmetrics.go
+++ b/ghproxy/ghmetrics/ghmetrics.go
@@ -64,7 +64,7 @@ var ghRequestWaitDurationHistVec = prometheus.NewHistogramVec(
 	prometheus.HistogramOpts{
 		Name:    "github_request_wait_duration_seconds",
 		Help:    "GitHub request wait duration before sending to API in seconds",
-		Buckets: []float64{0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60},
+		Buckets: []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 7.5, 10, 15, 20, 25, 30, 45, 60},
 	},
 	[]string{"token_hash", "request_type", "api"},
 )


### PR DESCRIPTION
After several weeks of running this algorithm, the buckets can
be adjusted to see more valuable data.

Signed-off-by: Jakub Guzik <jguzik@redhat.com>