### PR TITLE
Change interval for ci-benchmark-scheduler-master to finish test successfully without timeout

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -711,7 +711,7 @@ periodics:
   tags:
   - "perfDashPrefix: scheduler-benchmark"
   - "perfDashJobType: benchmark"
-  interval: 2h
+  interval: 3h
   annotations:
     testgrid-dashboards: sig-scalability-benchmarks
     testgrid-tab-name: scheduler
@@ -722,7 +722,7 @@ periodics:
     base_ref: master
     path_alias: k8s.io/kubernetes
   decoration_config:
-    timeout: 1h55m
+    timeout: 2h55m
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220421-357450329c-master
@@ -732,7 +732,7 @@ periodics:
       - ./test/integration/scheduler_perf
       env:
       - name: KUBE_TIMEOUT
-        value: --timeout=1h50m
+        value: --timeout=2h50m
       - name: TEST_PREFIX
         value: BenchmarkScheduling
       resources:


### PR DESCRIPTION
By #26060, we can now schedule Pods for ci-benchmark-scheduler-master.

But, next issue, all ci-benchmark-scheduler-master are failed with timeout: `Test killed with quit: ran too long (1h51m0s).`
- https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-benchmark-scheduler-master/1518675934658433024
- https://prow.k8s.io/?job=ci-benchmark-scheduler-master

This PR wants to fix this issue by changing interval and timeout 2h → 3h.