### PR TITLE
Add fakegerritserver to PROW_COMPONENTS in integration test cleanup

### DIFF
--- a/prow/test/integration/cleanup.sh
+++ b/prow/test/integration/cleanup.sh
@@ -20,7 +20,7 @@ set -o pipefail
 readonly DEFAULT_CLUSTER_NAME="kind-prow-integration"
 readonly DEFAULT_CONTEXT="kind-${DEFAULT_CLUSTER_NAME}"
 readonly DEFAULT_REGISTRY_NAME="kind-registry"
-readonly PROW_COMPONENTS="sinker crier hook horologium prow-controller-manager fakeghserver deck tide deck-tenanted"
+readonly PROW_COMPONENTS="sinker crier hook horologium prow-controller-manager fakegerritserver fakeghserver deck tide deck-tenanted"
 
 function do_kubectl() {
   kubectl --context=${DEFAULT_CONTEXT} $@


### PR DESCRIPTION
Just notice that when we are running integration tests we setup the fakegerritserver here: https://github.com/kubernetes/test-infra/blob/5cd9ffee49f354bdca4db091d15958cc1ebafc6a/prow/test/integration/setup-cluster.sh#L33

but it is not listed in the cleanup.sh script. Adding it in this PR