### PR TITLE
[release-1.24] Update kubekins e2e image variants

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -32,6 +32,12 @@ variants:
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
+  '1.24':
+    CONFIG: '1.24'
+    GO_VERSION: 1.18.1
+    K8S_RELEASE: stable-1.24
+    BAZEL_VERSION: 3.4.1
+    OLD_BAZEL_VERSION: 2.2.0
   '1.23':
     CONFIG: '1.23'
     GO_VERSION: 1.17.9

--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -56,9 +56,3 @@ variants:
     K8S_RELEASE: stable-1.21
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
-  '1.20':
-    CONFIG: '1.20'
-    GO_VERSION: 1.15.15
-    K8S_RELEASE: stable-1.20
-    BAZEL_VERSION: 3.4.1
-    OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
The change includes the following:
- kubekins-e2e: add variant for Kubernetes 1.24
- kubekins-e2e: removes variant for Kubernetes 1.20 as it is out of support

Part of https://github.com/kubernetes/sig-release/issues/1886

**IMPORTANT**
/hold for after the release-1.24 branch is available
**IMPORTANT**

/sig release
/area release-eng
/milestone v1.24
/priority critical-urgent
/assign @kubernetes/release-engineering