### PR TITLE
GitHub: Fix apps auth to work with base urls that contain a path

### DIFF
--- a/experiment/manual-trigger/manual-trigger.go
+++ b/experiment/manual-trigger/manual-trigger.go
@@ -152,7 +152,10 @@ func main() {
 		log.Fatalf("cannot setup Jenkins client: %v", err)
 	}
 
-	gc := github.NewClient(secret.GetTokenGenerator(o.githubTokenFile), secret.Censor, o.graphqlEndpoint, o.githubEndpoint)
+	gc, err := github.NewClient(secret.GetTokenGenerator(o.githubTokenFile), secret.Censor, o.graphqlEndpoint, o.githubEndpoint)
+	if err != nil {
+		log.Fatalf("failed to construct GitHub client: %v", err)
+	}
 
 	pr, err := gc.GetPullRequest(o.org, o.repo, o.num)
 	if err != nil {

--- a/ghproxy/ghproxy_test.go
+++ b/ghproxy/ghproxy_test.go
@@ -78,7 +78,7 @@ func TestDiskCachePruning(t *testing.T) {
 
 	server := httptest.NewServer(proxy(o, httpRoundTripper(roundTripper), time.Hour))
 	t.Cleanup(server.Close)
-	_, _, client := github.NewClientFromOptions(logrus.Fields{}, github.ClientOptions{
+	_, _, client, err := github.NewClientFromOptions(logrus.Fields{}, github.ClientOptions{
 		MaxRetries:      1,
 		Censor:          func(b []byte) []byte { return b },
 		AppID:           "123",
@@ -86,6 +86,9 @@ func TestDiskCachePruning(t *testing.T) {
 		Bases:           []string{server.URL},
 		GraphqlEndpoint: server.URL,
 	})
+	if err != nil {
+		t.Fatalf("failed to construct github client: %v", err)
+	}
 
 	if _, err := client.GetRef("org", "repo", "dev"); err != nil {
 		t.Fatalf("GetRef failed: %v", err)

--- a/label_sync/main.go
+++ b/label_sync/main.go
@@ -718,9 +718,12 @@ func newClient(tokenPath string, tokens, tokenBurst int, dryRun bool, graphqlEnd
 	}
 
 	if dryRun {
-		return github.NewDryRunClient(secret.GetTokenGenerator(tokenPath), secret.Censor, graphqlEndpoint, hosts...), nil
+		return github.NewDryRunClient(secret.GetTokenGenerator(tokenPath), secret.Censor, graphqlEndpoint, hosts...)
 	}
-	c := github.NewClient(secret.GetTokenGenerator(tokenPath), secret.Censor, graphqlEndpoint, hosts...)
+	c, err := github.NewClient(secret.GetTokenGenerator(tokenPath), secret.Censor, graphqlEndpoint, hosts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct github client: %v", err)
+	}
 	if tokens > 0 && tokenBurst >= tokens {
 		return nil, fmt.Errorf("--tokens=%d must exceed --token-burst=%d", tokens, tokenBurst)
 	}

--- a/prow/clonerefs/run.go
+++ b/prow/clonerefs/run.go
@@ -81,7 +81,8 @@ func (o *Options) createRecords() []clone.Record {
 			rec.Failed = true
 			return []clone.Record{rec}
 		}
-		tokenGenerator, userGenerator, _ = github.NewClientFromOptions(logrus.Fields{}, github.ClientOptions{
+		var err error
+		tokenGenerator, userGenerator, _, err = github.NewClientFromOptions(logrus.Fields{}, github.ClientOptions{
 			Censor: secret.Censor,
 			AppID:  o.GitHubAppID,
 			AppPrivateKey: func() *rsa.PrivateKey {
@@ -95,6 +96,11 @@ func (o *Options) createRecords() []clone.Record {
 			},
 			Bases: o.GitHubAPIEndpoints,
 		})
+		if err != nil {
+			logrus.WithError(err).Error("Failed to construct github client")
+			rec.Failed = true
+			return []clone.Record{rec}
+		}
 	}
 
 	// Print md5 sum of cookiefile for debugging purpose

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -633,7 +633,7 @@ func prodOnlyMain(cfg config.Getter, pluginAgent *plugins.ConfigAgent, authCfgGe
 
 		prStatusAgent := prstatus.NewDashboardAgent(repos, &githubOAuthConfig, logrus.WithField("client", "pr-status"))
 
-		clientCreator := func(accessToken string) prstatus.GitHubClient {
+		clientCreator := func(accessToken string) (prstatus.GitHubClient, error) {
 			return o.github.GitHubClientWithAccessToken(accessToken)
 		}
 		mux.Handle("/pr-data.js", handleNotCached(

--- a/prow/cmd/generic-autobumper/bumper/bumper.go
+++ b/prow/cmd/generic-autobumper/bumper/bumper.go
@@ -228,7 +228,10 @@ func processGitHub(ctx context.Context, o *Options, prh PRHandler) error {
 		return fmt.Errorf("start secrets agent: %w", err)
 	}
 
-	gc := github.NewClient(secret.GetTokenGenerator(o.GitHubToken), secret.Censor, github.DefaultGraphQLEndpoint, github.DefaultAPIEndpoint)
+	gc, err := github.NewClient(secret.GetTokenGenerator(o.GitHubToken), secret.Censor, github.DefaultGraphQLEndpoint, github.DefaultAPIEndpoint)
+	if err != nil {
+		return fmt.Errorf("failed to construct GitHub client: %v", err)
+	}
 
 	if o.GitHubLogin == "" || o.GitName == "" || o.GitEmail == "" {
 		user, err := gc.BotUser()

--- a/prow/cmd/tackle/main.go
+++ b/prow/cmd/tackle/main.go
@@ -556,9 +556,9 @@ func githubClient(tokenPath string, dry bool) (github.Client, error) {
 	gen := secret.GetTokenGenerator(tokenPath)
 	censor := secret.Censor
 	if dry {
-		return github.NewDryRunClient(gen, censor, github.DefaultGraphQLEndpoint, github.DefaultAPIEndpoint), nil
+		return github.NewDryRunClient(gen, censor, github.DefaultGraphQLEndpoint, github.DefaultAPIEndpoint)
 	}
-	return github.NewClient(gen, censor, github.DefaultGraphQLEndpoint, github.DefaultAPIEndpoint), nil
+	return github.NewClient(gen, censor, github.DefaultGraphQLEndpoint, github.DefaultAPIEndpoint)
 }
 
 func applySecret(ctx, ns, name, key, path string) error {

--- a/prow/flagutil/github.go
+++ b/prow/flagutil/github.go
@@ -289,7 +289,10 @@ func (o *GitHubOptions) githubClient(dryRun bool) (github.Client, error) {
 		return c, nil
 	}
 
-	tokenGenerator, userGenerator, client := github.NewClientFromOptions(fields, options)
+	tokenGenerator, userGenerator, client, err := github.NewClientFromOptions(fields, options)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct github client: %w", err)
+	}
 	o.tokenGenerator = tokenGenerator
 	o.userGenerator = userGenerator
 	return optionallyThrottled(client)
@@ -316,12 +319,12 @@ func (o *GitHubOptions) GitHubClient(dryRun bool) (github.Client, error) {
 }
 
 // GitHubClientWithAccessToken creates a GitHub client from an access token.
-func (o *GitHubOptions) GitHubClientWithAccessToken(token string) github.Client {
+func (o *GitHubOptions) GitHubClientWithAccessToken(token string) (github.Client, error) {
 	options := o.baseClientOptions()
 	options.GetToken = func() []byte { return []byte(token) }
 	options.AppID = "" // Since we are using a token, we should not use the app auth
-	_, _, client := github.NewClientFromOptions(logrus.Fields{}, options)
-	return client
+	_, _, client, err := github.NewClientFromOptions(logrus.Fields{}, options)
+	return client, err
 }
 
 // GitClient returns a Git client.

--- a/prow/github/app_auth_roundtripper_integration_test.go
+++ b/prow/github/app_auth_roundtripper_integration_test.go
@@ -43,7 +43,7 @@ func TestGetOrg(t *testing.T) {
 		t.Fatalf("Failed to parse key: %v", err)
 	}
 
-	_, _, client := NewAppsAuthClientWithFields(
+	_, _, client, err := NewAppsAuthClientWithFields(
 		logrus.Fields{},
 		func(b []byte) []byte { return b },
 		appID,
@@ -51,6 +51,9 @@ func TestGetOrg(t *testing.T) {
 		"https://api.github.com/graphql",
 		"http://localhost:8888",
 	)
+	if err != nil {
+		t.Fatalf("failed to constuct client: %v", err)
+	}
 
 	if _, err := client.GetOrg(org); err != nil {
 		t.Errorf("Failed to get org: %v", err)

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -3145,7 +3145,10 @@ func (rt testRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 // their arguments and calls them with an empty argument, then verifies via a RoundTripper that
 // all requests made had an org header set.
 func TestAllMethodsThatDoRequestSetOrgHeader(t *testing.T) {
-	_, _, ghClient := NewAppsAuthClientWithFields(logrus.Fields{}, func(_ []byte) []byte { return nil }, "some-app-id", func() *rsa.PrivateKey { return nil }, "", "")
+	_, _, ghClient, err := NewAppsAuthClientWithFields(logrus.Fields{}, func(_ []byte) []byte { return nil }, "some-app-id", func() *rsa.PrivateKey { return nil }, "", "https://api.github.com")
+	if err != nil {
+		t.Fatalf("failed to construct github client: %v", err)
+	}
 	toSkip := sets.NewString(
 		// TODO: Split the search query by org when app auth is used
 		"FindIssues",
@@ -3322,7 +3325,7 @@ func TestV4ClientSetsUserAgent(t *testing.T) {
 		return &http.Response{StatusCode: 200, Body: ioutil.NopCloser(bytes.NewBufferString("{}"))}, nil
 	}}
 
-	_, _, client := NewClientFromOptions(
+	_, _, client, err := NewClientFromOptions(
 		logrus.Fields{},
 		ClientOptions{
 			Censor:           func(b []byte) []byte { return b },
@@ -3330,11 +3333,14 @@ func TestV4ClientSetsUserAgent(t *testing.T) {
 			AppID:            "",
 			AppPrivateKey:    nil,
 			GraphqlEndpoint:  "",
-			Bases:            nil,
+			Bases:            []string{"https://api.github.com"},
 			DryRun:           false,
 			BaseRoundTripper: roundTripper,
 		}.Default(),
 	)
+	if err != nil {
+		t.Fatalf("failed to construct github client: %v", err)
+	}
 
 	t.Run("User agent gets set initially", func(t *testing.T) {
 		expectedUserAgent = "unset/0"

--- a/prow/githuboauth/githuboauth.go
+++ b/prow/githuboauth/githuboauth.go
@@ -76,11 +76,15 @@ func NewAuthenticatedUserIdentifier(options *flagutil.GitHubOptions) Authenticat
 }
 
 type authenticatedUserIdentifier struct {
-	clientFactory func(accessToken string) github.Client
+	clientFactory func(accessToken string) (github.Client, error)
 }
 
 func (a *authenticatedUserIdentifier) LoginForRequester(requester, token string) (string, error) {
-	user, err := a.clientFactory(token).ForSubcomponent(requester).BotUser()
+	client, err := a.clientFactory(token)
+	if err != nil {
+		return "", err
+	}
+	user, err := client.ForSubcomponent(requester).BotUser()
 	if err != nil {
 		return "", err
 	}

--- a/prow/prstatus/prstatus.go
+++ b/prow/prstatus/prstatus.go
@@ -167,7 +167,7 @@ type GitHubClient interface {
 	BotUser() (*github.UserData, error)
 }
 
-type githubClientCreator func(accessToken string) GitHubClient
+type githubClientCreator func(accessToken string) (GitHubClient, error)
 
 // HandlePrStatus returns a http handler function that handles request to /pr-status
 // endpoint. The handler takes user access token stored in the cookie to query to GitHub on behalf
@@ -203,7 +203,11 @@ func (da *DashboardAgent) HandlePrStatus(queryHandler pullRequestQueryHandler, c
 		var user *github.User
 		var botUser *github.UserData
 		if ok && token.Valid() {
-			githubClient := createClient(token.AccessToken)
+			githubClient, err := createClient(token.AccessToken)
+			if err != nil {
+				serverError("creating githubClient", err)
+				return
+			}
 			botUser, err = githubClient.BotUser()
 			if err != nil {
 				if strings.Contains(err.Error(), "401") {

--- a/prow/prstatus/prstatus_test.go
+++ b/prow/prstatus/prstatus_test.go
@@ -80,12 +80,12 @@ func (c fgc) BotUser() (*github.UserData, error) {
 }
 
 func newGitHubClientCreator(tokenUsers map[string]fgc) githubClientCreator {
-	return func(accessToken string) GitHubClient {
+	return func(accessToken string) (GitHubClient, error) {
 		who, ok := tokenUsers[accessToken]
 		if !ok {
 			panic("unexpected access token: " + accessToken)
 		}
-		return who
+		return who, nil
 	}
 }
 

--- a/prow/test/integration/test/crier_test.go
+++ b/prow/test/integration/test/crier_test.go
@@ -71,7 +71,10 @@ func TestReportGHStatus(t *testing.T) {
 				t.Fatalf("Failed creating clients for cluster %q: %v", clusterContext, err)
 			}
 
-			githubClient := github.NewClient(func() []byte { return nil }, func([]byte) []byte { return nil }, github.DefaultGraphQLEndpoint, "http://localhost/fakeghserver")
+			githubClient, err := github.NewClient(func() []byte { return nil }, func([]byte) []byte { return nil }, github.DefaultGraphQLEndpoint, "http://localhost/fakeghserver")
+			if err != nil {
+				t.Fatalf("failed to construct GitHub client: %v", err)
+			}
 
 			ctx := context.Background()
 

--- a/prow/test/integration/test/hook_test.go
+++ b/prow/test/integration/test/hook_test.go
@@ -42,7 +42,10 @@ func TestHook(t *testing.T) {
 
 	t.Parallel()
 
-	githubClient := github.NewClient(func() []byte { return nil }, func(b []byte) []byte { return b }, "", "http://localhost/fakeghserver")
+	githubClient, err := github.NewClient(func() []byte { return nil }, func(b []byte) []byte { return b }, "", "http://localhost/fakeghserver")
+	if err != nil {
+		t.Fatalf("failed to construct GitHub client: %v", err)
+	}
 
 	issueID, err := githubClient.CreateIssue(org, repo, "Dummy PR, do not merge", "", 0, []string{}, []string{})
 	if err != nil {

--- a/robots/commenter/main.go
+++ b/robots/commenter/main.go
@@ -185,9 +185,12 @@ func main() {
 
 	var c client
 	if o.confirm {
-		c = github.NewClient(secret.GetTokenGenerator(o.token), secret.Censor, o.graphqlEndpoint, o.endpoint.Strings()...)
+		c, err = github.NewClient(secret.GetTokenGenerator(o.token), secret.Censor, o.graphqlEndpoint, o.endpoint.Strings()...)
 	} else {
-		c = github.NewDryRunClient(secret.GetTokenGenerator(o.token), secret.Censor, o.graphqlEndpoint, o.endpoint.Strings()...)
+		c, err = github.NewDryRunClient(secret.GetTokenGenerator(o.token), secret.Censor, o.graphqlEndpoint, o.endpoint.Strings()...)
+	}
+	if err != nil {
+		log.Fatalf("Failed to construct GitHub client: %v", err)
 	}
 
 	query, err := makeQuery(o.query, o.includeArchived, o.includeClosed, o.includeLocked, o.updated)

--- a/robots/pr-labeler/main.go
+++ b/robots/pr-labeler/main.go
@@ -101,9 +101,12 @@ func main() {
 
 	var c client
 	if o.confirm {
-		c = github.NewClient(secret.GetTokenGenerator(o.tokenPath), secret.Censor, o.graphqlEndpoint, o.endpoint.Strings()...)
+		c, err = github.NewClient(secret.GetTokenGenerator(o.tokenPath), secret.Censor, o.graphqlEndpoint, o.endpoint.Strings()...)
 	} else {
-		c = github.NewDryRunClient(secret.GetTokenGenerator(o.tokenPath), secret.Censor, o.graphqlEndpoint, o.endpoint.Strings()...)
+		c, err = github.NewDryRunClient(secret.GetTokenGenerator(o.tokenPath), secret.Censor, o.graphqlEndpoint, o.endpoint.Strings()...)
+	}
+	if err != nil {
+		log.Fatalf("failed to construgt GitHub client: %v", err)
 	}
 
 	// get all open PRs


### PR DESCRIPTION
Currently, apps auth does not work with GitHub base urls that include a
path, which is used e.G. in GitHub Enterprise setups.

This is because the apps auth roundtripper decides how to authenticate a
given request based on the path. In order for that to work correctly,
the parts of the path that come from the base url need to be stripped
first.

This in turn requires to parse all base urls in order to safely extract
the path, if any. That results in the GitHub client creation now
potentially erroring, which is why this change got bigger. Changing this
is a good thing though, as it moves a fatal error condition from runtime
to client creation time (doing requests against an invalid base URL will
never work).

/cc @chaodaiG 