### PR TITLE
k8s-infra: Add testgrid dashboard for oci-proxy

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/oci-proxy/canaries.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/oci-proxy/canaries.yaml
@@ -59,6 +59,6 @@ periodics:
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-dashboards: sig-k8s-infra-canaries, sig-k8s-infra-oci-proxy
     testgrid-days-of-results: '7'
     testgrid-tab-name: kops-grid-gcr-mirror-canary

--- a/config/testgrids/kubernetes/sig-k8s-infra/config.yaml
+++ b/config/testgrids/kubernetes/sig-k8s-infra/config.yaml
@@ -9,6 +9,7 @@ dashboard_groups:
   - sig-k8s-infra-gcb
   - sig-k8s-infra-groups
   - sig-k8s-infra-k8sio
+  - sig-k8s-infra-oci-proxy
   - sig-k8s-infra-prow
 
 dashboards:
@@ -18,4 +19,5 @@ dashboards:
 - name: sig-k8s-infra-gcb
 - name: sig-k8s-infra-groups
 - name: sig-k8s-infra-k8sio
+- name: sig-k8s-infra-oci-proxy
 - name: sig-k8s-infra-prow


### PR DESCRIPTION
Related:
 - https://github.com/kubernetes-sigs/oci-proxy/issues/24

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>