### PR TITLE
Remove microbenchmarks job

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -900,42 +900,6 @@ periodics:
           cpu: 2
           memory: "4Gi"
 
-- name: ci-benchmark-microbenchmarks
-  interval: 20m
-  annotations:
-    testgrid-dashboards: sig-scalability-benchmarks
-    testgrid-tab-name: microbenchmarks
-  decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
-    path_alias: k8s.io/test-infra
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/benchmarkjunit:latest
-      command:
-      - /benchmarkjunit
-      args:
-      - --log-file=$(ARTIFACTS)/benchmark-log.txt
-      - --output=$(ARTIFACTS)/junit_benchmarks.xml
-      - --pass-on-error
-      - ../kubernetes/pkg/...
-      - ../kubernetes/plugin/...
-      - ../kubernetes/vendor/k8s.io/apimachinery/...
-      - ../kubernetes/vendor/k8s.io/apiserver/...
-      - ../kubernetes/vendor/k8s.io/client-go/...
-      resources:
-        requests:
-          cpu: 1
-          memory: "2Gi"
-        limits:
-          cpu: 1
-          memory: "2Gi"
 - name: ci-kubernetes-e2e-gce-network-metric-measurement
   cluster: k8s-infra-prow-build
   tags:


### PR DESCRIPTION
Having data from microbenchmarks is in theory very useful but:
- the job is failing due to https://github.com/kubernetes/kubernetes/issues/79464 (although underneath it was generating actual results)
- we don't have proof that anyone used that data for anything
- the job wasn't really officially adopted by any SIG

Given that, we're removing this job - we should readd that once we have a plan for making it green and adopted by any SIG.

/assign @marseel @dims 