### PR TITLE
Use the GCS credential for cloud-provider-vsphere for the E2E CI.

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
@@ -255,7 +255,7 @@ presubmits:
       preset-dind-enabled: "true"
       # Borrows CAPV credentials for cloud provider e2e testing
       preset-cluster-api-provider-vsphere-e2e-config: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
+      preset-cloud-provider-vsphere-e2e-config: "true"
       preset-kind-volume-mounts: "true"
     branches:
     - ^master$


### PR DESCRIPTION
Use GCS credential (i.e. the environment variable `GCR_KEY_FILE`) for CPV instead of CAPV, so that the E2E CI can push a cloud-controller-manager image for PRs.