### PR TITLE
Switch image bucket to k8s-staging-apisnoop

### DIFF
--- a/config/jobs/kubernetes/sig-arch/conformance-gate.yaml
+++ b/config/jobs/kubernetes/sig-arch/conformance-gate.yaml
@@ -11,7 +11,7 @@ periodics:
   spec:
     containers:
     - name: apisnoop-gate
-      image: k8s.gcr.io/apisnoop/snoopdb:v20220407-0.2.0-147-gcc8be61
+      image: gcr.io/k8s-staging-apisnoop/snoopdb:v20220407-0.2.0-147-gcc8be61
       command:
       - /usr/local/bin/docker-entrypoint.sh
       - postgres


### PR DESCRIPTION
we updated the image for the apisnoop conformance gate, but erroneously used an out of date image bucket. This PR updates where we pull the image from, to use the most recent, stable version of APISnoop