### PR TITLE
PR History yellow pending and gray aborted

### DIFF
--- a/prow/cmd/deck/template/pr-history.html
+++ b/prow/cmd/deck/template/pr-history.html
@@ -8,6 +8,12 @@
   .run-failure {
     background-color: rgba(255, 0, 0, 0.3);
   }
+  .run-pending {
+    background-color: rgba(255, 255, 0, 0.3);
+  }
+  .run-aborted {
+    background-color: rgba(200, 200, 200, 1.0);
+  }
 </style>
 {{end}}
 {{define "content"}}
@@ -32,7 +38,7 @@
       <tr>
         <td class="mdl-data-table__cell--non-numeric">{{if .Link}}<a href="{{.Link}}">{{.Name}}</a>{{else}}{{.Name}}{{end}}</td>
         {{range .Builds}}
-        <td class="mdl-data-table__cell--non-numeric {{if eq .Result "SUCCESS"}}run-success{{else if eq .Result "FAILURE"}}run-failure{{end}}">{{if .SpyglassLink}}<a href="{{.SpyglassLink}}">{{.ID}}</a>{{else}}{{.ID}}{{end}}</td>
+        <td class="mdl-data-table__cell--non-numeric {{if eq .Result "SUCCESS"}}run-success{{else if eq .Result "FAILURE"}}run-failure{{else if eq .Result "PENDING"}}run-pending{{else if eq .Result "ABORTED"}}run-aborted{{end}}">{{if .SpyglassLink}}<a href="{{.SpyglassLink}}">{{.ID}}</a>{{else}}{{.ID}}{{end}}</td>
         {{end}}
       </tr>
       {{end}}


### PR DESCRIPTION
The PR history page only had colors for SUCCESS and FAILURE, the rest
were defaulted to white. This commit should make it so that pending
and aborted jobs would have the yellow and gray colors, respectively,
exactly like in the Job history page.