### PR TITLE
gke: Handle KUBE_TEST_REPO_LIST_DOWNLOAD_LOCATION env var

### DIFF
--- a/kubetest/aksengine.go
+++ b/kubetest/aksengine.go
@@ -1261,29 +1261,7 @@ func (c *aksEngineDeployer) TestSetup() error {
 		}
 	}
 
-	// Download repo-list that defines repositories for Windows test images.
-	downloadUrl, ok := os.LookupEnv("KUBE_TEST_REPO_LIST_DOWNLOAD_LOCATION")
-	if !ok {
-		// Env value for downloadUrl is not set, nothing to do
-		log.Printf("KUBE_TEST_REPO_LIST_DOWNLOAD_LOCATION not set. Using default test image repos.")
-		return nil
-	}
-
-	downloadPath := path.Join(os.Getenv("HOME"), "repo-list")
-	f, err := os.Create(downloadPath)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	log.Printf("downloading %v from %v.", downloadPath, downloadUrl)
-	err = httpRead(downloadUrl, f)
-
-	if err != nil {
-		return fmt.Errorf("url=%s failed get %v: %v.", downloadUrl, downloadPath, err)
-	}
-	f.Chmod(0744)
-	if err := os.Setenv("KUBE_TEST_REPO_LIST", downloadPath); err != nil {
+	if err := initKubeTestRepoList(); err != nil {
 		return err
 	}
 	return nil

--- a/kubetest/gke.go
+++ b/kubetest/gke.go
@@ -566,6 +566,9 @@ func (g *gkeDeployer) TestSetup() error {
 	if err := g.setupEnv(); err != nil {
 		return err
 	}
+	if err := initKubeTestRepoList(); err != nil {
+		return err
+	}
 	g.setup = true
 	return nil
 }

--- a/kubetest/util.go
+++ b/kubetest/util.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path"
 	"regexp"
 	"sort"
 	"strconv"
@@ -347,5 +348,34 @@ func setKubeShhBastionEnv(gcpProject, gcpZone, sshProxyInstanceName string) erro
 		return err
 	}
 	log.Printf("KUBE_SSH_BASTION set to: %v\n", address)
+	return nil
+}
+
+func initKubeTestRepoList() error {
+	// Download repo-list that defines repositories for Windows test images.
+	downloadUrl, ok := os.LookupEnv("KUBE_TEST_REPO_LIST_DOWNLOAD_LOCATION")
+	if !ok {
+		// Env value for downloadUrl is not set, nothing to do
+		log.Printf("KUBE_TEST_REPO_LIST_DOWNLOAD_LOCATION not set. Using default test image repos.")
+		return nil
+	}
+
+	downloadPath := path.Join(os.Getenv("HOME"), "repo-list")
+	f, err := os.Create(downloadPath)
+	if err != nil {
+	        return err
+	}
+	defer f.Close()
+
+	log.Printf("downloading %v from %v.", downloadPath, downloadUrl)
+	err = httpRead(downloadUrl, f)
+
+	if err != nil {
+	        return fmt.Errorf("url=%s failed get %v: %v.", downloadUrl, downloadPath, err)
+	}
+	f.Chmod(0744)
+	if err := os.Setenv("KUBE_TEST_REPO_LIST", downloadPath); err != nil {
+	        return err
+	}
 	return nil
 }


### PR DESCRIPTION
Some Windows tests require different e2e test images, and the repos they're fetched from can be configured by setting the ``KUBE_TEST_REPO_LIST`` env var before running the tests. Some jobs have set presets, having the ``KUBE_TEST_REPO_LIST_DOWNLOAD_LOCATION`` env var, which contains the said repo list. AKS already handles this by downloading the file and setting up the right env variable.

GKE needs to do the same. This is needed for a few GCE Windows test jobs (for example, this is required by the 20h2 jobs: there is a test that tests image pulling from a private registry, and the test needs to be configured to pull from a registry that contains 20h2 Windows images available).