### PR TITLE
Tide makes decision based on common code review struct instead of directly accessing PullRequest

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -27,7 +27,6 @@ import (
 	"fmt"
 	"html/template"
 	"io/ioutil"
-	"k8s.io/test-infra/prow/io/providers"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -35,6 +34,9 @@ import (
 	"path"
 	"strings"
 	"time"
+
+	"k8s.io/test-infra/prow/io/providers"
+	"k8s.io/test-infra/prow/tide"
 
 	"github.com/NYTimes/gziphandler"
 	"github.com/gorilla/csrf"
@@ -1284,10 +1286,14 @@ func handleTidePools(cfg config.Getter, ta *tideAgent, log *logrus.Entry) http.H
 		pools := ta.pools
 		ta.Unlock()
 
+		var poolsForDeck []tide.PoolForDeck
+		for _, pool := range pools {
+			poolsForDeck = append(poolsForDeck, *tide.PoolToPoolForDeck(&pool))
+		}
 		payload := tidePools{
 			Queries:     queries,
 			TideQueries: queryConfigs,
-			Pools:       pools,
+			Pools:       poolsForDeck,
 		}
 		pd, err := json.Marshal(payload)
 		if err != nil {

--- a/prow/cmd/deck/static/api/github.ts
+++ b/prow/cmd/deck/static/api/github.ts
@@ -1,15 +1,6 @@
 export type MergeableState = "MERGEABLE" | "CONFLICTING" | "UNKNOWN";
 export type StatusState = "EXPECTED" | "ERROR" | "FAILURE" | "PENDING" | "SUCCESS";
 
-export interface Ref {
-  Name: string;
-  Prefix: string;
-}
-
-export interface Author {
-  Login: string;
-}
-
 export interface Context {
   Context: string;
   Description: string;
@@ -23,23 +14,12 @@ export interface Commit {
   OID: string;
 }
 
-export interface Repository {
-  Name: string;
-  NameWithOwner: string;
-  Owner: {
-    Login: string;
-  };
-}
-
 export interface Milestone {
   Title: string;
 }
 
 export interface PullRequest {
   Number: number;
-  Author: Author;
-  BaseRef: Ref;
   HeadRefOID: string;
   Mergeable: MergeableState;
-  Repository: Repository;
 }

--- a/prow/cmd/deck/static/api/pr.ts
+++ b/prow/cmd/deck/static/api/pr.ts
@@ -5,9 +5,29 @@ export interface Label {
   Name: string;
 }
 
+export interface Ref {
+  Name: string;
+  Prefix: string;
+}
+
+export interface Author {
+  Login: string;
+}
+
+export interface Repository {
+  Name: string;
+  NameWithOwner: string;
+  Owner: {
+    Login: string;
+  };
+}
+
 export interface PullRequest extends BasePullRequest {
   Merged: boolean;
   Title: string;
+  Author: Author;
+  BaseRef: Ref;
+  Repository: Repository;
   Labels: {
     Nodes: Array<{
       Label: Label;

--- a/prow/cmd/deck/static/api/tide.ts
+++ b/prow/cmd/deck/static/api/tide.ts
@@ -1,4 +1,4 @@
-import {Commit, PullRequest as BasePullRequest} from "./github";
+import {PullRequest as BasePullRequest} from "./github";
 
 export interface TideQuery {
   orgs?: string[];
@@ -15,16 +15,6 @@ export interface TideQuery {
 
 export interface PullRequest extends BasePullRequest {
   Title: string;
-  HeadRefName: string;
-  Commits: {
-    Nodes: Array<{
-      Commit: Commit;
-    }>;
-  };
-  Labels: string[];
-  Milestone?: {
-    Title: string;
-  };
 }
 
 export type Action = "WAIT" | "TRIGGER" | "TRIGGER_BATCH" | "MERGE" | "MERGE_BATCH" | "BLOCKED";

--- a/prow/cmd/deck/static/api/tide.ts
+++ b/prow/cmd/deck/static/api/tide.ts
@@ -21,11 +21,7 @@ export interface PullRequest extends BasePullRequest {
       Commit: Commit;
     }>;
   };
-  Labels: {
-    Nodes: Array<{
-      Name: string;
-    }>;
-  };
+  Labels: string[];
   Milestone?: {
     Title: string;
   };

--- a/prow/cmd/deck/static/pr/pr.ts
+++ b/prow/cmd/deck/static/pr/pr.ts
@@ -454,6 +454,8 @@ function createTidePoolLabel(pr: PullRequest, tidePool?: TidePool): HTMLElement 
         if (!poolType) {
             return false;
         }
+        // prInPool here references the PullRequest struct from tide, and pr
+        // here references the PullRequest struct from here.
         const index = poolType.findIndex((prInPool) => {
             return prInPool.Number === pr.Number;
         });

--- a/prow/cmd/deck/tide.go
+++ b/prow/cmd/deck/tide.go
@@ -36,7 +36,7 @@ import (
 type tidePools struct {
 	Queries     []string
 	TideQueries []config.TideQuery
-	Pools       []tide.Pool
+	Pools       []tide.PoolForDeck
 }
 
 type tideHistory struct {

--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -176,6 +176,7 @@ func main() {
 		}
 	})
 
+	// Deck consumes these endpoints
 	controllerMux := http.NewServeMux()
 	controllerMux.Handle("/", c)
 	controllerMux.Handle("/history", c.History)

--- a/prow/tide/codereview.go
+++ b/prow/tide/codereview.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tide
+
+import (
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+type CodeReviewCommon struct {
+	// NameWithOwner is from graphql.NameWithOwner, <org>/<repo>
+	NameWithOwner string
+	// The number of PR
+	Number int
+	Org    string
+	Repo   string
+	// BaseRefPrefix gets prefix of ref, such as /refs/head, /refs/tags
+	BaseRefPrefix string
+	BaseRefName   string
+	HeadRefName   string
+	HeadRefOID    string
+
+	Title       string
+	Body        string
+	AuthorLogin string
+	// Labels gets labels on the PR.
+	// TODO(chaodaiG): labels might mean something different on gerrit, consider
+	// how to name this nicely.
+	Labels        []string
+	IsMergeable   bool
+	UpdatedAtTime time.Time
+
+	Mergeable    string
+	CanBeRebased bool
+	LogFields    logrus.Fields
+
+	// Likely GitHub only
+	Milestone      *Milestone
+	Commits        Commits
+	ReviewDecision string
+	RepoWithOwner  string
+}
+
+func (crc *CodeReviewCommon) logFields() logrus.Fields {
+	return logrus.Fields{
+		"org":    crc.Org,
+		"repo":   crc.Repo,
+		"pr":     crc.Number,
+		"branch": crc.BaseRefName,
+		"sha":    crc.HeadRefOID,
+	}
+}
+
+func CodeReviewCommonFromPullRequest(pr *PullRequest) *CodeReviewCommon {
+	crc := &CodeReviewCommon{
+		NameWithOwner:  string(pr.Repository.NameWithOwner),
+		Number:         int(pr.Number),
+		Org:            string(pr.Repository.Owner.Login),
+		Repo:           string(pr.Repository.Name),
+		BaseRefPrefix:  string(pr.BaseRef.Prefix),
+		BaseRefName:    string(pr.BaseRef.Name),
+		HeadRefName:    string(pr.HeadRefName),
+		HeadRefOID:     string(pr.HeadRefOID),
+		Title:          string(pr.Title),
+		Body:           string(pr.Body),
+		AuthorLogin:    string(pr.Author.Login),
+		Mergeable:      string(pr.Mergeable),
+		CanBeRebased:   bool(pr.CanBeRebased),
+		UpdatedAtTime:  pr.UpdatedAt.Time,
+		Commits:        pr.Commits,
+		ReviewDecision: string(pr.ReviewDecision),
+		RepoWithOwner:  string(pr.Repository.NameWithOwner),
+		Milestone:      pr.Milestone,
+	}
+
+	for _, label := range pr.Labels.Nodes {
+		crc.Labels = append(crc.Labels, string(label.Name))
+	}
+
+	return crc
+}

--- a/prow/tide/codereview_test.go
+++ b/prow/tide/codereview_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tide
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	fuzz "github.com/google/gofuzz"
+)
+
+func TestMinStruct(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		seed := time.Now().UnixNano()
+		fuzzer := fuzz.NewWithSeed(seed)
+
+		crc := &CodeReviewCommon{}
+		fuzzer.Fuzz(crc)
+
+		want := CodeReviewForDeck{
+			Title:      crc.Title,
+			Number:     crc.Number,
+			HeadRefOID: crc.HeadRefOID,
+			Mergeable:  crc.Mergeable,
+		}
+		wantBytes, err := json.Marshal(&want)
+		if err != nil {
+			t.Fatalf("Unexpected marshal error from want struct: %v", err)
+		}
+
+		casted := MinCodeReviewCommon(*crc)
+		gotBytes, err := json.Marshal(&casted)
+		if err != nil {
+			t.Fatalf("Unexpected marshal error from got struct: %v", err)
+		}
+		if diff := cmp.Diff(string(wantBytes), string(gotBytes)); diff != "" {
+			t.Fatalf("Output mismatch. Want(-), got(+):\n%s", diff)
+		}
+	}
+}

--- a/prow/tide/search.go
+++ b/prow/tide/search.go
@@ -40,7 +40,7 @@ func floor(t time.Time) time.Time {
 	return t
 }
 
-func search(query querier, log *logrus.Entry, q string, start, end time.Time, org string) ([]PullRequest, error) {
+func search(query querier, log *logrus.Entry, q string, start, end time.Time, org string) ([]CodeReviewCommon, error) {
 	start = floor(start)
 	end = floor(end)
 	log = log.WithFields(logrus.Fields{
@@ -56,7 +56,7 @@ func search(query querier, log *logrus.Entry, q string, start, end time.Time, or
 	}
 
 	var totalCost, remaining int
-	var ret []PullRequest
+	var ret []CodeReviewCommon
 	var sq searchQuery
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
@@ -71,7 +71,7 @@ func search(query querier, log *logrus.Entry, q string, start, end time.Time, or
 		totalCost += int(sq.RateLimit.Cost)
 		remaining = int(sq.RateLimit.Remaining)
 		for _, n := range sq.Search.Nodes {
-			ret = append(ret, n.PullRequest)
+			ret = append(ret, *CodeReviewCommonFromPullRequest(&n.PullRequest))
 		}
 		if !sq.Search.PageInfo.HasNextPage {
 			break

--- a/prow/tide/search_test.go
+++ b/prow/tide/search_test.go
@@ -165,7 +165,11 @@ func TestSearch(t *testing.T) {
 				t.Errorf("failed to receive expected error")
 			}
 			// Always check prs because we might return some results on error
-			if !reflect.DeepEqual(tc.expected, prs) {
+			var expectedCrcs []CodeReviewCommon
+			for _, pr := range tc.expected {
+				expectedCrcs = append(expectedCrcs, *CodeReviewCommonFromPullRequest(&pr))
+			}
+			if !reflect.DeepEqual(expectedCrcs, prs) {
 				t.Errorf("prs do not match:\n%s", diff.ObjectReflectDiff(tc.expected, prs))
 			}
 		})

--- a/prow/tide/status_test.go
+++ b/prow/tide/status_test.go
@@ -930,7 +930,7 @@ func TestSetStatuses(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		var pr CodeReviewCommon
+		var pr PullRequest
 		pr.Commits.Nodes = []struct{ Commit Commit }{{}}
 		if tc.hasContext {
 			pr.Commits.Nodes[0].Commit.Status.Contexts = []Context{
@@ -941,9 +941,10 @@ func TestSetStatuses(t *testing.T) {
 				},
 			}
 		}
+		crc := CodeReviewCommonFromPullRequest(&pr)
 		pool := make(map[string]CodeReviewCommon)
 		if tc.inPool {
-			pool[prKey(&pr)] = pr
+			pool[prKey(crc)] = *crc
 		}
 		fc := &fgc{
 			refs: map[string]string{"/ heads/": "SHA"},
@@ -966,7 +967,7 @@ func TestSetStatuses(t *testing.T) {
 		if tc.inDontSetStatus {
 			sc.dontUpdateStatus = threadSafePRSet{data: map[pullRequestIdentifier]struct{}{{}: {}}}
 		}
-		sc.setStatuses([]CodeReviewCommon{pr}, pool, blockers.Blockers{}, nil, nil)
+		sc.setStatuses([]CodeReviewCommon{*crc}, pool, blockers.Blockers{}, nil, nil)
 		if str, err := log.String(); err != nil {
 			t.Fatalf("For case %s: failed to get log output: %v", tc.name, err)
 		} else if str != initialLog {
@@ -1285,8 +1286,8 @@ func TestStatusControllerSearch(t *testing.T) {
 			},
 			usesAppsAuth: true,
 			expected: []CodeReviewCommon{
-				{Number: 1},
-				{Number: 2},
+				*CodeReviewCommonFromPullRequest(&PullRequest{Number: 1}),
+				*CodeReviewCommonFromPullRequest(&PullRequest{Number: 2}),
 			},
 		},
 		{
@@ -1296,8 +1297,8 @@ func TestStatusControllerSearch(t *testing.T) {
 			},
 			usesAppsAuth: false,
 			expected: []CodeReviewCommon{
-				{Number: 1},
-				{Number: 2},
+				*CodeReviewCommonFromPullRequest(&PullRequest{Number: 1}),
+				*CodeReviewCommonFromPullRequest(&PullRequest{Number: 2}),
 			},
 		},
 	}

--- a/prow/tide/status_test.go
+++ b/prow/tide/status_test.go
@@ -792,9 +792,7 @@ func TestExpectedStatus(t *testing.T) {
 				Login githubql.String
 			}{githubql.String(tc.author)}
 			if tc.milestone != "" {
-				pr.Milestone = &struct {
-					Title githubql.String
-				}{githubql.String(tc.milestone)}
+				pr.Milestone = &Milestone{githubql.String(tc.milestone)}
 			}
 			if tc.mergeConflicts {
 				pr.Mergeable = githubql.MergeableStateConflicting
@@ -802,9 +800,9 @@ func TestExpectedStatus(t *testing.T) {
 			if tc.hasApprovingReview {
 				pr.ReviewDecision = githubql.PullRequestReviewDecisionApproved
 			}
-			var pool map[string]PullRequest
+			var pool map[string]CodeReviewCommon
 			if tc.inPool {
-				pool = map[string]PullRequest{"#0": {}}
+				pool = map[string]CodeReviewCommon{"#0": {}}
 			}
 			blocks := blockers.Blockers{
 				Repo: map[blockers.OrgRepo][]blockers.Blocker{},
@@ -826,7 +824,7 @@ func TestExpectedStatus(t *testing.T) {
 			ccg := func() (contextChecker, error) {
 				return &config.TideContextPolicy{RequiredContexts: tc.requiredContexts}, nil
 			}
-			state, desc, err := sc.expectedStatus(sc.logger, queriesByRepo, &pr, pool, ccg, blocks, tc.baseref)
+			state, desc, err := sc.expectedStatus(sc.logger, queriesByRepo, CodeReviewCommonFromPullRequest(&pr), pool, ccg, blocks, tc.baseref)
 			if err != nil {
 				t.Fatalf("error calling expectedStatus(): %v", err)
 			}
@@ -932,7 +930,7 @@ func TestSetStatuses(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		var pr PullRequest
+		var pr CodeReviewCommon
 		pr.Commits.Nodes = []struct{ Commit Commit }{{}}
 		if tc.hasContext {
 			pr.Commits.Nodes[0].Commit.Status.Contexts = []Context{
@@ -943,7 +941,7 @@ func TestSetStatuses(t *testing.T) {
 				},
 			}
 		}
-		pool := make(map[string]PullRequest)
+		pool := make(map[string]CodeReviewCommon)
 		if tc.inPool {
 			pool[prKey(&pr)] = pr
 		}
@@ -968,7 +966,7 @@ func TestSetStatuses(t *testing.T) {
 		if tc.inDontSetStatus {
 			sc.dontUpdateStatus = threadSafePRSet{data: map[pullRequestIdentifier]struct{}{{}: {}}}
 		}
-		sc.setStatuses([]PullRequest{pr}, pool, blockers.Blockers{}, nil, nil)
+		sc.setStatuses([]CodeReviewCommon{pr}, pool, blockers.Blockers{}, nil, nil)
 		if str, err := log.String(); err != nil {
 			t.Fatalf("For case %s: failed to get log output: %v", tc.name, err)
 		} else if str != initialLog {
@@ -1104,7 +1102,7 @@ func TestTargetUrl(t *testing.T) {
 	for _, tc := range testcases {
 		log := logrus.WithField("controller", "status-update")
 		c := &config.Config{ProwConfig: config.ProwConfig{Tide: tc.config}}
-		if actual, expected := targetURL(c, tc.pr, log), tc.expectedURL; actual != expected {
+		if actual, expected := targetURL(c, CodeReviewCommonFromPullRequest(tc.pr), log), tc.expectedURL; actual != expected {
 			t.Errorf("%s: expected target URL %s but got %s", tc.name, expected, actual)
 		}
 	}
@@ -1199,8 +1197,9 @@ func TestSetStatusRespectsRequiredContexts(t *testing.T) {
 		pjClient:     fakectrlruntimeclient.NewFakeClient(),
 		mergeChecker: newMergeChecker(ca.Config, fghc),
 	}
-	pool := map[string]PullRequest{prKey(&pr): pr}
-	sc.setStatuses([]PullRequest{pr}, pool, blockers.Blockers{}, nil, requiredContexts)
+	crc := CodeReviewCommonFromPullRequest(&pr)
+	pool := map[string]CodeReviewCommon{prKey(crc): *crc}
+	sc.setStatuses([]CodeReviewCommon{*crc}, pool, blockers.Blockers{}, nil, requiredContexts)
 	if str, err := log.String(); err != nil {
 		t.Fatalf("Failed to get log output: %v", err)
 	} else if str != initialLog {
@@ -1276,7 +1275,7 @@ func TestStatusControllerSearch(t *testing.T) {
 		prs          map[string][]PullRequest
 		usesAppsAuth bool
 
-		expected []PullRequest
+		expected []CodeReviewCommon
 	}{
 		{
 			name: "Apps auth: Query gets split by org",
@@ -1285,9 +1284,9 @@ func TestStatusControllerSearch(t *testing.T) {
 				"org-b": {{Number: githubql.Int(2)}},
 			},
 			usesAppsAuth: true,
-			expected: []PullRequest{
-				{Number: githubql.Int(1)},
-				{Number: githubql.Int(2)},
+			expected: []CodeReviewCommon{
+				{Number: 1},
+				{Number: 2},
 			},
 		},
 		{
@@ -1296,9 +1295,9 @@ func TestStatusControllerSearch(t *testing.T) {
 				"": {{Number: githubql.Int(1)}, {Number: githubql.Int(2)}},
 			},
 			usesAppsAuth: false,
-			expected: []PullRequest{
-				{Number: githubql.Int(1)},
-				{Number: githubql.Int(2)},
+			expected: []CodeReviewCommon{
+				{Number: 1},
+				{Number: 2},
 			},
 		},
 	}
@@ -1315,7 +1314,7 @@ func TestStatusControllerSearch(t *testing.T) {
 			}
 
 			result := sc.search()
-			if diff := cmp.Diff(result, tc.expected, cmpopts.SortSlices(func(a, b PullRequest) bool { return a.Number < b.Number })); diff != "" {
+			if diff := cmp.Diff(result, tc.expected, cmpopts.SortSlices(func(a, b CodeReviewCommon) bool { return a.Number < b.Number })); diff != "" {
 				t.Errorf("result differs from expected: %s", diff)
 			}
 		})

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -81,7 +81,7 @@ type Controller struct {
 	prowJobClient      ctrlruntimeclient.Client
 	gc                 git.ClientFactory
 	usesGitHubAppsAuth bool
-	pickNewBatch       func(sp subpool, candidates []PullRequest, maxBatchSize int) ([]PullRequest, error)
+	pickNewBatch       func(sp subpool, candidates []CodeReviewCommon, maxBatchSize int) ([]CodeReviewCommon, error)
 
 	sc *statusController
 
@@ -130,16 +130,16 @@ type Pool struct {
 	// PRs with passing tests, pending tests, and missing or failed tests.
 	// Note that these results are rolled up. If all tests for a PR are passing
 	// except for one pending, it will be in PendingPRs.
-	SuccessPRs []PullRequest
-	PendingPRs []PullRequest
-	MissingPRs []PullRequest
+	SuccessPRs []CodeReviewCommon
+	PendingPRs []CodeReviewCommon
+	MissingPRs []CodeReviewCommon
 
 	// Empty if there is no pending batch.
-	BatchPending []PullRequest
+	BatchPending []CodeReviewCommon
 
 	// Which action did we last take, and to what target(s), if any.
 	Action   Action
-	Target   []PullRequest
+	Target   []CodeReviewCommon
 	Blockers []blockers.Blocker
 	Error    string
 
@@ -341,8 +341,8 @@ func (c *Controller) Shutdown() {
 	c.sc.shutdown()
 }
 
-func prKey(pr *PullRequest) string {
-	return fmt.Sprintf("%s#%d", string(pr.Repository.NameWithOwner), int(pr.Number))
+func prKey(pr *CodeReviewCommon) string {
+	return fmt.Sprintf("%s#%d", string(pr.NameWithOwner), pr.Number)
 }
 
 // newExpectedContext creates a Context with Expected state.
@@ -450,10 +450,10 @@ func (c *Controller) Sync() error {
 	return nil
 }
 
-func (c *Controller) query() (map[string]PullRequest, error) {
+func (c *Controller) query() (map[string]CodeReviewCommon, error) {
 	lock := sync.Mutex{}
 	wg := sync.WaitGroup{}
-	prs := make(map[string]PullRequest)
+	prs := make(map[string]CodeReviewCommon)
 	var errs []error
 	for i, query := range c.config().Tide.Queries {
 
@@ -540,7 +540,7 @@ func subpoolsInParallel(goroutines int, sps map[string]*subpool, process func(*s
 // filterSubpools filters non-pool PRs out of the initially identified subpools,
 // deleting any pools that become empty.
 // See filterSubpool for filtering details.
-func (c *Controller) filterSubpools(mergeAllowed func(*PullRequest) (string, error), raw map[string]*subpool) map[string]*subpool {
+func (c *Controller) filterSubpools(mergeAllowed func(*CodeReviewCommon) (string, error), raw map[string]*subpool) map[string]*subpool {
 	filtered := make(map[string]*subpool)
 	var lock sync.Mutex
 
@@ -575,9 +575,9 @@ func (c *Controller) initSubpoolData(sp *subpool) error {
 	}
 	sp.cc = make(map[int]contextChecker, len(sp.prs))
 	for _, pr := range sp.prs {
-		sp.cc[int(pr.Number)], err = c.config().GetTideContextPolicy(c.gc, sp.org, sp.repo, sp.branch, refGetterFactory(string(sp.sha)), string(pr.HeadRefOID))
+		sp.cc[pr.Number], err = c.config().GetTideContextPolicy(c.gc, sp.org, sp.repo, sp.branch, refGetterFactory(string(sp.sha)), pr.HeadRefOID)
 		if err != nil {
-			return fmt.Errorf("error setting up context checker for pr %d: %w", int(pr.Number), err)
+			return fmt.Errorf("error setting up context checker for pr %d: %w", pr.Number, err)
 		}
 	}
 	return nil
@@ -587,8 +587,8 @@ func (c *Controller) initSubpoolData(sp *subpool) error {
 // filtered subpool.
 // If the subpool becomes empty 'nil' is returned to indicate that the subpool
 // should be deleted.
-func filterSubpool(ghc githubClient, mergeAllowed func(*PullRequest) (string, error), sp *subpool) *subpool {
-	var toKeep []PullRequest
+func filterSubpool(ghc githubClient, mergeAllowed func(*CodeReviewCommon) (string, error), sp *subpool) *subpool {
+	var toKeep []CodeReviewCommon
 	for _, pr := range sp.prs {
 		if !filterPR(ghc, mergeAllowed, sp, &pr) {
 			toKeep = append(toKeep, pr)
@@ -610,7 +610,7 @@ func filterSubpool(ghc githubClient, mergeAllowed func(*PullRequest) (string, er
 //   status is preventing merge. Required ProwJob statuses are allowed to be
 //   'pending' because this prevents kicking PRs from the pool when Tide is
 //   retesting them.)
-func filterPR(ghc githubClient, mergeAllowed func(*PullRequest) (string, error), sp *subpool, pr *PullRequest) bool {
+func filterPR(ghc githubClient, mergeAllowed func(*CodeReviewCommon) (string, error), sp *subpool, pr *CodeReviewCommon) bool {
 	log := sp.log.WithFields(pr.logFields())
 	// Skip PRs that are known to be unmergeable.
 	if reason, err := mergeAllowed(pr); err != nil {
@@ -629,14 +629,14 @@ func filterPR(ghc githubClient, mergeAllowed func(*PullRequest) (string, error),
 		return true
 	}
 	presubmitsHaveContext := func(context string) bool {
-		for _, job := range sp.presubmits[int(pr.Number)] {
+		for _, job := range sp.presubmits[pr.Number] {
 			if job.Context == context {
 				return true
 			}
 		}
 		return false
 	}
-	for _, ctx := range unsuccessfulContexts(contexts, sp.cc[int(pr.Number)], log) {
+	for _, ctx := range unsuccessfulContexts(contexts, sp.cc[pr.Number], log) {
 		if ctx.State != githubql.StatusStatePending {
 			log.WithField("context", ctx.Context).Debug("filtering out PR as unsuccessful context is not pending")
 			return true
@@ -714,8 +714,8 @@ func (m *mergeChecker) repoMethods(orgRepo config.OrgRepo) (map[types.PullReques
 // isAllowed checks if a PR does not have merge conflicts and requests an
 // allowed merge method. If there is no error it returns a string explanation if
 // not allowed or "" if allowed.
-func (m *mergeChecker) isAllowed(pr *PullRequest) (string, error) {
-	if pr.Mergeable == githubql.MergeableStateConflicting {
+func (m *mergeChecker) isAllowed(pr *CodeReviewCommon) (string, error) {
+	if pr.Mergeable == string(githubql.MergeableStateConflicting) {
 		return "PR has a merge conflict.", nil
 	}
 	mergeMethod, err := prMergeMethod(m.config().Tide, pr)
@@ -726,7 +726,7 @@ func (m *mergeChecker) isAllowed(pr *PullRequest) (string, error) {
 	if mergeMethod == types.MergeRebase && !pr.CanBeRebased {
 		return "PR can't be rebased", nil
 	}
-	orgRepo := config.OrgRepo{Org: string(pr.Repository.Owner.Login), Repo: string(pr.Repository.Name)}
+	orgRepo := config.OrgRepo{Org: pr.Org, Repo: pr.Repo}
 	repoMethods, err := m.repoMethods(orgRepo)
 	if err != nil {
 		return "", fmt.Errorf("error getting repo data: %w", err)
@@ -749,8 +749,8 @@ func baseSHAMap(subpoolMap map[string]*subpool) map[string]string {
 }
 
 // poolPRMap collects all subpool PRs into a map containing all pooled PRs.
-func poolPRMap(subpoolMap map[string]*subpool) map[string]PullRequest {
-	prs := make(map[string]PullRequest)
+func poolPRMap(subpoolMap map[string]*subpool) map[string]CodeReviewCommon {
+	prs := make(map[string]CodeReviewCommon)
 	for _, sp := range subpoolMap {
 		for _, pr := range sp.prs {
 			prs[prKey(&pr)] = pr
@@ -764,7 +764,7 @@ func requiredContextsMap(subpoolMap map[string]*subpool) map[string][]string {
 	for _, sp := range subpoolMap {
 		for _, pr := range sp.prs {
 			requiredContextsSet := sets.String{}
-			for _, requiredJob := range sp.presubmits[int(pr.Number)] {
+			for _, requiredJob := range sp.presubmits[pr.Number] {
 				requiredContextsSet.Insert(requiredJob.Context)
 			}
 			requiredContextsMap[prKey(&pr)] = requiredContextsSet.List()
@@ -792,7 +792,7 @@ func toSimpleState(s prowapi.ProwJobState) simpleState {
 
 // isPassingTests returns whether or not all contexts set on the PR except for
 // the tide pool context are passing.
-func (c *Controller) isPassingTests(log *logrus.Entry, pr *PullRequest, cc contextChecker) bool {
+func (c *Controller) isPassingTests(log *logrus.Entry, pr *CodeReviewCommon, cc contextChecker) bool {
 	log = log.WithFields(pr.logFields())
 	contexts, err := headContexts(log, c.ghc, pr)
 	if err != nil {
@@ -835,36 +835,36 @@ func unsuccessfulContexts(contexts []Context, cc contextChecker, log *logrus.Ent
 	return failed
 }
 
-func hasAllLabels(pr PullRequest, labels []string) bool {
+func hasAllLabels(pr CodeReviewCommon, labels []string) bool {
 	if len(labels) == 0 {
 		return true
 	}
 	prLabels := sets.NewString()
-	for _, l := range pr.Labels.Nodes {
-		prLabels.Insert(string(l.Name))
+	for _, l := range pr.Labels {
+		prLabels.Insert(l)
 	}
 	requiredLabels := sets.NewString(labels...)
 	return prLabels.Intersection(requiredLabels).Equal(requiredLabels)
 }
 
-func pickHighestPriorityPR(log *logrus.Entry, prs []PullRequest, cc map[int]contextChecker, isPassingTestsFunc func(*logrus.Entry, *PullRequest, contextChecker) bool, priorities []config.TidePriority) (bool, PullRequest) {
+func pickHighestPriorityPR(log *logrus.Entry, prs []CodeReviewCommon, cc map[int]contextChecker, isPassingTestsFunc func(*logrus.Entry, *CodeReviewCommon, contextChecker) bool, priorities []config.TidePriority) (bool, CodeReviewCommon) {
 	smallestNumber := -1
-	var smallestPR PullRequest
+	var smallestPR CodeReviewCommon
 	for _, p := range append(priorities, config.TidePriority{}) {
 		for _, pr := range prs {
 			if !hasAllLabels(pr, p.Labels) {
 				continue
 			}
-			if smallestNumber != -1 && int(pr.Number) >= smallestNumber {
+			if smallestNumber != -1 && pr.Number >= smallestNumber {
 				continue
 			}
 			if len(pr.Commits.Nodes) < 1 {
 				continue
 			}
-			if !isPassingTestsFunc(log, &pr, cc[int(pr.Number)]) {
+			if !isPassingTestsFunc(log, &pr, cc[pr.Number]) {
 				continue
 			}
-			smallestNumber = int(pr.Number)
+			smallestNumber = pr.Number
 			smallestPR = pr
 		}
 		if smallestNumber > -1 {
@@ -877,14 +877,14 @@ func pickHighestPriorityPR(log *logrus.Entry, prs []PullRequest, cc map[int]cont
 // accumulateBatch looks at existing batch ProwJobs and, if applicable, returns:
 // * A list of PRs that are part of a batch test that finished successfully
 // * A list of PRs that are part of a batch test that hasn't finished yet but didn't have any failures so far
-func (c *Controller) accumulateBatch(sp subpool) (successBatch []PullRequest, pendingBatch []PullRequest) {
+func (c *Controller) accumulateBatch(sp subpool) (successBatch []CodeReviewCommon, pendingBatch []CodeReviewCommon) {
 	sp.log.Debug("accumulating PRs for batch testing")
-	prNums := make(map[int]PullRequest)
+	prNums := make(map[int]CodeReviewCommon)
 	for _, pr := range sp.prs {
-		prNums[int(pr.Number)] = pr
+		prNums[pr.Number] = pr
 	}
 	type accState struct {
-		prs       []PullRequest
+		prs       []CodeReviewCommon
 		jobStates map[string]simpleState
 		// Are the pull requests in the ref still acceptable? That is, do they
 		// still point to the heads of the PRs?
@@ -903,7 +903,7 @@ func (c *Controller) accumulateBatch(sp subpool) (successBatch []PullRequest, pe
 				validPulls: true,
 			}
 			for _, pull := range pj.Spec.Refs.Pulls {
-				if pr, ok := prNums[pull.Number]; ok && string(pr.HeadRefOID) == pull.SHA {
+				if pr, ok := prNums[pull.Number]; ok && pr.HeadRefOID == pull.SHA {
 					state.prs = append(state.prs, pr)
 				} else if !ok {
 					state.validPulls = false
@@ -964,7 +964,7 @@ func (c *Controller) accumulateBatch(sp subpool) (successBatch []PullRequest, pe
 // prowJobsFromContexts constructs ProwJob objects from all successful presubmit contexts that include a baseSHA.
 // This is needed because otherwise we would always need retesting for results that are older than sinkers
 // max_prowjob_age.
-func prowJobsFromContexts(l *logrus.Entry, ghc githubClient, pr *PullRequest, baseSHA string) ([]prowapi.ProwJob, error) {
+func prowJobsFromContexts(l *logrus.Entry, ghc githubClient, pr *CodeReviewCommon, baseSHA string) ([]prowapi.ProwJob, error) {
 	headContexts, err := headContexts(l, ghc, pr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get head contexts: %w", err)
@@ -984,7 +984,7 @@ func prowJobsFromContexts(l *logrus.Entry, ghc githubClient, pr *PullRequest, ba
 		prowjobsFromContexts = append(prowjobsFromContexts, prowapi.ProwJob{
 			Spec: prowapi.ProwJobSpec{
 				Context: passingCurrentContext,
-				Refs:    &prowapi.Refs{Pulls: []prowapi.Pull{{Number: int(pr.Number), SHA: string(pr.HeadRefOID)}}},
+				Refs:    &prowapi.Refs{Pulls: []prowapi.Pull{{Number: pr.Number, SHA: pr.HeadRefOID}}},
 				Type:    prowapi.PresubmitJob,
 			},
 			Status: prowapi.ProwJobStatus{
@@ -998,7 +998,7 @@ func prowJobsFromContexts(l *logrus.Entry, ghc githubClient, pr *PullRequest, ba
 
 // accumulate returns the supplied PRs sorted into three buckets based on their
 // accumulated state across the presubmits.
-func accumulate(presubmits map[int][]config.Presubmit, prs []PullRequest, pjs []prowapi.ProwJob, log *logrus.Entry, baseSHA string, ghc githubClient) (successes, pendings, missings []PullRequest, missingTests map[int][]config.Presubmit) {
+func accumulate(presubmits map[int][]config.Presubmit, prs []CodeReviewCommon, pjs []prowapi.ProwJob, log *logrus.Entry, baseSHA string, ghc githubClient) (successes, pendings, missings []CodeReviewCommon, missingTests map[int][]config.Presubmit) {
 
 	missingTests = map[int][]config.Presubmit{}
 	for _, pr := range prs {
@@ -1016,10 +1016,10 @@ func accumulate(presubmits map[int][]config.Presubmit, prs []PullRequest, pjs []
 			if pj.Spec.Type != prowapi.PresubmitJob {
 				continue
 			}
-			if pj.Spec.Refs.Pulls[0].Number != int(pr.Number) {
+			if pj.Spec.Refs.Pulls[0].Number != pr.Number {
 				continue
 			}
-			if pj.Spec.Refs.Pulls[0].SHA != string(pr.HeadRefOID) {
+			if pj.Spec.Refs.Pulls[0].SHA != pr.HeadRefOID {
 				continue
 			}
 
@@ -1029,21 +1029,21 @@ func accumulate(presubmits map[int][]config.Presubmit, prs []PullRequest, pjs []
 		// The overall result for the PR is the worst of the best of all its
 		// required Presubmits
 		overallState := successState
-		for _, ps := range presubmits[int(pr.Number)] {
+		for _, ps := range presubmits[pr.Number] {
 			if s, ok := psStates[ps.Context]; !ok {
 				// No PJ with correct baseSHA+headSHA exists
-				missingTests[int(pr.Number)] = append(missingTests[int(pr.Number)], ps)
+				missingTests[pr.Number] = append(missingTests[pr.Number], ps)
 				log.WithFields(pr.logFields()).Debugf("missing presubmit %s", ps.Context)
 			} else if s == failureState {
 				// PJ with correct baseSHA+headSHA exists but failed
-				missingTests[int(pr.Number)] = append(missingTests[int(pr.Number)], ps)
+				missingTests[pr.Number] = append(missingTests[pr.Number], ps)
 				log.WithFields(pr.logFields()).Debugf("presubmit %s not passing", ps.Context)
 			} else if s == pendingState {
 				log.WithFields(pr.logFields()).Debugf("presubmit %s pending", ps.Context)
 				overallState = pendingState
 			}
 		}
-		if len(missingTests[int(pr.Number)]) > 0 {
+		if len(missingTests[pr.Number]) > 0 {
 			overallState = failureState
 		}
 
@@ -1058,17 +1058,17 @@ func accumulate(presubmits map[int][]config.Presubmit, prs []PullRequest, pjs []
 	return
 }
 
-func prNumbers(prs []PullRequest) []int {
+func prNumbers(prs []CodeReviewCommon) []int {
 	var nums []int
 	for _, pr := range prs {
-		nums = append(nums, int(pr.Number))
+		nums = append(nums, pr.Number)
 	}
 	return nums
 }
 
-func pickNewBatch(gc git.ClientFactory, cfg config.Getter) func(sp subpool, candidates []PullRequest, maxBatchSize int) ([]PullRequest, error) {
-	return func(sp subpool, candidates []PullRequest, maxBatchSize int) ([]PullRequest, error) {
-		var res []PullRequest
+func pickNewBatch(gc git.ClientFactory, cfg config.Getter) func(sp subpool, candidates []CodeReviewCommon, maxBatchSize int) ([]CodeReviewCommon, error) {
+	return func(sp subpool, candidates []CodeReviewCommon, maxBatchSize int) ([]CodeReviewCommon, error) {
+		var res []CodeReviewCommon
 		r, err := gc.ClientFor(sp.org, sp.repo)
 		if err != nil {
 			return nil, err
@@ -1093,7 +1093,7 @@ func pickNewBatch(gc git.ClientFactory, cfg config.Getter) func(sp subpool, cand
 				sp.log.WithFields(pr.logFields()).Warnf("Failed to get merge method for PR, will skip: %v.", err)
 				continue
 			}
-			if ok, err := r.MergeWithStrategy(string(pr.HeadRefOID), string(mergeMethod)); err != nil {
+			if ok, err := r.MergeWithStrategy(pr.HeadRefOID, string(mergeMethod)); err != nil {
 				// we failed to abort the merge and our git client is
 				// in a bad state; it must be cleaned before we try again
 				return nil, err
@@ -1110,9 +1110,9 @@ func pickNewBatch(gc git.ClientFactory, cfg config.Getter) func(sp subpool, cand
 	}
 }
 
-type newBatchFunc func(sp subpool, candidates []PullRequest, maxBatchSize int) ([]PullRequest, error)
+type newBatchFunc func(sp subpool, candidates []CodeReviewCommon, maxBatchSize int) ([]CodeReviewCommon, error)
 
-func (c *Controller) pickBatch(sp subpool, cc map[int]contextChecker, newBatchFunc newBatchFunc) ([]PullRequest, []config.Presubmit, error) {
+func (c *Controller) pickBatch(sp subpool, cc map[int]contextChecker, newBatchFunc newBatchFunc) ([]CodeReviewCommon, []config.Presubmit, error) {
 	batchLimit := c.config().Tide.BatchSizeLimit(config.OrgRepo{Org: sp.org, Repo: sp.repo})
 	if batchLimit < 0 {
 		sp.log.Debug("Batch merges disabled by configuration in this repo.")
@@ -1122,15 +1122,12 @@ func (c *Controller) pickBatch(sp subpool, cc map[int]contextChecker, newBatchFu
 	// we must choose the oldest PRs for the batch
 	sort.Slice(sp.prs, func(i, j int) bool { return sp.prs[i].Number < sp.prs[j].Number })
 
-	var candidates []PullRequest
-	for i := range sp.prs {
+	var candidates []CodeReviewCommon
+	for _, pr := range sp.prs {
 		// c.isRetestEligible appends `Commits` into the passed in PullRequest
 		// struct, which is used later to avoid repeatedly looking up on GitHub.
-		// So making sure that we are passing in the pointer from the slice
-		// instead of creating new instance of pr by `for _, pr := range sp.prs`.
-		ptrPr := &sp.prs[i]
-		if c.isRetestEligible(sp.log, ptrPr, cc[int(ptrPr.Number)]) {
-			candidates = append(candidates, *ptrPr)
+		if c.isRetestEligible(sp.log, &pr, cc[pr.Number]) {
+			candidates = append(candidates, pr)
 		}
 	}
 
@@ -1141,7 +1138,7 @@ func (c *Controller) pickBatch(sp subpool, cc map[int]contextChecker, newBatchFu
 	}
 	log.WithField("candidate_count", len(candidates)).Debug("Found PRs with passing tests when picking batch")
 
-	var res []PullRequest
+	var res []CodeReviewCommon
 	if c.config().Tide.PrioritizeExistingBatches(config.OrgRepo{Repo: sp.repo, Org: sp.org}) {
 		res = pickBatchWithPreexistingTests(sp, candidates, batchLimit)
 	}
@@ -1167,7 +1164,7 @@ func (c *Controller) pickBatch(sp subpool, cc map[int]contextChecker, newBatchFu
 // and was created by Tide, as that allows us to infer that this job passed in the past.
 // We look at the actively running ProwJob rather than a previous successful one, because the latter might
 // already be garbage collected.
-func (c *Controller) isRetestEligible(log *logrus.Entry, candidate *PullRequest, cc contextChecker) bool {
+func (c *Controller) isRetestEligible(log *logrus.Entry, candidate *CodeReviewCommon, cc contextChecker) bool {
 	candidateHeadContexts, err := headContexts(log, c.ghc, candidate)
 	if err != nil {
 		log.WithError(err).WithFields(candidate.logFields()).Debug("failed to get headContexts for batch candidate, ignoring.")
@@ -1192,9 +1189,9 @@ func (c *Controller) isRetestEligible(log *logrus.Entry, candidate *PullRequest,
 
 		pjLabels := createdByTideLabels()
 		pjLabels[kube.ProwJobTypeLabel] = string(prowapi.PresubmitJob)
-		pjLabels[kube.OrgLabel] = string(candidate.Repository.Owner.Login)
-		pjLabels[kube.RepoLabel] = string(candidate.Repository.Name)
-		pjLabels[kube.BaseRefLabel] = string(candidate.BaseRef.Name)
+		pjLabels[kube.OrgLabel] = string(candidate.Org)
+		pjLabels[kube.RepoLabel] = string(candidate.Repo)
+		pjLabels[kube.BaseRefLabel] = string(candidate.BaseRefName)
 		pjLabels[kube.PullLabel] = string(strconv.Itoa(int(candidate.Number)))
 		pjLabels[kube.ContextAnnotation] = string(headContext.Context)
 
@@ -1227,9 +1224,9 @@ func prowJobListHasProwJobWithMatchingHeadSHA(pjs *prowapi.ProwJobList, headSHA 
 	return false
 }
 
-func (c *Controller) prepareMergeDetails(commitTemplates config.TideMergeCommitTemplate, pr PullRequest, mergeMethod types.PullRequestMergeType) github.MergeDetails {
+func (c *Controller) prepareMergeDetails(commitTemplates config.TideMergeCommitTemplate, pr CodeReviewCommon, mergeMethod types.PullRequestMergeType) github.MergeDetails {
 	ghMergeDetails := github.MergeDetails{
-		SHA:         string(pr.HeadRefOID),
+		SHA:         pr.HeadRefOID,
 		MergeMethod: string(mergeMethod),
 	}
 
@@ -1256,16 +1253,16 @@ func (c *Controller) prepareMergeDetails(commitTemplates config.TideMergeCommitT
 	return ghMergeDetails
 }
 
-func prMergeMethod(c config.Tide, pr *PullRequest) (types.PullRequestMergeType, error) {
-	repo := config.OrgRepo{Org: string(pr.Repository.Owner.Login), Repo: string(pr.Repository.Name)}
+func prMergeMethod(c config.Tide, pr *CodeReviewCommon) (types.PullRequestMergeType, error) {
+	repo := config.OrgRepo{Org: pr.Org, Repo: pr.Repo}
 	method := c.MergeMethod(repo)
 	squashLabel := c.SquashLabel
 	rebaseLabel := c.RebaseLabel
 	mergeLabel := c.MergeLabel
 	if squashLabel != "" || rebaseLabel != "" || mergeLabel != "" {
 		labelCount := 0
-		for _, prlabel := range pr.Labels.Nodes {
-			switch string(prlabel.Name) {
+		for _, prlabel := range pr.Labels {
+			switch prlabel {
 			case "":
 				continue
 			case squashLabel:
@@ -1286,7 +1283,7 @@ func prMergeMethod(c config.Tide, pr *PullRequest) (types.PullRequestMergeType, 
 	return method, nil
 }
 
-func (c *Controller) mergePRs(sp subpool, prs []PullRequest) error {
+func (c *Controller) mergePRs(sp subpool, prs []CodeReviewCommon) error {
 	var merged, failed []int
 	defer func() {
 		if len(merged) == 0 {
@@ -1305,31 +1302,31 @@ func (c *Controller) mergePRs(sp subpool, prs []PullRequest) error {
 		if err != nil {
 			log.WithError(err).Error("Failed to determine merge method.")
 			errs = append(errs, err)
-			failed = append(failed, int(pr.Number))
+			failed = append(failed, pr.Number)
 			continue
 		}
 
 		// Ensure tide context has success state, otherwise PR merge will fail if branch protection
 		// in github is enabled and the loop to change tide context hasn't done it already
-		c.sc.dontUpdateStatus.insert(sp.org, sp.repo, int(pr.Number))
+		c.sc.dontUpdateStatus.insert(sp.org, sp.repo, pr.Number)
 		if err := setTideStatusSuccess(pr, c.ghc, c.config(), log); err != nil {
 			log.WithError(err).Error("Unable to set tide context to SUCCESS.")
 			errs = append(errs, err)
-			failed = append(failed, int(pr.Number))
+			failed = append(failed, pr.Number)
 			continue
 		}
 
 		commitTemplates := tideConfig.MergeCommitTemplate(config.OrgRepo{Org: sp.org, Repo: sp.repo})
 		keepTrying, err := tryMerge(func() error {
 			ghMergeDetails := c.prepareMergeDetails(commitTemplates, pr, mergeMethod)
-			return c.ghc.Merge(sp.org, sp.repo, int(pr.Number), ghMergeDetails)
+			return c.ghc.Merge(sp.org, sp.repo, pr.Number, ghMergeDetails)
 		})
 		if err != nil {
 			// These are user errors, shouldn't be printed as tide errors
 			log.WithError(err).Debug("Merge failed.")
 		} else {
 			log.Info("Merged.")
-			merged = append(merged, int(pr.Number))
+			merged = append(merged, pr.Number)
 		}
 		if !keepTrying {
 			break
@@ -1357,16 +1354,16 @@ func (c *Controller) mergePRs(sp subpool, prs []PullRequest) error {
 }
 
 // setTideStatusSuccess ensures the tide context is set to success
-func setTideStatusSuccess(pr PullRequest, ghc githubClient, cfg *config.Config, log *logrus.Entry) error {
+func setTideStatusSuccess(pr CodeReviewCommon, ghc githubClient, cfg *config.Config, log *logrus.Entry) error {
 	// Do not waste api tokens and risk hitting the 2.5k context limit by setting it to success if it is
 	// already set to success.
 	if prHasSuccessfullTideStatusContext(pr) {
 		return nil
 	}
 	return ghc.CreateStatus(
-		string(pr.Repository.Owner.Login),
-		string(pr.Repository.Name),
-		string(pr.HeadRefOID),
+		pr.Org,
+		pr.Repo,
+		pr.HeadRefOID,
 		github.Status{
 			Context:   statusContext,
 			State:     "success",
@@ -1374,9 +1371,9 @@ func setTideStatusSuccess(pr PullRequest, ghc githubClient, cfg *config.Config, 
 		})
 }
 
-func prHasSuccessfullTideStatusContext(pr PullRequest) bool {
+func prHasSuccessfullTideStatusContext(pr CodeReviewCommon) bool {
 	for _, commit := range pr.Commits.Nodes {
-		if commit.Commit.OID != pr.HeadRefOID {
+		if string(commit.Commit.OID) != pr.HeadRefOID {
 			continue
 		}
 		for _, context := range commit.Commit.Status.Contexts {
@@ -1451,7 +1448,7 @@ func tryMerge(mergeFunc func() error) (bool, error) {
 	return true, err
 }
 
-func (c *Controller) trigger(sp subpool, presubmits []config.Presubmit, prs []PullRequest) error {
+func (c *Controller) trigger(sp subpool, presubmits []config.Presubmit, prs []CodeReviewCommon) error {
 	refs := prowapi.Refs{
 		Org:     sp.org,
 		Repo:    sp.repo,
@@ -1462,10 +1459,10 @@ func (c *Controller) trigger(sp subpool, presubmits []config.Presubmit, prs []Pu
 		refs.Pulls = append(
 			refs.Pulls,
 			prowapi.Pull{
-				Number: int(pr.Number),
-				Title:  string(pr.Title),
-				Author: string(pr.Author.Login),
-				SHA:    string(pr.HeadRefOID),
+				Number: pr.Number,
+				Title:  pr.Title,
+				Author: string(pr.AuthorLogin),
+				SHA:    pr.HeadRefOID,
 			},
 		)
 	}
@@ -1525,7 +1522,7 @@ func (c *Controller) nonFailedBatchForJobAndRefsExists(jobName string, refs *pro
 	return len(pjs.Items) > 0
 }
 
-func (c *Controller) takeAction(sp subpool, batchPending, successes, pendings, missings, batchMerges []PullRequest, missingSerialTests map[int][]config.Presubmit) (Action, []PullRequest, error) {
+func (c *Controller) takeAction(sp subpool, batchPending, successes, pendings, missings, batchMerges []CodeReviewCommon, missingSerialTests map[int][]config.Presubmit) (Action, []CodeReviewCommon, error) {
 	// Merge the batch!
 	if len(batchMerges) > 0 {
 		return MergeBatch, batchMerges, c.mergePRs(sp, batchMerges)
@@ -1534,7 +1531,7 @@ func (c *Controller) takeAction(sp subpool, batchPending, successes, pendings, m
 	// invalidate the old batch result.
 	if len(successes) > 0 && len(batchPending) == 0 {
 		if ok, pr := pickHighestPriorityPR(sp.log, successes, sp.cc, c.isPassingTests, c.config().Tide.Priority); ok {
-			return Merge, []PullRequest{pr}, c.mergePRs(sp, []PullRequest{pr})
+			return Merge, []CodeReviewCommon{pr}, c.mergePRs(sp, []CodeReviewCommon{pr})
 		}
 	}
 	// If no presubmits are configured, just wait.
@@ -1554,7 +1551,7 @@ func (c *Controller) takeAction(sp subpool, batchPending, successes, pendings, m
 	// If we have no serial jobs pending or successful, trigger one.
 	if len(missings) > 0 && len(pendings) == 0 && len(successes) == 0 {
 		if ok, pr := pickHighestPriorityPR(sp.log, missings, sp.cc, c.isRetestEligible, c.config().Tide.Priority); ok {
-			return Trigger, []PullRequest{pr}, c.trigger(sp, missingSerialTests[int(pr.Number)], []PullRequest{pr})
+			return Trigger, []CodeReviewCommon{pr}, c.trigger(sp, missingSerialTests[pr.Number], []CodeReviewCommon{pr})
 		}
 	}
 	return Wait, nil, nil
@@ -1579,13 +1576,13 @@ type changeCacheKey struct {
 
 // prChanges gets the files changed by the PR, either from the cache or by
 // querying GitHub.
-func (c *changedFilesAgent) prChanges(pr *PullRequest) config.ChangedFilesProvider {
+func (c *changedFilesAgent) prChanges(pr *CodeReviewCommon) config.ChangedFilesProvider {
 	return func() ([]string, error) {
 		cacheKey := changeCacheKey{
-			org:    string(pr.Repository.Owner.Login),
-			repo:   string(pr.Repository.Name),
-			number: int(pr.Number),
-			sha:    string(pr.HeadRefOID),
+			org:    pr.Org,
+			repo:   pr.Repo,
+			number: pr.Number,
+			sha:    pr.HeadRefOID,
 		}
 
 		c.RLock()
@@ -1605,12 +1602,12 @@ func (c *changedFilesAgent) prChanges(pr *PullRequest) config.ChangedFilesProvid
 
 		// We need to query the changes from GitHub.
 		changes, err := c.ghc.GetPullRequestChanges(
-			string(pr.Repository.Owner.Login),
-			string(pr.Repository.Name),
-			int(pr.Number),
+			pr.Org,
+			pr.Repo,
+			pr.Number,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("error getting PR changes for #%d: %w", int(pr.Number), err)
+			return nil, fmt.Errorf("error getting PR changes for #%d: %w", pr.Number, err)
 		}
 		changedFiles = make([]string, 0, len(changes))
 		for _, change := range changes {
@@ -1624,7 +1621,7 @@ func (c *changedFilesAgent) prChanges(pr *PullRequest) config.ChangedFilesProvid
 	}
 }
 
-func (c *changedFilesAgent) batchChanges(prs []PullRequest) config.ChangedFilesProvider {
+func (c *changedFilesAgent) batchChanges(prs []CodeReviewCommon) config.ChangedFilesProvider {
 	return func() ([]string, error) {
 		result := sets.String{}
 		for _, pr := range prs {
@@ -1660,11 +1657,11 @@ func (c *Controller) presubmitsByPull(sp *subpool) (map[int][]config.Presubmit, 
 	presubmits := make(map[int][]config.Presubmit, len(sp.prs))
 
 	// filtered PRs contains all PRs for which we were able to get the presubmits
-	var filteredPRs []PullRequest
+	var filteredPRs []CodeReviewCommon
 
 	for _, pr := range sp.prs {
 		log := c.logger.WithField("base-sha", sp.sha).WithFields(pr.logFields())
-		presubmitsForPull, err := c.config().GetPresubmits(c.gc, sp.org+"/"+sp.repo, refGetterFactory(sp.sha), refGetterFactory(string(pr.HeadRefOID)))
+		presubmitsForPull, err := c.config().GetPresubmits(c.gc, sp.org+"/"+sp.repo, refGetterFactory(sp.sha), refGetterFactory(pr.HeadRefOID))
 		if err != nil {
 			c.logger.WithError(err).Debug("Failed to get presubmits for PR, excluding from subpool")
 			continue
@@ -1686,7 +1683,7 @@ func (c *Controller) presubmitsByPull(sp *subpool) (map[int][]config.Presubmit, 
 				continue
 			}
 
-			presubmits[int(pr.Number)] = append(presubmits[int(pr.Number)], ps)
+			presubmits[pr.Number] = append(presubmits[pr.Number], ps)
 		}
 	}
 
@@ -1694,12 +1691,12 @@ func (c *Controller) presubmitsByPull(sp *subpool) (map[int][]config.Presubmit, 
 	return presubmits, nil
 }
 
-func (c *Controller) presubmitsForBatch(prs []PullRequest, org, repo, baseSHA, baseBranch string) ([]config.Presubmit, error) {
+func (c *Controller) presubmitsForBatch(prs []CodeReviewCommon, org, repo, baseSHA, baseBranch string) ([]config.Presubmit, error) {
 	log := c.logger.WithFields(logrus.Fields{"repo": repo, "org": org, "base-sha": baseSHA, "base-branch": baseBranch})
 
 	var headRefGetters []config.RefGetter
 	for _, pr := range prs {
-		headRefGetters = append(headRefGetters, refGetterFactory(string(pr.HeadRefOID)))
+		headRefGetters = append(headRefGetters, refGetterFactory(pr.HeadRefOID))
 	}
 
 	presubmits, err := c.config().GetPresubmits(c.gc, org+"/"+repo, refGetterFactory(baseSHA), headRefGetters...)
@@ -1744,7 +1741,7 @@ func (c *Controller) syncSubpool(sp subpool, blocks []blockers.Blocker) (Pool, e
 
 	tenantIDs := sp.TenantIDs()
 	var act Action
-	var targets []PullRequest
+	var targets []CodeReviewCommon
 	var err error
 	var errorString string
 	if len(blocks) > 0 {
@@ -1793,14 +1790,14 @@ func (c *Controller) syncSubpool(sp subpool, blocks []blockers.Blocker) (Pool, e
 		err
 }
 
-func prMeta(prs ...PullRequest) []prowapi.Pull {
+func prMeta(prs ...CodeReviewCommon) []prowapi.Pull {
 	var res []prowapi.Pull
 	for _, pr := range prs {
 		res = append(res, prowapi.Pull{
-			Number: int(pr.Number),
-			Author: string(pr.Author.Login),
-			Title:  string(pr.Title),
-			SHA:    string(pr.HeadRefOID),
+			Number: pr.Number,
+			Author: pr.AuthorLogin,
+			Title:  pr.Title,
+			SHA:    pr.HeadRefOID,
 		})
 	}
 	return res
@@ -1817,7 +1814,7 @@ func sortPools(pools []Pool) {
 		return string(pools[i].Branch) < string(pools[j].Branch)
 	})
 
-	sortPRs := func(prs []PullRequest) {
+	sortPRs := func(prs []CodeReviewCommon) {
 		sort.Slice(prs, func(i, j int) bool { return int(prs[i].Number) < int(prs[j].Number) })
 	}
 	for i := range pools {
@@ -1839,7 +1836,7 @@ type subpool struct {
 	// pjs contains all ProwJobs of type Presubmit or Batch
 	// that have the same baseSHA as the subpool
 	pjs []prowapi.ProwJob
-	prs []PullRequest
+	prs []CodeReviewCommon
 
 	cc map[int]contextChecker
 	// presubmit contains all required presubmits for each PR
@@ -1865,13 +1862,13 @@ func poolKey(org, repo, branch string) string {
 
 // dividePool splits up the list of pull requests and prow jobs into a group
 // per repo and branch. It only keeps ProwJobs that match the latest branch.
-func (c *Controller) dividePool(pool map[string]PullRequest) (map[string]*subpool, error) {
+func (c *Controller) dividePool(pool map[string]CodeReviewCommon) (map[string]*subpool, error) {
 	sps := make(map[string]*subpool)
 	for _, pr := range pool {
-		org := string(pr.Repository.Owner.Login)
-		repo := string(pr.Repository.Name)
-		branch := string(pr.BaseRef.Name)
-		branchRef := string(pr.BaseRef.Prefix) + string(pr.BaseRef.Name)
+		org := pr.Org
+		repo := pr.Repo
+		branch := pr.BaseRefName
+		branchRef := pr.BaseRefPrefix + pr.BaseRefName
 		fn := poolKey(org, repo, branch)
 		if sps[fn] == nil {
 			sha, err := c.ghc.GetRef(org, repo, strings.TrimPrefix(branchRef, "refs/"))
@@ -1910,7 +1907,9 @@ func (c *Controller) dividePool(pool map[string]PullRequest) (map[string]*subpoo
 	return sps, nil
 }
 
-// PullRequest holds graphql data about a PR, including its commits and their contexts.
+// PullRequest holds graphql data about a PR, including its commits and their
+// contexts.
+// This struct is GitHub specific
 type PullRequest struct {
 	Number githubql.Int
 	Author struct {
@@ -1932,27 +1931,31 @@ type PullRequest struct {
 		}
 	}
 	ReviewDecision githubql.PullRequestReviewDecision `graphql:"reviewDecision"`
-	Commits        struct {
-		Nodes []struct {
-			Commit Commit
-		}
-		// Request the 'last' 4 commits hoping that one of them is the logically 'last'
-		// commit with OID matching HeadRefOID. If we don't find it we have to use an
-		// additional API token. (see the 'headContexts' func for details)
-		// We can't raise this too much or we could hit the limit of 50,000 nodes
-		// per query: https://developer.github.com/v4/guides/resource-limitations/#node-limit
-	} `graphql:"commits(last: 4)"`
-	Labels struct {
+	// Request the 'last' 4 commits hoping that one of them is the logically 'last'
+	// commit with OID matching HeadRefOID. If we don't find it we have to use an
+	// additional API token. (see the 'headContexts' func for details)
+	// We can't raise this too much or we could hit the limit of 50,000 nodes
+	// per query: https://developer.github.com/v4/guides/resource-limitations/#node-limit
+	Commits Commits `graphql:"commits(last: 4)"`
+	Labels  struct {
 		Nodes []struct {
 			Name githubql.String
 		}
 	} `graphql:"labels(first: 100)"`
-	Milestone *struct {
-		Title githubql.String
-	}
+	Milestone *Milestone
 	Body      githubql.String
 	Title     githubql.String
 	UpdatedAt githubql.DateTime
+}
+
+type Milestone struct {
+	Title githubql.String
+}
+
+type Commits struct {
+	Nodes []struct {
+		Commit Commit
+	}
 }
 
 type CommitNode struct {
@@ -2013,16 +2016,6 @@ type searchQuery struct {
 	} `graphql:"search(type: ISSUE, first: 37, after: $searchCursor, query: $query)"`
 }
 
-func (pr *PullRequest) logFields() logrus.Fields {
-	return logrus.Fields{
-		"org":    string(pr.Repository.Owner.Login),
-		"repo":   string(pr.Repository.Name),
-		"pr":     int(pr.Number),
-		"branch": string(pr.BaseRef.Name),
-		"sha":    string(pr.HeadRefOID),
-	}
-}
-
 // headContexts gets the status contexts for the commit with OID == pr.HeadRefOID
 //
 // First, we try to get this value from the commits we got with the PR query.
@@ -2032,26 +2025,26 @@ func (pr *PullRequest) logFields() logrus.Fields {
 // We list multiple commits with the query to increase our chance of success,
 // but if we don't find the head commit we have to ask GitHub for it
 // specifically (this costs an API token).
-func headContexts(log *logrus.Entry, ghc githubClient, pr *PullRequest) ([]Context, error) {
+func headContexts(log *logrus.Entry, ghc githubClient, pr *CodeReviewCommon) ([]Context, error) {
 	for _, node := range pr.Commits.Nodes {
-		if node.Commit.OID == pr.HeadRefOID {
+		if string(node.Commit.OID) == pr.HeadRefOID {
 			return append(node.Commit.Status.Contexts, checkRunNodesToContexts(log, node.Commit.StatusCheckRollup.Contexts.Nodes)...), nil
 		}
 	}
 	// We didn't get the head commit from the query (the commits must not be
 	// logically ordered) so we need to specifically ask GitHub for the status
 	// and coerce it to a graphql type.
-	org := string(pr.Repository.Owner.Login)
-	repo := string(pr.Repository.Name)
+	org := pr.Org
+	repo := pr.Repo
 	// Log this event so we can tune the number of commits we list to minimize this.
 	// TODO alvaroaleman: Add checkrun support here. Doesn't seem to happen often though,
 	// openshift doesn't have a single occurrence of this in the past seven days.
 	log.Warnf("'last' %d commits didn't contain logical last commit. Querying GitHub...", len(pr.Commits.Nodes))
-	combined, err := ghc.GetCombinedStatus(org, repo, string(pr.HeadRefOID))
+	combined, err := ghc.GetCombinedStatus(org, repo, pr.HeadRefOID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get the combined status: %w", err)
 	}
-	checkRunList, err := ghc.ListCheckRuns(org, repo, string(pr.HeadRefOID))
+	checkRunList, err := ghc.ListCheckRuns(org, repo, pr.HeadRefOID)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to list checkruns: %w", err)
 	}
@@ -2079,7 +2072,7 @@ func headContexts(log *logrus.Entry, ghc githubClient, pr *PullRequest) ([]Conte
 	pr.Commits.Nodes = append(pr.Commits.Nodes,
 		struct{ Commit Commit }{
 			Commit: Commit{
-				OID:    pr.HeadRefOID,
+				OID:    githubql.String(pr.HeadRefOID),
 				Status: struct{ Contexts []Context }{Contexts: contexts},
 			},
 		},
@@ -2253,7 +2246,7 @@ func checkRunToContext(checkRun CheckRun) Context {
 	return context
 }
 
-func pickBatchWithPreexistingTests(sp subpool, candidates []PullRequest, maxSize int) []PullRequest {
+func pickBatchWithPreexistingTests(sp subpool, candidates []CodeReviewCommon, maxSize int) []CodeReviewCommon {
 	batchCandidatesBySuccessfulJobCount := map[string]int{}
 	batchCandidatesByPendingJobCount := map[string]int{}
 
@@ -2304,10 +2297,10 @@ func pickBatchWithPreexistingTests(sp subpool, candidates []PullRequest, maxSize
 		resultPullNumbers = prNumbersFromMapKey(mapKeyWithHighestvalue(batchCandidatesByPendingJobCount))
 	}
 
-	var result []PullRequest
+	var result []CodeReviewCommon
 	for _, resultPRNumber := range resultPullNumbers {
 		for _, pr := range sp.prs {
-			if int(pr.Number) == resultPRNumber {
+			if pr.Number == resultPRNumber {
 				result = append(result, pr)
 				break
 			}
@@ -2317,7 +2310,7 @@ func pickBatchWithPreexistingTests(sp subpool, candidates []PullRequest, maxSize
 	return result
 }
 
-func isPullInPRList(pull prowapi.Pull, allPRs []PullRequest) bool {
+func isPullInPRList(pull prowapi.Pull, allPRs []CodeReviewCommon) bool {
 	for _, pullRequest := range allPRs {
 		if pull.Number != int(pullRequest.Number) {
 			continue


### PR DESCRIPTION
This is a refactoring, in preparation for tide supporting other code review providers, such as gerrit.

There were two possible approaches:
- a). Interfaces. For instance defining an interface supporting shared functions such as `GetNumber()`, `GetOrg()`, `GetRepo()`. And any GitHub only fields will be under an another interface, for example:
```
type CodeReviewCommon interface {
  GetNumber()

  GitHubOnly
}

type GitHubOnly interface {
  GetMilestone() *Milestone
}
```

- b). Common struct. The fields of this struct are derived directly from GitHub struct and potentially future struct such as from Gerrit.

I have almost finished the implementation of a), and while fixing the last failed unit test, realized that the `PullRequest` struct is marshalled by tide and unmarshalled by deck as part of `pool`, the use of interface made the case harder. Potentially we could implement our own unmarshaller, but the problem is in typescript, which would not agree with the unmarshalling logic. So implementing with b) feels like a cleaner solution.

/cc @cjwagner @alvaroaleman @mpherman2 @listx 
for early feedbacks. Note that this PR is missing the typescript change, which I'll work on early next week