### PR TITLE
Fix GINKGO_ARGS for cluster-api-provider-aws-periodics.yaml

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
@@ -28,7 +28,7 @@ periodics:
         value: "us-west-2"
       # Parallelize tests
       - name: GINKGO_ARGS
-        value: "-nodes 20 --ginkgo.skip=\\[ClusterClass\\]"
+        value: "-nodes 20 -skip='\\[ClusterClass\\]'"
       securityContext:
         privileged: true
       resources:


### PR DESCRIPTION
Fixing a failing [test](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-provider-aws-e2e/1516627357404762112)
* Correct the syntax: `--ginkgo.skip` -> `-skip`

Failure
```bash
time hack/tools/bin/ginkgo -tags=e2e -nodes 20 --ginkgo.skip=\[ClusterClass\] -stream -progress -v -trace -p ./test/e2e/suites/unmanaged/... -- -config-path="/home/prow/go/src/sigs.k8s.io/cluster-api-provider-aws/test/e2e/data/e2e_conf.yaml" -artifacts-folder="/logs/artifacts" --data-folder="/home/prow/go/src/sigs.k8s.io/cluster-api-provider-aws/test/e2e/data" -use-existing-cluster="false"
fatal: ambiguous argument 'origin/main': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
flag provided but not defined: -ginkgo.skip
...
  -skip value
    	If set, ginkgo will only run specs that do not match this regular expression. Can be specified multiple times, values are ORed.
```
