### PR TITLE
soak-tests - Replace REPORTS_DIR variable with ARTIFACTS

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
@@ -38,7 +38,7 @@ presubmits:
               ./run-e2e.sh cluster-loader2
               --testconfig=testing/windows-tests/config.yaml
               --provider=aks
-              --report-dir=${REPORTS_DIR}
+              --report-dir=${ARTIFACTS}
               --v=2
           securityContext:
             privileged: true
@@ -61,8 +61,6 @@ presubmits:
               value: "6443"
             - name: PROMETHEUS_SCRAPE_WINDOWS_NODE_EXPORTER
               value: "true"
-            - name: REPORTS_DIR
-              value: "reports"
             # azuredisk variables - required for Prometheus PVC
             - name: DEPLOY_AZURE_CSI_DRIVER
               value: "true"


### PR DESCRIPTION
Store Prometheus metrics as Prow artifacts

Artifact Directory - Jobs can expect an $ARTIFACTS environment variable to be specified. It indicates an existent directory where job artifacts can be dumped for automatic upload to GCS upon job completion.

 https://github.com/kubernetes/test-infra/blob/master/prow/pod-utilities.md


/sig-windows