### PR TITLE
Add apidiff pre-submit for CAPV

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -79,6 +79,21 @@ presets:
 
 presubmits:
   kubernetes-sigs/cluster-api-provider-vsphere:
+  - name: pull-cluster-api-provider-vsphere-apidiff-main
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-1.23
+          command:
+          - hack/ci-apidiff.sh
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      testgrid-tab-name: pr-apidiff
+      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      description: Checks for API changes in the PR
+
   - name: pull-cluster-api-provider-vsphere-verify-lint
     always_run: false
     run_if_changed: '^((api|cmd|config|contrib|controllers|pkg)/|Makefile|hack/check-lint\.sh)'


### PR DESCRIPTION
This PR adds a new pre-submit job to run apidiff on CAPV's PRs.

For more context: 
- kubernetes-sigs/cluster-api-provider-vsphere#1445
- kubernetes-sigs/cluster-api-provider-vsphere#1525
- kubernetes-sigs/cluster-api-provider-vsphere#1527

Signed-off-by: Tushar <ditsuke@protonmail.com>
