### PR TITLE
Switch to newer images for some flaky CI jobs

### DIFF
--- a/jobs/e2e_node/containerd/containerd-master/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-master/image-config.yaml
@@ -1,9 +1,9 @@
 images:
   ubuntu:
-    image: ubuntu-gke-1804-1-17-v20200729 # docker 19.03.2 / containerd 1.2.10
+    image_family: pipeline-1-23
     project: ubuntu-os-gke-cloud
     metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-master/env"
   cos-stable:
-    image_family: cos-89-lts
+    image_family: cos-97-lts
     project: cos-cloud
     metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-master/env,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/containerd/containerd-master/systemd/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-master/systemd/image-config.yaml
@@ -1,5 +1,5 @@
 images:
   cos-stable:
-    image_family: cos-89-lts
+    image_family: cos-97-lts
     project: cos-cloud
     metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-master/systemd/env,gci-update-strategy=update_disabled"


### PR DESCRIPTION
Targeting `ci-containerd-node-e2e` and `ci-cgroup-systemd-containerd-node-e2e` 

Validated these in https://github.com/kubernetes/test-infra/pull/25970 and the jobs there are 💚 

We are using very old images, let's switch to newer ones:
- https://cloud.google.com/container-optimized-os/docs/release-notes
- https://cloud.google.com/container-optimized-os/docs/release-notes/m97

```
NAME: ubuntu-gke-2004-1-23-v20220415
PROJECT: ubuntu-os-gke-cloud
FAMILY: pipeline-1-23
DEPRECATED:
STATUS: READY

NAME: cos-97-16919-29-9
PROJECT: cos-cloud
FAMILY: cos-97-lts
DEPRECATED:
STATUS: READY
```

Signed-off-by: Davanum Srinivas <davanum@gmail.com>