### PR TITLE
Gencred rotating kubeconfig for build cluster in k8s-prow -builds

### DIFF
--- a/config/prow/gencred-config/gencred-config.yaml
+++ b/config/prow/gencred-config/gencred-config.yaml
@@ -1,4 +1,11 @@
 clusters:
+# Build cluster from k8s-prow-builds
+- gke: projects/k8s-prow-builds/locations/us-central1-f/clusters/prow
+  name: build-k8s-prow-builds
+  duration: 48h
+  gsm:
+    name: gke_k8s-prow-builds_us-central1-f_prow__default__build-k8s-prow-builds
+    project: k8s-prow
 - gke: projects/k8s-prow/locations/us-central1-f/clusters/prow
   name: prow-services
   duration: 48h


### PR DESCRIPTION
The build cluster certificate will expire very soon, re-onboarding this cluster to prow means generating new kubeconfig for this build cluster, which now needs to be rotated as the kubeconfig will only be valid for up to 2 days. A followup PR will be created to sync from GSM to prow