### PR TITLE
bump etcd version 3.5.3 for CAPI

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
@@ -159,7 +159,7 @@ periodics:
         - name: KUBERNETES_VERSION_UPGRADE_TO
           value: "stable-1.22"
         - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.1-0"
+          value: "3.5.3-0"
         - name: COREDNS_VERSION_UPGRADE_TO
           value: "v1.8.4"
         - name: GINKGO_FOCUS
@@ -203,7 +203,7 @@ periodics:
         - name: KUBERNETES_VERSION_UPGRADE_TO
           value: "stable-1.23"
         - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.1-0"
+          value: "3.5.3-0"
         - name: COREDNS_VERSION_UPGRADE_TO
           value: "v1.8.6"
         - name: GINKGO_FOCUS
@@ -247,7 +247,7 @@ periodics:
       - name: KUBERNETES_VERSION_UPGRADE_TO
         value: "ci/latest-1.24"
       - name: ETCD_VERSION_UPGRADE_TO
-        value: "3.5.1-0"
+        value: "3.5.3-0"
       - name: COREDNS_VERSION_UPGRADE_TO
         value: "v1.8.6"
       - name: GINKGO_FOCUS

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-4-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-4-upgrades.yaml
@@ -159,7 +159,7 @@ periodics:
         - name: KUBERNETES_VERSION_UPGRADE_TO
           value: "stable-1.22"
         - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.1-0"
+          value: "3.5.3-0"
         - name: COREDNS_VERSION_UPGRADE_TO
           value: "v1.8.4"
         - name: GINKGO_FOCUS
@@ -203,7 +203,7 @@ periodics:
         - name: KUBERNETES_VERSION_UPGRADE_TO
           value: "stable-1.23"
         - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.1-0"
+          value: "3.5.3-0"
         - name: COREDNS_VERSION_UPGRADE_TO
           # CAPI 0.4 only supports up to CoreDNS version 1.8.4.
           value: "v1.8.4"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-0-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-0-upgrades.yaml
@@ -159,7 +159,7 @@ periodics:
         - name: KUBERNETES_VERSION_UPGRADE_TO
           value: "stable-1.22"
         - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.1-0"
+          value: "3.5.3-0"
         - name: COREDNS_VERSION_UPGRADE_TO
           value: "v1.8.4"
         - name: GINKGO_FOCUS
@@ -203,7 +203,7 @@ periodics:
         - name: KUBERNETES_VERSION_UPGRADE_TO
           value: "stable-1.23"
         - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.1-0"
+          value: "3.5.3-0"
         - name: COREDNS_VERSION_UPGRADE_TO
           # CAPI 1.0 only supports up to CoreDNS version 1.8.5.
           value: "v1.8.5"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-1-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-1-upgrades.yaml
@@ -159,7 +159,7 @@ periodics:
         - name: KUBERNETES_VERSION_UPGRADE_TO
           value: "stable-1.22"
         - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.1-0"
+          value: "3.5.3-0"
         - name: COREDNS_VERSION_UPGRADE_TO
           value: "v1.8.4"
         - name: GINKGO_FOCUS
@@ -203,7 +203,7 @@ periodics:
         - name: KUBERNETES_VERSION_UPGRADE_TO
           value: "stable-1.23"
         - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.1-0"
+          value: "3.5.3-0"
         - name: COREDNS_VERSION_UPGRADE_TO
           value: "v1.8.6"
         - name: GINKGO_FOCUS
@@ -247,7 +247,7 @@ periodics:
       - name: KUBERNETES_VERSION_UPGRADE_TO
         value: "ci/latest-1.24"
       - name: ETCD_VERSION_UPGRADE_TO
-        value: "3.5.1-0"
+        value: "3.5.3-0"
       - name: COREDNS_VERSION_UPGRADE_TO
         value: "v1.8.6"
       - name: GINKGO_FOCUS

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -261,7 +261,7 @@ presubmits:
           - name: KUBERNETES_VERSION_UPGRADE_TO
             value: "ci/latest-1.24"
           - name: ETCD_VERSION_UPGRADE_TO
-            value: "3.5.1-0"
+            value: "3.5.3-0"
           - name: COREDNS_VERSION_UPGRADE_TO
             value: "v1.8.6"
           - name: GINKGO_FOCUS

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-0-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-0-4.yaml
@@ -260,7 +260,7 @@ presubmits:
           - name: KUBERNETES_VERSION_UPGRADE_TO
             value: "ci/latest-1.24"
           - name: ETCD_VERSION_UPGRADE_TO
-            value: "3.5.1-0"
+            value: "3.5.3-0"
           - name: COREDNS_VERSION_UPGRADE_TO
             value: "v1.8.6"
           - name: GINKGO_FOCUS

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-0.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-0.yaml
@@ -260,7 +260,7 @@ presubmits:
           - name: KUBERNETES_VERSION_UPGRADE_TO
             value: "ci/latest-1.24"
           - name: ETCD_VERSION_UPGRADE_TO
-            value: "3.5.1-0"
+            value: "3.5.3-0"
           - name: COREDNS_VERSION_UPGRADE_TO
             value: "v1.8.6"
           - name: GINKGO_FOCUS

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-1.yaml
@@ -287,7 +287,7 @@ presubmits:
           - name: KUBERNETES_VERSION_UPGRADE_TO
             value: "ci/latest-1.24"
           - name: ETCD_VERSION_UPGRADE_TO
-            value: "3.5.1-0"
+            value: "3.5.3-0"
           - name: COREDNS_VERSION_UPGRADE_TO
             value: "v1.8.6"
           - name: GINKGO_FOCUS


### PR DESCRIPTION
Upgrading etcd to the version that mitigates a critical issue which leds to data corruption --> https://github.com/ahrtr/etcd-issues/tree/master/issues/13766

