### PR TITLE
Remove preset-use-new-registry label from sig-cli

### DIFF
--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -150,7 +150,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
-    preset-use-new-registry: "true"
   spec:
     containers:
     - args:


### PR DESCRIPTION
This PR reverts the sig-cli changes from https://github.com/kubernetes/test-infra/pull/25839 to temporarily fix https://github.com/kubernetes/kubernetes/issues/109511.

`preset-use-new-registry` sets the `KUBE_TEST_REPO_LIST` which invokes logic added in https://github.com/kubernetes/kubernetes/pull/108429. The issue here is that this is a skew test testing against older versions of Kubernetes without this logic. Cherry picking at https://github.com/kubernetes/kubernetes/pull/109512 should make the skew test compatible.

cc @dims @zachmandeville 