### PR TITLE
don't create linux worker nodes for some capz windows test clusters

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -685,6 +685,8 @@ presubmits:
               value: "true"
             - name: KUBERNETES_VERSION
               value: "v1.23.5"
+            - name: WORKER_MACHINE_COUNT
+              value: "0" # Don't create any linux worker nodes
     annotations:
       testgrid-dashboards: provider-azure-azuredisk-csi-driver
       testgrid-tab-name: pull-azuredisk-csi-driver-e2e-capz-windows-2019
@@ -736,6 +738,8 @@ presubmits:
               value: "true"
             - name: KUBERNETES_VERSION
               value: "v1.23.5"
+            - name: WORKER_MACHINE_COUNT
+              value: "0" # Don't create any linux worker nodes
     annotations:
       testgrid-dashboards: provider-azure-azuredisk-csi-driver
       testgrid-tab-name: pull-azuredisk-csi-driver-e2e-capz-windows-2022

--- a/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
@@ -560,6 +560,8 @@ presubmits:
               value: "Standard_D4s_v3"
             - name: KUBERNETES_VERSION
               value: "v1.23.5"
+            - name: WORKER_MACHINE_COUNT
+              value: "0" # Don't create any linux worker nodes
     annotations:
       testgrid-dashboards: provider-azure-azurefile-csi-driver
       testgrid-tab-name: pull-azurefile-csi-driver-e2e-capz-windows-2019
@@ -611,6 +613,8 @@ presubmits:
               value: "true"
             - name: KUBERNETES_VERSION
               value: "v1.23.5"
+            - name: WORKER_MACHINE_COUNT
+              value: "0" # Don't create any linux worker nodes
     annotations:
       testgrid-dashboards: provider-azure-azurefile-csi-driver
       testgrid-tab-name: pull-azurefile-csi-driver-e2e-capz-windows-2022


### PR DESCRIPTION
Skip creation of linux worker nodes for some windows specific jobs in CAPZ because they do not get used.

https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/1703ef3434cdbe35a31062e1abb04e4291fdb9fc/scripts/ci-entrypoint.sh#L66 and https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/1703ef3434cdbe35a31062e1abb04e4291fdb9fc/scripts/ci-entrypoint.sh#L118-L129r

Signed-off-by: Mark Rossetti <marosset@microsoft.com>

/assign @andyzhangx 