### PR TITLE
Create a prowjob default service account in default build cluster

### DIFF
--- a/config/prow/cluster/build/build_serviceaccounts.yaml
+++ b/config/prow/cluster/build/build_serviceaccounts.yaml
@@ -31,6 +31,18 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
+    # Default prowjob runner for default build cluster. This service account
+    # doesn't have GCP permission other than writing artifacts into the default
+    # GCS artifacts location for prow.
+    # Please creating separate service account for special needs.
+    iam.gke.io/gcp-service-account: prowjob-default-sa@k8s-prow-builds.iam.gserviceaccount.com
+  name: prowjob-default-sa
+  namespace: test-pods
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
     # Used by Kops testing jobs
     iam.gke.io/gcp-service-account: pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com
   name: k8s-kops-test


### PR DESCRIPTION
This service account has only GCS admin permission on the prow jobs artifacts GCS bucket, will be used by prow jobs that don't need GCP permissions.

Will create followup PR(s) instructing prow jobs authors how to migrate their jobs to use workload identity.

/cc @cjwagner @BenTheElder 