### PR TITLE
Drop perma-fail ci-kubernetes-e2e-gce-taint-evict CI job

### DIFF
--- a/config/jobs/kubernetes/sig-apps/sig-apps-config.yaml
+++ b/config/jobs/kubernetes/sig-apps/sig-apps-config.yaml
@@ -1,31 +1,5 @@
 periodics:
 - interval: 30m
-  name: ci-kubernetes-e2e-gce-taint-evict
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=80
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
-      # TODO(gmarek): Enable this when we've split 1.2 tests into another project.
-      - --env=CONTROLLER_MANAGER_TEST_ARGS=--feature-gates=TaintBasedEvictions=true --enable-taint-manager=true
-      - --extract=ci/latest
-      - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
-      - --provider=gce
-      - --test_args=--ginkgo.focus=\[Feature:TaintEviction\] --minStartupPods=8
-      - --timeout=50m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220413-ebb00ad7a6-master
-
-
-  annotations:
-    testgrid-dashboards: google-gce
-    testgrid-tab-name: gce-taint-evict
-- interval: 30m
   name: ci-kubernetes-e2e-gci-gce-statefulset
   labels:
     preset-service-account: "true"


### PR DESCRIPTION
`TaintBasedEvictions` went GA a long time ago (1.19) so this job has
been failing since then because the feature gate no longer exists!

See test-grid : https://testgrid.k8s.io/google-gce#gce-taint-evict

From https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-taint-evict/1516438770801446912 you can see that the manager just keeps looping and eventually fails.
```
bootstrap-e2e-master/kube-controller-manager.log:Error: invalid argument "TaintBasedEvictions=true" for "--feature-gates" flag: unrecognized feature gate: TaintBasedEvictions
bootstrap-e2e-master/kube-controller-manager.log:Error: invalid argument "TaintBasedEvictions=true" for "--feature-gates" flag: unrecognized feature gate: TaintBasedEvictions
bootstrap-e2e-master/kube-controller-manager.log:Error: invalid argument "TaintBasedEvictions=true" for "--feature-gates" flag: unrecognized feature gate: TaintBasedEvictions
bootstrap-e2e-master/kube-controller-manager.log:Error: invalid argument "TaintBasedEvictions=true" for "--feature-gates" flag: unrecognized feature gate: TaintBasedEvictions
bootstrap-e2e-master/kube-controller-manager.log:Error: invalid argument "TaintBasedEvictions=true" for "--feature-gates" flag: unrecognized feature gate: TaintBasedEvictions
bootstrap-e2e-master/kube-controller-manager.log:Error: invalid argument "TaintBasedEvictions=true" for "--feature-gates" flag: unrecognized feature gate: TaintBasedEvictions
bootstrap-e2e-master/kube-controller-manager.log:Error: invalid argument "TaintBasedEvictions=true" for "--feature-gates" flag: unrecognized feature gate: TaintBasedEvictions
bootstrap-e2e-master/kube-controller-manager.log:Error: invalid argument "TaintBasedEvictions=true" for "--feature-gates" flag: unrecognized feature gate: TaintBasedEvictions
bootstrap-e2e-master/kube-controller-manager.log:Error: invalid argument "TaintBasedEvictions=true" for "--feature-gates" flag: unrecognized feature gate: TaintBasedEvictions
bootstrap-e2e-master/kube-controller-manager.log:Error: invalid argument "TaintBasedEvictions=true" for "--feature-gates" flag: unrecognized feature gate: TaintBasedEvictions
bootstrap-e2e-master/kube-controller-manager.log:Error: invalid argument "TaintBasedEvictions=true" for "--feature-gates" flag: unrecognized feature gate: TaintBasedEvictions
```

Signed-off-by: Davanum Srinivas <davanum@gmail.com>