### PR TITLE
Remove sig-windows/generate-presubmits from autobump

### DIFF
--- a/config/prow/autobump-config/prow-job-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-job-autobump-config.yaml
@@ -18,7 +18,6 @@ extraFiles:
   - "config/jobs/kubernetes/sig-cloud-provider/azure/generate.sh"
   - "config/jobs/kubernetes/kops/build_jobs.py"
   - "config/jobs/kubernetes-csi/gen-jobs.sh"
-  - "config/jobs/kubernetes-sigs/sig-windows/generate-presubmits.sh"
   - "config/jobs/README.md"
   - "releng/generate_tests.py"
   - "releng/test_config.yaml"


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/26283 caused https://testgrid.k8s.io/sig-testing-prow#autobump-prowjobs to fail, since it deletes a file the autobump script expects.

/assign @listx 
/cc @jsturtevant