### PR TITLE
Switch to newer images for CI jobs

### DIFF
--- a/jobs/e2e_node/containerd/image-config.yaml
+++ b/jobs/e2e_node/containerd/image-config.yaml
@@ -1,9 +1,9 @@
 images:
   ubuntu:
-    image_family: pipeline-1-20
+    image_family: pipeline-1-23
     project: ubuntu-os-gke-cloud
     metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"
   cos-stable:
-    image_family: cos-89-lts
+    image_family: cos-97-lts
     project: cos-cloud
     metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"


### PR DESCRIPTION
We are using very old images, let's switch to newer ones:
- https://cloud.google.com/container-optimized-os/docs/release-notes
- https://cloud.google.com/container-optimized-os/docs/release-notes/m97

```
NAME: ubuntu-gke-2004-1-23-v20220415
PROJECT: ubuntu-os-gke-cloud
FAMILY: pipeline-1-23
DEPRECATED:
STATUS: READY

NAME: cos-97-16919-29-9
PROJECT: cos-cloud
FAMILY: cos-97-lts
DEPRECATED:
STATUS: READY
```

Signed-off-by: Davanum Srinivas <davanum@gmail.com>