### PR TITLE
Add back the cleaned Windows GCE test jobs

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml
@@ -717,6 +717,212 @@ periodics:
           memory: 9Gi
       securityContext:
         privileged: true
+- name: ci-kubernetes-e2e-windows-containerd-gce-1-22
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  extra_refs:
+  - base_ref: master
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/windows-testing
+    repo: windows-testing
+  interval: 4h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+    preset-common-gce-windows: "true"
+    preset-e2e-gce-windows: "true"
+    preset-e2e-gce-windows-containerd: "true"
+    preset-windows-repo-list-master: "true"
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --cluster=
+      - --extract=ci/latest-1.22
+      - --gcp-zone=us-west1-b
+      - --provider=gce
+      - --gcp-nodes=2
+      - --test=false
+      - --test-cmd=$GOPATH/src/sigs.k8s.io/windows-testing/gce/run-e2e.sh
+      - --test_args=--node-os-distro=windows --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]\[Feature:Windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[alpha\]|\[Slow\]|\[GMSA\]|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|\[sig-api-machinery\].Aggregator
+      - --test-cmd-args=--node-os-distro=windows --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]\[Feature:Windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[alpha\]|\[Slow\]|\[GMSA\]|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|\[sig-api-machinery\].Aggregator
+      - --ginkgo-parallel=4
+      - --timeout=230m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      env:
+      - name: NO_LINUX_POOL_TAINT
+        value: "true"
+      - name: WINDOWS_NODE_OS_DISTRIBUTION
+        value: "win2019"
+      - name: KUBE_WINDOWS_CONTAINER_RUNTIME
+        value: "containerd"
+      - name: PREPULL_YAML
+        value: prepull-1.22.yaml
+      - name: NODE_SIZE
+        value: "n1-standard-4"
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-1.22
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-windows-gce, sig-windows-1.22-release
+    testgrid-tab-name: gce-windows-2019-containerd-1.22
+    description: Runs tests on a Kubernetes cluster with Windows containerd nodes on GCE
+- name: ci-kubernetes-e2e-windows-20h2-containerd-gce-1-22
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  extra_refs:
+  - base_ref: master
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/windows-testing
+    repo: windows-testing
+  interval: 4h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+    preset-common-gce-windows: "true"
+    preset-e2e-gce-windows: "true"
+    preset-e2e-gce-windows-containerd: "true"
+    preset-windows-repo-list-master: "true"
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --cluster=
+      - --extract=ci/latest-1.22
+      - --gcp-zone=us-west1-b
+      - --provider=gce
+      - --gcp-nodes=2
+      - --test=false
+      - --test-cmd=$GOPATH/src/sigs.k8s.io/windows-testing/gce/run-e2e.sh
+      - --test_args=--node-os-distro=windows --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]\[Feature:Windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[alpha\]|\[Slow\]|\[GMSA\]|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|\[sig-api-machinery\].Aggregator
+      - --test-cmd-args=--node-os-distro=windows --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]\[Feature:Windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[alpha\]|\[Slow\]|\[GMSA\]|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|\[sig-api-machinery\].Aggregator
+      - --ginkgo-parallel=4
+      - --timeout=230m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      env:
+      - name: NO_LINUX_POOL_TAINT
+        value: "true"
+      - name: WINDOWS_NODE_OS_DISTRIBUTION
+        value: "win20h2"
+      - name: KUBE_WINDOWS_CONTAINER_RUNTIME
+        value: "containerd"
+      - name: PREPULL_YAML
+        value: prepull-1.22.yaml
+      - name: NODE_SIZE
+        value: "n1-standard-4"
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-1.22
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-windows-gce, sig-windows-1.22-release
+    testgrid-tab-name: gce-windows-20h2-containerd-1.22
+    description: Runs tests on a Kubernetes cluster with Windows containerd nodes on GCE
+- name: ci-kubernetes-e2e-windows-gce-1-22
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  extra_refs:
+  - base_ref: master
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/windows-testing
+    repo: windows-testing
+  interval: 4h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+    preset-common-gce-windows: "true"
+    preset-e2e-gce-windows: "true"
+    preset-windows-repo-list-master: "true"
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --cluster=
+      - --extract=ci/latest-1.22
+      - --gcp-zone=us-west1-b
+      - --provider=gce
+      - --gcp-nodes=2
+      - --test=false
+      - --test-cmd=$GOPATH/src/sigs.k8s.io/windows-testing/gce/run-e2e.sh
+      - --test_args=--node-os-distro=windows --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]\[Feature:Windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[alpha\]|\[Slow\]|\[GMSA\]|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|\[sig-api-machinery\].Aggregator
+      - --test-cmd-args=--node-os-distro=windows --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]\[Feature:Windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[alpha\]|\[Slow\]|\[GMSA\]|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|\[sig-api-machinery\].Aggregator
+      - --ginkgo-parallel=4
+      - --timeout=230m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      env:
+      - name: NO_LINUX_POOL_TAINT
+        value: "true"
+      - name: WINDOWS_NODE_OS_DISTRIBUTION
+        value: "win2019"
+      - name: PREPULL_YAML
+        value: prepull-1.22.yaml
+      - name: NODE_SIZE
+        value: "n1-standard-4"
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-1.22
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-windows-gce, sig-windows-1.22-release
+    testgrid-tab-name: gce-windows-2019-docker-1.22
+    description: Runs tests on a Kubernetes cluster with Windows docker nodes on GCE
+- name: ci-kubernetes-e2e-windows-20h2-gce-1-22
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  extra_refs:
+  - base_ref: master
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/windows-testing
+    repo: windows-testing
+  interval: 4h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+    preset-common-gce-windows: "true"
+    preset-e2e-gce-windows: "true"
+    preset-windows-repo-list-master: "true"
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --cluster=
+      - --extract=ci/latest-1.22
+      - --gcp-zone=us-west1-b
+      - --provider=gce
+      - --gcp-nodes=2
+      - --test=false
+      - --test-cmd=$GOPATH/src/sigs.k8s.io/windows-testing/gce/run-e2e.sh
+      - --test_args=--node-os-distro=windows --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]\[Feature:Windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[alpha\]|\[Slow\]|\[GMSA\]|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|\[sig-api-machinery\].Aggregator
+      - --test-cmd-args=--node-os-distro=windows --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]\[Feature:Windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[alpha\]|\[Slow\]|\[GMSA\]|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|\[sig-api-machinery\].Aggregator
+      - --ginkgo-parallel=4
+      - --timeout=230m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      env:
+      - name: NO_LINUX_POOL_TAINT
+        value: "true"
+      - name: WINDOWS_NODE_OS_DISTRIBUTION
+        value: "win20h2"
+      - name: PREPULL_YAML
+        value: prepull-1.22.yaml
+      - name: NODE_SIZE
+        value: "n1-standard-4"
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-1.22
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-windows-gce, sig-windows-1.22-release
+    testgrid-tab-name: gce-windows-20h2-docker-1.22
+    description: Runs tests on a Kubernetes cluster with Windows docker nodes on GCE
 postsubmits: {}
 presubmits:
   kubernetes/kubernetes:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.23.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.23.yaml
@@ -657,6 +657,108 @@ periodics:
           memory: 9Gi
       securityContext:
         privileged: true
+- name: ci-kubernetes-e2e-windows-containerd-gce-1-23
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  extra_refs:
+  - base_ref: master
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/windows-testing
+    repo: windows-testing
+  interval: 4h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+    preset-common-gce-windows: "true"
+    preset-e2e-gce-windows: "true"
+    preset-e2e-gce-windows-containerd: "true"
+    preset-windows-repo-list-master: "true"
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --cluster=
+      - --extract=ci/latest-1.23
+      - --gcp-zone=us-west1-b
+      - --provider=gce
+      - --gcp-nodes=2
+      - --test=false
+      - --test-cmd=$GOPATH/src/sigs.k8s.io/windows-testing/gce/run-e2e.sh
+      - --test_args=--node-os-distro=windows -prepull-images=true --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]\[Feature:Windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[alpha\]|\[Slow\]|\[GMSA\]|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|\[sig-api-machinery\].Aggregator
+      - --test-cmd-args=--node-os-distro=windows -prepull-images=true --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]\[Feature:Windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[alpha\]|\[Slow\]|\[GMSA\]|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|\[sig-api-machinery\].Aggregator
+      - --ginkgo-parallel=4
+      - --timeout=230m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      env:
+      - name: NO_LINUX_POOL_TAINT
+        value: "true"
+      - name: WINDOWS_NODE_OS_DISTRIBUTION
+        value: "win2019"
+      - name: KUBE_WINDOWS_CONTAINER_RUNTIME
+        value: "containerd"
+      - name: NODE_SIZE
+        value: "n1-standard-4"
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-1.23
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-windows-gce, sig-windows-1.23-release
+    testgrid-tab-name: gce-windows-2019-containerd-1.23
+    description: Runs tests on a Kubernetes cluster with Windows containerd nodes on GCE
+- name: ci-kubernetes-e2e-windows-20h2-containerd-gce-1-23
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  extra_refs:
+  - base_ref: master
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/windows-testing
+    repo: windows-testing
+  interval: 4h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+    preset-common-gce-windows: "true"
+    preset-e2e-gce-windows: "true"
+    preset-e2e-gce-windows-containerd: "true"
+    preset-windows-repo-list-master: "true"
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --cluster=
+      - --extract=ci/latest-1.23
+      - --gcp-zone=us-west1-b
+      - --provider=gce
+      - --gcp-nodes=2
+      - --test=false
+      - --test-cmd=$GOPATH/src/sigs.k8s.io/windows-testing/gce/run-e2e.sh
+      - --test_args=--node-os-distro=windows -prepull-images=true --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]\[Feature:Windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[alpha\]|\[Slow\]|\[GMSA\]|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|\[sig-api-machinery\].Aggregator
+      - --test-cmd-args=--node-os-distro=windows -prepull-images=true --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]\[Feature:Windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[alpha\]|\[Slow\]|\[GMSA\]|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|\[sig-api-machinery\].Aggregator
+      - --ginkgo-parallel=4
+      - --timeout=230m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      env:
+      - name: NO_LINUX_POOL_TAINT
+        value: "true"
+      - name: WINDOWS_NODE_OS_DISTRIBUTION
+        value: "win20h2"
+      - name: KUBE_WINDOWS_CONTAINER_RUNTIME
+        value: "containerd"
+      - name: NODE_SIZE
+        value: "n1-standard-4"
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-1.23
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-windows-gce, sig-windows-1.23-release
+    testgrid-tab-name: gce-windows-20h2-containerd-1.23
+    description: Runs tests on a Kubernetes cluster with Windows containerd nodes on GCE
 postsubmits: {}
 presubmits:
   kubernetes/kubernetes:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.24.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.24.yaml
@@ -568,6 +568,104 @@ periodics:
           memory: 9Gi
       securityContext:
         privileged: true
+- name: ci-kubernetes-e2e-windows-containerd-gce-1-24
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  extra_refs:
+  - base_ref: master
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/windows-testing
+    repo: windows-testing
+  interval: 4h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+    preset-common-gce-windows: "true"
+    preset-e2e-gce-windows: "true"
+    preset-e2e-gce-windows-containerd: "true"
+    preset-windows-repo-list-master: "true"
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --cluster=
+      - --extract=ci/latest-1.24
+      - --gcp-zone=us-west1-b
+      - --provider=gce
+      - --gcp-nodes=2
+      - --test=false
+      - --test-cmd=$GOPATH/src/sigs.k8s.io/windows-testing/gce/run-e2e.sh
+      - --test_args=--node-os-distro=windows -prepull-images=true --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]\[Feature:Windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[alpha\]|\[Slow\]|\[GMSA\]|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|\[sig-api-machinery\].Aggregator
+      - --test-cmd-args=--node-os-distro=windows -prepull-images=true --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]\[Feature:Windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[alpha\]|\[Slow\]|\[GMSA\]|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|\[sig-api-machinery\].Aggregator
+      - --ginkgo-parallel=4
+      - --timeout=230m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      env:
+      - name: NO_LINUX_POOL_TAINT
+        value: "true"
+      - name: WINDOWS_NODE_OS_DISTRIBUTION
+        value: "win2019"
+      - name: NODE_SIZE
+        value: "n1-standard-4"
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-1.24
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-windows-gce
+    testgrid-tab-name: gce-windows-2019-containerd-1.24
+    description: Runs tests on a Kubernetes cluster with Windows containerd nodes on GCE
+- name: ci-kubernetes-e2e-windows-20h2-containerd-gce-1-24
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  extra_refs:
+  - base_ref: master
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/windows-testing
+    repo: windows-testing
+  interval: 4h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+    preset-common-gce-windows: "true"
+    preset-e2e-gce-windows: "true"
+    preset-e2e-gce-windows-containerd: "true"
+    preset-windows-repo-list-master: "true"
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --cluster=
+      - --extract=ci/latest-1.24
+      - --gcp-zone=us-west1-b
+      - --provider=gce
+      - --gcp-nodes=2
+      - --test=false
+      - --test-cmd=$GOPATH/src/sigs.k8s.io/windows-testing/gce/run-e2e.sh
+      - --test_args=--node-os-distro=windows -prepull-images=true --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]\[Feature:Windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[alpha\]|\[Slow\]|\[GMSA\]|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|\[sig-api-machinery\].Aggregator
+      - --test-cmd-args=--node-os-distro=windows -prepull-images=true --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]\[Feature:Windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[alpha\]|\[Slow\]|\[GMSA\]|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|\[sig-api-machinery\].Aggregator
+      - --ginkgo-parallel=4
+      - --timeout=230m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      env:
+      - name: NO_LINUX_POOL_TAINT
+        value: "true"
+      - name: WINDOWS_NODE_OS_DISTRIBUTION
+        value: "win20h2"
+      - name: NODE_SIZE
+        value: "n1-standard-4"
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-1.24
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-windows-gce
+    testgrid-tab-name: gce-windows-20h2-containerd-1.24
+    description: Runs tests on a Kubernetes cluster with Windows containerd nodes on GCE
 postsubmits: {}
 presubmits:
   kubernetes/kubernetes:

--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -20,8 +20,6 @@ presets:
 - labels:
     preset-e2e-gce-windows-containerd: "true"
   env:
-  - name: PREPULL_TIMEOUT
-    value: "30m"
   - name: WINDOWS_ENABLE_DSR
     value: "true"
 - labels:
@@ -51,3 +49,103 @@ presets:
     value: "--profiling --metrics-bind-address=0.0.0.0"
   - name: WINDOWS_NODE_OS_DISTRIBUTION
     value: "win2019"
+
+periodics:
+- name: ci-kubernetes-e2e-windows-containerd-gce-master
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  extra_refs:
+  - base_ref: master
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/windows-testing
+    repo: windows-testing
+  interval: 4h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+    preset-common-gce-windows: "true"
+    preset-e2e-gce-windows: "true"
+    preset-e2e-gce-windows-containerd: "true"
+    preset-windows-repo-list-master: "true"
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --cluster=
+      - --extract=ci/latest
+      - --gcp-zone=us-west1-b
+      - --provider=gce
+      - --gcp-nodes=2
+      - --test=false
+      - --test-cmd=$GOPATH/src/sigs.k8s.io/windows-testing/gce/run-e2e.sh
+      - --test_args=--node-os-distro=windows -prepull-images=true --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]\[Feature:Windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[alpha\]|\[Slow\]|\[GMSA\]|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|\[sig-api-machinery\].Aggregator
+      - --test-cmd-args=--node-os-distro=windows -prepull-images=true --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]\[Feature:Windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[alpha\]|\[Slow\]|\[GMSA\]|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|\[sig-api-machinery\].Aggregator
+      - --ginkgo-parallel=4
+      - --timeout=230m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      env:
+      - name: NO_LINUX_POOL_TAINT
+        value: "true"
+      - name: WINDOWS_NODE_OS_DISTRIBUTION
+        value: "win2019"
+      - name: NODE_SIZE
+        value: "n1-standard-4"
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-master
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-windows-gce
+    testgrid-tab-name: gce-windows-2019-containerd-master
+    description: Runs tests on a Kubernetes cluster with Windows containerd nodes on GCE
+- name: ci-kubernetes-e2e-windows-20h2-containerd-gce-master
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  extra_refs:
+  - base_ref: master
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/windows-testing
+    repo: windows-testing
+  interval: 4h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+    preset-common-gce-windows: "true"
+    preset-e2e-gce-windows: "true"
+    preset-e2e-gce-windows-containerd: "true"
+    preset-windows-repo-list-master: "true"
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --cluster=
+      - --extract=ci/latest
+      - --gcp-zone=us-west1-b
+      - --provider=gce
+      - --gcp-nodes=2
+      - --test=false
+      - --test-cmd=$GOPATH/src/sigs.k8s.io/windows-testing/gce/run-e2e.sh
+      - --test_args=--node-os-distro=windows -prepull-images=true --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]\[Feature:Windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[alpha\]|\[Slow\]|\[GMSA\]|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|\[sig-api-machinery\].Aggregator
+      - --test-cmd-args=--node-os-distro=windows -prepull-images=true --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]\[Feature:Windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[alpha\]|\[Slow\]|\[GMSA\]|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|\[sig-api-machinery\].Aggregator
+      - --ginkgo-parallel=4
+      - --timeout=230m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      env:
+      - name: NO_LINUX_POOL_TAINT
+        value: "true"
+      - name: WINDOWS_NODE_OS_DISTRIBUTION
+        value: "win20h2"
+      - name: NODE_SIZE
+        value: "n1-standard-4"
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-master
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-windows-gce
+    testgrid-tab-name: gce-windows-20h2-containerd-master
+    description: Runs tests on a Kubernetes cluster with Windows containerd nodes on GCE

--- a/config/testgrids/kubernetes/sig-windows/config.yaml
+++ b/config/testgrids/kubernetes/sig-windows/config.yaml
@@ -7,6 +7,7 @@ dashboard_groups:
     - sig-windows-1.23-release
     - sig-windows-master-release
     - sig-windows-presubmit
+    - sig-windows-gce
     - sig-windows-sac
     - sig-windows-networking
     - sig-windows-containerd-runtime-signal
@@ -19,6 +20,7 @@ dashboards:
 - name: sig-windows-1.23-release
 - name: sig-windows-master-release
 - name: sig-windows-presubmit
+- name: sig-windows-gce
 - name: sig-windows-sac
 - name: sig-windows-push-images
 - name: sig-windows-networking


### PR DESCRIPTION
The change adds back the Windows GCE jobs removed in https://github.com/kubernetes/test-infra/pull/26075.

- The jobs got cleaned up to keep the maintained version x container-runtime supported variations. and fixing incorrect passed container-runtime types.
- Taints are removed from Linux nodes (https://github.com/kubernetes-sigs/windows-testing/pull/318).
- Filters are updated.
- Jobs for >=1.23 now utilizes "-prepull-images=true" with static prepull disabled, to prevent future maintenance. Thanks @claudiubelu !  

Tested 1.22 jobs -> passing with the following change locally: https://github.com/kubernetes-sigs/windows-testing/pull/320
Tested 1.23 jobs -> passing
Tested 1.24/master jobs -> failing because of containerd cni incorrect path issue (should resolve when the following change is merged and ported to 1.24: https://github.com/kubernetes/kubernetes/pull/109657)