### PR TITLE
Make testfreeze plugin work with auto fast-forward

### DIFF
--- a/prow/plugins/testfreeze/checker/checker.go
+++ b/prow/plugins/testfreeze/checker/checker.go
@@ -17,15 +17,28 @@ limitations under the License.
 package checker
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
 	"strings"
+	"time"
 
 	"github.com/blang/semver"
 	git "github.com/go-git/go-git/v5"
 	gitconfig "github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	gitmemory "github.com/go-git/go-git/v5/storage/memory"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+)
+
+const (
+	prowjobsURL = "https://prow.k8s.io/prowjobs.js?omit=annotations,labels,decoration_config,pod_spec"
+	jobName     = "ci-fast-forward"
+	unknownTime = "unknown"
 )
 
 // Checker is the main structure of checking if we're in Test Freeze.
@@ -44,12 +57,20 @@ type Result struct {
 
 	// Tag is the latest minor release tag to be expected.
 	Tag string
+
+	// LastFastForward specifies the latest point int time when a fast forward
+	// was successful.
+	LastFastForward string
 }
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 //counterfeiter:generate . checker
 type checker interface {
 	ListRefs(*git.Remote) ([]*plumbing.Reference, error)
+	HttpGet(string) (*http.Response, error)
+	CloseBody(*http.Response) error
+	ReadAllBody(*http.Response) ([]byte, error)
+	UnmarshalProwJobs([]byte) (*v1.ProwJobList, error)
 }
 
 type defaultChecker struct{}
@@ -74,7 +95,7 @@ func (c *Checker) InTestFreeze() (*Result, error) {
 	refs, err := c.checker.ListRefs(remote)
 	if err != nil {
 		c.log.Errorf("Unable to list git remote: %v", err)
-		return nil, errors.Wrap(err, "list git remote")
+		return nil, fmt.Errorf("list git remote: %w", err)
 	}
 
 	const releaseBranchPrefix = "release-"
@@ -97,7 +118,7 @@ func (c *Checker) InTestFreeze() (*Result, error) {
 
 			parsed, err := semver.Parse(version)
 			if err != nil {
-				c.log.WithField("version", version).WithError(err).Debug("Unable parse version.")
+				c.log.WithField("version", version).WithError(err).Debug("Unable to parse version.")
 				continue
 			}
 
@@ -118,7 +139,7 @@ func (c *Checker) InTestFreeze() (*Result, error) {
 
 			parsed, err := semver.Parse(tag)
 			if err != nil {
-				c.log.WithField("tag", tag).WithError(err).Debug("Unable parse tag.")
+				c.log.WithField("tag", tag).WithError(err).Debug("Unable to parse tag.")
 				continue
 			}
 
@@ -134,15 +155,70 @@ func (c *Checker) InTestFreeze() (*Result, error) {
 		}
 	}
 
+	lastFastForward := unknownTime
+	last, err := c.lastFastForward()
+	if err != nil {
+		c.log.WithError(err).Error("Unable to get last fast forward result.")
+	} else {
+		lastFastForward = last.Format(time.UnixDate)
+	}
+
 	// Latest minor version not found in latest release branch,
 	// we're in Test Freeze.
 	return &Result{
-		InTestFreeze: true,
-		Branch:       latestBranch,
-		Tag:          "v" + latestSemver.String(),
+		InTestFreeze:    true,
+		Branch:          latestBranch,
+		Tag:             "v" + latestSemver.String(),
+		LastFastForward: lastFastForward,
 	}, nil
+}
+
+func (c *Checker) lastFastForward() (*metav1.Time, error) {
+	resp, err := c.checker.HttpGet(prowjobsURL)
+	if err != nil {
+		return nil, fmt.Errorf("get prow jobs: %w", err)
+	}
+	defer c.checker.CloseBody(resp)
+
+	body, err := c.checker.ReadAllBody(resp)
+	if err != nil {
+		return nil, fmt.Errorf("read response body: %w", err)
+	}
+
+	prowJobs, err := c.checker.UnmarshalProwJobs(body)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal prow jobs: %w", err)
+	}
+
+	for _, job := range prowJobs.Items {
+		if job.Spec.Job == jobName && job.Status.State == v1.SuccessState {
+			return job.Status.CompletionTime, nil
+		}
+	}
+
+	return nil, errors.New("unable to find successful run")
 }
 
 func (*defaultChecker) ListRefs(r *git.Remote) ([]*plumbing.Reference, error) {
 	return r.List(&git.ListOptions{})
+}
+
+func (*defaultChecker) HttpGet(url string) (*http.Response, error) {
+	return http.Get(url)
+}
+
+func (*defaultChecker) CloseBody(resp *http.Response) error {
+	return resp.Body.Close()
+}
+
+func (*defaultChecker) ReadAllBody(resp *http.Response) ([]byte, error) {
+	return io.ReadAll(resp.Body)
+}
+
+func (*defaultChecker) UnmarshalProwJobs(data []byte) (*v1.ProwJobList, error) {
+	prowJobs := &v1.ProwJobList{}
+	if err := json.Unmarshal(data, prowJobs); err != nil {
+		return nil, err
+	}
+	return prowJobs, nil
 }

--- a/prow/plugins/testfreeze/checker/checkerfakes/fake_checker.go
+++ b/prow/plugins/testfreeze/checker/checkerfakes/fake_checker.go
@@ -18,13 +18,39 @@ limitations under the License.
 package checkerfakes
 
 import (
+	"net/http"
 	"sync"
 
 	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	v1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 )
 
 type FakeChecker struct {
+	CloseBodyStub        func(*http.Response) error
+	closeBodyMutex       sync.RWMutex
+	closeBodyArgsForCall []struct {
+		arg1 *http.Response
+	}
+	closeBodyReturns struct {
+		result1 error
+	}
+	closeBodyReturnsOnCall map[int]struct {
+		result1 error
+	}
+	HttpGetStub        func(string) (*http.Response, error)
+	httpGetMutex       sync.RWMutex
+	httpGetArgsForCall []struct {
+		arg1 string
+	}
+	httpGetReturns struct {
+		result1 *http.Response
+		result2 error
+	}
+	httpGetReturnsOnCall map[int]struct {
+		result1 *http.Response
+		result2 error
+	}
 	ListRefsStub        func(*git.Remote) ([]*plumbing.Reference, error)
 	listRefsMutex       sync.RWMutex
 	listRefsArgsForCall []struct {
@@ -38,8 +64,159 @@ type FakeChecker struct {
 		result1 []*plumbing.Reference
 		result2 error
 	}
+	ReadAllBodyStub        func(*http.Response) ([]byte, error)
+	readAllBodyMutex       sync.RWMutex
+	readAllBodyArgsForCall []struct {
+		arg1 *http.Response
+	}
+	readAllBodyReturns struct {
+		result1 []byte
+		result2 error
+	}
+	readAllBodyReturnsOnCall map[int]struct {
+		result1 []byte
+		result2 error
+	}
+	UnmarshalProwJobsStub        func([]byte) (*v1.ProwJobList, error)
+	unmarshalProwJobsMutex       sync.RWMutex
+	unmarshalProwJobsArgsForCall []struct {
+		arg1 []byte
+	}
+	unmarshalProwJobsReturns struct {
+		result1 *v1.ProwJobList
+		result2 error
+	}
+	unmarshalProwJobsReturnsOnCall map[int]struct {
+		result1 *v1.ProwJobList
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeChecker) CloseBody(arg1 *http.Response) error {
+	fake.closeBodyMutex.Lock()
+	ret, specificReturn := fake.closeBodyReturnsOnCall[len(fake.closeBodyArgsForCall)]
+	fake.closeBodyArgsForCall = append(fake.closeBodyArgsForCall, struct {
+		arg1 *http.Response
+	}{arg1})
+	stub := fake.CloseBodyStub
+	fakeReturns := fake.closeBodyReturns
+	fake.recordInvocation("CloseBody", []interface{}{arg1})
+	fake.closeBodyMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeChecker) CloseBodyCallCount() int {
+	fake.closeBodyMutex.RLock()
+	defer fake.closeBodyMutex.RUnlock()
+	return len(fake.closeBodyArgsForCall)
+}
+
+func (fake *FakeChecker) CloseBodyCalls(stub func(*http.Response) error) {
+	fake.closeBodyMutex.Lock()
+	defer fake.closeBodyMutex.Unlock()
+	fake.CloseBodyStub = stub
+}
+
+func (fake *FakeChecker) CloseBodyArgsForCall(i int) *http.Response {
+	fake.closeBodyMutex.RLock()
+	defer fake.closeBodyMutex.RUnlock()
+	argsForCall := fake.closeBodyArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeChecker) CloseBodyReturns(result1 error) {
+	fake.closeBodyMutex.Lock()
+	defer fake.closeBodyMutex.Unlock()
+	fake.CloseBodyStub = nil
+	fake.closeBodyReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeChecker) CloseBodyReturnsOnCall(i int, result1 error) {
+	fake.closeBodyMutex.Lock()
+	defer fake.closeBodyMutex.Unlock()
+	fake.CloseBodyStub = nil
+	if fake.closeBodyReturnsOnCall == nil {
+		fake.closeBodyReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.closeBodyReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeChecker) HttpGet(arg1 string) (*http.Response, error) {
+	fake.httpGetMutex.Lock()
+	ret, specificReturn := fake.httpGetReturnsOnCall[len(fake.httpGetArgsForCall)]
+	fake.httpGetArgsForCall = append(fake.httpGetArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.HttpGetStub
+	fakeReturns := fake.httpGetReturns
+	fake.recordInvocation("HttpGet", []interface{}{arg1})
+	fake.httpGetMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeChecker) HttpGetCallCount() int {
+	fake.httpGetMutex.RLock()
+	defer fake.httpGetMutex.RUnlock()
+	return len(fake.httpGetArgsForCall)
+}
+
+func (fake *FakeChecker) HttpGetCalls(stub func(string) (*http.Response, error)) {
+	fake.httpGetMutex.Lock()
+	defer fake.httpGetMutex.Unlock()
+	fake.HttpGetStub = stub
+}
+
+func (fake *FakeChecker) HttpGetArgsForCall(i int) string {
+	fake.httpGetMutex.RLock()
+	defer fake.httpGetMutex.RUnlock()
+	argsForCall := fake.httpGetArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeChecker) HttpGetReturns(result1 *http.Response, result2 error) {
+	fake.httpGetMutex.Lock()
+	defer fake.httpGetMutex.Unlock()
+	fake.HttpGetStub = nil
+	fake.httpGetReturns = struct {
+		result1 *http.Response
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeChecker) HttpGetReturnsOnCall(i int, result1 *http.Response, result2 error) {
+	fake.httpGetMutex.Lock()
+	defer fake.httpGetMutex.Unlock()
+	fake.HttpGetStub = nil
+	if fake.httpGetReturnsOnCall == nil {
+		fake.httpGetReturnsOnCall = make(map[int]struct {
+			result1 *http.Response
+			result2 error
+		})
+	}
+	fake.httpGetReturnsOnCall[i] = struct {
+		result1 *http.Response
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeChecker) ListRefs(arg1 *git.Remote) ([]*plumbing.Reference, error) {
@@ -106,11 +283,152 @@ func (fake *FakeChecker) ListRefsReturnsOnCall(i int, result1 []*plumbing.Refere
 	}{result1, result2}
 }
 
+func (fake *FakeChecker) ReadAllBody(arg1 *http.Response) ([]byte, error) {
+	fake.readAllBodyMutex.Lock()
+	ret, specificReturn := fake.readAllBodyReturnsOnCall[len(fake.readAllBodyArgsForCall)]
+	fake.readAllBodyArgsForCall = append(fake.readAllBodyArgsForCall, struct {
+		arg1 *http.Response
+	}{arg1})
+	stub := fake.ReadAllBodyStub
+	fakeReturns := fake.readAllBodyReturns
+	fake.recordInvocation("ReadAllBody", []interface{}{arg1})
+	fake.readAllBodyMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeChecker) ReadAllBodyCallCount() int {
+	fake.readAllBodyMutex.RLock()
+	defer fake.readAllBodyMutex.RUnlock()
+	return len(fake.readAllBodyArgsForCall)
+}
+
+func (fake *FakeChecker) ReadAllBodyCalls(stub func(*http.Response) ([]byte, error)) {
+	fake.readAllBodyMutex.Lock()
+	defer fake.readAllBodyMutex.Unlock()
+	fake.ReadAllBodyStub = stub
+}
+
+func (fake *FakeChecker) ReadAllBodyArgsForCall(i int) *http.Response {
+	fake.readAllBodyMutex.RLock()
+	defer fake.readAllBodyMutex.RUnlock()
+	argsForCall := fake.readAllBodyArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeChecker) ReadAllBodyReturns(result1 []byte, result2 error) {
+	fake.readAllBodyMutex.Lock()
+	defer fake.readAllBodyMutex.Unlock()
+	fake.ReadAllBodyStub = nil
+	fake.readAllBodyReturns = struct {
+		result1 []byte
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeChecker) ReadAllBodyReturnsOnCall(i int, result1 []byte, result2 error) {
+	fake.readAllBodyMutex.Lock()
+	defer fake.readAllBodyMutex.Unlock()
+	fake.ReadAllBodyStub = nil
+	if fake.readAllBodyReturnsOnCall == nil {
+		fake.readAllBodyReturnsOnCall = make(map[int]struct {
+			result1 []byte
+			result2 error
+		})
+	}
+	fake.readAllBodyReturnsOnCall[i] = struct {
+		result1 []byte
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeChecker) UnmarshalProwJobs(arg1 []byte) (*v1.ProwJobList, error) {
+	var arg1Copy []byte
+	if arg1 != nil {
+		arg1Copy = make([]byte, len(arg1))
+		copy(arg1Copy, arg1)
+	}
+	fake.unmarshalProwJobsMutex.Lock()
+	ret, specificReturn := fake.unmarshalProwJobsReturnsOnCall[len(fake.unmarshalProwJobsArgsForCall)]
+	fake.unmarshalProwJobsArgsForCall = append(fake.unmarshalProwJobsArgsForCall, struct {
+		arg1 []byte
+	}{arg1Copy})
+	stub := fake.UnmarshalProwJobsStub
+	fakeReturns := fake.unmarshalProwJobsReturns
+	fake.recordInvocation("UnmarshalProwJobs", []interface{}{arg1Copy})
+	fake.unmarshalProwJobsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeChecker) UnmarshalProwJobsCallCount() int {
+	fake.unmarshalProwJobsMutex.RLock()
+	defer fake.unmarshalProwJobsMutex.RUnlock()
+	return len(fake.unmarshalProwJobsArgsForCall)
+}
+
+func (fake *FakeChecker) UnmarshalProwJobsCalls(stub func([]byte) (*v1.ProwJobList, error)) {
+	fake.unmarshalProwJobsMutex.Lock()
+	defer fake.unmarshalProwJobsMutex.Unlock()
+	fake.UnmarshalProwJobsStub = stub
+}
+
+func (fake *FakeChecker) UnmarshalProwJobsArgsForCall(i int) []byte {
+	fake.unmarshalProwJobsMutex.RLock()
+	defer fake.unmarshalProwJobsMutex.RUnlock()
+	argsForCall := fake.unmarshalProwJobsArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeChecker) UnmarshalProwJobsReturns(result1 *v1.ProwJobList, result2 error) {
+	fake.unmarshalProwJobsMutex.Lock()
+	defer fake.unmarshalProwJobsMutex.Unlock()
+	fake.UnmarshalProwJobsStub = nil
+	fake.unmarshalProwJobsReturns = struct {
+		result1 *v1.ProwJobList
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeChecker) UnmarshalProwJobsReturnsOnCall(i int, result1 *v1.ProwJobList, result2 error) {
+	fake.unmarshalProwJobsMutex.Lock()
+	defer fake.unmarshalProwJobsMutex.Unlock()
+	fake.UnmarshalProwJobsStub = nil
+	if fake.unmarshalProwJobsReturnsOnCall == nil {
+		fake.unmarshalProwJobsReturnsOnCall = make(map[int]struct {
+			result1 *v1.ProwJobList
+			result2 error
+		})
+	}
+	fake.unmarshalProwJobsReturnsOnCall[i] = struct {
+		result1 *v1.ProwJobList
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeChecker) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.closeBodyMutex.RLock()
+	defer fake.closeBodyMutex.RUnlock()
+	fake.httpGetMutex.RLock()
+	defer fake.httpGetMutex.RUnlock()
 	fake.listRefsMutex.RLock()
 	defer fake.listRefsMutex.RUnlock()
+	fake.readAllBodyMutex.RLock()
+	defer fake.readAllBodyMutex.RUnlock()
+	fake.unmarshalProwJobsMutex.RLock()
+	defer fake.unmarshalProwJobsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/prow/plugins/testfreeze/testfreeze.go
+++ b/prow/plugins/testfreeze/testfreeze.go
@@ -36,9 +36,10 @@ const (
 	PluginName                  = "testfreeze"
 	defaultKubernetesBranch     = "master"
 	defaultKubernetesRepoAndOrg = "kubernetes"
-	templateString              = `{{ if .InTestFreeze -}}
-Please note that we're already in [Test Freeze](https://github.com/kubernetes/sig-release/blob/master/releases/release_phases.md#test-freeze) for the ` + "`{{ .Branch }}`" + ` branch. This means every merged PR has to be cherry-picked into the release branch to be part of the upcoming {{ .Tag }} release.
-{{ end }}`
+	templateString              = `Please note that we're already in [Test Freeze](https://github.com/kubernetes/sig-release/blob/master/releases/release_phases.md#test-freeze) for the ` + "`{{ .Branch }}`" + ` branch. This means every merged PR will be automatically fast-forwarded via the periodic [ci-fast-forward](https://testgrid.k8s.io/sig-release-releng-blocking#git-repo-kubernetes-fast-forward) job to the release branch of the upcoming {{ .Tag }} release.
+
+The most recent automatic fast forward was: {{ .LastFastForward }}.
+`
 )
 
 func init() {

--- a/prow/plugins/testfreeze/testfreeze_test.go
+++ b/prow/plugins/testfreeze/testfreeze_test.go
@@ -48,9 +48,10 @@ func TestHandle(t *testing.T) {
 			branch: defaultKubernetesBranch,
 			prepare: func(mock *testfreezefakes.FakeVerifier) {
 				mock.CheckInTestFreezeReturns(&checker.Result{
-					InTestFreeze: true,
-					Tag:          "v1.23.0",
-					Branch:       "release-1.23",
+					InTestFreeze:    true,
+					Tag:             "v1.23.0",
+					Branch:          "release-1.23",
+					LastFastForward: "Wed May  4 16:15:37 CEST 2022",
 				}, nil)
 			},
 			assert: func(mock *testfreezefakes.FakeVerifier, err error) {
@@ -59,7 +60,7 @@ func TestHandle(t *testing.T) {
 				_, _, _, _, comment := mock.CreateCommentArgsForCall(0)
 				assert.Contains(t, comment, "Please note that we're already")
 				assert.Contains(t, comment, "for the `release-1.23` branch")
-				assert.Contains(t, comment, "upcoming v1.23.0 release")
+				assert.Contains(t, comment, "The most recent automatic fast forward was: Wed May  4 16:15:37 CEST 2022")
 			},
 		},
 		{


### PR DESCRIPTION
We enabled the automatic fast forward for the v1.25 release branch in: https://github.com/kubernetes/test-infra/pull/26188

This means we now have to adapt the testfreeze plugin to take this into account. Beside mentioning the auto fast forward the plugin will now determine the last successful run as well.

Refers to https://github.com/kubernetes/release/issues/2386