### PR TITLE
Bump k/org jobs to go1.18

### DIFF
--- a/config/jobs/kubernetes/org/kubernetes-org-jobs.yaml
+++ b/config/jobs/kubernetes/org/kubernetes-org-jobs.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: golang:1.17
+      - image: golang:1.18
         command:
         - make
         args:
@@ -22,7 +22,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: golang:1.17
+      - image: golang:1.18
         command:
         - make
         args:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -8,7 +8,7 @@ postsubmits:
     max_concurrency: 1
     spec:
       containers:
-      - image: golang:1.17
+      - image: golang:1.18
         command:
         - ./admin/update.sh
         args:
@@ -539,7 +539,7 @@ periodics:
     base_ref: main
   spec:
     containers:
-    - image: golang:1.17
+    - image: golang:1.18
       command:
       - ./admin/update.sh
       args:


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/commit/0e771b68d04fcb5421e36ff68d98a85d60f0e508 added code which uses generics. This requires go1.18.
Without these, we hit compile errors.

This will fix the currently broken peribolos:
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-org-peribolos/1519718548375605248

```
 # k8s.io/test-infra/prow/config/secret
prow/config/secret/agent.go:73:19: syntax error: unexpected [, expecting (
prow/config/secret/reloader.go:27:30: syntax error: unexpected any, expecting ]
prow/config/secret/reloader.go:32:25: syntax error: unexpected (, expecting name or (
prow/config/secret/reloader.go:33:1: syntax error: non-declaration statement outside function body
prow/config/secret/reloader.go:35:31: syntax error: unexpected [, expecting comma or )
prow/config/secret/reloader.go:50:31: syntax error: unexpected [, expecting comma or )
prow/config/secret/reloader.go:52:2: syntax error: non-declaration statement outside function body
prow/config/secret/reloader.go:89:31: syntax error: unexpected [, expecting comma or )
prow/config/secret/reloader.go:95:31: syntax error: unexpected [, expecting comma or )
prow/config/secret/secret.go:34:32: syntax error: unexpected [, expecting (
prow/config/secret/secret.go:34:32: too many errors
note: module requires Go 1.18
```