### PR TITLE
AllAlpha based job needs a tweak for DisableKubeletCloudCredentialProviders feature

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -487,7 +487,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true,DisableCloudProviders=false,CSIMigration=false,InTreePluginGCEUnregister=false
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true,DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false,CSIMigration=false,InTreePluginGCEUnregister=false
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
       - --extract=ci/latest


### PR DESCRIPTION
2 sig-apps owned tests are failing with the following in ci-kubernetes-e2e-gci-gce-alpha-enabled-default CI job:
https://storage.googleapis.com/k8s-triage/index.html?job=ci-kubernetes-e2e-gci-gce-alpha-enabled&test=sig-apps

```
Failed: Failed to pull image "gcr.io/k8s-authenticated-test/agnhost:2.6": rpc error: code = Unknown desc = failed to pull and unpack image "gcr.io/k8s-authenticated-test/agnhost:2.6": failed to resolve reference "gcr.io/k8s-authenticated-test/agnhost:2.6": unexpected status code [manifests 2.6]: 401 Unauthorized
```

We need DisableKubeletCloudCredentialProviders set to `false` explicitly for these 2 tests to pass.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>