### PR TITLE
switch to cronjob v1 for scalability testing

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -229,7 +229,7 @@ presets:
       core/v1/Secret
       core/v1/Service
       batch/v1/Job
-      batch/v1beta1/CronJob
+      batch/v1/CronJob
       apps/v1/DaemonSet
       apps/v1/Deployment
       apps/v1/ReplicaSet


### PR DESCRIPTION
found in https://github.com/kubernetes/kubernetes/pull/108797

v1beta1 is removed in 1.25 after many releases of deprecation.