### PR TITLE
Update README.md to reflect Go version bump from v1.13 to v1.16 in gcloud-in-go image

### DIFF
--- a/images/gcloud-in-go/README.md
+++ b/images/gcloud-in-go/README.md
@@ -5,7 +5,7 @@ Use this image when you want to use `go` and `gcloud` in the same job
 ## contents
 
 - base:
-  - golang:1.13
+  - golang:1.16
 - directories:
   - `/workspace` default working dir for `run` commands
 - languages:


### PR DESCRIPTION
The PR updates the [README.md](https://github.com/jasonbraganza/test-infra/blob/master/images/gcloud-in-go/README.md) file to reflect Go version bump from v1.13 to v1.16 in gcloud-in-go image