### PR TITLE
Configure deck to display pod link from trusted cluster

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -141,8 +141,16 @@ deck:
         - ^artifacts/filtered\.html$
     - lens:
         name: podinfo
+        config:
+          runner_configs:
+              "default":
+                pod_link_template: "https://console.cloud.google.com/kubernetes/pod/us-central1-f/prow/test-pods/{{ .Name }}/details?project=k8s-prow-builds"
+              "test-infra-trusted":
+                pod_link_template: "https://console.cloud.google.com/kubernetes/pod/us-central1-f/prow/test-pods/{{ .Name }}/details?project=k8s-prow"
       required_files:
         - ^podinfo\.json$
+      optional_files:
+        - ^prowjob\.json$
     - lens:
         name: links
       required_files:

--- a/prow/spyglass/README.md
+++ b/prow/spyglass/README.md
@@ -103,8 +103,17 @@ deck:
       - ^artifacts/junit.*\.xml$
     - lens:
         name: podinfo
+        config:
+          runner_configs: # Would only work if `prowjob.json` is configured below
+            "<BUILD_CLUSTER_ALIAS>":
+              pod_link_template: "https://<YOUR_CLOUD_PROVIDER_URL>/{{ .Name }}" # Name is directly from the Pod truct.
+            # Example:
+            # "default":
+            #    pod_link_template: "https://console.cloud.google.com/kubernetes/pod/us-central1-f/prow/test-pods/{{ .Name }}/details?project=k8s-prow-builds"
       required_files:
         - ^podinfo\.json$
+      optional_files:
+        - ^prowjob\.json$ # Only if runner_configs is configured.
 ```
 
 ### Accessing custom storage buckets


### PR DESCRIPTION
This feature was added as of https://github.com/kubernetes/test-infra/pull/26102, and proved to be working on one of our own prow instance https://oss.gprow.dev/view/gs/oss-prow/logs/ci-oss-test-infra-heartbeat/1521219555358150656, configure it here for easier debug


/cc @cjwagner @alvaroaleman 