### PR TITLE
1.24 will be the last supported release for 20H2

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-sac.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-sac.yaml
@@ -1,6 +1,6 @@
 periodics:
 - interval: 24h
-  name: ci-kubernetes-e2e-aks-engine-azure-master-windows-20h2-containerd
+  name: ci-kubernetes-e2e-aks-engine-azure-1-24-windows-20h2-containerd
   decorate: true
   decoration_config:
     timeout: 3h
@@ -15,11 +15,11 @@ periodics:
   extra_refs:
   - org: kubernetes
     repo: kubernetes
-    base_ref: master
+    base_ref: release-1.24
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-1.24
       command:
       - runner.sh
       - kubetest
@@ -52,11 +52,11 @@ periodics:
         privileged: true
   annotations:
     testgrid-dashboards: sig-windows-sac
-    testgrid-tab-name: aks-engine-windows-20h2-containerd-master
+    testgrid-tab-name: aks-engine-windows-20h2-containerd-1.24
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
 - interval: 48h
-  name: ci-kubernetes-e2e-aks-engine-azure-master-windows-20h2-containerd-serial-slow
+  name: ci-kubernetes-e2e-aks-engine-azure-1-24-windows-20h2-containerd-serial-slow
   decorate: true
   decoration_config:
     timeout: 5h
@@ -71,11 +71,11 @@ periodics:
   extra_refs:
   - org: kubernetes
     repo: kubernetes
-    base_ref: master
+    base_ref: release-1.24
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-1.24
       command:
       - runner.sh
       - kubetest
@@ -107,6 +107,6 @@ periodics:
         privileged: true
   annotations:
     testgrid-dashboards: sig-windows-sac
-    testgrid-tab-name: aks-engine-windows-20h2-containerd-serial-slow-master
+    testgrid-tab-name: aks-engine-windows-20h2-containerd-serial-slow-1.24
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs serial Windows tests on a Kubernetes cluster running containerd provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud


### PR DESCRIPTION
kubernetes 1.24 will be the last release that will support Windows 20H2 SAC which has an [EOL in August](https://docs.microsoft.com/en-us/windows-server/get-started/windows-server-release-info) before the release of [1.25](https://github.com/kubernetes/sig-release/tree/master/releases/release-1.25). 

This will the test for 1.24 branch as aks-engine will not support 1.25 and the tests are [currently failing](https://github.com/kubernetes/kubernetes/issues/109908).

/sig windows 
/assign @marosset 