### PR TITLE
Create build cluster script uses old binary

### DIFF
--- a/prow/create-build-cluster.sh
+++ b/prow/create-build-cluster.sh
@@ -235,14 +235,17 @@ function gencreds() {
   local outfile="${OUT_FILE}"
 
   cd "${ROOT_DIR}"
-  # Cred created will expire in 10 years. If we still don't have a better
-  # solution than permaneng cred for accessing a build cluster then we can
-  # consider us failed.
-  go run ./gencred --context="$(kubectl config current-context)" --name="${clusterAlias}" --output="${origdir}/${outfile}" --duration=3650 || (
+  # TODO(chaodai): remove git checkout line after
+  # https://github.com/kubernetes/test-infra/issues/25993 is fixed.
+  # TLDR: https://github.com/kubernetes/test-infra/pull/25873 potentially caused
+  # regression of short-lived kubeconfig being generated.
+  git checkout 799656f1600a4cc5d2ee8d41487365913aaf3622
+  go run ./gencred --context="$(kubectl config current-context)" --name="${clusterAlias}" --output="${origdir}/${outfile}" || (
     echo "gencred failed:" >&2
     cat "$origdir/$outfile" >&2
     return 1
   )
+  git checkout master
 
   # Store kubeconfig secret in the same project where build cluster is located
   # and set up externalsecret in prow service cluster so that it's synced.


### PR DESCRIPTION
Gencred was updated to work with v1 API, and the generated token is only valid for up to 2 days. This doesn't quite work with how build clusters work with prow. Temporarily pinning the version of gencred before a better solution is introduced

/cc @cjwagner 