### PR TITLE
cherrypicker better support for cherry-pick within a cherry-pick PR

### DIFF
--- a/prow/external-plugins/cherrypicker/server_test.go
+++ b/prow/external-plugins/cherrypicker/server_test.go
@@ -495,6 +495,152 @@ func testCherryPickPR(clients localgit.Clients, t *testing.T) {
 	}
 }
 
+func TestCherryPickOfCherryPickPR(t *testing.T) {
+	t.Parallel()
+	testCherryPickOfCherryPickPR(localgit.New, t)
+}
+
+func TestCherryPickOfCherryPickPRV2(t *testing.T) {
+	t.Parallel()
+	testCherryPickOfCherryPickPR(localgit.NewV2, t)
+}
+
+// testCherryPickOfCherryPickPR checks that the omitBaseBranchFromTitle
+// function works as intended when the user performs a cherry-pick from
+// a branch that's already a cherry-pick branch
+func testCherryPickOfCherryPickPR(clients localgit.Clients, t *testing.T) {
+	lg, c, err := clients()
+	if err != nil {
+		t.Fatalf("Making localgit: %v", err)
+	}
+	defer func() {
+		if err := lg.Clean(); err != nil {
+			t.Errorf("Cleaning up localgit: %v", err)
+		}
+		if err := c.Clean(); err != nil {
+			t.Errorf("Cleaning up client: %v", err)
+		}
+	}()
+	if err := lg.MakeFakeRepo("foo", "bar"); err != nil {
+		t.Fatalf("Making fake repo: %v", err)
+	}
+	if err := lg.AddCommit("foo", "bar", initialFiles); err != nil {
+		t.Fatalf("Adding initial commit: %v", err)
+	}
+	expectedBranches := []string{"release-1.5", "release-1.6", "release-1.8"}
+	for _, branch := range expectedBranches {
+		if err := lg.CheckoutNewBranch("foo", "bar", branch); err != nil {
+			t.Fatalf("Checking out pull branch: %v", err)
+		}
+	}
+
+	ghc := &fghc{
+		orgMembers: []github.TeamMember{
+			{
+				Login: "approver",
+			},
+		},
+		prComments: []github.IssueComment{
+			{
+				User: github.User{
+					Login: "approver",
+				},
+				Body: "/cherrypick release-1.8",
+			},
+		},
+		prs: []github.PullRequest{},
+		isMember: true,
+		patch:    patch,
+	}
+
+	pr := github.PullRequestEvent{
+		Action: github.PullRequestActionClosed,
+		PullRequest: github.PullRequest{
+			Base: github.PullRequestBranch{
+				Ref: "master",
+				Repo: github.Repo{
+					Owner: github.User{
+						Login: "foo",
+					},
+					Name: "bar",
+				},
+			},
+			Number:   2,
+			Merged:   true,
+			MergeSHA: new(string),
+			Title:    "This is a fix for Y",
+		},
+	}
+
+	botUser := &github.UserData{Login: "ci-robot", Email: "ci-robot@users.noreply.github.com"}
+
+	getSecret := func() []byte {
+		return []byte("sha=abcdefg")
+	}
+
+	s := &Server{
+		botUser:        botUser,
+		gc:             c,
+		push:           func(forkName, newBranch string, force bool) error { return nil },
+		ghc:            ghc,
+		tokenGenerator: getSecret,
+		log:            logrus.StandardLogger().WithField("client", "cherrypicker"),
+		repos:          []github.Repo{{Fork: true, FullName: "ci-robot/bar"}},
+
+		prowAssignments: false,
+	}
+
+	// Cherry pick master -> release-1.8
+	if err := s.handlePullRequest(logrus.NewEntry(logrus.StandardLogger()), pr); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Cherry pick release-1.8 -> release-1.6
+	pr.PullRequest.Base.Ref = "release-1.8"
+	pr.PullRequest.Title = "[release-1.8] This is a fix for Y"
+	ghc.prComments[0].Body = "/cherrypick release-1.6"
+	if err := s.handlePullRequest(logrus.NewEntry(logrus.StandardLogger()), pr); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Cherry pick release-1.6 -> release-1.5
+	pr.PullRequest.Base.Ref = "release-1.6"
+	pr.PullRequest.Title = "[release-1.6] This is a fix for Y"
+	ghc.prComments[0].Body = "/cherrypick release-1.5"
+	if err := s.handlePullRequest(logrus.NewEntry(logrus.StandardLogger()), pr); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var expectedFn = func(branch string) string {
+		expectedTitle := fmt.Sprintf("[%s] This is a fix for Y", branch)
+		expectedBody := "This is an automated cherry-pick of #2"
+		expectedHead := fmt.Sprintf(botUser.Login+":"+cherryPickBranchFmt, 2, branch)
+		expectedLabels := s.labels
+		return fmt.Sprintf(expectedFmt, expectedTitle, expectedBody, expectedHead, branch, expectedLabels)
+	}
+
+	if len(ghc.prs) != len(expectedBranches) {
+		t.Fatalf("Expected %d PRs, got %d", len(expectedBranches), len(ghc.prs))
+	}
+
+	expectedPrs := make(map[string]string)
+	for _, branch := range expectedBranches {
+		expectedPrs[expectedFn(branch)] = branch
+	}
+	seenBranches := make(map[string]struct{})
+	for _, p := range ghc.prs {
+		pr := prToString(p)
+		branch, present := expectedPrs[pr]
+		if !present {
+			t.Errorf("Unexpected PR:\n%s\nExpected to target one of the following branches: %v\n", pr, expectedBranches)
+		}
+		seenBranches[branch] = struct{}{}
+	}
+	if len(seenBranches) != len(expectedBranches) {
+		t.Fatalf("Expected to see PRs for %d branches, got %d (%v)", len(expectedBranches), len(seenBranches), seenBranches)
+	}
+}
+
 func TestCherryPickPRWithLabels(t *testing.T) {
 	t.Parallel()
 	testCherryPickPRWithLabels(localgit.New, t)
@@ -809,13 +955,13 @@ func TestHandleLocks(t *testing.T) {
 
 	go func() {
 		defer close(routine1Done)
-		if err := s.handle(l, "", &github.IssueComment{}, "org", "repo", "targetBranch", "title", "body", 0); err != nil {
+		if err := s.handle(l, "", &github.IssueComment{}, "org", "repo", "targetBranch", "baseBranch", "title", "body", 0); err != nil {
 			t.Errorf("routine failed: %v", err)
 		}
 	}()
 	go func() {
 		defer close(routine2Done)
-		if err := s.handle(l, "", &github.IssueComment{}, "org", "repo", "targetBranch", "title", "body", 0); err != nil {
+		if err := s.handle(l, "", &github.IssueComment{}, "org", "repo", "targetBranch", "baseBranch", "title", "body", 0); err != nil {
 			t.Errorf("routine failed: %v", err)
 		}
 	}()


### PR DESCRIPTION
# Change tl;dr

Avoid creating very long titles when doing a cherry-pick of a
cherry-pick

# Motivation

In OpenShift repositories it's easier to cherry-pick to multiple
versions "serially" rather than all from the main PR. What I mean by
that is that we first `/cherry-pick X` in the master branch PR, then
once a new cherry pick PR is created for the X branch, we submit another
`/cherry-pick X-1` comment in the X PR, rather than in the master PR. We
do that because we have another bot that handles a lot of boring
BugZilla work automatically for us, and it's crucial for that bot that
those cherry-picks happen serially.

This almost works OK, except for a small issue with the PR titles that
this commit aims to fix.

# The issue

When asking the bot to do a cherry-pick when already in a branch that
was created (and more importantly, titled) by the bot, the new
cherry-pick PR will have a title with a target branch indicator
containing both the indicator of the original cherry-pick, and of
the target branch of the new cherry-pick. This is undesired as
a sequence of cherry-pick would create ever-growing titles unless
the user manually trims the titles to remove older indicators.

Here is an example demonstrating the issue:
```
Original PR title: "Hello world"
Backport to release-9.9 title: "[release-9.9] Hello world"
Backport to release-9.8 title: "[release-9.8] [release-9.9] Hello world"
```

And here is how it would look like after the fix:
```
Original PR title: "Hello world"
Backport to release-9.9 title: "[release-9.9] Hello world"
Backport to release-9.8 title: "[release-9.8] Hello world"
```

# The fix

See the comment above `omitBaseBranchFromTitle` for details, but in
short, when creating the title for a cherry-pick, we should also
consider the target branch of the PR the cherry-pick comment originated
from (henceforth "Base branch").

We then make sure, when creating the title for the new cherry-pick PR,
to remove the existing `[base branch] ` indicator, if one exists, so
that when we add `[cherry-pick branch] ` it would be the only indicator.