### PR TITLE
add DownwardAPIHugePages=true for ci-kubernetes-e2e-gci-gce-serial-ku…

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -663,6 +663,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[sig-storage\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
+      - --node-test-args=--feature-gates=DownwardAPIHugePages=true
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-master
 
 - interval: 6h


### PR DESCRIPTION
…be-dns-nodecache

To fix https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-serial-kube-dns-nodecache/1522104838224089088, this is caused by https://github.com/kubernetes/kubernetes/pull/109649
/cc pohly SergeyKanzhelev

- https://storage.googleapis.com/k8s-triage/index.html#46c6ebec3f62ee000cb3  ci-cri-containerd-e2e-cos-gce-serial
- https://storage.googleapis.com/k8s-triage/index.html#16ae3f774c3255733716  ci-kubernetes-e2e-gci-gce-serial-kube-dns-nodecache ci-kubernetes-e2e-gci-gce-serial-kube-dns
