### PR TITLE
may fix e2e-gce-iscsi failing test

### DIFF
--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -178,6 +178,7 @@ presubmits:
         - --build=quick
         - --cluster=
         - --extract=local
+        - --gcp-master-image=ubuntu
         - --gcp-node-image=ubuntu
         - --image-family=ubuntu-2004-lts
         - --image-project=ubuntu-os-cloud
@@ -224,6 +225,7 @@ presubmits:
         - --build=quick
         - --cluster=
         - --extract=local
+        - --gcp-master-image=ubuntu
         - --gcp-node-image=ubuntu
         - --image-family=ubuntu-2004-lts
         - --image-project=ubuntu-os-cloud
@@ -297,6 +299,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --extract=ci/latest
+      - --gcp-master-image=ubuntu
       - --gcp-node-image=ubuntu
       - --image-family=ubuntu-2004-lts
       - --image-project=ubuntu-os-cloud
@@ -324,6 +327,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --extract=ci/latest
+      - --gcp-master-image=ubuntu
       - --gcp-node-image=ubuntu
       - --image-family=ubuntu-2004-lts
       - --image-project=ubuntu-os-cloud


### PR DESCRIPTION
Signed-off-by: Abirdcfly <fp544037857@gmail.com>

Maybe Fix https://github.com/kubernetes/kubernetes/issues/109645 and https://github.com/kubernetes/kubernetes/issues/107377

I guess the reason for the failed test is that the master node was unable to install containerd and the error log is as follows.
```
Apr 20 14:51:56.561286 e2e-f0798abd79-decf4-master configure.sh[988]: Unable to automatically install containerd in non-ubuntu image. Bailing out...
```
This is from https://github.com/kubernetes/kubernetes/blob/master/cluster/gce/gci/configure.sh#L481
```bash
function install-containerd-ubuntu {
  # bailout if we are not on ubuntu
  if [[ -z "$(command -v lsb_release)" || $(lsb_release -si) != "Ubuntu" ]]; then
    echo "Unable to automatically install containerd in non-ubuntu image. Bailing out..."
    exit 2
  fi
  ...
```
At first, I thought the error came from not installing lsb_release and using lsb_release directly, so I change it to `if [[ $(awk -F= '$1=="NAME" { print $2 ;}' /etc/os-release) != '"Ubuntu"' ]]; then` but log show
```
Apr 25 10:02:45.859384 e2e-79202c3eb4-decf4-master configure.sh[973]: ++ awk -F= '$1=="NAME" { print $2 ;}' /etc/os-release
Apr 25 10:02:45.860301 e2e-79202c3eb4-decf4-master configure.sh[973]: + [[ "Container-Optimized OS" != \"\U\b\u\n\t\u\" ]]
Apr 25 10:02:45.860403 e2e-79202c3eb4-decf4-master configure.sh[973]: + echo 'Unable to automatically install containerd in non-ubuntu image. Bailing out...'
Apr 25 10:02:45.860450 e2e-79202c3eb4-decf4-master configure.sh[973]: Unable to automatically install containerd in non-ubuntu image. Bailing out...
Apr 25 10:02:45.860500 e2e-79202c3eb4-decf4-master configure.sh[973]: + exit 2
```

and change it to  `if ! command -v apt-get >/dev/null 2>&1; then` also failed.

So, I guess we should change master image to ubuntu not gci.

**But I'm sorry, I don't have a way to test that this change is correct and can fix the wrong test**