### PR TITLE
swap-fedora: Setup authorized keys

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -106,6 +106,8 @@ periodics:
         env:
           - name: GOPATH
             value: /go
+          - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
+            value: "1"
         resources:
           limits:
             cpu: 4
@@ -201,6 +203,8 @@ periodics:
       env:
         - name: GOPATH
           value: /go
+        - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
+          value: "1"
 
 # TODO: migrate performance special config tests to containerd/cri-o
 #- name: ci-kubernetes-node-kubelet-performance-test

--- a/jobs/e2e_node/swap/crio_swap1g.ign
+++ b/jobs/e2e_node/swap/crio_swap1g.ign
@@ -10,6 +10,13 @@
   "storage": {
     "files": [
       {
+        "path": "/etc/ssh-key-secret/ssh-public",
+        "contents": {
+          "source": "data:text/plain;base64,GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
+        },
+        "mode": 420
+      },
+      {
         "path": "/etc/zincati/config.d/90-disable-auto-updates.toml",
         "contents": {
           "source": "data:,%5Bupdates%5D%0Aenabled%20%3D%20false%0A"
@@ -20,6 +27,11 @@
   },
   "systemd": {
     "units": [
+      {
+        "contents": "[Unit]\nDescription=Copy authorized keys\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c '/usr/bin/mkdir -m 0700 -p /home/core/.ssh && /usr/bin/cat /etc/ssh-key-secret/ssh-public >> /home/core/.ssh/authorized_keys && chown -R core:core /home/core/.ssh && chmod 0600 /home/core/.ssh/authorized_keys'\n\n[Install]\nWantedBy=multi-user.target\n",
+        "enabled": true,
+        "name": "authorized-key.service"
+      },
       {
         "contents": "[Unit]\nDescription=Download and install dbus-tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/rpm-ostree install --apply-live --allow-inactive dbus-tools\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,


### PR DESCRIPTION
I previously misunderstood how the ignition injection stuff works - it seems that we need it for jobs to run successfully on the community owned build cluster.

I've modeled this on the jobs that use `image-config-cgrpv1-k8s-infra-prow-build.yaml` with the assumption that it _should_ work, but this is unverifiable outside of the cluster.

/cc @haircommander @saschagrunert 