### PR TITLE
[WIP] switch to CNI 1.0 and containerd v2 config

### DIFF
--- a/jobs/e2e_node/containerd/10-containerd-net.conflist
+++ b/jobs/e2e_node/containerd/10-containerd-net.conflist
@@ -1,0 +1,32 @@
+{
+  "cniVersion": "0.4.0",
+  "name": "containerd-net",
+  "plugins": [
+    {
+      "type": "bridge",
+      "bridge": "cni0",
+      "isGateway": true,
+      "ipMasq": true,
+      "promiscMode": true,
+      "ipam": {
+        "type": "host-local",
+        "ranges": [
+          [{
+            "subnet": "10.88.0.0/16"
+          }],
+          [{
+            "subnet": "2001:4860:4860::/64"
+          }]
+        ],
+        "routes": [
+          { "dst": "0.0.0.0/0" },
+          { "dst": "::/0" }
+        ]
+      }
+    },
+    {
+      "type": "portmap",
+      "capabilities": {"portMappings": true}
+    }
+  ]
+}

--- a/jobs/e2e_node/containerd/config.toml
+++ b/jobs/e2e_node/containerd/config.toml
@@ -1,20 +1,26 @@
+version = 2
+required_plugins = ["io.containerd.grpc.v1.cri"]
 # Kubernetes doesn't use containerd restart manager.
-disabled_plugins = ["restart"]
+disabled_plugins = ["io.containerd.internal.v1.restart"]
+oom_score = -999
 
 [debug]
   level = "debug"
 
-[plugins.cri]
+[plugins."io.containerd.grpc.v1.cri"]
   stream_server_address = "127.0.0.1"
   max_container_log_line_size = 262144
-
-[plugins.cri.cni]
+[plugins."io.containerd.grpc.v1.cri".cni]
   bin_dir = "/home/containerd/"
   conf_dir = "/etc/cni/net.d"
   conf_template = "/home/containerd/cni.template"
-
-[plugins.cri.registry.mirrors."docker.io"]
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
   endpoint = ["https://mirror.gcr.io","https://registry-1.docker.io"]
+
+[plugins."io.containerd.grpc.v1.cri".containerd]
+  default_runtime_name = "runc"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+  runtime_type = "io.containerd.runc.v2"
 
 # Runtime handler used for runtime class test.
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler]
@@ -22,5 +28,5 @@ disabled_plugins = ["restart"]
 
 # Enable registry.k8s.io as the primary mirror for k8s.gcr.io
 # See: https://github.com/kubernetes/k8s.io/issues/3411
-[plugins.cri.registry.mirrors."k8s.gcr.io"]
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."k8s.gcr.io"]
   endpoint = ["https://registry.k8s.io", "https://k8s.gcr.io",]

--- a/jobs/e2e_node/containerd/image-config.yaml
+++ b/jobs/e2e_node/containerd/image-config.yaml
@@ -2,8 +2,8 @@ images:
   ubuntu:
     image_family: pipeline-1-23
     project: ubuntu-os-gke-cloud
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"
+    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml,cni-config</workspace/test-infra/jobs/e2e_node/containerd/10-containerd-net.conflist"
   cos-stable:
     image_family: cos-97-lts
     project: cos-cloud
-    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"
+    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml,cni-config</workspace/test-infra/jobs/e2e_node/containerd/10-containerd-net.conflist"

--- a/jobs/e2e_node/containerd/init.yaml
+++ b/jobs/e2e_node/containerd/init.yaml
@@ -1,13 +1,25 @@
 #cloud-config
 
 runcmd:
-  - mount /tmp /tmp -o remount,exec,suid
+  - echo "This will configure built-in containerd for k8s tests. Containerd version is:"
+  - ctr version # current version of containerd
+
+  - echo "Download and install CNI configuration to /home/containerd and /etc/cni/net.d"
   - mkdir -p /home/containerd
   - mount --bind /home/containerd /home/containerd
   - mount -o remount,exec /home/containerd
-  - mkdir -p /etc/containerd
   - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /home/containerd/cni.template http://metadata.google.internal/computeMetadata/v1/instance/attributes/cni-template'
-  - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /etc/containerd/config.toml http://metadata.google.internal/computeMetadata/v1/instance/attributes/containerd-config'
-  - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /home/containerd/cni.tgz https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz'
+  - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /etc/cni/net.d/10-containerd-net.conflist http://metadata.google.internal/computeMetadata/v1/instance/attributes/cni-config'
+
+  - echo "Download and install CNI to /home/containerd"
+  - 'curl -sSL --fail --retry 5 --retry-delay 3 --silent --show-error -o /home/containerd/cni.tgz https://github.com/containernetworking/plugins/releases/download/v1.0.1/cni-plugins-linux-amd64-v1.0.1.tgz'
   - tar xzf /home/containerd/cni.tgz -C /home/containerd --overwrite
+
+  - echo "Set containerd configuration"
+  - mkdir -p /etc/containerd
+  - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /etc/containerd/config.toml http://metadata.google.internal/computeMetadata/v1/instance/attributes/containerd-config'
+
+  - echo "Restarting containerd"
   - systemctl restart containerd
+
+  - echo "Configuration complete"


### PR DESCRIPTION
This is a PR to discuss how we can change the tests using pre-installed version of Containerd.

To test changes to image config I was using this, not sure if there is a better way to test it:

```
gcloud compute instances create test-image-config-changed \
    --image-family cos-stable \
    --image-project cos-cloud \
    --metadata-from-file user-data=jobs/e2e_node/containerd/init.yaml,cni-template=jobs/e2e_node/containerd/cni.template,containerd-config=jobs/e2e_node/containerd/config.toml,cni-config=jobs/e2e_node/containerd/10-containerd-net.conflist
```

The change in this PR:

- Switch to containerd configuration version=2 (should be ok to merge separately)
- Upgrade to CNI 1.0 (also download it from GitHub, same as local-up.sh script in k/k). This change is a bit more involved. But I think it's also OK even for older jobs (like 1.22 and 1.23 release blocking tests that are also using this).
- Install `10-containerd-net.conflist`. This is puzzling me. The missing config definitely causing CNI config reading error in the beginning. But I think other infra pieces also writing this config file at some point

For example on [lock contention job](https://testgrid.k8s.io/sig-node-kubelet#kubelet-gce-e2e-lock-contention) I see this log:

```
Apr 21 16:31:35 tmp-node-e2e-bf2fb1d5-cos-97-16919-29-16 containerd[664]: time="2022-04-21T16:31:35.478938544Z" level=info msg="Generating cni config from template \"/home/containerd/cni.template\""
Apr 21 16:31:35 tmp-node-e2e-bf2fb1d5-cos-97-16919-29-16 containerd[664]: time="2022-04-21T16:31:35.501754718Z" level=debug msg="ignore event from cni conf dir: \"/etc/cni/net.d/10-containerd-net.conflist\": CREATE"
Apr 21 16:31:35 tmp-node-e2e-bf2fb1d5-cos-97-16919-29-16 containerd[664]: time="2022-04-21T16:31:35.503222360Z" level=debug msg="receiving change event from cni conf dir: \"/etc/cni/net.d/10-containerd-net.conflist\": WRITE"
Apr 21 16:31:35 tmp-node-e2e-bf2fb1d5-cos-97-16919-29-16 containerd[664]: time="2022-04-21T16:31:35.503393598Z" level=error msg="failed to reload cni configuration after receiving fs change event(\"/etc/cni/net.d/10-containerd-net.conflist\": WRITE)" error="cni config load failed: failed to load CNI config list file /etc/cni/net.d/10-containerd-net.conflist: error parsing configuration list: unexpected end of JSON input: invalid cni config: failed to load cni config"
Apr 21 16:31:35 tmp-node-e2e-bf2fb1d5-cos-97-16919-29-16 containerd[664]: time="2022-04-21T16:31:35.505098315Z" level=debug msg="receiving change event from cni conf dir: \"/etc/cni/net.d/10-containerd-net.conflist\": WRITE"
Apr 21 16:31:35 tmp-node-e2e-bf2fb1d5-cos-97-16919-29-16 containerd[664]: time="2022-04-21T16:31:35.507028824Z" level=debug msg="receiving change event from cni conf dir: \"/etc/cni/net.d/10-containerd-net.conflist\": WRITE"
```

I cannot understand when this was written and whether we need to do it in image config at all. This is what I wanted to discuss in this PR.

/sig node
/kind cleanup