### PR TITLE
Switch to newer image for swap CI job

### DIFF
--- a/jobs/e2e_node/swap/image-config-swap.yaml
+++ b/jobs/e2e_node/swap/image-config-swap.yaml
@@ -3,7 +3,7 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu:
-    image: ubuntu-gke-2004-1-20-v20210401 # docker 19.03.8 / containerd 1.4.3
+    image_family: pipeline-1-23
     project: ubuntu-os-gke-cloud
     metadata: "user-data</workspace/test-infra/jobs/e2e_node/swap/ubuntu-swap-1G-allocation.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"
     machine: n1-standard-2


### PR DESCRIPTION
Targeting `ci-kubernetes-node-swap-ubuntu` flakiness for the `stats api` test

```
NAME: ubuntu-gke-2004-1-23-v20220415
PROJECT: ubuntu-os-gke-cloud
FAMILY: pipeline-1-23
DEPRECATED:
STATUS: READY
```

Signed-off-by: Davanum Srinivas <davanum@gmail.com>