### PR TITLE
Sync kubeconfig for k8s-prow-builds cluster from GSM to prow

### DIFF
--- a/config/prow/cluster/kubernetes_external_secrets.yaml
+++ b/config/prow/cluster/kubernetes_external_secrets.yaml
@@ -82,6 +82,19 @@ spec:
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
+  name: kubeconfig-build-k8s-prow-builds
+  namespace: default
+spec:
+  backendType: gcpSecretsManager
+  projectId: k8s-prow
+  data:
+  - key: gke_k8s-prow-builds_us-central1-f_prow__default__build-k8s-prow-builds
+    name: kubeconfig
+    version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
   name: cluster-api-provider-digitalocean-quayio
   namespace: default
 spec:

--- a/config/prow/gencred-config/gencred-config.yaml
+++ b/config/prow/gencred-config/gencred-config.yaml
@@ -1,4 +1,11 @@
 clusters:
+# Build cluster from k8s-prow-builds
+- gke: projects/k8s-prow-builds/locations/us-central1-f/clusters/prow
+  name: build-k8s-prow-builds
+  duration: 48h
+  gsm:
+    name: gke_k8s-prow-builds_us-central1-f_prow__default__build-k8s-prow-builds
+    project: k8s-prow
 - gke: projects/k8s-prow/locations/us-central1-f/clusters/prow
   name: prow-services
   duration: 48h


### PR DESCRIPTION
This is the second step for re-onboarding k8s-prow-builds cluster, previous step is https://github.com/kubernetes/test-infra/pull/26334

/hold
depends on #26334