### PR TITLE
Allow to configure GCS viewer by bucket name

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"html/template"
 	"io/ioutil"
+	"k8s.io/test-infra/prow/io/providers"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -1037,7 +1038,11 @@ lensesLoop:
 	}
 
 	artifactsLink := ""
-	gcswebPrefix := cfg().Deck.Spyglass.GCSBrowserPrefixes.GetGCSBrowserPrefix(org, repo)
+	bucket := ""
+	if jobPath != "" && strings.HasPrefix(jobPath, providers.GS) {
+		bucket = strings.Split(jobPath, "/")[1] // The provider (gs) will be in index 0, followed by the bucket name
+	}
+	gcswebPrefix := cfg().Deck.Spyglass.GetGCSBrowserPrefix(org, repo, bucket)
 	if gcswebPrefix != "" {
 		runPath, err := sg.RunPath(src)
 		if err == nil {

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -347,9 +347,16 @@ deck:
         # prefix or scheme) will be appended to GCSBrowserPrefix and shown to the user.
         gcs_browser_prefix: ' '
 
-        # GCSBrowserPrefixes are used to generate a link to a human-usable GCS browser.
+        # GCSBrowserPrefixesByRepo are used to generate a link to a human-usable GCS browser.
         # They are mapped by org, org/repo or '*' which is the default value.
+        # These are the most specific and will override GCSBrowserPrefixesByBucket if both are resolved.
         gcs_browser_prefixes:
+            "": ""
+
+        # GCSBrowserPrefixesByBucket are used to generate a link to a human-usable GCS browser.
+        # They are mapped by bucket name or '*' which is the default value.
+        # They will only be utilized if there is not a GCSBrowserPrefixesByRepo for the org/repo
+        gcs_browser_prefixes_by_bucket:
             "": ""
 
         # HidePRHistLink allows prow hiding PR History link from deck, this is handy especially for


### PR DESCRIPTION
It is currently possible to configure a GCS viewer on a "by `org/repo`" basis, but that only functions on `presubmit` tests. `Periodics` and `postsubmits` do not contain the org and repo in the spyglass url, and there is no good way to determine what it is. Therefore, the config is not used and the default is returned.

By adding a new configuration (`gcs_browser_prefixes_by_bucket`) alongside the existing `gcs_browser_prefixes` we can allow the GCS viewer to be configured per bucket name. This config can work alongside the existing config as it is less specific than `org/repo` so the new config should be overridden in the case of `presubmits`.