### PR TITLE
Revive perma failing ci-kubernetes-e2e-node-canary CI job

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -75,8 +75,8 @@ periodics:
       args:
       - --deployment=node
       - --gcp-zone=us-west1-b
-      - --node-args=--images=cos-stable-60-9592-76-0 --image-project=cos-cloud
-      - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
+      - --node-args=--image-family=cos-97-lts --image-project=cos-cloud
+      - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
       - --node-tests=true
       - --provider=gce
       - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Serial\]"


### PR DESCRIPTION
Test grid shows:
https://testgrid.k8s.io/sig-testing-canaries#node&width=20

Looks like this broke when we went from docker->containerd by default

Make this look more like `ci-containerd-node-e2e` and switch to newer images

Signed-off-by: Davanum Srinivas <davanum@gmail.com>