### PR TITLE
Add path to jq for metrics-bigquery job

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
@@ -58,6 +58,7 @@ periodics:
       - ./metrics/bigquery.py
       - --bucket=gs://k8s-metrics
       - --project=k8s-infra-prow-build-trusted
+      - --jq=/usr/bin/jq
 
 - name: ci-test-infra-triage
   interval: 30m


### PR DESCRIPTION
a9b7a9b89d2df96da926736098d50a75b00340f4 missed a spot, causing issues
in the CI job.

```
FileNotFoundError: [Errno 2] No such file or directory: '../_bin/jq-1.5/jq': '../_bin/jq-1.5/jq'
```

see
https://storage.googleapis.com/kubernetes-jenkins/logs/metrics-bigquery/1516024660066570240/build-log.txt
for example

Looked in `gcr.io/k8s-staging-test-infra/bigquery:v20220330-0567932c13`
image to find the `jq` path and setting it explicitly for the CI job

Signed-off-by: Davanum Srinivas <davanum@gmail.com>