### PR TITLE
Add Tekton Testgrid Config

### DIFF
--- a/config/mergelists/canary.yaml
+++ b/config/mergelists/canary.yaml
@@ -8,3 +8,5 @@ sources:
   location: "gs://istio-testgrid/config"
 - name: "kubevirt"
   location: "gs://kubevirt-prow/testgrid/config"
+- name: "tekton"
+  location: "gs://tekton-prow/testgrid/config"

--- a/config/mergelists/prod.yaml
+++ b/config/mergelists/prod.yaml
@@ -8,4 +8,5 @@ sources:
   location: "gs://istio-testgrid/config"
 - name: "kubevirt"
   location: "gs://kubevirt-prow/testgrid/config"
-
+- name: "tekton"
+  location: "gs://tekton-prow/testgrid/config"


### PR DESCRIPTION
The tekton-prow GCS bucket is publicly accessible, so the k8s-testgrid service accounts
should be able to access this configuration.