### PR TITLE
[CPO] Disable e2e conformance test

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-master-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-master-config.yaml
@@ -35,40 +35,40 @@ presubmits:
       testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
       testgrid-tab-name: presubmit-e2e-test
 
-  - name: openstack-cloud-controller-manager-e2e-conformance-test
-    labels:
-      preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    path_alias: "k8s.io/cloud-provider-openstack"
-    always_run: false
-    branches:
-      - ^master$
-    run_if_changed: '^(pkg\/openstack\/|cmd\/openstack-cloud-controller-manager\/|tests\/e2e\/cloudprovider\/)'
-    optional: false
-    decorate: true
-    decoration_config:
-      timeout: 3h
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-master
-          env:
-          - name: "BOSKOS_HOST"
-            value: "boskos.test-pods.svc.cluster.local"
-          command:
-          - "runner.sh"
-          - "./tests/ci-occm-e2e-conformance.sh"
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              memory: "1Gi"
-              cpu: 1
-    annotations:
-      testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
-      testgrid-tab-name: presubmit-e2e-conformance-test
+  # - name: openstack-cloud-controller-manager-e2e-conformance-test
+  #   labels:
+  #     preset-service-account: "true"
+  #     preset-bazel-scratch-dir: "true"
+  #     preset-bazel-remote-cache-enabled: "true"
+  #     preset-dind-enabled: "true"
+  #     preset-kind-volume-mounts: "true"
+  #   path_alias: "k8s.io/cloud-provider-openstack"
+  #   always_run: false
+  #   branches:
+  #     - ^master$
+  #   run_if_changed: '^(pkg\/openstack\/|cmd\/openstack-cloud-controller-manager\/|tests\/e2e\/cloudprovider\/)'
+  #   optional: false
+  #   decorate: true
+  #   decoration_config:
+  #     timeout: 3h
+  #   spec:
+  #     containers:
+  #       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-master
+  #         env:
+  #         - name: "BOSKOS_HOST"
+  #           value: "boskos.test-pods.svc.cluster.local"
+  #         command:
+  #         - "runner.sh"
+  #         - "./tests/ci-occm-e2e-conformance.sh"
+  #         securityContext:
+  #           privileged: true
+  #         resources:
+  #           requests:
+  #             memory: "1Gi"
+  #             cpu: 1
+  #   annotations:
+  #     testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
+  #     testgrid-tab-name: presubmit-e2e-conformance-test
 
   - name: openstack-cloud-csi-cinder-e2e-test
     labels:


### PR DESCRIPTION
e2e conformation test is not fully migrated and not functional yet.
Until active progress on the job, disable the job.