### PR TITLE
Clean up sig windows 1.24  release jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.24-windows.yaml
@@ -1,0 +1,82 @@
+presets:
+- labels:
+    preset-capz-windows-common-124: "true"
+  env:
+  - name: "KUBERNETES_VERSION"
+    value: "latest-1.24"
+  - name: E2E_ARGS
+    value: "-kubetest.use-ci-artifacts"
+  - name: WINDOWS
+    value: "true"
+  - name: AZURE_NODE_MACHINE_TYPE
+    value: "Standard_D4s_v3"
+periodics:
+- name: ci-kubernetes-e2e-capz-master-containerd-windows-1-24
+  interval: 3h
+  decorate: true
+  decoration_config:
+    timeout: 4h0m0s
+  labels:
+    preset-azure-cred-only: "true"
+    preset-capz-containerd-latest: "true"
+    preset-capz-windows-2019: "true"
+    preset-capz-windows-common-124: "true"
+    preset-capz-windows-parallel: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - base_ref: main
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    repo: cluster-api-provider-azure
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - ./scripts/ci-conformance.sh
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-1.24
+      name: ""
+      resources:
+        requests:
+          cpu: "2"
+          memory: 9Gi
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-dashboards: sig-release-1.24-informing, sig-windows-1.24-release, sig-windows-signal
+    testgrid-tab-name: capz-windows-containerd-1.24
+- name: ci-kubernetes-e2e-capz-master-containerd-windows-serial-slow-1-24
+  interval: 24h
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-capz-windows-common-124: "true"
+    preset-capz-windows-2019: "true"
+    preset-capz-containerd-latest: "true"
+    preset-capz-serial-slow: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-master
+        command:
+          - "runner.sh"
+          - "./scripts/ci-conformance.sh"
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 2
+            memory: "9Gi"
+  annotations:
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-dashboards: sig-windows-1.24-release
+    testgrid-tab-name: capz-windows-containerd-serial-slow-1.24

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.24.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.24.yaml
@@ -533,41 +533,6 @@ periodics:
           memory: 9Gi
       securityContext:
         privileged: true
-- annotations:
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
-    testgrid-dashboards: sig-release-1.24-informing, sig-windows-master-release, sig-windows-signal
-    testgrid-tab-name: capz-windows-containerd-1.24
-  decorate: true
-  decoration_config:
-    timeout: 4h0m0s
-  extra_refs:
-  - base_ref: main
-    org: kubernetes-sigs
-    path_alias: sigs.k8s.io/cluster-api-provider-azure
-    repo: cluster-api-provider-azure
-  interval: 3h
-  labels:
-    preset-azure-cred-only: "true"
-    preset-capz-containerd-latest: "true"
-    preset-capz-windows-2019: "true"
-    preset-capz-windows-common-main: "true"
-    preset-capz-windows-parallel: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  name: ci-kubernetes-e2e-capz-master-containerd-windows-1-24
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - ./scripts/ci-conformance.sh
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-1.24
-      name: ""
-      resources:
-        requests:
-          cpu: "2"
-          memory: 9Gi
-      securityContext:
-        privileged: true
 - name: ci-kubernetes-e2e-windows-containerd-gce-1-24
   decorate: true
   decoration_config:

--- a/config/testgrids/kubernetes/sig-windows/config.yaml
+++ b/config/testgrids/kubernetes/sig-windows/config.yaml
@@ -5,6 +5,7 @@ dashboard_groups:
     - sig-windows-1.21-release
     - sig-windows-1.22-release
     - sig-windows-1.23-release
+    - sig-windows-1.24-release
     - sig-windows-master-release
     - sig-windows-presubmit
     - sig-windows-gce
@@ -18,6 +19,7 @@ dashboards:
 - name: sig-windows-1.21-release
 - name: sig-windows-1.22-release
 - name: sig-windows-1.23-release
+- name: sig-windows-1.24-release
 - name: sig-windows-master-release
 - name: sig-windows-presubmit
 - name: sig-windows-gce


### PR DESCRIPTION
The 1.24 branch was cut:

- this keeps the Sig-windows jobs organized together
- ensures the 1.24 job is using the 1.24 ci builds.
- creates a serial slow job sig-windows tracks


/sig windows
/assign @marosset 