### PR TITLE
Add README.md for gcloud-terraform image

### DIFF
--- a/images/gcloud-terraform/README.md
+++ b/images/gcloud-terraform/README.md
@@ -1,0 +1,23 @@
+# gcloud-terraform image
+
+Use this image when you want to use `gcloud` and `terraform` in the same job
+
+## contents
+
+- base:
+  - `gcr.io/k8s-prow/alpine:v20210618-2814345`
+- directories:
+  - `/workspace` default working dir for `run` commands
+- languages:
+  - `python3`
+- tools:
+  - `bash`
+  - `curl` 
+  - `gcloud` installed via rapid channel, components include:
+    - `alpha`
+    - `beta`
+    - `kubectl`
+  - `make`
+  - `rsync`
+  - `terraform` v0.14.9-r1
+  - `wget`


### PR DESCRIPTION
This PR adds a `README.md` for the `gcloud-terraform` image.

Part of issue: https://github.com/kubernetes/test-infra/issues/13129