### PR TITLE
node-swap-fedora(-serial): Fix ignition

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -200,8 +200,8 @@ periodics:
           cpu: 4
           memory: 6Gi
       env:
-        - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
-          value: "1"
+        - name: GOPATH
+          value: /go
 
 # TODO: migrate performance special config tests to containerd/cri-o
 #- name: ci-kubernetes-node-kubelet-performance-test

--- a/jobs/e2e_node/swap/crio_swap1g.ign
+++ b/jobs/e2e_node/swap/crio_swap1g.ign
@@ -21,9 +21,9 @@
   "systemd": {
     "units": [
       {
-        "contents": "[Unit]\nDescription=Enable swap on CoreOS\nBefore=swap-enable.service\nConditionFirstBoot=yes\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c \"sudo rpm-ostree install dbus-tools && sudo systemctl reboot\"\n[Install]\n\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Download and install dbus-tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/rpm-ostree install --apply-live --allow-inactive dbus-tools\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
-        "name": "dbus-send-install.service"
+        "name": "dbus-tools-install.service"
       },
       {
         "contents": "[Unit]\nDescription=Enable swap on CoreOS\nBefore=crio-install.service\nConditionFirstBoot=no\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c \"sudo dd if=/dev/zero of=/var/swapfile count=1024 bs=1MiB && sudo chmod 600 /var/swapfile && sudo mkswap /var/swapfile && sudo swapon /var/swapfile && free -h\"\n[Install]\n\nWantedBy=multi-user.target\n",


### PR DESCRIPTION
https://testgrid.k8s.io/sig-node-kubelet#kubelet-gce-e2e-swap-fedora-serial
https://testgrid.k8s.io/sig-node-kubelet#kubelet-gce-e2e-swap-fedora

Both have been failing to wait for the crio service. This was reproducible with `make test-e2e-node` pointing to the image-config-file, and now the tests can consistently start and successfully run individual tests locally (I haven't ran full suites, I'll follow up with other failures if/when they occur in CI).