### PR TITLE
Windows GCE: Use containerd for containerd jobs

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml
@@ -624,6 +624,7 @@ periodics:
     - args:
       - --check-leaked-resources
       - --cluster=
+      - --env=KUBE_WINDOWS_CONTAINER_RUNTIME=containerd
       - --extract=ci/latest-1.22
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=8
@@ -733,6 +734,7 @@ periodics:
     - args:
       - --check-leaked-resources
       - --cluster=
+      - --env=KUBE_WINDOWS_CONTAINER_RUNTIME=containerd
       - --extract=ci/latest-1.22
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=8

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.23.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.23.yaml
@@ -695,6 +695,7 @@ periodics:
     - args:
       - --check-leaked-resources
       - --cluster=
+      - --env=KUBE_WINDOWS_CONTAINER_RUNTIME=containerd
       - --extract=ci/latest-1.23
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=8

--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -327,6 +327,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --cluster=
+      - --env=KUBE_WINDOWS_CONTAINER_RUNTIME=containerd
       - --extract=ci/latest-1.21
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=8
@@ -376,6 +377,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --cluster=
+      - --env=KUBE_WINDOWS_CONTAINER_RUNTIME=containerd
       - --extract=ci/latest-1.21
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=8


### PR DESCRIPTION
Some Windows test runs have "containerd" in their names, however, they are actually using docker runtimes. This causes a few tests that are meant to run on containerd to fail.

Using the ``KUBE_WINDOWS_CONTAINER_RUNTIME`` option: https://github.com/kubernetes/kubernetes/blob/fa7ac2ece9aeac914e1c2c9843481754001aa677/cluster/gce/config-default.sh#L102

Fixes: https://github.com/kubernetes/test-infra/issues/26029

Related: https://github.com/kubernetes/kubernetes/issues/109521