### PR TITLE
capi-aws: stop use bazel remote cache

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
@@ -124,8 +124,6 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-0.6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-0.6.yaml
@@ -60,8 +60,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     always_run: false
     optional: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-0.7.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-0.7.yaml
@@ -60,8 +60,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     always_run: false
     optional: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -82,8 +82,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     always_run: false
     optional: true


### PR DESCRIPTION
Related:
  - https://github.com/kubernetes/test-infra/issues/24247

Followup of:
  - https://github.com/kubernetes/test-infra/pull/26021

Stop to use bazel cache for job execution.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>