### PR TITLE
crio: update eviction image to be the same as conformance

### DIFF
--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -183,7 +183,7 @@ periodics:
       - --provider=gce
       - --test_args=--nodes=1 --focus="\[NodeFeature:Eviction\]"
       - --timeout=300m
-      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/crio/latest/image-config-cgrpv1-serial.yaml
+      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/crio/latest/image-config-cgrpv1.yaml
       env:
       - name: GOPATH
         value: /go


### PR DESCRIPTION
I suspect the serial image is expected to run on the community cluster and there are some configuration pieces missing

Signed-off-by: Peter Hunt <pehunt@redhat.com>