### PR TITLE
kubetest-canaries: node, specify image

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -75,7 +75,11 @@ periodics:
       args:
       - --deployment=node
       - --gcp-zone=us-west1-b
-      - --node-args=--image-family=cos-97-lts --image-project=cos-cloud
+        # node_e2e doesn't support passing an image-family on the CLI, only via
+        # a file, so here we manually specify an image to run tests against.
+        # To find the latest cos-97-lts image run:
+        #   gcloud compute images describe-from-family cos-97-lts --project cos-cloud --format='value(name)'
+      - --node-args=--images=cos-97-16919-29-21 --image-project=cos-cloud
       - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
       - --node-tests=true
       - --provider=gce


### PR DESCRIPTION
e2e_node has never supported providing an image-family over the CLI, instead requiring those to come from a config file.

This updates the kubetest canary to provide an image directly, and provides instructions for future updates should the image go out of support.

It has been failing for 272 days: https://storage.cloud.google.com/k8s-metrics/failures-latest.json - so I'm not sure anyone is looking at this test. Let me know if it should be removed instead.