### PR TITLE
bump containerd version used in the CI jobs

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -248,7 +248,7 @@ presubmits:
             - --
             - --build=quick
             - --cluster=
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0
+            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.4
             - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -307,7 +307,7 @@ presubmits:
             - --
             - --build=quick
             - --cluster=
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0
+            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.4
             - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -439,7 +439,7 @@ periodics:
           - --scenario=kubernetes_e2e
           - --
           - --check-leaked-resources
-          - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0
+          - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.4
           - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
           - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
           - --env=CONTAINER_RUNTIME_TEST_HANDLER=true

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -38,7 +38,7 @@ presubmits:
         - --build=quick
         - --extract=local
         - --env=ALLOW_PRIVILEGED=true
-        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.4
         - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -105,7 +105,7 @@ presubmits:
         - --env=ALLOW_PRIVILEGED=true
         - --env=NETWORK_POLICY_PROVIDER=calico
         - --env=KUBE_FEATURE_GATES=NetworkPolicyEndPort=true
-        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.4
         - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -174,7 +174,7 @@ presubmits:
         args:
         - --build=quick
         - --env=ALLOW_PRIVILEGED=true
-        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.4
         - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -681,7 +681,7 @@ periodics:
       - --env=ALLOW_PRIVILEGED=true
       - --env=NETWORK_POLICY_PROVIDER=calico
       - --env=KUBE_FEATURE_GATES=NetworkPolicyEndPort=true
-      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0
+      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.4
       - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
       - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
       - --env=CONTAINER_RUNTIME_TEST_HANDLER=true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.24.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.24.yaml
@@ -804,7 +804,7 @@ presubmits:
         - --
         - --build=quick
         - --cluster=
-        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.4
         - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --env=CONTAINER_RUNTIME_TEST_HANDLER=true

--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -182,7 +182,7 @@ presubmits:
         - --gcp-node-image=ubuntu
         - --image-family=ubuntu-2004-lts
         - --image-project=ubuntu-os-cloud
-        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.4
         - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
         - --gcp-zone=us-west1-b
         - --provider=gce
@@ -229,7 +229,7 @@ presubmits:
         - --gcp-node-image=ubuntu
         - --image-family=ubuntu-2004-lts
         - --image-project=ubuntu-os-cloud
-        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.4
         - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
         - --gcp-zone=us-west1-b
         - --provider=gce
@@ -303,7 +303,7 @@ periodics:
       - --gcp-node-image=ubuntu
       - --image-family=ubuntu-2004-lts
       - --image-project=ubuntu-os-cloud
-      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0
+      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.4
       - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
       - --gcp-zone=us-west1-b
       - --provider=gce
@@ -331,7 +331,7 @@ periodics:
       - --gcp-node-image=ubuntu
       - --image-family=ubuntu-2004-lts
       - --image-project=ubuntu-os-cloud
-      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.0
+      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.6.4
       - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.0
       - --gcp-zone=us-west1-b
       - --provider=gce


### PR DESCRIPTION
containerd 1.6.4 was released 7 days ago with 2 notable updates
- fixed the go-cni regresion
- fixed broken selinux relabeling

https://github.com/containerd/containerd/releases/tag/v1.6.4

We should use the latest version the ci