### PR TITLE
Update path_alias for the perf_tests repository

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
@@ -6,7 +6,7 @@ presubmits:
     optional: true
     decoration_config:
       timeout: 8h
-    path_alias: sigs.k8s.io/perf-tests
+    path_alias: k8s.io/perf-tests
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -23,7 +23,7 @@ presubmits:
       # - org: kubernetes
       #   repo: perf-tests
       #   base_ref: "main"
-      #   path_alias: "sigs.k8s.io/perf-tests"
+      #   path_alias: "k8s.io/perf-tests"
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
         base_ref: main


### PR DESCRIPTION
clusterloader2 expects the manifests to be in this location: /home/prow/go/src/k8s.io/perf-tests/clusterloader2/pkg/prometheus/manifests

path_alias for the kubernetes/perf_tests repo has to be updated.

Failing job: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/perf-tests/2051/soak-tests-capz-windows-2019/1521900787930763264

