### PR TITLE
apiserver-network-proxy: kubekins e2e image should use v1.23 image with go v1.17

### DIFF
--- a/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits.yaml
@@ -25,7 +25,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-1.23
         command:
         - "runner.sh"
         args:
@@ -47,7 +47,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-1.23
         command:
         - "runner.sh"
         args:
@@ -69,7 +69,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-1.23
         command:
         - "runner.sh"
         args:


### PR DESCRIPTION
apiserver-network-proxy: kubekins e2e image should use v1.23 image with go v1.17

Stolen from Andrews 25962.
Signed-off-by: Andrew Sy Kim andrewsy@google.com