### PR TITLE
update python packages

### DIFF
--- a/images/krte/Dockerfile
+++ b/images/krte/Dockerfile
@@ -41,8 +41,8 @@ COPY wrapper.sh /usr/local/bin/
 
 # Install tools needed to:
 # - install docker
-# - build kind (dockerized)
-# - build kubernetes (dockerized, or with bazel)
+# - build kind
+# - build kubernetes
 #
 # TODO: the `sed` is a bit of a hack, look into alternatives.
 # Why this exists: `docker service start` on debian runs a `cgroupfs_mount` method,
@@ -64,9 +64,7 @@ RUN echo "Installing Packages ..." \
             mercurial \
             pkg-config \
             procps \
-            python \
-            python-dev \
-            python-pip \
+            python3 \
             rsync \
             software-properties-common \
             unzip \


### PR DESCRIPTION
krte doesn't support bazel anymore, we should just need a python3 runtime for the google cloud sdk

follow up to https://github.com/kubernetes/test-infra/pull/26288