### PR TITLE
sig-windows: Skips HostProcessContainer test and GMSA test for Hyper-V runs

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-containerd-hyperv.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-containerd-hyperv.yaml
@@ -100,7 +100,7 @@ periodics:
       - --aksengine-win-binaries
       - --aksengine-deploy-custom-k8s
       # Specific test args
-      - --test_args=--node-os-distro=windows --docker-config-file=$(DOCKER_CONFIG_FILE) -prepull-images=true --ginkgo.focus=(\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-autoscaling\].\[Feature:HPA\]|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\]) --ginkgo.skip==\[LinuxOnly\]|device.plugin.for.Windows|\[Feature:WindowsHostProcessContainers\]
+      - --test_args=--node-os-distro=windows --docker-config-file=$(DOCKER_CONFIG_FILE) -prepull-images=true --ginkgo.focus=(\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-autoscaling\].\[Feature:HPA\]|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\]) --ginkgo.skip==\[LinuxOnly\]|device.plugin.for.Windows|\[Feature:WindowsHostProcessContainers\]|should.run.as.a.reboot.process.on.the.host.node|GMSA
       - --ginkgo-parallel=1
       securityContext:
         privileged: true


### PR DESCRIPTION
GMSA tests require additional environment configuration and are typically skipped on most test runs.

The ``should run as a reboot process on the host/node`` test requires HostProcessContainers, which are not supported in this scenario.

x-ref: https://github.com/kubernetes/kubernetes/issues/109521