### PR TITLE
disable auto run of sanity test

### DIFF
--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
@@ -25,7 +25,7 @@ presubmits:
       testgrid-tab-name: presubmit-gcp-compute-persistent-disk-csi-driver-e2e
       description: Kubernetes e2e tests for Kubernetes Master branch and Driver latest build
   - name: pull-gcp-compute-persistent-disk-csi-driver-sanity
-    always_run: true
+    always_run: false
     labels:
       preset-service-account: "true"
     spec:


### PR DESCRIPTION
See [pdcsi issue](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/issues/990) and [PR](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/988) for reference