### PR TITLE
Sync prow kubeconfig from GSM for hmac usage

### DIFF
--- a/config/prow/cluster/kubernetes_external_secrets.yaml
+++ b/config/prow/cluster/kubernetes_external_secrets.yaml
@@ -56,6 +56,19 @@ spec:
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
+  name: kubeconfig-prow-services
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: k8s-prow
+  data:
+  - key: gke_k8s-prow_us-central1-f_prow__default__prow-services
+    name: config
+    version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
   name: kubeconfig-build-test-infra-trusted
   namespace: default
 spec:


### PR DESCRIPTION
The secret in GSM is created an rotated by gencred periodically, set up external secret sync for rotating the k8s secret as well

/cc @cjwagner 
