### PR TITLE
Fix failure in pull-kubernetes-conformance-image-test with new registry

### DIFF
--- a/experiment/kind-conformance-image-e2e.sh
+++ b/experiment/kind-conformance-image-e2e.sh
@@ -142,7 +142,8 @@ run_tests() {
 
   # build and load the conformance image into the kind nodes
   make build ARCH=amd64
-  kind load docker-image k8s.gcr.io/conformance-amd64:${VERSION}
+  kind load docker-image k8s.gcr.io/conformance-amd64:${VERSION} ||
+      kind load docker-image registry.k8s.io/conformance-amd64:${VERSION}
 
   # patch the image in manifest
   sed -i "s|conformance-amd64:.*|conformance-amd64:${VERSION}|g" conformance-e2e.yaml


### PR DESCRIPTION
Context for PR: https://github.com/kubernetes/kubernetes/pull/109938
Context for logs : https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/109938/pull-kubernetes-conformance-image-test/1524008161281839104/

failure snippet:
```
W0510 13:07:49.582] ++ kind load docker-image k8s.gcr.io/conformance-amd64:v1.25.0-alpha.0.395
W0510 13:07:49.661] ERROR: image: "k8s.gcr.io/conformance-amd64:v1.25.0-alpha.0.395" not present locally
```

When we move to the new registry we should still go green on the job. for this, look for the older image first and then the newer image if the older one is absent


Signed-off-by: Davanum Srinivas <davanum@gmail.com>