### PR TITLE
lower cpu and memory requests on ci-benchmark-scheduler-master to make the Pod more easily scheduled 

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -737,11 +737,11 @@ periodics:
         value: BenchmarkScheduling
       resources:
         requests:
-          cpu: 8
-          memory: "32Gi"
+          cpu: 6
+          memory: "24Gi"
         limits:
-          cpu: 8
-          memory: "32Gi"
+          cpu: 6
+          memory: "24Gi"
 
 - name: ci-benchmark-scheduler-perf-master
   cluster: k8s-infra-prow-build


### PR DESCRIPTION
For ci-benchmark-scheduler-master, it seems that all tests are failed to run with the following reason.
> There are no nodes that your pod can schedule to - check your requests, tolerations, and node selectors (0/57 nodes are available: 18 Insufficient memory, 3 node(s) had taint {dedicated: greenhouse}, that the pod didn’t tolerate, 54 Insufficient cpu.)
https://prow.k8s.io/?job=ci-benchmark-scheduler-master

And, seems because ci-benchmark-scheduler-master have large cpu/memory requests..? (8 / 32Gi) 
https://github.com/kubernetes/test-infra/blob/71cf119c846b21f8fc37ab7bac00899a80ce9bea/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml#L741

Since ci-benchmark-scheduler-perf-master are always successfully scheduled, I set the same requests to ci-benchmark-scheduler-master. Let's see how it goes... 
(Let me know if you have any suggestions on the requests value.)