### PR TITLE
add label matcher for cloud-provider-azure

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -756,6 +756,11 @@ require_matching_label:
     If CAPA/CAPI contributors determines this is a relevant issue, they will accept it by applying the `triage/accepted` label and provide further guidance.
 
     The `triage/accepted` label can be added by org members by writing `/triage accepted` in a comment.
+- missing_label: needs-kind
+  org: kubernetes-sigs
+  repo: cloud-provider-azure
+  prs: true
+  regexp: ^kind/
 - missing_label: needs-sig
   org: kubernetes
   repo: test-infra


### PR DESCRIPTION
Add label matcher for https://github.com/kubernetes-sigs/cloud-provider-azure