### PR TITLE
containerd config v2 and CNI 1.0.1

### DIFF
--- a/jobs/e2e_node/containerd/config.toml
+++ b/jobs/e2e_node/containerd/config.toml
@@ -1,20 +1,26 @@
+version = 2
+required_plugins = ["io.containerd.grpc.v1.cri"]
 # Kubernetes doesn't use containerd restart manager.
-disabled_plugins = ["restart"]
+disabled_plugins = ["io.containerd.internal.v1.restart"]
+oom_score = -999
 
 [debug]
   level = "debug"
 
-[plugins.cri]
+[plugins."io.containerd.grpc.v1.cri"]
   stream_server_address = "127.0.0.1"
   max_container_log_line_size = 262144
-
-[plugins.cri.cni]
+[plugins."io.containerd.grpc.v1.cri".cni]
   bin_dir = "/home/containerd/"
   conf_dir = "/etc/cni/net.d"
   conf_template = "/home/containerd/cni.template"
-
-[plugins.cri.registry.mirrors."docker.io"]
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
   endpoint = ["https://mirror.gcr.io","https://registry-1.docker.io"]
+
+[plugins."io.containerd.grpc.v1.cri".containerd]
+  default_runtime_name = "runc"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+  runtime_type = "io.containerd.runc.v2"
 
 # Runtime handler used for runtime class test.
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler]
@@ -22,5 +28,5 @@ disabled_plugins = ["restart"]
 
 # Enable registry.k8s.io as the primary mirror for k8s.gcr.io
 # See: https://github.com/kubernetes/k8s.io/issues/3411
-[plugins.cri.registry.mirrors."k8s.gcr.io"]
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."k8s.gcr.io"]
   endpoint = ["https://registry.k8s.io", "https://k8s.gcr.io",]

--- a/jobs/e2e_node/containerd/init.yaml
+++ b/jobs/e2e_node/containerd/init.yaml
@@ -1,13 +1,27 @@
 #cloud-config
 
 runcmd:
+  - echo "Test run from /tmp folder, remounting it"
   - mount /tmp /tmp -o remount,exec,suid
+
+  - echo "This will configure built-in containerd for k8s tests. Containerd version is:"
+  - ctr version # current version of containerd
+
+  - echo "Download and install CNI configuration to /home/containerd"
   - mkdir -p /home/containerd
   - mount --bind /home/containerd /home/containerd
   - mount -o remount,exec /home/containerd
-  - mkdir -p /etc/containerd
   - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /home/containerd/cni.template http://metadata.google.internal/computeMetadata/v1/instance/attributes/cni-template'
-  - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /etc/containerd/config.toml http://metadata.google.internal/computeMetadata/v1/instance/attributes/containerd-config'
-  - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /home/containerd/cni.tgz https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz'
+
+  - echo "Download and install CNI to /home/containerd"
+  - 'curl -sSL --fail --retry 5 --retry-delay 3 --silent --show-error -o /home/containerd/cni.tgz https://github.com/containernetworking/plugins/releases/download/v1.0.1/cni-plugins-linux-amd64-v1.0.1.tgz'
   - tar xzf /home/containerd/cni.tgz -C /home/containerd --overwrite
+
+  - echo "Set containerd configuration"
+  - mkdir -p /etc/containerd
+  - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /etc/containerd/config.toml http://metadata.google.internal/computeMetadata/v1/instance/attributes/containerd-config'
+
+  - echo "Restarting containerd"
   - systemctl restart containerd
+
+  - echo "Configuration complete"


### PR DESCRIPTION
Subset of this PR: https://github.com/kubernetes/test-infra/pull/26062/

- Switching to containerd config v2 (v1 is deprecated)
- Switching to CNI v1.0.1

/sig node
/priority backlog

I'm still trying to understand what writes the file `10-containerd-net.conflist`, but this can be improved separately
