### PR TITLE
Clickable pod link on job result page

### DIFF
--- a/prow/spyglass/lenses/podinfo/template.html
+++ b/prow/spyglass/lenses/podinfo/template.html
@@ -28,7 +28,7 @@
       {{if ne $podLink ""}}
       <tr>
         <td class="mdl-data-table__cell--non-numeric">Pod Link</td>
-        <td class="mdl-data-table__cell--non-numeric literal">{{$podLink}}</td>
+        <td class="mdl-data-table__cell--non-numeric literal"><a href="{{$podLink}}">Click to pod</a></td>
       </tr>
       {{end}}
       <tr>

--- a/prow/spyglass/lenses/podinfo/testdata/test_base.html
+++ b/prow/spyglass/lenses/podinfo/testdata/test_base.html
@@ -20,7 +20,7 @@
       
       <tr>
         <td class="mdl-data-table__cell--non-numeric">Pod Link</td>
-        <td class="mdl-data-table__cell--non-numeric literal">http://somewhere/pod/abc-123</td>
+        <td class="mdl-data-table__cell--non-numeric literal"><a href="http://somewhere/pod/abc-123">Click to pod</a></td>
       </tr>
       
       <tr>


### PR DESCRIPTION
The pod link is displayed as plain text on the job result page, and not clickable, see https://oss.gprow.dev/view/gs/oss-prow/logs/ci-oss-test-infra-heartbeat/1521219555358150656 as an example

/cc @cjwagner @mpherman2 