### PR TITLE
Adds private registry preset for Windows GCE jobs

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml
@@ -787,6 +787,7 @@ periodics:
     preset-e2e-gce-windows: "true"
     preset-e2e-gce-windows-containerd: "true"
     preset-windows-repo-list-master: "true"
+    preset-windows-private-registry-cred: "true"
   spec:
     containers:
     - args:
@@ -889,6 +890,7 @@ periodics:
     preset-common-gce-windows: "true"
     preset-e2e-gce-windows: "true"
     preset-windows-repo-list-master: "true"
+    preset-windows-private-registry-cred: "true"
   spec:
     containers:
     - args:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.23.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.23.yaml
@@ -725,6 +725,7 @@ periodics:
     preset-e2e-gce-windows: "true"
     preset-e2e-gce-windows-containerd: "true"
     preset-windows-repo-list-master: "true"
+    preset-windows-private-registry-cred: "true"
   spec:
     containers:
     - args:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.24.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.24.yaml
@@ -599,6 +599,7 @@ periodics:
     preset-e2e-gce-windows: "true"
     preset-e2e-gce-windows-containerd: "true"
     preset-windows-repo-list-master: "true"
+    preset-windows-private-registry-cred: "true"
   spec:
     containers:
     - args:

--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -117,6 +117,7 @@ periodics:
     preset-e2e-gce-windows: "true"
     preset-e2e-gce-windows-containerd: "true"
     preset-windows-repo-list-master: "true"
+    preset-windows-private-registry-cred: "true"
   spec:
     containers:
     - args:


### PR DESCRIPTION
The test ``[sig-node] Container Runtime blackbox test when running a container with a new image should be able to pull from private registry with secret [NodeConformance]`` is testing that images from private registries can be pulled using a docker config file containing the right credentials.

The preset ``preset-windows-private-registry-cred`` contains the necessary secrets and env variables that allows the test to pass on Windows, providing it the necessary credentials to pull from a registry that contains a Windows manifest list containing an image for Windows 20H2.