### PR TITLE
🌱 Change running apidiff job to optional

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -81,6 +81,7 @@ presubmits:
   kubernetes-sigs/cluster-api-provider-vsphere:
   - name: pull-cluster-api-provider-vsphere-apidiff-main
     always_run: true
+    optional: true
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:


### PR DESCRIPTION
This PR changes the config of the presubmit job `pull-cluster-api-provider-vsphere-apidiff-main` and sets `optional` to true which ensures that the PR merge is not blocked on this job