### PR TITLE
Switch to releng-ci:latest-go1.18-bullseye for go 1.17 jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/bom/bom-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/bom/bom-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     path_alias: "sigs.k8s.io/bom"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye
         imagePullPolicy: Always
         command:
         - go
@@ -25,7 +25,7 @@ presubmits:
     path_alias: "sigs.k8s.io/bom"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye
         imagePullPolicy: Always
         command:
         - go

--- a/config/jobs/kubernetes-sigs/downloadkubernetes/downloadkubernetes-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/downloadkubernetes/downloadkubernetes-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: "sigs.k8s.io/downloadkubernetes"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye
         imagePullPolicy: Always
         command:
         - make
@@ -22,7 +22,7 @@ presubmits:
     path_alias: "sigs.k8s.io/downloadkubernetes"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye
         imagePullPolicy: Always
         command:
         - make

--- a/config/jobs/kubernetes-sigs/mdtoc/mdtoc-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/mdtoc/mdtoc-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     path_alias: sigs.k8s.io/mdtoc
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye
         imagePullPolicy: Always
         command:
         - make
@@ -22,7 +22,7 @@ presubmits:
     path_alias: sigs.k8s.io/mdtoc
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye
         imagePullPolicy: Always
         command:
         - make

--- a/config/jobs/kubernetes-sigs/promo-tools/promo-tools.yaml
+++ b/config/jobs/kubernetes-sigs/promo-tools/promo-tools.yaml
@@ -139,7 +139,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye
         imagePullPolicy: Always
         command:
         - make

--- a/config/jobs/kubernetes-sigs/release-sdk/release-sdk-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/release-sdk/release-sdk-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     path_alias: "sigs.k8s.io/release-sdk"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye
         imagePullPolicy: Always
         command:
         - go
@@ -50,7 +50,7 @@ presubmits:
     path_alias: "sigs.k8s.io/release-sdk"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye
         imagePullPolicy: Always
         command:
         - go

--- a/config/jobs/kubernetes-sigs/release-utils/release-utils-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/release-utils/release-utils-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     path_alias: "sigs.k8s.io/release-utils"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye
         imagePullPolicy: Always
         command:
         - go
@@ -25,7 +25,7 @@ presubmits:
     path_alias: "sigs.k8s.io/release-utils"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye
         imagePullPolicy: Always
         command:
         - go

--- a/config/jobs/kubernetes-sigs/zeitgeist/zeitgeist-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/zeitgeist/zeitgeist-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     path_alias: "sigs.k8s.io/zeitgeist"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye
         imagePullPolicy: Always
         command:
         - make
@@ -22,7 +22,7 @@ presubmits:
     path_alias: "sigs.k8s.io/zeitgeist"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye
         imagePullPolicy: Always
         command:
         - make
@@ -38,7 +38,7 @@ presubmits:
     path_alias: "sigs.k8s.io/zeitgeist"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17-bullseye
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye
         imagePullPolicy: Always
         command:
         - make

--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -46,7 +46,7 @@ presubmits:
     path_alias: k8s.io/release
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye
         imagePullPolicy: Always
         command:
         - make
@@ -63,7 +63,7 @@ presubmits:
     path_alias: k8s.io/release
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye
         imagePullPolicy: Always
         command:
         - make
@@ -80,7 +80,7 @@ presubmits:
     path_alias: k8s.io/release
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye
         imagePullPolicy: Always
         command:
         - make

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -189,7 +189,7 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-gcr-promoter-bak
     containers:
-    - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.17
+    - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.18-bullseye
       imagePullPolicy: Always
       command:
       - infra/gcp/bash/backup_tools/backup.sh


### PR DESCRIPTION
The latest version of the releng-ci image is the go1.18bullseye tag,
which is what we should prefer for overall consistency.

cc @kubernetes/release-managers 