### PR TITLE
Gencred generated default build cluster should be named default

### DIFF
--- a/config/prow/gencred-config/gencred-config.yaml
+++ b/config/prow/gencred-config/gencred-config.yaml
@@ -1,7 +1,7 @@
 clusters:
 # Build cluster from k8s-prow-builds
 - gke: projects/k8s-prow-builds/locations/us-central1-f/clusters/prow
-  name: build-k8s-prow-builds
+  name: default
   duration: 48h
   gsm:
     name: gke_k8s-prow-builds_us-central1-f_prow__default__build-k8s-prow-builds


### PR DESCRIPTION
This is the build cluster alias it's referenced in k8s-prow

/cc @cjwagner @mpherman2 @chases2 