### PR TITLE
periodic-cluster-api-e2e-main use workload identity

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -148,6 +148,9 @@ periodics:
     base_ref: master
     path_alias: k8s.io/kubernetes
   spec:
+    decoration_config:
+      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
+    serviceAccountName: prowjob-default-sa
     containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220514-17efd5d2c3-1.23
         args:


### PR DESCRIPTION
This will be served as an example of migrating a prow job to use workload identity, this is the most basic scenario where the job doesn't interact directly with GCP. The only place where the prow job pod need to access GCP is when the sidecar container from inside the test pod need to upload artifacts to GCS

/cc @cjwagner @killianmuldoon 

/hold
This won't work until #26356 is merged.