### PR TITLE
pull containerd as I switched to use containerd main branch

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -1221,6 +1221,7 @@ periodics:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220420-14f1a66a0f-master
         args:
           - --repo=k8s.io/kubernetes=master
+          - --repo=github.com/containerd/containerd=main
           - --timeout=90
           - --root=/go/src
           - --scenario=kubernetes_e2e


### PR DESCRIPTION
The PR: #26017 broke tests yesterday as I forgot to pull containerd repo - it is actually being used now for performance tests