### PR TITLE
fixing KUBENERETES_VERSION env vars for azuredisk windows capz jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -684,7 +684,7 @@ presubmits:
             - name: DISABLE_ZONE
               value: "true"
             - name: KUBERNETES_VERSION
-              value: 1.23.5
+              value: "v1.23.5"
     annotations:
       testgrid-dashboards: provider-azure-azuredisk-csi-driver
       testgrid-tab-name: pull-azuredisk-csi-driver-e2e-capz-windows-2019
@@ -735,7 +735,7 @@ presubmits:
             - name: DISABLE_ZONE
               value: "true"
             - name: KUBERNETES_VERSION
-              value: 1.23.5
+              value: "v1.23.5"
     annotations:
       testgrid-dashboards: provider-azure-azuredisk-csi-driver
       testgrid-tab-name: pull-azuredisk-csi-driver-e2e-capz-windows-2022


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

/assign @andyzhangx 

this should fix the issues where kube-proxy image is not starting as discussed in https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/1280#issuecomment-1098555329