### PR TITLE
kOps - Remove "image" prefix from distro test names

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -727,7 +727,7 @@ def generate_distros():
                        networking='kubenet',
                        k8s_version='stable',
                        kops_channel='alpha',
-                       name_override=f"kops-aws-distro-image{distro}",
+                       name_override=f"kops-aws-distro-{distro}",
                        extra_dashboards=['kops-distros'],
                        runs_per_day=3,
                        )
@@ -747,7 +747,7 @@ def generate_presubmits_distros():
                 networking='calico',
                 k8s_version='stable',
                 kops_channel='alpha',
-                name=f"pull-kops-aws-distro-image{distro}",
+                name=f"pull-kops-aws-distro-{distro}",
                 tab_name=f"e2e-{distro}",
                 always_run=False,
             )

--- a/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
@@ -3,8 +3,8 @@
 periodics:
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-aws-distro-imagedebian10
-  cron: '30 6-23/8 * * *'
+- name: e2e-kops-aws-distro-debian10
+  cron: '52 1-23/8 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -64,11 +64,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-deb10, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-aws-distro-imagedebian10
+    testgrid-tab-name: kops-aws-distro-debian10
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb11", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-aws-distro-imagedebian11
-  cron: '48 0-23/8 * * *'
+- name: e2e-kops-aws-distro-debian11
+  cron: '42 7-23/8 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -128,11 +128,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-deb11, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-aws-distro-imagedebian11
+    testgrid-tab-name: kops-aws-distro-debian11
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-aws-distro-imageubuntu1804
-  cron: '11 0-23/8 * * *'
+- name: e2e-kops-aws-distro-ubuntu1804
+  cron: '18 4-23/8 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -192,11 +192,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-u1804, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-aws-distro-imageubuntu1804
+    testgrid-tab-name: kops-aws-distro-ubuntu1804
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-aws-distro-imageubuntu2004
-  cron: '53 6-23/8 * * *'
+- name: e2e-kops-aws-distro-ubuntu2004
+  cron: '44 2-23/8 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -256,11 +256,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-u2004, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-aws-distro-imageubuntu2004
+    testgrid-tab-name: kops-aws-distro-ubuntu2004
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-aws-distro-imageubuntu2204
-  cron: '47 0-23/8 * * *'
+- name: e2e-kops-aws-distro-ubuntu2204
+  cron: '34 4-23/8 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -320,11 +320,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-u2204, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-aws-distro-imageubuntu2204
+    testgrid-tab-name: kops-aws-distro-ubuntu2204
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-aws-distro-imageamazonlinux2
-  cron: '55 3-23/8 * * *'
+- name: e2e-kops-aws-distro-amazonlinux2
+  cron: '59 1-23/8 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -384,11 +384,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-amzn2, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-aws-distro-imageamazonlinux2
+    testgrid-tab-name: kops-aws-distro-amazonlinux2
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-aws-distro-imagerhel8
-  cron: '49 7-23/8 * * *'
+- name: e2e-kops-aws-distro-rhel8
+  cron: '36 3-23/8 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -448,11 +448,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-rhel8, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-aws-distro-imagerhel8
+    testgrid-tab-name: kops-aws-distro-rhel8
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rocky8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-aws-distro-imagerocky8
-  cron: '59 1-23/8 * * *'
+- name: e2e-kops-aws-distro-rocky8
+  cron: '8 4-23/8 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -512,11 +512,11 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-rocky8, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-aws-distro-imagerocky8
+    testgrid-tab-name: kops-aws-distro-rocky8
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": null, "networking": "kubenet"}
-- name: e2e-kops-aws-distro-imageflatcar
-  cron: '36 6-23/8 * * *'
+- name: e2e-kops-aws-distro-flatcar
+  cron: '44 4-23/8 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -579,4 +579,4 @@ periodics:
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: google-aws, kops-distro-flatcar, kops-distros, kops-k8s-stable, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-aws-distro-imageflatcar
+    testgrid-tab-name: kops-aws-distro-flatcar

--- a/config/jobs/kubernetes/kops/kops-presubmits-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-distros.yaml
@@ -4,7 +4,7 @@ presubmits:
   kubernetes/kops:
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
-  - name: pull-kops-aws-distro-imagedebian10
+  - name: pull-kops-aws-distro-debian10
     branches:
     - master
     always_run: false
@@ -70,7 +70,7 @@ presubmits:
       testgrid-tab-name: e2e-debian10
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb11", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
-  - name: pull-kops-aws-distro-imagedebian11
+  - name: pull-kops-aws-distro-debian11
     branches:
     - master
     always_run: false
@@ -136,7 +136,7 @@ presubmits:
       testgrid-tab-name: e2e-debian11
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
-  - name: pull-kops-aws-distro-imageubuntu1804
+  - name: pull-kops-aws-distro-ubuntu1804
     branches:
     - master
     always_run: false
@@ -202,7 +202,7 @@ presubmits:
       testgrid-tab-name: e2e-ubuntu1804
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
-  - name: pull-kops-aws-distro-imageubuntu2004
+  - name: pull-kops-aws-distro-ubuntu2004
     branches:
     - master
     always_run: false
@@ -268,7 +268,7 @@ presubmits:
       testgrid-tab-name: e2e-ubuntu2004
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2204", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
-  - name: pull-kops-aws-distro-imageubuntu2204
+  - name: pull-kops-aws-distro-ubuntu2204
     branches:
     - master
     always_run: false
@@ -334,7 +334,7 @@ presubmits:
       testgrid-tab-name: e2e-ubuntu2204
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
-  - name: pull-kops-aws-distro-imageamazonlinux2
+  - name: pull-kops-aws-distro-amazonlinux2
     branches:
     - master
     always_run: false
@@ -400,7 +400,7 @@ presubmits:
       testgrid-tab-name: e2e-amazonlinux2
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
-  - name: pull-kops-aws-distro-imagerhel8
+  - name: pull-kops-aws-distro-rhel8
     branches:
     - master
     always_run: false
@@ -466,7 +466,7 @@ presubmits:
       testgrid-tab-name: e2e-rhel8
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rocky8", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
-  - name: pull-kops-aws-distro-imagerocky8
+  - name: pull-kops-aws-distro-rocky8
     branches:
     - master
     always_run: false
@@ -532,7 +532,7 @@ presubmits:
       testgrid-tab-name: e2e-rocky8
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
-  - name: pull-kops-aws-distro-imageflatcar
+  - name: pull-kops-aws-distro-flatcar
     branches:
     - master
     always_run: false


### PR DESCRIPTION
Should make tab names more readable: https://testgrid.k8s.io/kops-distros#Summary.
All tests are green at the moment, so not a big deal losing the history for these tests.

/cc @rifelpet @olemarkus 