### PR TITLE
cadvisor e2e tests are sensitive to image versions (keep them separate)

### DIFF
--- a/config/jobs/cadvisor/cadvisor.yaml
+++ b/config/jobs/cadvisor/cadvisor.yaml
@@ -39,7 +39,7 @@ presubmits:
         - --deployment=node
         - --gcp-project=cadvisor-e2e
         - --gcp-zone=us-central1-f
-        - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/image-config.yaml --test-suite=cadvisor
+        - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/image-cadvisor.yaml --test-suite=cadvisor
         - --node-tests=true
         - --provider=gce
         - --test_args=--nodes=1
@@ -70,7 +70,7 @@ periodics:
       - --deployment=node
       - --gcp-project=ci-cadvisor-e2e
       - --gcp-zone=us-central1-f
-      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/image-config.yaml --test-suite=cadvisor
+      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/image-cadvisor.yaml --test-suite=cadvisor
       - --node-tests=true
       - --provider=gce
       - --test_args=--nodes=1

--- a/jobs/e2e_node/containerd/image-cadvisor.yaml
+++ b/jobs/e2e_node/containerd/image-cadvisor.yaml
@@ -1,0 +1,9 @@
+images:
+  ubuntu:
+    image_family: pipeline-1-23
+    project: ubuntu-os-gke-cloud
+    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"
+  cos-stable:
+    image_family: cos-89-lts
+    project: cos-cloud
+    metadata: "user-data</workspace/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</workspace/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</workspace/test-infra/jobs/e2e_node/containerd/config.toml"


### PR DESCRIPTION
cadvisor presubmit and periodic jobs are failing since we switched to newer images. let's keep the cadvisor images separate for now.
- https://testgrid.k8s.io/presubmits-misc#cadvisor
- https://testgrid.k8s.io/sig-node-cadvisor#cadvisor-e2e

Slack thread is here: https://kubernetes.slack.com/archives/C0BP8PW9G/p1650764115479609

Signed-off-by: Davanum Srinivas <davanum@gmail.com>