### PR TITLE
cloud-provider-gcp presubmit: invoke bazel directly.

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -24,7 +24,7 @@ presubmits:
           if [ -f Makefile ]; then
             make test
           else
-            ../test-infra/hack/bazel.sh test --test_output=errors -- //... -//vendor/...
+            bazel test --test_output=errors -- //... -//vendor/...
           fi
   - name: cloud-provider-gcp-verify-all
     always_run: true


### PR DESCRIPTION
invoke bazel directly instead of using test-infra scripts.

This is because the bazel scripts are removed from test-infra.