### PR TITLE
Add periodic job to check for test coverage in CAPV

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-periodics.yaml
@@ -112,3 +112,54 @@ periodics:
       testgrid-tab-name: periodic-clusterctl-upgrade-main
       testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
       description: Runs clusterctl upgrade tests for CAPV
+
+- name: periodic-cluster-api-provider-vsphere-coverage
+  labels:
+    preset-dind-enabled: "true"
+    preset-cluster-api-provider-vsphere-e2e-config: "true"
+    preset-cluster-api-provider-vsphere-gcs-creds: "true"
+    preset-kind-volume-mounts: "true"
+  interval: 12h
+  decorate: true
+  path_alias: "sigs.k8s.io/cluster-api-provider-vsphere"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-vsphere
+      base_ref: main
+      path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    - org: kubernetes
+      repo: test-infra
+      base_ref: main
+      path_alias: k8s.io/test-infra
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220413-ebb00ad7a6-1.23
+        command:
+          - runner.sh
+          - bash
+        args:
+          - -c
+          - |
+            result=0
+            ./hack/ci-test-coverage.sh || result=$?
+            cp coverage.* ${ARTIFACTS}
+            cd ../../k8s.io/test-infra/gopherage
+            GO111MODULE=on go build .
+            ./gopherage filter --exclude-path="zz_generated,generated\.go" "${ARTIFACTS}/coverage.out" > "${ARTIFACTS}/filtered.cov" || result=$?
+            ./gopherage html "${ARTIFACTS}/filtered.cov" > "${ARTIFACTS}/coverage.html" || result=$?
+            ./gopherage junit --threshold 0 "${ARTIFACTS}/filtered.cov" > "${ARTIFACTS}/junit_coverage.xml" || result=$?
+            exit $result
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["NET_ADMIN"]
+        resources:
+          requests:
+            cpu: "4000m"
+            memory: "6Gi"
+  annotations:
+    testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+    testgrid-tab-name: periodic-test-coverage
+    testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+    description: Shows test coverage for CAPV


### PR DESCRIPTION
Currently there is no peroidic job to check test coverage
in CAPV. This will check every 24 hours and update the status in
coverage.txt and coverage.html

Signed-off-by: geetikab@vmware.com geetikab@vmware.com