### PR TITLE
Update codesearch periodic job to run different script

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-apps-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-apps-periodics.yaml
@@ -1,7 +1,7 @@
 periodics:
 - name: periodic-k8sio-deploy-app-codesearch
   cluster: k8s-infra-prow-build-trusted
-  interval: 24h
+  cron: "0 11 * * 2,4" # At 11:00 UTC on Tuesday and Thursday.
   decorate: true
   extra_refs:
   - org: kubernetes

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-apps-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-apps-periodics.yaml
@@ -28,7 +28,7 @@ periodics:
     - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
       imagePullPolicy: Always
       command:
-      - ./apps/codesearch/deploy.sh
+      - ./apps/codesearch/restart.sh
       volumeMounts:
       - name: github
         mountPath: /etc/github-token


### PR DESCRIPTION
Resolves: https://github.com/kubernetes/k8s.io/issues/2182 

Supporting PR: https://github.com/kubernetes/k8s.io/pull/3679 

This PR updates the `periodic-k8sio-deploy-app-codesearch` job to run the new `restart.sh` script. 
The `deploy.sh` doesn't trigger an app restart unless there are changes, so using `restart.sh` (this runs a `rollout restart deployment`) makes more sense.

This will ensure we restart codesearch daily and update search indexes to include any new git changes. 
Since we are using rolling upgrades with health checks, restarts will (should) NOT cause downtime.