### PR TITLE
Fix default path of jq to what is in the image

### DIFF
--- a/metrics/bigquery.py
+++ b/metrics/bigquery.py
@@ -30,7 +30,7 @@ import requests
 import ruamel.yaml as yaml
 
 BACKFILL_DAYS = 30
-DEFAULT_JQ_BIN = '../_bin/jq-1.5/jq'
+DEFAULT_JQ_BIN = '/usr/bin/jq'
 
 def check(cmd, **kwargs):
     """Logs and runs the command, raising on errors."""


### PR DESCRIPTION
We should default to the path of `jq` to what is in the image itself. the make/test harness can pass `--jq` as needed

Signed-off-by: Davanum Srinivas <davanum@gmail.com>