### PR TITLE
kubekins: correct K8S_RELEASE value for 1.24 variant

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -35,7 +35,7 @@ variants:
   '1.24':
     CONFIG: '1.24'
     GO_VERSION: 1.18.1
-    K8S_RELEASE: stable-1.24
+    K8S_RELEASE: latest-1.24
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.23':


### PR DESCRIPTION
Signed-off-by: Nabarun Pal <pal.nabarun95@gmail.com>

/cc @kubernetes/release-engineering 
/priority critical-urgent
/kind bug