### PR TITLE
Fix metric error: took_action always false as run before plugin handler

### DIFF
--- a/prow/hook/events.go
+++ b/prow/hook/events.go
@@ -91,8 +91,9 @@ func (s *Server) handleReviewEvent(l *logrus.Entry, re github.ReviewEvent) {
 				re.PullRequest.Number,
 			)
 			start := time.Now()
+			err := errorOnPanic(func() error { return h(agent, re) })
 			labels := prometheus.Labels{"event_type": l.Data[eventTypeField].(string), "action": string(re.Action), "plugin": p, "took_action": strconv.FormatBool(agent.TookAction())}
-			if err := errorOnPanic(func() error { return h(agent, re) }); err != nil {
+			if err != nil {
 				agent.Logger.WithError(err).Error("Error handling ReviewEvent.")
 				s.Metrics.PluginHandleErrors.With(labels).Inc()
 			}
@@ -148,8 +149,9 @@ func (s *Server) handleReviewCommentEvent(l *logrus.Entry, rce github.ReviewComm
 				rce.PullRequest.Number,
 			)
 			start := time.Now()
+			err := errorOnPanic(func() error { return h(agent, rce) })
 			labels := prometheus.Labels{"event_type": l.Data[eventTypeField].(string), "action": string(rce.Action), "plugin": p, "took_action": strconv.FormatBool(agent.TookAction())}
-			if err := errorOnPanic(func() error { return h(agent, rce) }); err != nil {
+			if err != nil {
 				agent.Logger.WithError(err).Error("Error handling ReviewCommentEvent.")
 				s.Metrics.PluginHandleErrors.With(labels).Inc()
 			}
@@ -205,8 +207,9 @@ func (s *Server) handlePullRequestEvent(l *logrus.Entry, pr github.PullRequestEv
 				pr.PullRequest.Number,
 			)
 			start := time.Now()
+			err := errorOnPanic(func() error { return h(agent, pr) })
 			labels := prometheus.Labels{"event_type": l.Data[eventTypeField].(string), "action": string(pr.Action), "plugin": p, "took_action": strconv.FormatBool(agent.TookAction())}
-			if err := errorOnPanic(func() error { return h(agent, pr) }); err != nil {
+			if err != nil {
 				agent.Logger.WithError(err).Error("Error handling PullRequestEvent.")
 				s.Metrics.PluginHandleErrors.With(labels).Inc()
 			}
@@ -258,8 +261,9 @@ func (s *Server) handlePushEvent(l *logrus.Entry, pe github.PushEvent) {
 			defer s.wg.Done()
 			agent := plugins.NewAgent(s.ConfigAgent, s.Plugins, s.ClientAgent, pe.Repo.Owner.Login, s.Metrics.Metrics, l, p)
 			start := time.Now()
+			err := errorOnPanic(func() error { return h(agent, pe) })
 			labels := prometheus.Labels{"event_type": l.Data[eventTypeField].(string), "action": "none", "plugin": p, "took_action": strconv.FormatBool(agent.TookAction())}
-			if err := errorOnPanic(func() error { return h(agent, pe) }); err != nil {
+			if err != nil {
 				agent.Logger.WithError(err).Error("Error handling PushEvent.")
 				s.Metrics.PluginHandleErrors.With(labels).Inc()
 			}
@@ -289,8 +293,9 @@ func (s *Server) handleIssueEvent(l *logrus.Entry, i github.IssueEvent) {
 				i.Issue.Number,
 			)
 			start := time.Now()
+			err := errorOnPanic(func() error { return h(agent, i) })
 			labels := prometheus.Labels{"event_type": l.Data[eventTypeField].(string), "action": string(i.Action), "plugin": p, "took_action": strconv.FormatBool(agent.TookAction())}
-			if err := errorOnPanic(func() error { return h(agent, i) }); err != nil {
+			if err != nil {
 				agent.Logger.WithError(err).Error("Error handling IssueEvent.")
 				s.Metrics.PluginHandleErrors.With(labels).Inc()
 			}
@@ -348,8 +353,9 @@ func (s *Server) handleIssueCommentEvent(l *logrus.Entry, ic github.IssueComment
 				ic.Issue.Number,
 			)
 			start := time.Now()
+			err := errorOnPanic(func() error { return h(agent, ic) })
 			labels := prometheus.Labels{"event_type": l.Data[eventTypeField].(string), "action": string(ic.Action), "plugin": p, "took_action": strconv.FormatBool(agent.TookAction())}
-			if err := errorOnPanic(func() error { return h(agent, ic) }); err != nil {
+			if err != nil {
 				agent.Logger.WithError(err).Error("Error handling IssueCommentEvent.")
 				s.Metrics.PluginHandleErrors.With(labels).Inc()
 			}
@@ -402,8 +408,9 @@ func (s *Server) handleStatusEvent(l *logrus.Entry, se github.StatusEvent) {
 			defer s.wg.Done()
 			agent := plugins.NewAgent(s.ConfigAgent, s.Plugins, s.ClientAgent, se.Repo.Owner.Login, s.Metrics.Metrics, l, p)
 			start := time.Now()
+			err := errorOnPanic(func() error { return h(agent, se) })
 			labels := prometheus.Labels{"event_type": l.Data[eventTypeField].(string), "action": "none", "plugin": p, "took_action": strconv.FormatBool(agent.TookAction())}
-			if err := errorOnPanic(func() error { return h(agent, se) }); err != nil {
+			if err != nil {
 				agent.Logger.WithError(err).Error("Error handling StatusEvent.")
 				s.Metrics.PluginHandleErrors.With(labels).Inc()
 			}
@@ -439,8 +446,9 @@ func (s *Server) handleGenericComment(l *logrus.Entry, ce *github.GenericComment
 				ce.Number,
 			)
 			start := time.Now()
+			err := errorOnPanic(func() error { return h(agent, *ce) })
 			labels := prometheus.Labels{"event_type": l.Data[eventTypeField].(string), "action": string(ce.Action), "plugin": p, "took_action": strconv.FormatBool(agent.TookAction())}
-			if err := errorOnPanic(func() error { return h(agent, *ce) }); err != nil {
+			if err != nil {
 				agent.Logger.WithError(err).Error("Error handling GenericCommentEvent.")
 				s.Metrics.PluginHandleErrors.With(labels).Inc()
 			}


### PR DESCRIPTION
As labels are assigned before handler execution, `took_action` is always false. This is a fix for that.

Signed-off-by: Jakub Guzik <jguzik@redhat.com>