### PR TITLE
kubelet-serial-crio: use prow user

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -59,7 +59,6 @@ periodics:
           - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/crio/latest/image-config-cgrpv1-serial.yaml
           - --node-tests=true
           - --provider=gce
-          - --env=KUBE_SSH_USER=core
           - --test_args=--nodes=1 --focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]|\[Feature:DynamicKubeletConfig\]|\[NodeFeature:DevicePluginProbe\]"
           - --timeout=240m
       env:


### PR DESCRIPTION
This job is setup to initialize a `prow` user and uses the `IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE` env var. As such, the `core` user ends up being inaccessible with the provided configuration and we fail to SSH in to the node: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-serial-cri-o/1518944927638097920

This job has been failing for 34 days - which predates its most recent changes - there will likely be follow up after SSH access is fixed.

/cc @rphillips