### PR TITLE
azure: add periodic job using capz at main

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -268,7 +268,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
 periodics:
 - interval: 24h
-  # cloud-provider-azure-master-capz runs Azure specific tests periodically.
+  # cloud-provider-azure-master-capz runs Azure specific tests periodically using a stable capz release.
   name: cloud-provider-azure-master-capz
   decorate: true
   decoration_config:
@@ -310,11 +310,63 @@ periodics:
           value: "standard"
         - name: CONTROL_PLANE_MACHINE_COUNT
           value: "3"
+        - name: KUBERNETES_VERSION
+          value: 1.23.5
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
     testgrid-tab-name: cloud-provider-azure-master-capz
     testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
-    description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
+    description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) using a stable capz release."
+- interval: 24h
+  # cloud-provider-azure-master-capz runs Azure specific tests periodically using capz:main.
+  name: cloud-provider-azure-master-capz-main
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: main
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    - org: kubernetes-sigs
+      repo: cloud-provider-azure
+      base_ref: master
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      workdir: false
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220412-bafd59ddb3-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU
+          value: "standard"
+        - name: CONTROL_PLANE_MACHINE_COUNT
+          value: "3"
+        - name: KUBERNETES_VERSION
+          value: 1.23.5
+  annotations:
+    testgrid-dashboards: provider-azure-cloud-provider-azure
+    testgrid-tab-name: cloud-provider-azure-master-capz-main
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
+    description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) using capz:main."
 - interval: 24h
   # cloud-provider-azure-autoscaling runs node autoscaling tests periodically.
   name: cloud-provider-azure-autoscaling


### PR DESCRIPTION
This PR adds a periodic cloud-provider-azure E2E job that targets capz:main to perform cluster buildout.

The reason why this additional test is valuable is that we want to be able to detect issues w/ cloud-provider-azure + capz *in capz* before we cherry-pick capz changes into the stable release branch. Without this test, we may chery-pick breaking test-infra changes into the stable capz release branch and break lots of tests inadvertently.