### PR TITLE
Prefer to build Ginkgo V2

### DIFF
--- a/experiment/kind-conformance-image-e2e.sh
+++ b/experiment/kind-conformance-image-e2e.sh
@@ -106,12 +106,21 @@ run_tests() {
   NEW_CONFORMANCE_DIR="test/conformance/image"
   # before https://github.com/kubernetes/kubernetes/pull/103874
   OLD_CONFORMANCE_DIR="cluster/images/conformance"
-  if [ -d "${NEW_CONFORMANCE_DIR}/go-runner" ]; then
-      make WHAT="test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo cmd/kubectl ${NEW_CONFORMANCE_DIR}/go-runner"
-  elif [ -d "${OLD_CONFORMANCE_DIR}/go-runner" ]; then
-      make WHAT="test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo cmd/kubectl ${OLD_CONFORMANCE_DIR}/go-runner"
+
+  # Ginkgo v1 is deprecated, perfer to build Ginkgo V2.
+  GINKGO_SRC_V2="vendor/github.com/onsi/ginkgo/v2/ginkgo"
+  if [ -d "$GINKGO_SRC_V2" ]; then
+      GINKGO_SRC_DIR="$GINKGO_SRC_V2"
   else
-      make WHAT="test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo cmd/kubectl"
+      GINKGO_SRC_DIR="vendor/github.com/onsi/ginkgo/ginkgo"
+  fi
+
+  if [ -d "${NEW_CONFORMANCE_DIR}/go-runner" ]; then
+      make WHAT="test/e2e/e2e.test $GINKGO_SRC_DIR cmd/kubectl ${NEW_CONFORMANCE_DIR}/go-runner"
+  elif [ -d "${OLD_CONFORMANCE_DIR}/go-runner" ]; then
+      make WHAT="test/e2e/e2e.test $GINKGO_SRC_DIR cmd/kubectl ${OLD_CONFORMANCE_DIR}/go-runner"
+  else
+      make WHAT="test/e2e/e2e.test $GINKGO_SRC_DIR cmd/kubectl"
   fi
 
   # grab the version number for kubernetes


### PR DESCRIPTION
Ginkgo V1 has been deprecated, for this issue like this https://github.com/onsi/ginkgo/issues/222 will be fixed in the v2 only.

>With the release of Ginkgo 2.0 the 1.x version is formally deprecated and no longer supported. All future development will occur on version 2.


The efforts to migrate the Ginkgo from v1 to v2 is being done here: https://github.com/kubernetes/kubernetes/pull/109111

But the check of `pull-kubernetes-conformance-image-test` is building Ginkgo V1 only, pls see the details: [pull-kubernetes-conformance-image-test](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/109111/pull-kubernetes-conformance-image-test/1514937224158777344/)

Signed-off-by: Dave Chen <dave.chen@arm.com>