### PR TITLE
removed DIND

### DIFF
--- a/config/jobs/kubernetes/sig-network/ingress-nginx/ingress-nginx-periodics-main.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-nginx/ingress-nginx-periodics-main.yaml
@@ -14,7 +14,6 @@ periodics:
   skip_submodules: true
   labels:
     preset-kind-volume-mounts: "true"
-    preset-dind-enabled: "true"
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/krte:v20220427-c2db0f69b7-master


### PR DESCRIPTION
DIND is breaking testgrid jobs for ingress-nginx. Details below ;

https://github.com/kubernetes/ingress-nginx/issues/8552
https://github.com/kubernetes/kubernetes/issues/109912
https://github.com/kubernetes/ingress-nginx/pull/8569

If just removing the DIND makes the test pass then ok. Otherwise will change periodicity of job to enable debugging at will.

/assign @rikatz 