### PR TITLE
Deck supports displaying pod link

### DIFF
--- a/prow/spyglass/lenses/podinfo/podinfo_test.go
+++ b/prow/spyglass/lenses/podinfo/podinfo_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podinfo
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"path"
+	"testing"
+
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/spyglass/api"
+	"k8s.io/test-infra/prow/spyglass/lenses/fake"
+)
+
+func TestBody(t *testing.T) {
+	tests := []struct {
+		name      string
+		artifacts []api.Artifact
+		tmpl      string
+		ownConfig ownConfig
+		want      string
+	}{
+		{
+			name: "base",
+			artifacts: []api.Artifact{
+				&fake.Artifact{
+					Path: "podinfo.json",
+					Content: []byte(`{
+  "pod": {
+      "metadata": {
+        "name": "abc-123"
+      }
+  }
+}`),
+				},
+				&fake.Artifact{
+					Path: "prowjob.json",
+					Content: []byte(`{
+"spec": {
+  "cluster": "bar"
+}
+}`),
+				},
+			},
+			ownConfig: ownConfig{
+				RunnerConfigs: map[string]RunnerConfig{
+					"bar": {
+						PodLinkTemplate: "http://somewhere/pod/{{ .Name }}",
+					},
+				},
+			},
+		},
+		{
+			name: "no-prowjob-json",
+			artifacts: []api.Artifact{
+				&fake.Artifact{
+					Path: "podinfo.json",
+					Content: []byte(`{
+  "pod": {
+      "metadata": {
+        "name": "abc-123"
+      }
+  }
+}`),
+				},
+			},
+			ownConfig: ownConfig{
+				RunnerConfigs: map[string]RunnerConfig{
+					"bar": {
+						PodLinkTemplate: "http://somewhere/pod/{{ .Name }}",
+					},
+				},
+			},
+		},
+		{
+			name: "no-cluster-info",
+			artifacts: []api.Artifact{
+				&fake.Artifact{
+					Path: "podinfo.json",
+					Content: []byte(`{
+  "pod": {
+      "metadata": {
+        "name": "abc-123"
+      }
+  }
+}`),
+				},
+				&fake.Artifact{
+					Path: "prowjob.json",
+					Content: []byte(`{
+"spec": {
+  "cluster": "bar"
+}
+}`),
+				},
+			},
+			ownConfig: ownConfig{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			wantFile := path.Join("testdata", "test_"+tc.name+".html")
+			wantBytes, err := ioutil.ReadFile(wantFile)
+			if err != nil {
+				t.Fatalf("Failed reading output file %s: %v", wantFile, err)
+			}
+			oc, err := json.Marshal(tc.ownConfig)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, want := Lens{}.Body(tc.artifacts, ".", "", json.RawMessage(oc), config.Spyglass{}), string(wantBytes)
+			if got != want {
+				t.Fatalf("Output mismatch\nwant: %s\n got: %s", want, got)
+			}
+		})
+	}
+}

--- a/prow/spyglass/lenses/podinfo/template.html
+++ b/prow/spyglass/lenses/podinfo/template.html
@@ -6,6 +6,7 @@
 
 {{define "body"}}
 {{$pod:=.PodReport.Pod}}
+{{$podLink:=.PodLink}}
 <div class="mdl-tabs mdl-js-tabs mdl-js-ripple-effect" id="podinfo">
   <div class="mdl-tabs__tab-bar">
     <a href="#pod-panel" data-preserve-anchor="true" class="mdl-tabs__tab">Pod</a>
@@ -24,6 +25,12 @@
         <td class="mdl-data-table__cell--non-numeric">Pod name</td>
         <td class="mdl-data-table__cell--non-numeric literal">{{$pod.Name}}</td>
       </tr>
+      {{if ne $podLink ""}}
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Pod Link</td>
+        <td class="mdl-data-table__cell--non-numeric literal">{{$podLink}}</td>
+      </tr>
+      {{end}}
       <tr>
         <td class="mdl-data-table__cell--non-numeric">Start time</td>
         <td class="mdl-data-table__cell--non-numeric">{{$pod.Status.StartTime}}</td>

--- a/prow/spyglass/lenses/podinfo/testdata/test_base.html
+++ b/prow/spyglass/lenses/podinfo/testdata/test_base.html
@@ -1,0 +1,92 @@
+
+
+
+<div class="mdl-tabs mdl-js-tabs mdl-js-ripple-effect" id="podinfo">
+  <div class="mdl-tabs__tab-bar">
+    <a href="#pod-panel" data-preserve-anchor="true" class="mdl-tabs__tab">Pod</a>
+    <a href="#volumes-panel" data-preserve-anchor="true" class="mdl-tabs__tab">Volumes</a>
+    <a href="#events-panel" data-preserve-anchor="true" class="mdl-tabs__tab">Events</a>
+    
+    <a href="#yaml-panel" data-preserve-anchor="true" class="mdl-tabs__tab">YAML</a>
+  </div>
+
+  <div class="mdl-tabs__panel" id="pod-panel">
+    <table class="mdl-data-table mdl-js-data-table metadata-table">
+      <tbody>
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Pod name</td>
+        <td class="mdl-data-table__cell--non-numeric literal">abc-123</td>
+      </tr>
+      
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Pod Link</td>
+        <td class="mdl-data-table__cell--non-numeric literal">http://somewhere/pod/abc-123</td>
+      </tr>
+      
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Start time</td>
+        <td class="mdl-data-table__cell--non-numeric">&lt;nil&gt;</td>
+      </tr>
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Pod status</td>
+        <td class="mdl-data-table__cell--non-numeric literal"></td>
+      </tr>
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Node</td>
+        <td class="mdl-data-table__cell--non-numeric"><code></code> / <code></code></td>
+      </tr>
+      
+      
+      
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Labels</td>
+        <td class="mdl-data-table__cell--non-numeric">
+          <ul class="data">
+            
+            
+            
+          </ul>
+        </td>
+      </tr>
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Annotations</td>
+        <td class="mdl-data-table__cell--non-numeric">
+          <ul class="data">
+            
+            
+            
+          </ul>
+        </td>
+      </tr>
+    </table>
+  </div>
+  <div class="mdl-tabs__panel" id="volumes-panel">
+    <table class="mdl-data-table mdl-js-data-table">
+      
+    </table>
+  </div>
+  <div class="mdl-tabs__panel" id="events-panel">
+    <table class="mdl-data-table mdl-js-data-table">
+      <thead>
+      <tr>
+        <th>Type</th>
+        <th>Reason</th>
+        <th>Age</th>
+        <th>Source</th>
+        <th>Message</th>
+      </tr>
+      </thead>
+      
+    </table>
+  </div>
+  
+  <div class="mdl-tabs__panel" id="yaml-panel">
+    <div class="pre literal">metadata:
+  creationTimestamp: null
+  name: abc-123
+spec:
+  containers: null
+status: {}
+</div>
+  </div>
+</div>

--- a/prow/spyglass/lenses/podinfo/testdata/test_no-cluster-info.html
+++ b/prow/spyglass/lenses/podinfo/testdata/test_no-cluster-info.html
@@ -1,0 +1,87 @@
+
+
+
+<div class="mdl-tabs mdl-js-tabs mdl-js-ripple-effect" id="podinfo">
+  <div class="mdl-tabs__tab-bar">
+    <a href="#pod-panel" data-preserve-anchor="true" class="mdl-tabs__tab">Pod</a>
+    <a href="#volumes-panel" data-preserve-anchor="true" class="mdl-tabs__tab">Volumes</a>
+    <a href="#events-panel" data-preserve-anchor="true" class="mdl-tabs__tab">Events</a>
+    
+    <a href="#yaml-panel" data-preserve-anchor="true" class="mdl-tabs__tab">YAML</a>
+  </div>
+
+  <div class="mdl-tabs__panel" id="pod-panel">
+    <table class="mdl-data-table mdl-js-data-table metadata-table">
+      <tbody>
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Pod name</td>
+        <td class="mdl-data-table__cell--non-numeric literal">abc-123</td>
+      </tr>
+      
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Start time</td>
+        <td class="mdl-data-table__cell--non-numeric">&lt;nil&gt;</td>
+      </tr>
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Pod status</td>
+        <td class="mdl-data-table__cell--non-numeric literal"></td>
+      </tr>
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Node</td>
+        <td class="mdl-data-table__cell--non-numeric"><code></code> / <code></code></td>
+      </tr>
+      
+      
+      
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Labels</td>
+        <td class="mdl-data-table__cell--non-numeric">
+          <ul class="data">
+            
+            
+            
+          </ul>
+        </td>
+      </tr>
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Annotations</td>
+        <td class="mdl-data-table__cell--non-numeric">
+          <ul class="data">
+            
+            
+            
+          </ul>
+        </td>
+      </tr>
+    </table>
+  </div>
+  <div class="mdl-tabs__panel" id="volumes-panel">
+    <table class="mdl-data-table mdl-js-data-table">
+      
+    </table>
+  </div>
+  <div class="mdl-tabs__panel" id="events-panel">
+    <table class="mdl-data-table mdl-js-data-table">
+      <thead>
+      <tr>
+        <th>Type</th>
+        <th>Reason</th>
+        <th>Age</th>
+        <th>Source</th>
+        <th>Message</th>
+      </tr>
+      </thead>
+      
+    </table>
+  </div>
+  
+  <div class="mdl-tabs__panel" id="yaml-panel">
+    <div class="pre literal">metadata:
+  creationTimestamp: null
+  name: abc-123
+spec:
+  containers: null
+status: {}
+</div>
+  </div>
+</div>

--- a/prow/spyglass/lenses/podinfo/testdata/test_no-prowjob-json.html
+++ b/prow/spyglass/lenses/podinfo/testdata/test_no-prowjob-json.html
@@ -1,0 +1,87 @@
+
+
+
+<div class="mdl-tabs mdl-js-tabs mdl-js-ripple-effect" id="podinfo">
+  <div class="mdl-tabs__tab-bar">
+    <a href="#pod-panel" data-preserve-anchor="true" class="mdl-tabs__tab">Pod</a>
+    <a href="#volumes-panel" data-preserve-anchor="true" class="mdl-tabs__tab">Volumes</a>
+    <a href="#events-panel" data-preserve-anchor="true" class="mdl-tabs__tab">Events</a>
+    
+    <a href="#yaml-panel" data-preserve-anchor="true" class="mdl-tabs__tab">YAML</a>
+  </div>
+
+  <div class="mdl-tabs__panel" id="pod-panel">
+    <table class="mdl-data-table mdl-js-data-table metadata-table">
+      <tbody>
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Pod name</td>
+        <td class="mdl-data-table__cell--non-numeric literal">abc-123</td>
+      </tr>
+      
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Start time</td>
+        <td class="mdl-data-table__cell--non-numeric">&lt;nil&gt;</td>
+      </tr>
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Pod status</td>
+        <td class="mdl-data-table__cell--non-numeric literal"></td>
+      </tr>
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Node</td>
+        <td class="mdl-data-table__cell--non-numeric"><code></code> / <code></code></td>
+      </tr>
+      
+      
+      
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Labels</td>
+        <td class="mdl-data-table__cell--non-numeric">
+          <ul class="data">
+            
+            
+            
+          </ul>
+        </td>
+      </tr>
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Annotations</td>
+        <td class="mdl-data-table__cell--non-numeric">
+          <ul class="data">
+            
+            
+            
+          </ul>
+        </td>
+      </tr>
+    </table>
+  </div>
+  <div class="mdl-tabs__panel" id="volumes-panel">
+    <table class="mdl-data-table mdl-js-data-table">
+      
+    </table>
+  </div>
+  <div class="mdl-tabs__panel" id="events-panel">
+    <table class="mdl-data-table mdl-js-data-table">
+      <thead>
+      <tr>
+        <th>Type</th>
+        <th>Reason</th>
+        <th>Age</th>
+        <th>Source</th>
+        <th>Message</th>
+      </tr>
+      </thead>
+      
+    </table>
+  </div>
+  
+  <div class="mdl-tabs__panel" id="yaml-panel">
+    <div class="pre literal">metadata:
+  creationTimestamp: null
+  name: abc-123
+spec:
+  containers: null
+status: {}
+</div>
+  </div>
+</div>


### PR DESCRIPTION
This will be a handy feature for users to debug prow job failures. Currently a user would need to be very familiar with the UI to figure out how to navigate to UI for debugging pod level failures when it happens, this allows team to display pod url in spyglass by predefined template

/cc @alvaroaleman @cjwagner @mpherman2 @listx 