### PR TITLE
provider-openstack: stop use bazel remote cache

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-master-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-master-config.yaml
@@ -3,8 +3,6 @@ presubmits:
   - name: openstack-cloud-controller-manager-e2e-test
     labels:
       preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
@@ -38,8 +36,6 @@ presubmits:
   # - name: openstack-cloud-controller-manager-e2e-conformance-test
   #   labels:
   #     preset-service-account: "true"
-  #     preset-bazel-scratch-dir: "true"
-  #     preset-bazel-remote-cache-enabled: "true"
   #     preset-dind-enabled: "true"
   #     preset-kind-volume-mounts: "true"
   #   path_alias: "k8s.io/cloud-provider-openstack"
@@ -73,8 +69,6 @@ presubmits:
   - name: openstack-cloud-csi-cinder-e2e-test
     labels:
       preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
@@ -108,8 +102,6 @@ presubmits:
   - name: openstack-cloud-csi-manila-e2e-test
     labels:
       preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
@@ -181,8 +173,6 @@ presubmits:
   - name: openstack-cloud-keystone-authentication-authorization-test
     labels:
       preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.23-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.23-config.yaml
@@ -22,8 +22,6 @@ presubmits:
   - name: openstack-cloud-controller-manager-e2e-test-release-123
     labels:
       preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
@@ -57,8 +55,6 @@ presubmits:
   - name: openstack-cloud-csi-cinder-e2e-test-release-123
     labels:
       preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
@@ -92,8 +88,6 @@ presubmits:
   - name: openstack-cloud-csi-manila-e2e-test-release-123
     labels:
       preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"


### PR DESCRIPTION
Related:
  - https://github.com/kubernetes/test-infra/issues/24247

Followup of:
   - https://github.com/kubernetes/test-infra/pull/26021

Stop bazel cache for job execution.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>