### PR TITLE
Return reasonable slug when using CreateTeam in dry mode

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -3593,6 +3593,8 @@ func (c *client) CreateTeam(org string, team Team) (*Team, error) {
 	if c.fake {
 		return nil, nil
 	} else if c.dry {
+		// When in dry mode we need a believable slug to call corresponding methods for this team
+		team.Slug = strings.ToLower(strings.ReplaceAll(team.Name, " ", "-"))
 		return &team, nil
 	}
 	path := fmt.Sprintf("/orgs/%s/teams", org)


### PR DESCRIPTION
When `CreateTeam` is used in dry mode we need to return a reasonable slug so that the team can be used with subsequent `client` methods. This was surfaced when a child team was newly added to knative's peribolos config, and the config was ran with `confirm=false`. After the team was created `EditTeam` was called, but since the team had no slug (normally returned from github when making the API call to create the team) it errored.

Closes https://github.com/kubernetes/test-infra/issues/26234