### PR TITLE
Moving aks-engine based azure dualstack jobs to target release-1.24

### DIFF
--- a/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml
@@ -159,7 +159,7 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Dual-stack e2e tests on a 1.23 Kubernetes cluster provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"
 - interval: 24h
-  name: ci-dualstack-azure-e2e-master-iptables
+  name: ci-dualstack-azure-e2e-1-24-iptables
   decorate: true
   decoration_config:
     timeout: 5h
@@ -170,11 +170,11 @@ periodics:
   extra_refs:
   - org: kubernetes
     repo: kubernetes
-    base_ref: master
+    base_ref: release-1.24
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220514-17efd5d2c3-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220514-17efd5d2c3-1.24
       command:
       - runner.sh
       - kubetest
@@ -207,12 +207,12 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-network-dualstack-azure-e2e, provider-azure-dualstack, provider-azure-master-signal
-    testgrid-tab-name: dualstack-azure-e2e-master-iptables
+    testgrid-dashboards: sig-network-dualstack-azure-e2e, provider-azure-dualstack, provider-azure-1.24-signal
+    testgrid-tab-name: dualstack-azure-e2e-1-24-iptables
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Dual-stack and Conformance e2e tests on a Kubernetes cluster provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud in iptables mode"
 - interval: 24h
-  name: ci-dualstack-azure-e2e-master-ipvs
+  name: ci-dualstack-azure-e2e-1-24-ipvs
   decorate: true
   decoration_config:
     timeout: 5h
@@ -223,11 +223,11 @@ periodics:
   extra_refs:
   - org: kubernetes
     repo: kubernetes
-    base_ref: master
+    base_ref: release-1.24
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220514-17efd5d2c3-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220514-17efd5d2c3-1.24
       command:
       - runner.sh
       - kubetest
@@ -260,120 +260,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-network-dualstack-azure-e2e, provider-azure-dualstack, provider-azure-master-signal
-    testgrid-tab-name: dualstack-azure-e2e-master-ipvs
+    testgrid-dashboards: sig-network-dualstack-azure-e2e, provider-azure-dualstack, provider-azure-1.24-signal
+    testgrid-tab-name: dualstack-azure-e2e-1-24-ipvs
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Dual-stack and Conformance e2e tests on a Kubernetes cluster provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud in ipvs mode"
-
-presubmits:
-  kubernetes/kubernetes:
-  - name: pull-kubernetes-e2e-ipvs-azure-dualstack
-    decorate: true
-    decoration_config:
-      timeout: 2h
-    always_run: false
-    optional: true
-    path_alias: k8s.io/kubernetes
-    branches:
-    # TODO(releng): Remove once repo default branch has been renamed
-    - master
-    - main
-    labels:
-      preset-service-account: "true"
-      preset-azure-cred: "true"
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220514-17efd5d2c3-master
-        command:
-        - runner.sh
-        - kubetest
-        args:
-        # Generic e2e test args
-        - --test
-        - --up
-        - --down
-        - --build=quick
-        - --dump=$(ARTIFACTS)
-        # Azure-specific test args
-        - --provider=skeleton
-        - --deployment=aksengine
-        - --aksengine-agentpoolcount=2
-        - --aksengine-admin-username=azureuser
-        - --aksengine-creds=$(AZURE_CREDENTIALS)
-        - --aksengine-orchestratorRelease=1.24
-        - --aksengine-mastervmsize=Standard_DS2_v2
-        - --aksengine-agentvmsize=Standard_D4s_v3
-        - --aksengine-deploy-custom-k8s
-        - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
-        - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux-dual-stack-ipvs-kubenet.json
-        - --aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz
-        # Skipping "Should recreate evicted statefulset" because of an issue in dockershim for dualstack
-        # Suggested fix - https://github.com/kubernetes/kubernetes/pull/94382
-        # Skipping "HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol" because of kubenet bug in HostPort impl
-        # Skipping Feature:SCTPConnectivity tests because the vhd used for tests doesn't have sctp enabled
-        - --test_args=--ginkgo.focus=\[Feature:IPv6DualStack\]|\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\]|\[Feature:SCTPConnectivity\]|Should.recreate.evicted.statefulset|HostPort.validates.that.there.is.no.conflict.between.pods.with.same.hostPort.but.different.hostIP.and.protocol
-        - --ginkgo-parallel=20
-        securityContext:
-          privileged: true
-    annotations:
-      testgrid-dashboards: sig-network-dualstack-azure-e2e, provider-azure-dualstack
-      testgrid-tab-name: pr-dualstack-e2e-ipvs
-      testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
-      description: Run e2e tests for dualstack on azure in ipvs mode
-      testgrid-num-columns-recent: '30'
-  - name: pull-kubernetes-e2e-iptables-azure-dualstack
-    decorate: true
-    decoration_config:
-      timeout: 2h
-    always_run: false
-    optional: true
-    path_alias: k8s.io/kubernetes
-    branches:
-    # TODO(releng): Remove once repo default branch has been renamed
-    - master
-    - main
-    labels:
-      preset-service-account: "true"
-      preset-azure-cred: "true"
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220514-17efd5d2c3-master
-        command:
-        - runner.sh
-        - kubetest
-        args:
-        # Generic e2e test args
-        - --test
-        - --up
-        - --down
-        - --build=quick
-        - --dump=$(ARTIFACTS)
-        # Azure-specific test args
-        - --provider=skeleton
-        - --deployment=aksengine
-        - --aksengine-agentpoolcount=2
-        - --aksengine-admin-username=azureuser
-        - --aksengine-creds=$(AZURE_CREDENTIALS)
-        - --aksengine-orchestratorRelease=1.24
-        - --aksengine-mastervmsize=Standard_DS2_v2
-        - --aksengine-agentvmsize=Standard_D4s_v3
-        - --aksengine-deploy-custom-k8s
-        - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
-        - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux-dual-stack-iptables-kubenet.json
-        - --aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz
-        # Skipping "Should recreate evicted statefulset" because of an issue in dockershim for dualstack
-        # Suggested fix - https://github.com/kubernetes/kubernetes/pull/94382
-        # Skipping "HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol" because of kubenet bug in HostPort impl
-        # Skipping Feature:SCTPConnectivity tests because the vhd used for tests doesn't have sctp enabled
-        - --test_args=--ginkgo.focus=\[Feature:IPv6DualStack\]|\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\]|\[Feature:SCTPConnectivity\]|Should.recreate.evicted.statefulset|HostPort.validates.that.there.is.no.conflict.between.pods.with.same.hostPort.but.different.hostIP.and.protocol
-        - --ginkgo-parallel=20
-        securityContext:
-          privileged: true
-    annotations:
-      testgrid-dashboards: sig-network-dualstack-azure-e2e, provider-azure-dualstack
-      testgrid-tab-name: pr-dualstack-e2e-iptables
-      testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
-      description: Run e2e tests for dualstack on azure in iptables mode
-      testgrid-num-columns-recent: '30'

--- a/config/testgrids/kubernetes/sig-cloud-provider/azure/config.yaml
+++ b/config/testgrids/kubernetes/sig-cloud-provider/azure/config.yaml
@@ -12,6 +12,7 @@ dashboard_groups:
     - provider-azure-dualstack
     - provider-azure-presubmit
     - provider-azure-master-signal
+    - provider-azure-1.24-signal
     - provider-azure-1.23-signal
     - provider-azure-1.22-signal
     - provider-azure-1.21-signal
@@ -28,6 +29,7 @@ dashboards:
 - name: provider-azure-dualstack
 - name: provider-azure-presubmit
 - name: provider-azure-master-signal
+- name: provider-azure-1.24-signal
 - name: provider-azure-1.23-signal
 - name: provider-azure-1.22-signal
 - name: provider-azure-1.21-signal


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

aks-engine is deprecated and will not support K8s versions beyond 1.24.
This PR re-targets the existing dualstack jobs from `master` to `release-1.24`

New azure dualstack jobs targeting `master` / 1.25 branch will be added in a future PR and will use CAPZ for cluster provisioning.

/assign @aramase @chewong 