### PR TITLE
CAPI Operator: Add github token to e2e config

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-periodics-main.yaml
@@ -17,5 +17,5 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
     testgrid-tab-name: capi-operator-test-main
-    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-operator-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"

--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-main.yaml
@@ -118,6 +118,19 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+      env:
+      - name: GITHUB_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: cluster-lifecycle-github-token
+            key: cluster-lifecycle-github-token
+    volumes:
+    - name: cluster-lifecycle-github-token
+      secret:
+        secretName: cluster-lifecycle-github-token
+        items:
+        - key: cluster-lifecycle-github-token
+          path: cluster-lifecycle-github-token
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
       testgrid-tab-name: capi-operator-pr-e2e-main


### PR DESCRIPTION
Add GitHub token to e2e config. The operator e2e tests make requests to Github, having a token keeps it safe from hitting request quotas.