### PR TITLE
Specify K8s version for azuredisk capz windows jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -683,6 +683,8 @@ presubmits:
               value: "Standard_D4s_v3"
             - name: DISABLE_ZONE
               value: "true"
+            - name: KUBERNETES_VERSION
+              value: 1.23.5
     annotations:
       testgrid-dashboards: provider-azure-azuredisk-csi-driver
       testgrid-tab-name: pull-azuredisk-csi-driver-e2e-capz-windows-2019
@@ -732,6 +734,8 @@ presubmits:
               value: "Standard_D4s_v3"
             - name: DISABLE_ZONE
               value: "true"
+            - name: KUBERNETES_VERSION
+              value: 1.23.5
     annotations:
       testgrid-dashboards: provider-azure-azuredisk-csi-driver
       testgrid-tab-name: pull-azuredisk-csi-driver-e2e-capz-windows-2022


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

Right now these jobs are defaulting to using K8s 1.22.1 which is causing some issues discussed in https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/1280

It looks like the cloud provider azure jobs are setting to an explicit patch version so we will do that here too.
https://github.com/kubernetes/test-infra/blob/512ddd5dd2c65a782b742b5563808b4ad4e7b523/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml#L189-L190

/assign @andyzhangx 