### PR TITLE
windows alpha job has GAed feature flag WindowsGMSA - need to remove

### DIFF
--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -198,8 +198,6 @@ periodics:
         value: "win2019"
       - name: PREPULL_YAML
         value: "prepull-head.yaml"
-      - name: KUBE_FEATURE_GATES
-        value: "WindowsGMSA=true"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220413-ebb00ad7a6-master
   annotations:
     testgrid-dashboards: google-windows, sig-windows-gce


### PR DESCRIPTION
https://testgrid.k8s.io/google-windows#gce-windows-2019-master-alpha-features is all 🔴 

Kubelet logs show:
`Apr 17 22:26:44.420580 e2e-651e591cd0-a4c99-master kubelet[2342]: Error: failed to set feature gates from initial flags-based config: unrecognized feature gate: WindowsGMSA`

Looks like `WindowsGMSA` was GA'ed and hence removed in https://github.com/kubernetes/kubernetes/pull/96531

The job was probably failing since then with none looking :(

/sig windows
/sig node

Signed-off-by: Davanum Srinivas <davanum@gmail.com>