### PR TITLE
Add `RequestedTeams` to github `PullRequest` type

### DIFF
--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -253,6 +253,7 @@ type PullRequest struct {
 	Title              string            `json:"title"`
 	Body               string            `json:"body"`
 	RequestedReviewers []User            `json:"requested_reviewers"`
+	RequestedTeams     []Team            `json:"requested_teams"`
 	Assignees          []User            `json:"assignees"`
 	State              string            `json:"state"`
 	Draft              bool              `json:"draft"`


### PR DESCRIPTION
`requested_teams` is an attribute of github's get pull request(s) response. See https://docs.github.com/en/rest/pulls/pulls#list-pull-requests for documentation. I would like to use the attribute downstream.