### PR TITLE
[WIP] releng: Remove configs for k8s-beta jobs / add k8s-stable4 variants

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -772,36 +772,6 @@ periodics:
     testgrid-tab-name: gce-gci
 
 - interval: 12h
-  name: ci-kubernetes-soak-gci-gce-beta
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=1420
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
-      - --down=false
-      - --env=DOCKER_TEST_LOG_LEVEL=--log-level=warn
-      - --extract=ci/k8s-beta
-      - --gcp-master-image=gci
-      - --gcp-node-image=gci
-      - --gcp-project=k8s-jkns-gce-soak-1-6
-      - --gcp-zone=us-west1-b
-      - --provider=gce
-      - --save=gs://kubernetes-e2e-soak-configs/ci-kubernetes-soak-gci-gce-beta
-      - --soak
-      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
-      - --timeout=1400m
-      - --up=false
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220413-ebb00ad7a6-master
-  annotations:
-    testgrid-dashboards: google-gce
-    testgrid-tab-name: soak-gci-gce-1.15
-
-- interval: 12h
   name: ci-kubernetes-soak-gci-gce-stable1
   labels:
     preset-service-account: "true"

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -34,74 +34,34 @@ jobs:
   # GCE e2e tests
 
   # release branch jobs - cos only (cvm is deprecated at 1.8)
-  # beta release (inactive)
-  ci-kubernetes-e2e-gce-cos-k8sbeta-reboot:
-    interval: 1h
-    sigOwners: [sig-cloud-provider-gcp]
-    releaseBlocking: true
-  ci-kubernetes-e2e-gce-cos-k8sbeta-ingress:
-    interval: 1h
-    sigOwners: [sig-cloud-provider-gcp]
-    releaseBlocking: true
-  ci-kubernetes-e2e-gce-cos-k8sbeta-default:
-    args:
-    - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
-    interval: 1h
-    sigOwners: [sig-cloud-provider-gcp]
-    releaseBlocking: true
-  ci-kubernetes-e2e-gce-cos-k8sbeta-serial:
-    interval: 1h
-    sigOwners: [sig-cloud-provider-gcp]
-    releaseInforming: true
-    testgridNumFailuresToAlert: 6
-  ci-kubernetes-e2e-gce-cos-k8sbeta-slow:
-    interval: 1h
-    sigOwners: [sig-cloud-provider-gcp]
-    releaseInforming: true
-    testgridNumFailuresToAlert: 6
-  ci-kubernetes-e2e-gce-cos-k8sbeta-alphafeatures:
-    interval: 1h
-    args:
-    - --env=KUBE_PROXY_DAEMONSET=true
-    - --env=ENABLE_POD_PRIORITY=true
-    - --env=KUBE_FEATURE_GATES=AllAlpha=true,DisableCloudProviders=false,CSIMigration=false,InTreePluginGCEUnregister=false
-    # Panic if anything mutates a shared informer cache
-    - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
-    - --runtime-config=api/all=true
-    - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking
-      --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Networking-IPv6)\]|csi-hostpath-v0
-      --minStartupPods=8
-    sigOwners: [sig-cloud-provider-gcp]
-    releaseBlocking: true
-    
   # stable1
   ci-kubernetes-e2e-gce-cos-k8sstable1-reboot:
-    interval: 2h
+    interval: 1h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
   ci-kubernetes-e2e-gce-cos-k8sstable1-ingress:
-    interval: 2h
+    interval: 1h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
   ci-kubernetes-e2e-gce-cos-k8sstable1-default:
     args:
     - --env=ENABLE_POD_SECURITY_POLICY=true
-    interval: 2h
+    interval: 1h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
     testgridNumFailuresToAlert: 6
   ci-kubernetes-e2e-gce-cos-k8sstable1-serial:
-    interval: 2h
+    interval: 1h
     sigOwners: [sig-cloud-provider-gcp]
     releaseInforming: true
     testgridNumFailuresToAlert: 6
   ci-kubernetes-e2e-gce-cos-k8sstable1-slow:
-    interval: 2h
+    interval: 1h
     sigOwners: [sig-cloud-provider-gcp]
     releaseInforming: true
     testgridNumFailuresToAlert: 6
   ci-kubernetes-e2e-gce-cos-k8sstable1-alphafeatures:
-    interval: 2h
+    interval: 1h
     args:
     - --env=KUBE_PROXY_DAEMONSET=true
     - --env=ENABLE_POD_PRIORITY=true
@@ -117,30 +77,30 @@ jobs:
 
   # stable2
   ci-kubernetes-e2e-gce-cos-k8sstable2-reboot:
-    interval: 6h
+    interval: 2h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
   ci-kubernetes-e2e-gce-cos-k8sstable2-ingress:
-    interval: 6h
+    interval: 2h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
   ci-kubernetes-e2e-gce-cos-k8sstable2-default:
-    interval: 6h
+    interval: 2h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
     testgridNumFailuresToAlert: 6
   ci-kubernetes-e2e-gce-cos-k8sstable2-serial:
-    interval: 6h
+    interval: 2h
     sigOwners: [sig-cloud-provider-gcp]
     releaseInforming: true
     testgridNumFailuresToAlert: 6
   ci-kubernetes-e2e-gce-cos-k8sstable2-slow:
-    interval: 6h
+    interval: 2h
     sigOwners: [sig-cloud-provider-gcp]
     releaseInforming: true
     testgridNumFailuresToAlert: 6
   ci-kubernetes-e2e-gce-cos-k8sstable2-alphafeatures:
-    interval: 6h
+    interval: 2h
     args:
     - --env=KUBE_PROXY_DAEMONSET=true
     - --env=ENABLE_POD_PRIORITY=true
@@ -157,30 +117,30 @@ jobs:
 
   # stable3
   ci-kubernetes-e2e-gce-cos-k8sstable3-ingress:
-    interval: 24h
+    interval: 6h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
   ci-kubernetes-e2e-gce-cos-k8sstable3-reboot:
-    interval: 24h
+    interval: 6h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
   ci-kubernetes-e2e-gce-cos-k8sstable3-default:
-    interval: 24h
+    interval: 6h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
     testgridNumFailuresToAlert: 6
   ci-kubernetes-e2e-gce-cos-k8sstable3-serial:
-    interval: 24h
+    interval: 6h
     sigOwners: [sig-cloud-provider-gcp]
     releaseInforming: true
     testgridNumFailuresToAlert: 6
   ci-kubernetes-e2e-gce-cos-k8sstable3-slow:
-    interval: 24h
+    interval: 6h
     sigOwners: [sig-cloud-provider-gcp]
     releaseInforming: true
     testgridNumFailuresToAlert: 6
   ci-kubernetes-e2e-gce-cos-k8sstable3-alphafeatures:
-    interval: 24h
+    interval: 6h
     args:
     - --env=KUBE_PROXY_DAEMONSET=true
     - --env=ENABLE_POD_PRIORITY=true
@@ -192,6 +152,53 @@ jobs:
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
   ci-kubernetes-e2e-gce-cos-k8sstable3-betaapis:
+    interval: 6h
+    args:
+    - --env=KUBE_PROXY_DAEMONSET=true
+    - --env=ENABLE_POD_PRIORITY=true
+    # Panic if anything mutates a shared informer cache
+    - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
+    - --runtime-config=api/beta=true
+    sigOwners: [sig-cloud-provider-gcp]
+    releaseBlocking: true
+
+  # stable4
+  ci-kubernetes-e2e-gce-cos-k8sstable4-ingress:
+    interval: 24h
+    sigOwners: [sig-cloud-provider-gcp]
+    releaseBlocking: true
+  ci-kubernetes-e2e-gce-cos-k8sstable4-reboot:
+    interval: 24h
+    sigOwners: [sig-cloud-provider-gcp]
+    releaseBlocking: true
+  ci-kubernetes-e2e-gce-cos-k8sstable4-default:
+    interval: 24h
+    sigOwners: [sig-cloud-provider-gcp]
+    releaseBlocking: true
+    testgridNumFailuresToAlert: 6
+  ci-kubernetes-e2e-gce-cos-k8sstable4-serial:
+    interval: 24h
+    sigOwners: [sig-cloud-provider-gcp]
+    releaseInforming: true
+    testgridNumFailuresToAlert: 6
+  ci-kubernetes-e2e-gce-cos-k8sstable4-slow:
+    interval: 24h
+    sigOwners: [sig-cloud-provider-gcp]
+    releaseInforming: true
+    testgridNumFailuresToAlert: 6
+  ci-kubernetes-e2e-gce-cos-k8sstable4-alphafeatures:
+    interval: 24h
+    args:
+    - --env=KUBE_PROXY_DAEMONSET=true
+    - --env=ENABLE_POD_PRIORITY=true
+    # TODO(releng): add "InTreePluginGCEUnregister=false" to feature gates when this 1.21 reaches k8sstable3
+    - --env=KUBE_FEATURE_GATES=AllAlpha=true,CSIMigration=false
+    # Panic if anything mutates a shared informer cache
+    - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
+    - --runtime-config=api/all=true
+    sigOwners: [sig-cloud-provider-gcp]
+    releaseBlocking: true
+  ci-kubernetes-e2e-gce-cos-k8sstable4-betaapis:
     interval: 24h
     args:
     - --env=KUBE_PROXY_DAEMONSET=true
@@ -250,22 +257,22 @@ k8sVersions:
     - --extract=ci/latest
     - --extract-ci-bucket=k8s-release-dev
     version: master
-  beta:
+  stable1:
     args:
     - --extract=ci/latest-1.23
     - --extract-ci-bucket=k8s-release-dev
     version: '1.23'
-  stable1:
+  stable2:
     args:
     - --extract=ci/latest-1.22
     - --extract-ci-bucket=k8s-release-dev
     version: '1.22'
-  stable2:
+  stable3:
     args:
     - --extract=ci/latest-1.21
     - --extract-ci-bucket=k8s-release-dev
     version: '1.21'
-  stable3:
+  stable4:
     args:
     - --extract=ci/latest-1.20
     - --extract-ci-bucket=k8s-release-dev
@@ -404,19 +411,19 @@ nodeK8sVersions:
     args:
     - --repo=k8s.io/kubernetes=master
     prowImage: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220413-ebb00ad7a6-master
-  beta:
+  stable1:
     args:
     - --repo=k8s.io/kubernetes=release-1.23
     prowImage: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220413-ebb00ad7a6-1.23
-  stable1:
+  stable2:
     args:
     - --repo=k8s.io/kubernetes=release-1.22
     prowImage: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220413-ebb00ad7a6-1.22
-  stable2:
+  stable3:
     args:
     - --repo=k8s.io/kubernetes=release-1.21
     prowImage: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220413-ebb00ad7a6-1.21
-  stable3:
+  stable4:
     args:
     - --repo=k8s.io/kubernetes=release-1.20
     prowImage: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220413-ebb00ad7a6-1.20


### PR DESCRIPTION
(Continuation of https://github.com/kubernetes/test-infra/pull/26015.)

For years, we've had issues with the `k8s-beta` generic version
marker.

There are a few scenarios...

During the dev cycle:
- beta should not exist, but actually points to the previous release

After a beta release:
- beta should exist, but:
  1. no one really updated this manually
  2. the branch cuts and job creation happens at the RC stage

After an RC release (branch cut):
- beta should have already existed
- beta represents the RC version after branch job creation

After an official release:
- beta should not exist, but actually points to the previous release

None of these scenarios are acceptable, so it's time to remove this
marker. Generated jobs that reference `beta` in their name have
already been using version-specific markers for multiple releases, so
this has minimal impact.

Here we instead add a `k8s-stable4` marker, to provide a version
marker for a release branch that is in maintenance mode/soon-to-be
EOL-ed.

Adding a marker at the end of the set means we no longer have to
consider moving the `k8s-beta` marker during a release cycle.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @puerco @Verolop @palnabarun 
cc: @kubernetes/release-engineering 