### PR TITLE
Gencred supports running continuously, and store output in GSM

### DIFF
--- a/gencred/cmd/gencred/main_test.go
+++ b/gencred/cmd/gencred/main_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package gencred
 
 import (
+	"io/ioutil"
 	"os"
+	"path"
 	"testing"
 
 	"github.com/spf13/pflag"
@@ -27,6 +29,7 @@ func TestValidateFlags(t *testing.T) {
 	tests := []struct {
 		name        string
 		args        []string
+		config      string
 		errExpected bool
 	}{
 		{
@@ -59,6 +62,45 @@ func TestValidateFlags(t *testing.T) {
 			args:        []string{"--output=/tmp"},
 			errExpected: true,
 		},
+		{
+			name: "config",
+			config: `clusters:
+- context: foo
+  name: bar
+`,
+			errExpected: false,
+		},
+		{
+			name: "config-with-gkeconnection",
+			config: `clusters:
+- gke: somewhere/something
+  name: bar
+`,
+			errExpected: false,
+		},
+		{
+			name: "config-missing-context",
+			config: `clusters:
+- name: bar
+`,
+			errExpected: true,
+		},
+		{
+			name: "config-missing-name",
+			config: `clusters:
+- context: foo
+`,
+			errExpected: true,
+		},
+		{
+			name: "mix-config-with-global",
+			args: []string{"--context=test-context", "--name=test-name"},
+			config: `clusters:
+- context: foo
+  name: bar
+`,
+			errExpected: true,
+		},
 	}
 
 	for _, test := range tests {
@@ -68,10 +110,21 @@ func TestValidateFlags(t *testing.T) {
 			os.Args = []string{"gencred"}
 			pflag.CommandLine = pflag.NewFlagSet(os.Args[0], pflag.ContinueOnError)
 			os.Args = append(os.Args, test.args...)
+
+			if len(test.config) > 0 {
+				tmpDir := t.TempDir()
+				tmpFile := path.Join(tmpDir, test.name+".yaml")
+				if err := ioutil.WriteFile(tmpFile, []byte(test.config), 0644); err != nil {
+					t.Fatalf("Failed writing tmp file: %v", err)
+				}
+				os.Args = append(os.Args, "--config="+tmpFile)
+			}
+
 			o.parseFlags()
 
-			if hasErr := o.validateFlags() != nil; hasErr != test.errExpected {
-				t.Errorf("expected err: %t but was %t", test.errExpected, hasErr)
+			_, gotErr := o.defaultAndValidateFlags()
+			if hasErr := (gotErr != nil); hasErr != test.errExpected {
+				t.Errorf("expected err: %t but was %v", test.errExpected, gotErr)
 			}
 		})
 	}

--- a/gencred/pkg/secretmanager/secretmanager.go
+++ b/gencred/pkg/secretmanager/secretmanager.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secretmanager
+
+import (
+	"context"
+	"fmt"
+
+	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	"google.golang.org/api/iterator"
+	secretmanagerpb "google.golang.org/genproto/googleapis/cloud/secretmanager/v1"
+)
+
+// Client is a wrapper of secretmanager client
+type Client struct {
+	// ProjectID is GCP project in which to store secrets in Secret Manager.
+	ProjectID string
+	client    *secretmanager.Client
+	dryrun    bool
+}
+
+// ClientInterface is the interface for manipulating secretmanager
+type ClientInterface interface {
+	CreateSecret(ctx context.Context, secretID string) (*secretmanagerpb.Secret, error)
+	AddSecretVersion(ctx context.Context, secretName string, payload []byte) error
+	ListSecrets(ctx context.Context) ([]*secretmanagerpb.Secret, error)
+}
+
+// NewClient creates a client for secretmanager, it would fail if not authenticated
+func NewClient(projectID string, dryrun bool) (*Client, error) {
+	// Create the client.
+	ctx := context.Background()
+	client, err := secretmanager.NewClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup client: %w", err)
+	}
+	return &Client{ProjectID: projectID, client: client, dryrun: dryrun}, nil
+}
+
+// CreateSecret creates a secret
+func (c *Client) CreateSecret(ctx context.Context, secretID string) (*secretmanagerpb.Secret, error) {
+	if c.dryrun {
+		return nil, nil
+	}
+	// Create the request to create the secret.
+	createSecretReq := &secretmanagerpb.CreateSecretRequest{
+		Parent:   fmt.Sprintf("projects/%s", c.ProjectID),
+		SecretId: secretID,
+		Secret: &secretmanagerpb.Secret{
+			Replication: &secretmanagerpb.Replication{
+				Replication: &secretmanagerpb.Replication_Automatic_{
+					Automatic: &secretmanagerpb.Replication_Automatic{},
+				},
+			},
+		},
+	}
+
+	return c.client.CreateSecret(ctx, createSecretReq)
+}
+
+// AddSecretVersion adds a secret version, aka update the value of a secret
+func (c *Client) AddSecretVersion(ctx context.Context, secretName string, payload []byte) error {
+	if c.dryrun {
+		return nil
+	}
+	// Build the request.
+	addSecretVersionReq := &secretmanagerpb.AddSecretVersionRequest{
+		Parent: fmt.Sprintf("projects/%s/secrets/%s", c.ProjectID, secretName),
+		Payload: &secretmanagerpb.SecretPayload{
+			Data: payload,
+		},
+	}
+
+	// Call the API.
+	_, err := c.client.AddSecretVersion(ctx, addSecretVersionReq)
+	return err
+}
+
+// ListSecrets lists all secrets under current project
+func (c *Client) ListSecrets(ctx context.Context) ([]*secretmanagerpb.Secret, error) {
+	var res []*secretmanagerpb.Secret
+	// Build the request.
+	listRequest := &secretmanagerpb.ListSecretsRequest{
+		Parent: fmt.Sprintf("projects/%s", c.ProjectID),
+	}
+
+	// Call the API.
+	it := c.client.ListSecrets(ctx, listRequest)
+	for {
+		s, err := it.Next()
+		if err != nil {
+			if err == iterator.Done {
+				break
+			}
+			return nil, err
+		}
+		res = append(res, s)
+	}
+	return res, nil
+}

--- a/gencred/pkg/serviceaccount/serviceaccount_test.go
+++ b/gencred/pkg/serviceaccount/serviceaccount_test.go
@@ -18,6 +18,7 @@ package serviceaccount
 
 import (
 	"testing"
+	"time"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
 	authorizationv1 "k8s.io/api/authorization/v1"
@@ -99,7 +100,7 @@ func TestCreateClusterServiceAccountCredentials(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			client := test.createClient()
-			_, _, err := CreateClusterServiceAccountCredentials(client, 7)
+			_, _, err := CreateClusterServiceAccountCredentials(client, metav1.Duration{Duration: 2 * 24 * time.Hour})
 			success := err == nil
 
 			if success != test.expected {


### PR DESCRIPTION
Gencred can now only generate kubeconfig valid for up to two days, this means newly onboarded build cluster would stop working in two days. Extending the capability of gencred to allow it rotating the kubeconfig

Part of: https://github.com/kubernetes/test-infra/issues/25993

/cc @cjwagner 
