### PR TITLE
Gencred job not trigger on job change

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -384,7 +384,7 @@ postsubmits:
         - gencred/
   - name: post-test-infra-gencred-refresh-kubeconfig
     cluster: test-infra-trusted
-    run_if_changed: '^(config/prow/gencred-config/|config/jobs/kubernetes/test-infra/test-infra-trusted\.yaml)'
+    run_if_changed: '^config/prow/gencred-config/'
     decorate: true
     branches:
     - ^master$


### PR DESCRIPTION
The job config change is not in effect when the gencred postsubmit job is triggered, so it doesn't really make sense to trigger on job config change PR. This will also help reduce the time controller manager restart (it almost restarts every time gencred runs)

/cc @cjwagner @chases2 