### PR TITLE
capi-gcp: stop use bazel remote cache

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-main.yaml
@@ -44,8 +44,6 @@ periodics:
 - name: periodic-cluster-api-provider-gcp-make-conformance-main
   labels:
     preset-service-account: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
   decorate: true
@@ -84,8 +82,6 @@ periodics:
 - name: periodic-cluster-api-provider-gcp-make-conformance-main-ci-artifacts
   labels:
     preset-service-account: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
   decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-release-0-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-release-0-4.yaml
@@ -2,8 +2,6 @@ periodics:
 - name: periodic-cluster-api-provider-gcp-conformance-release-0-4
   labels:
     preset-service-account: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
   decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-release-1-0.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-release-1-0.yaml
@@ -44,8 +44,6 @@ periodics:
 - name: periodic-cluster-api-provider-gcp-conformance-release-1-0
   labels:
     preset-service-account: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
   decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-main.yaml
@@ -90,8 +90,6 @@ presubmits:
   - name: pull-cluster-api-provider-gcp-e2e-test
     labels:
       preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
@@ -127,8 +125,6 @@ presubmits:
   - name: pull-cluster-api-provider-gcp-conformance-ci-artifacts
     labels:
       preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
@@ -174,8 +170,6 @@ presubmits:
   - name: pull-cluster-api-provider-gcp-conformance
     labels:
       preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
@@ -211,8 +205,6 @@ presubmits:
   - name: pull-cluster-api-provider-gcp-capi-e2e
     labels:
       preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
@@ -248,8 +240,6 @@ presubmits:
   - name: pull-cluster-api-provider-gcp-e2e-workload-upgrade
     labels:
       preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-0-4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-0-4.yaml
@@ -67,8 +67,6 @@ presubmits:
   - name: pull-cluster-api-provider-gcp-e2e-test-release-release-0-4
     labels:
       preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
@@ -110,8 +108,6 @@ presubmits:
   - name: pull-cluster-api-provider-gcp-make-conformance-release-release-0-4
     labels:
       preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-0.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-0.yaml
@@ -67,8 +67,6 @@ presubmits:
   - name: pull-cluster-api-provider-gcp-e2e-test-release-release-1-0
     labels:
       preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
@@ -109,8 +107,6 @@ presubmits:
   - name: pull-cluster-api-provider-gcp-make-conformance-release-release-1-0
     labels:
       preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
@@ -146,8 +142,6 @@ presubmits:
   - name: pull-cluster-api-provider-gcp-capi-e2e-release-release-1-0
     labels:
       preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"


### PR DESCRIPTION
Related:
  - https://github.com/kubernetes/test-infra/issues/24247

Followup of:
  - https://github.com/kubernetes/test-infra/pull/26021

Stop use bazel cache for job execution.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>