### PR TITLE
prow/plugins: update milestone-applier rules to reflect 1.24 release

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -358,23 +358,23 @@ slack:
 
 milestone_applier:
   kubernetes/enhancements:
-    master: v1.24
+    master: v1.25
   kubernetes/kubernetes:
-    master: v1.24
+    master: v1.25
+    release-1.24: v1.24
     release-1.23: v1.23
     release-1.22: v1.22
     release-1.21: v1.21
-    release-1.20: v1.20
   kubernetes/org:
-    main: v1.24
+    main: v1.25
   kubernetes/release:
-    master: v1.24
+    master: v1.25
   kubernetes/sig-release:
-    master: v1.24
+    master: v1.25
   kubernetes/test-infra:
-    master: v1.24
+    master: v1.25
   kubernetes/k8s.io:
-    main: v1.24
+    main: v1.25
   kubernetes/kops:
     master: v1.24
     release-1.23: v1.23


### PR DESCRIPTION
Part of https://github.com/kubernetes/sig-release/issues/1886

**IMPORTANT**
/hold for after the release-1.24 branch is available
**IMPORTANT**

/sig release
/area release-eng
/milestone v1.24
/priority critical-urgent
/assign @kubernetes/release-engineering