### PR TITLE
Merge cert-manager's testgrid config

### DIFF
--- a/config/mergelists/canary.yaml
+++ b/config/mergelists/canary.yaml
@@ -10,3 +10,5 @@ sources:
   location: "gs://kubevirt-prow/testgrid/config"
 - name: "tekton"
   location: "gs://tekton-prow/testgrid/config"
+- name: "cert-manager"
+  location: "gs://jetstack-testgrid/config"

--- a/config/mergelists/prod.yaml
+++ b/config/mergelists/prod.yaml
@@ -10,3 +10,5 @@ sources:
   location: "gs://kubevirt-prow/testgrid/config"
 - name: "tekton"
   location: "gs://tekton-prow/testgrid/config"
+- name: "cert-manager"
+  location: "gs://jetstack-testgrid/config"


### PR DESCRIPTION
We're configuring cert-manager Prow to upload testgrid configs using config merger.
We've [created a  GCP bucket](https://github.com/jetstack/terraform-jetstack/pull/1107) with [read-access from the Kubernetes testgrid service accounts](https://github.com/kubernetes/test-infra/blob/master/testgrid/merging.md)

We're [ironing out some problems](https://github.com/jetstack/testing/issues/673) with the uploading, but once we've got it working this can be reviewed and merged.

Part of: 
 * https://github.com/jetstack/testing/issues/629