### PR TITLE
Sync CAPZ owners with Azure provider project

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/OWNERS
@@ -2,21 +2,13 @@
 
 approvers:
 - alexeldeib
-- andyzhangx
-- brendandburns
 - CecileRobertMichon
-- feiskyer
 - devigned
-- karataliu
-- khenidak
-- nader-ziada
+- mboersma
 - shysank
 reviewers:
-- cpanato
 - jackfrancis
 - jsturtevant
-- juan-lee
-- mboersma
 
 labels:
 - sig/cluster-lifecycle


### PR DESCRIPTION
Syncs up with recent changes to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/OWNERS_ALIASES

cc: @andyzhangx @brendanburns @cpanato @feiskyer @juan-lee @karataliu @khenidak @nader-ziada 