### PR TITLE
Cluster API jobs update to Kubernetes 1.24

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main-upgrades.yaml
@@ -220,7 +220,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 
-- name: periodic-cluster-api-e2e-workload-upgrade-1-23-latest-main
+- name: periodic-cluster-api-e2e-workload-upgrade-1-23-1-24-main
   interval: 24h
   decorate: true
   labels:
@@ -245,7 +245,7 @@ periodics:
       - name: KUBERNETES_VERSION_UPGRADE_FROM
         value: "stable-1.23"
       - name: KUBERNETES_VERSION_UPGRADE_TO
-        value: "ci/latest-1.24"
+        value: "stable-1.24"
       - name: ETCD_VERSION_UPGRADE_TO
         value: "3.5.3-0"
       - name: COREDNS_VERSION_UPGRADE_TO
@@ -260,6 +260,50 @@ periodics:
           cpu: 7300m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-    testgrid-tab-name: capi-e2e-main-1-23-latest
+    testgrid-tab-name: capi-e2e-main-1-23-1-24
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "4"
+
+- name: periodic-cluster-api-e2e-workload-upgrade-1-24-latest-main
+  interval: 24h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api
+      base_ref: main
+      path_alias: sigs.k8s.io/cluster-api
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-1.23
+        args:
+          - runner.sh
+          - "./scripts/ci-e2e.sh"
+        env:
+          - name: KUBERNETES_VERSION_UPGRADE_FROM
+            value: "stable-1.24"
+          - name: KUBERNETES_VERSION_UPGRADE_TO
+            value: "ci/latest-1.25"
+          - name: ETCD_VERSION_UPGRADE_TO
+            value: "3.5.3-0"
+          - name: COREDNS_VERSION_UPGRADE_TO
+            value: "v1.8.6"
+          - name: GINKGO_FOCUS
+            value: "\\[K8s-Upgrade\\]"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+    testgrid-tab-name: capi-e2e-main-1-24-latest
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -119,7 +119,7 @@ periodics:
       - name: INIT_WITH_PROVIDERS_CONTRACT
         value: v1beta1
       - name: INIT_WITH_KUBERNETES_VERSION
-        value: v1.23.4
+        value: v1.24.0
 
       # we need privileged mode in order to do docker in docker
       securityContext:

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-1-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-1-upgrades.yaml
@@ -220,7 +220,7 @@ periodics:
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
 
-- name: periodic-cluster-api-e2e-workload-upgrade-1-23-latest-release-1-1
+- name: periodic-cluster-api-e2e-workload-upgrade-1-23-1-24-release-1-1
   interval: 24h
   decorate: true
   labels:
@@ -245,7 +245,7 @@ periodics:
       - name: KUBERNETES_VERSION_UPGRADE_FROM
         value: "stable-1.23"
       - name: KUBERNETES_VERSION_UPGRADE_TO
-        value: "ci/latest-1.24"
+        value: "stable-1.24"
       - name: ETCD_VERSION_UPGRADE_TO
         value: "3.5.3-0"
       - name: COREDNS_VERSION_UPGRADE_TO
@@ -260,6 +260,50 @@ periodics:
           cpu: 7300m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.1
-    testgrid-tab-name: capi-e2e-release-1-1-1-23-latest
+    testgrid-tab-name: capi-e2e-release-1-1-1-23-1-24
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "4"
+
+- name: periodic-cluster-api-e2e-workload-upgrade-1-24-latest-release-1-1
+  interval: 24h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api
+      base_ref: release-1.1
+      path_alias: sigs.k8s.io/cluster-api
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-1.23
+        args:
+          - runner.sh
+          - "./scripts/ci-e2e.sh"
+        env:
+          - name: KUBERNETES_VERSION_UPGRADE_FROM
+            value: "stable-1.24"
+          - name: KUBERNETES_VERSION_UPGRADE_TO
+            value: "ci/latest-1.25"
+          - name: ETCD_VERSION_UPGRADE_TO
+            value: "3.5.3-0"
+          - name: COREDNS_VERSION_UPGRADE_TO
+            value: "v1.8.6"
+          - name: GINKGO_FOCUS
+            value: "\\[K8s-Upgrade\\]"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.1
+    testgrid-tab-name: capi-e2e-release-1-1-1-24-latest
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-1.yaml
@@ -93,7 +93,7 @@ periodics:
       - name: INIT_WITH_PROVIDERS_CONTRACT
         value: v1beta1
       - name: INIT_WITH_KUBERNETES_VERSION
-        value: v1.23.3
+        value: v1.24.0
 
       # we need privileged mode in order to do docker in docker
       securityContext:

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -233,7 +233,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-e2e-full-main
-  - name: pull-cluster-api-e2e-workload-upgrade-1-23-latest-main
+  - name: pull-cluster-api-e2e-workload-upgrade-1-24-latest-main
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -257,9 +257,9 @@ presubmits:
           - "./scripts/ci-e2e.sh"
         env:
           - name: KUBERNETES_VERSION_UPGRADE_FROM
-            value: "stable-1.23"
+            value: "stable-1.24"
           - name: KUBERNETES_VERSION_UPGRADE_TO
-            value: "ci/latest-1.24"
+            value: "ci/latest-1.25"
           - name: ETCD_VERSION_UPGRADE_TO
             value: "3.5.3-0"
           - name: COREDNS_VERSION_UPGRADE_TO
@@ -274,4 +274,4 @@ presubmits:
             cpu: 7300m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-      testgrid-tab-name: capi-pr-e2e-main-1-23-latest
+      testgrid-tab-name: capi-pr-e2e-main-1-24-latest


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Update the jobs related to Cluster API to test with the latests Kubernetes release.

Part of https://github.com/kubernetes-sigs/cluster-api/issues/5968

@sbueringer @fabriziopandini 