### PR TITLE
Use AKS provider

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
@@ -42,7 +42,7 @@ presubmits:
               cd ${GOPATH}/src/k8s.io/perf-tests/clusterloader2 &&
               go run cmd/clusterloader.go
               --testconfig=testing/windows-tests/config.yaml
-              --provider=skeleton
+              --provider=aks
               --report-dir=${REPORTS_DIR}
               --v=2
           securityContext:
@@ -61,6 +61,10 @@ presubmits:
               value: "kubernetes.io/azure-disk"
             - name: PROMETHEUS_STORAGE_CLASS_VOLUME_TYPE
               value: "StandardSSD_LRS"
+            - name: PROMETHEUS_SCRAPE_APISERVER_ONLY
+              value: "true"
+            - name: PROMETHEUS_APISERVER_SCRAPE_PORT
+              value: "6443"
             - name: PROMETHEUS_SCRAPE_WINDOWS_NODE_EXPORTER
               value: "true"
             - name: REPORTS_DIR


### PR DESCRIPTION
- Use AKS provider for soak tests
- Change default scrape port for APISERVER
- Scrape only APISERVER from control-plane nodes

depends on https://github.com/kubernetes/perf-tests/pull/2051
depends on https://github.com/kubernetes/perf-tests/pull/2061

/sig-windows