### PR TITLE
Build gencred as part of prow images

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -43,6 +43,7 @@ baseImageOverrides:
   k8s.io/test-infra/robots/pr-creator: gcr.io/k8s-prow/git:v20220215-ddc3ad9
   k8s.io/test-infra/testgrid/cmd/transfigure: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:v20210128-721ee66-test-infra
   k8s.io/test-infra/gcsweb/cmd/gcsweb: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
+  k8s.io/test-infra/gencred: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
   # prow integration test
   k8s.io/test-infra/prow/test/integration/fakeghserver: gcr.io/k8s-prow/alpine:v20200713-e9b3d9d
 

--- a/prow/.prow-images.yaml
+++ b/prow/.prow-images.yaml
@@ -45,3 +45,4 @@ images:
   - dir: testgrid/cmd/configurator
   - dir: testgrid/cmd/transfigure
   - dir: gcsweb/cmd/gcsweb
+  - dir: gencred


### PR DESCRIPTION
So that gencred can be used in deployments or prow jobs. This is required for automatically rotating generated kubeconfigs

A little context: the gencred generated kubeconfigs expire in at most two days, will need something to rotate the kubeconfigs so that prow can keep working with build clusters

/cc @cjwagner @alvaroaleman 