### PR TITLE
Fix flake in bugzilla config merging

### DIFF
--- a/prow/plugins/config_test.go
+++ b/prow/plugins/config_test.go
@@ -1566,6 +1566,14 @@ func TestConfigMergingProperties(t *testing.T) {
 		{
 			name: "Merging a config into itself always fails",
 			verification: func(t *testing.T, fuzzedMergeableConfig *Configuration) {
+
+				// An empty bugzilla org config does nothing, so clean those.
+				for org, val := range fuzzedMergeableConfig.Bugzilla.Orgs {
+					if reflect.DeepEqual(val, BugzillaOrgOptions{}) {
+						delete(fuzzedMergeableConfig.Bugzilla.Orgs, org)
+					}
+				}
+				// An exception to the rule is merging an empty config into itself, that is valid and will just do nothing.
 				if apiequality.Semantic.DeepEqual(fuzzedMergeableConfig, &Configuration{}) {
 					return
 				}


### PR DESCRIPTION
Fixes #24074

Without this, the failure in https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/test-infra/25656/pull-test-infra-unit-test/1504167885168185344 is easily reproducible by re-using the seed from that job:

```diff
diff --git a/prow/plugins/config_test.go b/prow/plugins/config_test.go
index e1fc62adaa..af9e5ad84e 100644
--- a/prow/plugins/config_test.go
+++ b/prow/plugins/config_test.go
@@ -1589,7 +1589,7 @@ func TestConfigMergingProperties(t *testing.T) {
                },
        }
 
-       seed := time.Now().UnixNano()
+       seed := int64(1647456756607879927)
        // Print the seed so failures can easily be reproduced
        t.Logf("Seed: %d", seed)
        fuzzer := fuzz.NewWithSeed(seed)
```

```shell
go test ./prow/plugins -run TestConfigMergingProperties -count=3
```

cc @AlexNPavel 