### PR TITLE
Mention that fast forwards happen every 6 hours

### DIFF
--- a/prow/plugins/testfreeze/testfreeze.go
+++ b/prow/plugins/testfreeze/testfreeze.go
@@ -38,7 +38,7 @@ const (
 	defaultKubernetesRepoAndOrg = "kubernetes"
 	templateString              = `Please note that we're already in [Test Freeze](https://github.com/kubernetes/sig-release/blob/master/releases/release_phases.md#test-freeze) for the ` + "`{{ .Branch }}`" + ` branch. This means every merged PR will be automatically fast-forwarded via the periodic [ci-fast-forward](https://testgrid.k8s.io/sig-release-releng-blocking#git-repo-kubernetes-fast-forward) job to the release branch of the upcoming {{ .Tag }} release.
 
-The most recent automatic fast forward was: {{ .LastFastForward }}.
+Fast forwards are scheduled to happen every 6 hours, whereas the most recent run was: {{ .LastFastForward }}.
 `
 )
 

--- a/prow/plugins/testfreeze/testfreeze_test.go
+++ b/prow/plugins/testfreeze/testfreeze_test.go
@@ -60,7 +60,7 @@ func TestHandle(t *testing.T) {
 				_, _, _, _, comment := mock.CreateCommentArgsForCall(0)
 				assert.Contains(t, comment, "Please note that we're already")
 				assert.Contains(t, comment, "for the `release-1.23` branch")
-				assert.Contains(t, comment, "The most recent automatic fast forward was: Wed May  4 16:15:37 CEST 2022")
+				assert.Contains(t, comment, "Fast forwards are scheduled to happen every 6 hours, whereas the most recent run was: Wed May  4 16:15:37 CEST 2022")
 			},
 		},
 		{


### PR DESCRIPTION
This is a slight information addition to let users know that we automatically fast forward every 6 hours.

cc @kubernetes/release-engineering 