### PR TITLE
Remove unused `K8S_AZURE_*` vars

### DIFF
--- a/kubetest/aksengine.go
+++ b/kubetest/aksengine.go
@@ -1208,23 +1208,6 @@ func (c *aksEngineDeployer) GetClusterCreated(clusterName string) (time.Time, er
 }
 
 func (c *aksEngineDeployer) setCred() error {
-	// TODO (cecile): remove old variables once the cloud provider e2e test variables are updated.
-	if err := os.Setenv("K8S_AZURE_TENANTID", c.credentials.TenantID); err != nil {
-		return err
-	}
-	if err := os.Setenv("K8S_AZURE_SUBSID", c.credentials.SubscriptionID); err != nil {
-		return err
-	}
-	if err := os.Setenv("K8S_AZURE_SPID", c.credentials.ClientID); err != nil {
-		return err
-	}
-	if err := os.Setenv("K8S_AZURE_SPSEC", c.credentials.ClientSecret); err != nil {
-		return err
-	}
-	if err := os.Setenv("K8S_AZURE_LOCATION", c.location); err != nil {
-		return err
-	}
-
 	if err := os.Setenv("AZURE_TENANT_ID", c.credentials.TenantID); err != nil {
 		return err
 	}


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/21917 prepared to rename and https://github.com/kubernetes-sigs/cloud-provider-azure/pull/599 actually did it.
[The search result on GitHub](https://github.com/search?q=K8S_AZURE_LOADBALANCE_SKU&type=code) also shows they're safely removed.