### PR TITLE
chore: Wrap CAPV apidiff with runner.sh

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -88,7 +88,9 @@ presubmits:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220428-de61deb68b-1.23
           command:
-          - hack/ci-apidiff.sh
+          - runner.sh
+          args:
+          - ./hack/ci-apidiff.sh
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-apidiff


### PR DESCRIPTION
We added a new apidiff presubmit job to CAPV with #26243. 
However the job isn't wrapped with `runner.sh` which provides some useful information for wrapped processes including the exit code, something we can potentially use in diagnosing reasons of failure. It is already in use with most of our existing job, so this PR wraps apidiff too for reasons of consistency and utility.