### PR TITLE
azure: Skip GPU test in CAPZ v1alpha4 release 0.5 test

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-release-v1alpha4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-release-v1alpha4.yaml
@@ -92,7 +92,7 @@ periodics:
         - name: GINKGO_FOCUS
           value: "Workload cluster creation"
         - name: GINKGO_SKIP
-          value: ""
+          value: "Creating a GPU-enabled cluster"
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true


### PR DESCRIPTION
We are skipping the GPU test as discussed in a sync up with @jackfrancis. In [this PR](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2276) we updated the GPU operator to a new version, and in v1alpha4 we aren't using the GPU operator, just a static CRS. Since CAPZ just uses a known working solution in v1alpha4, there's no need to test it specifically. 