### PR TITLE
releng: Branch job generator fixes

### DIFF
--- a/releng/README.md
+++ b/releng/README.md
@@ -1,0 +1,73 @@
+# Release Engineering tooling
+
+This directory contains tooling to generate Prow jobs.
+While some of this may be generically useful for other cases, the primary
+function of these tools is to generate release branch jobs after
+kubernetes/kubernetes releases which create new branches.
+
+> NOTE: The documentation here supersedes overlapping guidance from the
+[Release Manager handbooks][branch-manager-handbook] (which will be removed at
+a future date).
+
+- [Tools](#tools)
+- [Release branch jobs](#release-branch-jobs)
+  - [Generate jobs](#generate-jobs)
+  - [Update release dashboards](#update-release-dashboards)
+  - [Check/resolve configuration errors](#checkresolve-configuration-errors)
+  - [Create a pull request](#create-a-pull-request)
+  - [Validate](#validate)
+  - [Announce](#announce)
+
+## Tools
+
+- [`generate_tests.py`](./generate_tests.py): Populates generated jobs based on
+  the configurations specified in [`test_config.yaml`](./test_config.yaml)
+- [`prepare_release_branch.py`](./releng/prepare_release_branch.py): Generates
+  release branch jobs using `config-forker` and `config-rotator`
+- [`config-forker`](./config-forker/README.md): Forks presubmit, periodic, and
+  postsubmit job configs with the `fork-per-release` annotation
+- [`config-rotator`](./config-rotator/README.md): Rotates forked presubmit,
+  periodic, and postsubmit job configs created by `config-forker`
+
+## Release branch jobs
+
+This task should be done after the release is complete and previous PRs are
+merged. The following steps should be run from the root of this repository.
+
+### Generate jobs
+
+```console
+make -C releng prepare-release-branch
+```
+
+### Update release dashboards
+
+Update release dashboards in the [Testgrid config](https://git.k8s.io/test-infra/config/testgrids/kubernetes/sig-release/config.yaml) ([example commit](https://github.com/kubernetes/test-infra/pull/15023/commits/cad8a3ce8ef3537568b12619634dff702b16cda7)).
+
+- Remove the oldest release `sig-release-<version>-{blocking,informing}` dashboards
+- Add dashboards for the current release e.g., `sig-release-1.23-{blocking,informing}`
+
+### Check/resolve configuration errors
+
+```console
+make verify
+```
+
+### Create a pull request
+
+Issue a PR with the new release branch job configurations ([example PR](https://github.com/kubernetes/test-infra/pull/15023)).
+
+### Validate
+
+Once the PR has merged, verify that the new dashboards have been created and are populated with jobs.
+
+Examples:
+
+- [sig-release-1.23-blocking](https://testgrid.k8s.io/sig-release-1.23-blocking)
+- [sig-release-1.23-informing](https://testgrid.k8s.io/sig-release-1.23-informing)
+
+### Announce
+
+[Announce in #sig-release and #release-management](https://kubernetes.slack.com/archives/C2C40FMNF/p1565746110248300?thread_ts=1565701466.241200&cid=C2C40FMNF) that this work has been completed.
+
+[branch-manager-handbook]: https://git.k8s.io/sig-release/release-engineering/role-handbooks/branch-manager.md

--- a/releng/README.md
+++ b/releng/README.md
@@ -17,6 +17,7 @@ a future date).
   - [Create a pull request](#create-a-pull-request)
   - [Validate](#validate)
   - [Announce](#announce)
+- [TODOs](#todos)
 
 ## Tools
 
@@ -69,5 +70,13 @@ Examples:
 ### Announce
 
 [Announce in #sig-release and #release-management](https://kubernetes.slack.com/archives/C2C40FMNF/p1565746110248300?thread_ts=1565701466.241200&cid=C2C40FMNF) that this work has been completed.
+
+## TODOs
+
+- [ ] Branch jobs build the wrong marker after new branch job creation
+  
+  e.g., `k8s-master` instead of `k8s-stable1`
+  
+  This suggests that the generic marker suffixes are not being properly replaced.
 
 [branch-manager-handbook]: https://git.k8s.io/sig-release/release-engineering/role-handbooks/branch-manager.md

--- a/releng/config-rotator/main.go
+++ b/releng/config-rotator/main.go
@@ -150,3 +150,39 @@ func main() {
 		log.Fatalf("Failed to write new presubmits: %v.\n", err)
 	}
 }
+
+// Version marker logic
+
+const (
+	markerDefault     = "k8s-master"
+	markerBeta        = "k8s-beta"
+	markerStableOne   = "k8s-stable1"
+	markerStableTwo   = "k8s-stable2"
+	markerStableThree = "k8s-stable3"
+)
+
+var allowedMarkers = []string{
+	markerDefault,
+	markerBeta,
+	markerStableOne,
+	markerStableTwo,
+	markerStableThree,
+}
+
+func updateGenericVersionMarker(s, marker string) string {
+	var newMarker string
+	switch marker {
+	case markerDefault:
+		newMarker = markerBeta
+	case markerBeta:
+		newMarker = markerStableOne
+	case markerStableOne:
+		newMarker = markerStableTwo
+	case markerStableTwo:
+		newMarker = markerStableThree
+	default:
+		newMarker = marker
+	}
+
+	return updateString(s, marker, newMarker)
+}

--- a/releng/config-rotator/main.go
+++ b/releng/config-rotator/main.go
@@ -78,9 +78,11 @@ func updateJobBase(j *config.JobBase, old, new string) {
 		c := &j.Spec.Containers[i]
 		for j := range c.Args {
 			c.Args[j] = updateString(c.Args[j], old, new)
+			c.Args[j] = updateGenericVersionMarker(c.Args[j])
 		}
 		for j := range c.Command {
 			c.Command[j] = updateString(c.Command[j], old, new)
+			c.Command[j] = updateGenericVersionMarker(c.Command[j])
 		}
 	}
 }
@@ -169,8 +171,22 @@ var allowedMarkers = []string{
 	markerStableThree,
 }
 
-func updateGenericVersionMarker(s, marker string) string {
+func getMarker(s string) string {
+	var marker string
+	for _, m := range allowedMarkers {
+		if strings.Contains(s, m) {
+			marker = m
+			break
+		}
+	}
+
+	return marker
+}
+
+func updateGenericVersionMarker(s string) string {
 	var newMarker string
+
+	marker := getMarker(s)
 	switch marker {
 	case markerDefault:
 		newMarker = markerBeta

--- a/releng/config-rotator/main_test.go
+++ b/releng/config-rotator/main_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func TestUpdateGenericVersionMarker(t *testing.T) {
+	type args struct {
+		s      string
+		marker string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "k8s-master",
+			args: args{
+				s:      "--extra-version-markers=k8s-master",
+				marker: markerDefault,
+			},
+			want: "--extra-version-markers=k8s-beta",
+		},
+		{
+			name: "k8s-beta",
+			args: args{
+				s:      "--extra-version-markers=k8s-beta",
+				marker: markerBeta,
+			},
+			want: "--extra-version-markers=k8s-stable1",
+		},
+		{
+			name: "k8s-stable1",
+			args: args{
+				s:      "--extra-version-markers=k8s-stable1",
+				marker: markerStableOne,
+			},
+			want: "--extra-version-markers=k8s-stable2",
+		},
+		{
+			name: "k8s-stable2",
+			args: args{
+				s:      "--extra-version-markers=k8s-stable2",
+				marker: markerStableTwo,
+			},
+			want: "--extra-version-markers=k8s-stable3",
+		},
+		{
+			name: "noReplace",
+			args: args{
+				s:      "no-replace",
+				marker: "no",
+			},
+			want: "no-replace",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := updateGenericVersionMarker(tt.args.s, tt.args.marker); got != tt.want {
+				t.Errorf("updateGenericVersionMarker() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/releng/config-rotator/main_test.go
+++ b/releng/config-rotator/main_test.go
@@ -71,7 +71,7 @@ func TestUpdateGenericVersionMarker(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := updateGenericVersionMarker(tt.args.s, tt.args.marker); got != tt.want {
+			if got := updateGenericVersionMarker(tt.args.s); got != tt.want {
 				t.Errorf("updateGenericVersionMarker() = %v, want %v", got, tt.want)
 			}
 		})

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -8,15 +8,14 @@
 # the test definition and Prow configuration from the test name by pulling the
 # configs of each dimension in the test name and assembling them together.
 #
-# E.g., for test "ci-kubernetes-e2e-gce-ubuntu1-k8sdev-serial", its
+# e.g., for test "ci-kubernetes-e2e-gce-ubuntu1-k8sdev-serial", its
 # configuration will be generated from the configs of cloud provider "gce", the
 # image "ubuntu1", the Kubernetes version "k8sdev" and the test suite "serial".
 
 # To generate the test definitions and Prow configurations from this file:
 #
-#   bazel run //releng:generate_tests -- \
-#     --yaml-config-path=releng/test_config.yaml
-
+#   make -C releng generate-tests
+#
 # Supported tests:
 #
 #  * cluster e2e test


### PR DESCRIPTION
- releng: Add documentation for running job generators
- releng: Add TODOs to capture branch creation problems
- config-rotator: Add logic for updating generic version markers
- config-rotator: Integrate version marker updates into job updates

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @puerco @palnabarun
cc: @kubernetes/release-engineering 
/hold just creating this PR to have the reference to link in https://kubernetes.slack.com/archives/CJH2GBF7Y/p1650390368800099?thread_ts=1650361377.623769&cid=CJH2GBF7Y