### PR TITLE
Windows capz azuredisk: ci-entrypoint assumes that k8s is checkout to path

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -208,6 +208,10 @@ periodics:
     preset-capz-windows-ci-entrypoint-common-main: "true"
     preset-capz-windows-azuredisk: "true"
   extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
     base_ref: main


### PR DESCRIPTION
The job https://testgrid.k8s.io/sig-windows-master-release#capz-azuredisk-windows-2019

was failing with `./scripts/ci-entrypoint.sh: line 91: cd: /home/prow/go/src/k8s.io/kubernetes: No such file or directory`

/sig windows
/assign @marosset 