### PR TITLE
add an optional ingress-nginx job to run against latest kind

### DIFF
--- a/config/jobs/kubernetes/sig-network/ingress-nginx/ingress-nginx-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-nginx/ingress-nginx-presubmit.yaml
@@ -149,6 +149,35 @@ presubmits:
       testgrid-dashboards: sig-network-ingress-nginx
       testgrid-tab-name: test
 
+  - name: pull-ingress-nginx-e2e-main
+    always_run: false
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    max_concurrency: 5
+    path_alias: k8s.io/ingress-nginx
+    #run_if_changed: '\.go$|^rootfs/'
+    labels:
+      preset-kind-volume-mounts: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/krte:v20220427-c2db0f69b7-master
+        command:
+          - wrapper.sh
+          - bash
+          - -c
+          - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && make kind-e2e-test
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        env:
+        - name: REPO_INFO
+          value: https://github.com/kubernetes/ingress-nginx
+    annotations:
+      testgrid-dashboards: sig-network-ingress-nginx
+      testgrid-tab-name: e2e-main
+
   - name: pull-ingress-nginx-e2e-1-16
     always_run: false
     decorate: true


### PR DESCRIPTION
the other jobs in presubmit has the Kind image pinned, I don't know exactly the logic in the ingress-nginx makefile, but this is exactly the same as the periodic

