### PR TITLE
Add README.md for git image

### DIFF
--- a/images/git/README.md
+++ b/images/git/README.md
@@ -1,0 +1,14 @@
+# git image
+
+Use this image when you want to use `git` and `alpine` as base in a job.
+
+## contents
+
+- base:
+  - `gcr.io/k8s-prow/alpine:v20211015-92dc282`
+- directories:
+  - `/github_known_hosts` holds the [`github-known-hosts`](/images/git/github-known-hosts) file copied during image build
+  - `/etc/ssh/ssh_config` contains [`ssh-config`](/images/git/ssh-config) file copied during image build
+- tools:
+  - `git`
+  - `openssh`


### PR DESCRIPTION
This PR adds a `README.md` for the `git` image.

Part of issue: https://github.com/kubernetes/test-infra/issues/13129