### PR TITLE
Deck: Sort consistently

### DIFF
--- a/prow/deck/jobs/jobs.go
+++ b/prow/deck/jobs/jobs.go
@@ -282,7 +282,12 @@ type byPJStartTime []prowapi.ProwJob
 func (a byPJStartTime) Len() int      { return len(a) }
 func (a byPJStartTime) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a byPJStartTime) Less(i, j int) bool {
-	return a[i].Status.StartTime.Time.After(a[j].Status.StartTime.Time)
+	if a[i].Status.StartTime.Time != a[j].Status.StartTime.Time {
+		return a[i].Status.StartTime.Time.After(a[j].Status.StartTime.Time)
+	}
+	// Start time only has second granularity and we often start many jobs in the
+	// same second. Use the name as tie breaker.
+	return a[i].Spec.Job < a[j].Spec.Job
 }
 
 func (ja *JobAgent) update() error {


### PR DESCRIPTION
Deck already sorts jobs on the serverside by StartTime. Unfortunately,
we often start many jobs at the same time, resulting in the order
flipping in the frontend every 30 seconds (because deck caches jobs for
30 s).

This change makes us fallback to sort by jobname if the startTime is
identical for two jobs.