### PR TITLE
Drop ci-kubemci-ingress-conformance CI job

### DIFF
--- a/config/jobs/GoogleCloudPlatform/k8s-multicluster-ingress/k8s-multicluster-ingress-config.yaml
+++ b/config/jobs/GoogleCloudPlatform/k8s-multicluster-ingress/k8s-multicluster-ingress-config.yaml
@@ -99,29 +99,3 @@ periodics:
   annotations:
     testgrid-dashboards: sig-multicluster-kubemci
     testgrid-tab-name: ci-kubemci-unit-tests
-- interval: 60m
-  name: ci-kubemci-ingress-conformance
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=110
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --env=GCE_GLBC_IMAGE=gcr.io/k8s-ingress-image-push/ingress-gce-glbc-amd64:master
-      - --extract=ci/latest
-      - --gcp-node-image=gci
-      - --gcp-project-type=ingress-project
-      - --gcp-zone=us-central1-f
-      - --provider=gce
-      - --test_args=--ginkgo.focus=\[Feature:kubemci\] --minStartupPods=8
-      - --timeout=90m
-      image: gcr.io/k8s-testimages/e2e-kubemci:latest
-      imagePullPolicy: Always
-  annotations:
-    testgrid-dashboards: sig-multicluster-kubemci
-    testgrid-tab-name: kubemci-ingress-conformance


### PR DESCRIPTION
`Feature:kubemci` was removed from e2e tests in:
da9ec0d4c74b60e27cf74199ea2cc6b60176e1b3

So this CI job is meaning less and perma-fails as well:
https://testgrid.k8s.io/sig-multicluster-kubemci#kubemci-ingress-conformance

Signed-off-by: Davanum Srinivas <davanum@gmail.com>