### PR TITLE
Job history page: use a gray color for aborted jobs

### DIFF
--- a/prow/cmd/deck/static/job-history/job-history.ts
+++ b/prow/cmd/deck/static/job-history/job-history.ts
@@ -17,6 +17,9 @@ window.onload = (): void => {
       case "FAILURE":
         className = "run-failure";
         break;
+      case "ABORTED":
+        className = "run-aborted";
+        break;
       default:
         className = "run-pending";
     }

--- a/prow/cmd/deck/template/job-history.html
+++ b/prow/cmd/deck/template/job-history.html
@@ -15,6 +15,9 @@
   .run-pending {
     background-color: rgba(255, 255, 0, 0.3);
   }
+  .run-aborted {
+    background-color: rgba(200, 200, 200, 1.0);
+  }
 </style>
 {{end}}
 


### PR DESCRIPTION
The job history page uses a yellow color for "ABORTED" jobs, this is the
same color as the one used for pending jobs. This similarity is
confusing as it makes aborted jobs look as if they're still running.

This commit makes it so that aborted jobs will get their own color,
gray, to indicate that they have been aborted. This color was chosen
because its neutral - aborted jobs are not very interesting, they don't
indicate a failure or a success, they're usually a result of a PR being
forced-pushed to or a PR being closed while the job was running.

![image](https://user-images.githubusercontent.com/10882062/165085014-7a010ffb-7708-4c91-8486-7d6fcd0830a5.png)
