### PR TITLE
Disable `ci-cri-containerd-e2e-cos-gce-alpha-features` temporarily

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -449,35 +449,36 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-cos
     testgrid-tab-name: e2e-cos
-- interval: 2h
-  name: ci-cri-containerd-e2e-cos-gce-alpha-features
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-    preset-e2e-containerd: "true"
-    preset-e2e-containerd-image-load: "true"
-  spec:
-    containers:
-    - args:
-      - --repo=github.com/containerd/containerd=main
-      - --timeout=200
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=false
-      - --env=KUBE_PROXY_DAEMONSET=true
-      - --env=ENABLE_POD_PRIORITY=true
-      - --extract=ci/latest
-      - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
-      - --provider=gce
-      - --runtime-config=api/all=true
-      - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandPersistentVolumes|VolumeSubpathEnvExpansion|RunAsGroup|NodeLease)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes|Feature:SCTPConnectivity --minStartupPods=8
-      - --timeout=180m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-master
-  annotations:
-    testgrid-dashboards: sig-node-cos
-    testgrid-tab-name: e2e-cos-alpha-features
+# TODO (https://github.com/kubernetes/test-infra/issues/26127) consider restoring once we will figure out the right set of alpha features.
+# - interval: 2h
+#   name: ci-cri-containerd-e2e-cos-gce-alpha-features
+#   labels:
+#     preset-service-account: "true"
+#     preset-k8s-ssh: "true"
+#     preset-e2e-containerd: "true"
+#     preset-e2e-containerd-image-load: "true"
+#   spec:
+#     containers:
+#     - args:
+#       - --repo=github.com/containerd/containerd=main
+#       - --timeout=200
+#       - --scenario=kubernetes_e2e
+#       - --
+#       - --check-leaked-resources
+#       - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=false
+#       - --env=KUBE_PROXY_DAEMONSET=true
+#       - --env=ENABLE_POD_PRIORITY=true
+#       - --extract=ci/latest
+#       - --gcp-node-image=gci
+#       - --gcp-zone=us-west1-b
+#       - --provider=gce
+#       - --runtime-config=api/all=true
+#       - --test_args=--ginkgo.focus=\[Feature:()\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes|Feature:SCTPConnectivity --minStartupPods=8
+#       - --timeout=180m
+#       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-master
+#   annotations:
+#     testgrid-dashboards: sig-node-cos
+#     testgrid-tab-name: e2e-cos-alpha-features
 
 - name: ci-kubernetes-node-kubelet-containerd-eviction
   cluster: k8s-infra-prow-build


### PR DESCRIPTION
Related issue: #26127 (maybe we could close it by this PR)
Looking at https://github.com/kubernetes/website/blob/main/content/en/docs/reference/command-line-tools-reference/feature-gates.md, there's no alpha feature on the `--ginkgo.focus` list, so just disable it like https://github.com/kubernetes/test-infra/pull/26128
Question: there're a lot of alpha features in the above table, do we want to test them instead?

/sig node