### PR TITLE
specify DisableCloudProviders=false for gci-gce-alpha-enabled-default job

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -487,7 +487,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true,CSIMigration=false,InTreePluginGCEUnregister=false
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true,DisableCloudProviders=false,CSIMigration=false,InTreePluginGCEUnregister=false
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
       - --extract=ci/latest


### PR DESCRIPTION
`ci-kubernetes-e2e-gci-gce-alpha-enabled-default` has been 🔴 for a while:
https://testgrid.k8s.io/google-gce#gci-gce-alpha-enabled-default

Looking at kubelet logs we see:
`Apr 17 23:39:21.263389 bootstrap-e2e-master kubelet[2039]: Error: failed to run Kubelet: failed to create kubelet: cloud provider "gce" was specified, but built-in cloud providers are disabled. Please set --cloud-provider=external and migrate to an external cloud provider`

(from https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-alpha-enabled-default/1515836418243432448/artifacts/bootstrap-e2e-master/kubelet.log)

So we gotta set `DisableCloudProviders` explicitly to `false`

Signed-off-by: Davanum Srinivas <davanum@gmail.com>