### PR TITLE
Enable auto fast-forward job in nomock mode

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -221,6 +221,7 @@ periodics:
       - fast-forward
       - --non-interactive
       - --submit
+      - --nomock
       resources:
         requests:
           cpu: 4
@@ -234,5 +235,5 @@ periodics:
         slug: release-managers
   annotations:
     testgrid-alert-email: release-managers+alerts@kubernetes.io
-    testgrid-dashboards: sig-release-releng-informing
+    testgrid-dashboards: sig-release-releng-blocking
     testgrid-tab-name: git-repo-kubernetes-fast-forward


### PR DESCRIPTION
We have proven that the job works as expected in mock mode (without
pushing to upstream) during the past release cycle.

This means we now can promote the jobs to `sig-release-releng-blocking`
as well as enable it finally.

After that we will update the testfreeze plugin to mention the new
process, adapt docs as well as sending a not to the k-dev mailing list.

Refers to https://github.com/kubernetes/release/issues/2386

cc @kubernetes/release-managers 