### PR TITLE
Add CI jobs for containerd 1.6.x branch

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -100,6 +100,25 @@ periodics:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-build-test-images
     description: "builds test images for development in progress branch of upstream containerd"
+- name: ci-containerd-build-1-6
+  interval: 30m
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220413-ebb00ad7a6-master
+        args:
+          - --repo=github.com/containerd/containerd=release/1.6
+          - --root=/go/src
+          - --upload=gs://kubernetes-jenkins/logs
+          - --scenario=execute
+          - --
+          - --env=DEPLOY_DIR=release-1.6
+          - /go/src/github.com/containerd/containerd/test/build.sh
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    testgrid-tab-name: containerd-build-1.6
+    description: "builds release/1.6 branch of upstream containerd"
 - interval: 1h
   name: ci-containerd-e2e-ubuntu-gce
   labels:
@@ -235,6 +254,43 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-node-e2e-1.5
+- name: ci-containerd-node-e2e-1-6
+  cluster: k8s-infra-prow-build
+  interval: 1h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220413-ebb00ad7a6-1.23
+        args:
+          - --root=/go/src
+          - --repo=k8s.io/kubernetes=release-1.23
+          - --repo=github.com/containerd/containerd=release/1.6
+          - --timeout=90
+          - --scenario=kubernetes_e2e
+          - --
+          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.6/image-config.yaml
+          - --deployment=node
+          - --gcp-zone=us-central1-b
+          - '--node-test-args=--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
+          - --node-tests=true
+          - --provider=gce
+          - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Serial\]"
+          - --timeout=65m
+        env:
+          - name: GOPATH
+            value: /go
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    testgrid-tab-name: containerd-node-e2e-1.6
 - name: ci-containerd-node-e2e-features-1-5
   cluster: k8s-infra-prow-build
   interval: 1h
@@ -272,6 +328,43 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-node-e2e-features-1.5
+- name: ci-containerd-node-e2e-features-1-6
+  cluster: k8s-infra-prow-build
+  interval: 1h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220413-ebb00ad7a6-1.23
+        args:
+          - --root=/go/src
+          - --repo=k8s.io/kubernetes=release-1.23
+          - --repo=github.com/containerd/containerd=release/1.6
+          - --timeout=90
+          - --scenario=kubernetes_e2e
+          - --
+          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.6/image-config.yaml
+          - --deployment=node
+          - --gcp-zone=us-central1-b
+          - '--node-test-args=--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
+          - --node-tests=true
+          - --provider=gce
+          - --test_args=--nodes=8 --focus="\[NodeFeature:.+\]|\[NodeFeature\]" --skip="\[Flaky\]|\[Serial\]"
+          - --timeout=65m
+        env:
+          - name: GOPATH
+            value: /go
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    testgrid-tab-name: containerd-node-e2e-features-1.6
 - interval: 12h
   name: ci-containerd-soak-cos-gce
   labels:

--- a/jobs/e2e_node/containerd/containerd-release-1.6/env
+++ b/jobs/e2e_node/containerd/containerd-release-1.6/env
@@ -1,0 +1,8 @@
+CONTAINERD_TEST: 'true'
+CONTAINERD_LOG_LEVEL: 'debug'
+CONTAINERD_DEPLOY_PATH: 'cri-containerd-staging/containerd/release-1.6'
+CONTAINERD_PKG_PREFIX: 'containerd-cni'
+
+CONTAINERD_EXTRA_RUNTIME_HANDLER: 'test-handler'
+CONTAINERD_EXTRA_RUNTIME_OPTIONS: |
+  BinaryName = "/home/containerd/usr/local/sbin/runc"

--- a/jobs/e2e_node/containerd/containerd-release-1.6/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-release-1.6/image-config.yaml
@@ -1,0 +1,9 @@
+images:
+  ubuntu:
+    image: ubuntu-gke-2004-1-21-v20210722 # docker 19.03.8 / containerd 1.4.3
+    project: ubuntu-os-gke-cloud
+    metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.6/env"
+  cos-stable:
+    image_family: cos-89-lts
+    project: cos-cloud
+    metadata: "user-data</go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.6/env,gci-update-strategy=update_disabled"


### PR DESCRIPTION
Containerd folks are talking about a 1.7 drop off of containerd/main branch. So let's prep a set of CI jobs for containerd 1.6 branch.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>