### PR TITLE
CAPZ: Update milestone plugin for v1.3 release

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -397,12 +397,9 @@ milestone_applier:
     release-0.7: v0.7.x
     release-0.6: v0.6.x
   kubernetes-sigs/cluster-api-provider-azure:
-    main: v1.3
+    main: v1.4
+    release-1.3: v1.3
     release-1.2: v1.2
-    release-1.1: v1.1
-    release-1.0: v1.0
-    release-0.5: v0.5
-    release-0.4: v0.4
   kubernetes-sigs/cluster-api-provider-digitalocean:
     main: v1.1.0
     release-1.0: v1.0.0


### PR DESCRIPTION
Adds v1.4 milestone for the main branch, and keeps the last two minor versions (v1.2 and v1.3) milestones for backports (following discussion in https://kubernetes.slack.com/archives/CEX9HENG7/p1651164689853749) to prepare for the v1.3.0 release.