### PR TITLE
Gencred expiration date set to seconds instead of days

### DIFF
--- a/gencred/README.md
+++ b/gencred/README.md
@@ -22,7 +22,7 @@ The following is a list of supported options for the `gencred` CLI. All options 
   -o, --output string    Output path for generated kubeconfig file. (default "/dev/stdout")
       --overwrite        Overwrite (rather than merge) output file if exists.
   -s, --serviceaccount   Authorize with a service account. (default true)
-  -d, --duration         How many days the cred is valid. (default 7)
+  -d, --duration         How many seconds the cred is valid. (default 7)
 ```
 
 Create a kubeconfig entry with context name `mycluster` using `serviceaccount` authorization and output to a file `config.yaml`.

--- a/gencred/cmd/gencred/main.go
+++ b/gencred/cmd/gencred/main.go
@@ -39,7 +39,8 @@ const (
 	defaultContextName = "build"
 	// defaultConfigFileName is the default kubeconfig filename.
 	defaultConfigFileName = "/dev/stdout"
-	defaultDurationInDays = 7
+	// Two days. This is the largest allowed value for token expiration.
+	defaultDurationInDays = 172800
 )
 
 // options are the available command-line flags.
@@ -49,7 +50,7 @@ type options struct {
 	output         string
 	certificate    bool
 	serviceaccount bool
-	duration       int
+	duration       int64
 	overwrite      bool
 }
 
@@ -60,7 +61,7 @@ func (o *options) parseFlags() {
 	flag.StringVarP(&o.output, "output", "o", defaultConfigFileName, "Output path for generated kubeconfig file.")
 	flag.BoolVarP(&o.certificate, "certificate", "c", false, "Authorize with a client certificate and key.")
 	flag.BoolVarP(&o.serviceaccount, "serviceaccount", "s", false, "Authorize with a service account.")
-	flag.IntVar(&o.duration, "duration", defaultDurationInDays, "How many days the cred is valid, default is 7.")
+	flag.Int64Var(&o.duration, "duration", defaultDurationInDays, "How many seconds the cred is valid, default is 172800, can only set to be lower than the default.")
 	flag.BoolVar(&o.overwrite, "overwrite", false, "Overwrite (rather than merge) output file if exists.")
 
 	flag.Parse()

--- a/gencred/pkg/serviceaccount/serviceaccount_test.go
+++ b/gencred/pkg/serviceaccount/serviceaccount_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestCreateClusterServiceAccountCredentials(t *testing.T) {
+	var expirationDuration int64 = 7
 	tests := []struct {
 		name         string
 		createClient func() kubernetes.Interface
@@ -79,6 +80,9 @@ func TestCreateClusterServiceAccountCredentials(t *testing.T) {
 						Status: authenticationv1.TokenRequestStatus{
 							Token: "abc",
 						},
+						Spec: authenticationv1.TokenRequestSpec{
+							ExpirationSeconds: &expirationDuration,
+						},
 					}
 					return true, r, nil
 				})
@@ -99,7 +103,7 @@ func TestCreateClusterServiceAccountCredentials(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			client := test.createClient()
-			_, _, err := CreateClusterServiceAccountCredentials(client, 7)
+			_, _, err := CreateClusterServiceAccountCredentials(client, expirationDuration)
 			success := err == nil
 
 			if success != test.expected {


### PR DESCRIPTION
As tested manually, that the largest allowed expiration duration for the generated token is 48 hours, so it doesn't make much sense to set expiration date on the scale of days.

