### PR TITLE
add parsing release-note no block

### DIFF
--- a/prow/plugins/releasenote/releasenote.go
+++ b/prow/plugins/releasenote/releasenote.go
@@ -52,7 +52,7 @@ var (
 
 	noteMatcherRE = regexp.MustCompile(`(?s)(?:Release note\*\*:\s*(?:<!--[^<>]*-->\s*)?` + "```(?:release-note)?|```release-note)(.+?)```")
 	cpRe          = regexp.MustCompile(`Cherry pick of #([[:digit:]]+) on release-([[:digit:]]+\.[[:digit:]]+).`)
-	noneRe        = regexp.MustCompile(`(?i)^\W*NONE\W*$`)
+	noneRe        = regexp.MustCompile(`(?i)^\W*(NONE|NO)\W*$`)
 
 	allRNLabels = []string{
 		labels.ReleaseNoteNone,

--- a/prow/plugins/releasenote/releasenote_test.go
+++ b/prow/plugins/releasenote/releasenote_test.go
@@ -84,6 +84,17 @@ func TestReleaseNoteComment(t *testing.T) {
 			addedLabel:    labels.ReleaseNoteNone,
 		},
 		{
+			name:          "author release-note-none with \"no\" block",
+			action:        github.IssueCommentActionCreated,
+			isAuthor:      true,
+			commentBody:   "/release-note-none",
+			issueBody:     "bologna ```release-note \nno \n ```",
+			currentLabels: []string{labels.ReleaseNoteLabelNeeded, "other"},
+
+			deletedLabels: []string{labels.ReleaseNoteLabelNeeded},
+			addedLabel:    labels.ReleaseNoteNone,
+		},
+		{
 			name:          "author release-note-none, trailing space.",
 			action:        github.IssueCommentActionCreated,
 			isAuthor:      true,


### PR DESCRIPTION
Signed-off-by: Abirdcfly <fp544037857@gmail.com>
like https://github.com/kubernetes/kubernetes/pull/108432 or https://github.com/kubernetes/kubernetes/pull/107769

Sometimes we will just leave a `No` instead of a `None`, and it is better to be compatible with this situation