### PR TITLE
update snoop image to latest version

### DIFF
--- a/config/jobs/kubernetes/sig-arch/conformance-gate.yaml
+++ b/config/jobs/kubernetes/sig-arch/conformance-gate.yaml
@@ -11,7 +11,7 @@ periodics:
   spec:
     containers:
     - name: apisnoop-gate
-      image: k8s.gcr.io/apisnoop/snoopdb:v0.2.0
+      image: k8s.gcr.io/apisnoop/snoopdb:v20220407-0.2.0-147-gcc8be61
       command:
       - /usr/local/bin/docker-entrypoint.sh
       - postgres


### PR DESCRIPTION
This update should fix the [currently failing conformance-gate job](https://testgrid.k8s.io/sig-arch-conformance#apisnoop-conformance-gate)