### PR TITLE
[cloud-provider-azure] Add vmss jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -81,7 +81,7 @@ presubmits:
       testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-basic-lb
       description: "Runs Azure specific tests (VMSS + basic LB) with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
       testgrid-num-columns-recent: '30'
-    # pull-cloud-provider-azure-e2e-ccm-vmss runs Azure specific e2e tests with vmss.
+    # pull-cloud-provider-azure-e2e-ccm-vmss runs Azure specific e2e tests on vmss.
   - name: pull-cloud-provider-azure-e2e-ccm-vmss
     skip_if_only_changed: "^docs/|^site/|^helm/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     decorate: true
@@ -140,6 +140,58 @@ presubmits:
       testgrid-dashboards: provider-azure-cloud-provider-azure
       testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss
       description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
+      testgrid-num-columns-recent: '30'
+  # pull-cloud-provider-azure-e2e-ccm-vmss-capz runs Azure specific e2e tests on vmss.
+  - name: pull-cloud-provider-azure-e2e-ccm-vmss-capz
+    always_run: false
+    optional: true
+    skip_if_only_changed: "^docs/|^site/|^helm/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
+    decorate: true
+    decoration_config:
+      timeout: 3h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+      - master
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: cluster-api-provider-azure
+        base_ref: release-1.3
+        path_alias: sigs.k8s.io/cluster-api-provider-azure
+        workdir: true
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220514-17efd5d2c3-master
+          command:
+          - runner.sh
+          args:
+          - ./scripts/ci-entrypoint.sh
+          - bash
+          - -c
+          - >-
+            cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+            make test-ccm-e2e
+          securityContext:
+            privileged: true
+          env:
+            - name: TEST_CCM
+              value: "true"
+            - name: CONTROL_PLANE_MACHINE_COUNT
+              value: "3"
+            - name: KUBERNETES_VERSION
+              value: 1.23.5
+            - name: CLUSTER_TEMPLATE
+              value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss.yaml
+            - name: AZURE_LOADBALANCER_SKU
+              value: "Standard"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-capz
+      description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on vmss, using cluster-api-provider-azure."
       testgrid-num-columns-recent: '30'
   # pull-cloud-provider-azure-e2e-capz runs kubernetes conformance tests.
   - name: pull-cloud-provider-azure-e2e-capz
@@ -550,7 +602,7 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
     description: "Runs Kubernetes conformance tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
 - interval: 24h
-  # cloud-provider-azure-slow runs Kubernetes slow tests periodically.
+  # cloud-provider-azure-slow-capz runs Kubernetes slow tests periodically.
   name: cloud-provider-azure-slow-capz
   decorate: true
   decoration_config:
@@ -736,6 +788,58 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
     description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on VMSS."
 - interval: 24h
+  # cloud-provider-azure-master-vmss-capz runs Azure specific tests periodically using a stable capz release on vmss.
+  name: cloud-provider-azure-master-vmss-capz
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.3
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    - org: kubernetes-sigs
+      repo: cloud-provider-azure
+      base_ref: master
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      workdir: false
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220514-17efd5d2c3-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM
+          value: "true"
+        - name: CONTROL_PLANE_MACHINE_COUNT
+          value: "3"
+        - name: KUBERNETES_VERSION
+          value: 1.23.5
+        - name: CLUSTER_TEMPLATE
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss.yaml
+        - name: AZURE_LOADBALANCER_SKU
+          value: "Standard"
+  annotations:
+    testgrid-dashboards: provider-azure-cloud-provider-azure
+    testgrid-tab-name: cloud-provider-azure-master-vmss-capz
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
+    description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on vmss using a stable capz release."
+- interval: 24h
   # cloud-provider-azure-conformance-vmss runs Kubernetes conformance tests periodically on VMSS.
   name: cloud-provider-azure-conformance-vmss
   decorate: true
@@ -793,6 +897,66 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
     description: "Runs Kubernetes conformance tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on VMSS."
 - interval: 24h
+  # cloud-provider-azure-conformance-vmss-capz runs Kubernetes conformance tests periodically on vmss.
+  name: cloud-provider-azure-conformance-vmss-capz
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.3
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: true
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+    workdir: false
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: master
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220514-17efd5d2c3-master
+      command:
+      - runner.sh
+      args:
+      - ./scripts/ci-entrypoint.sh
+      - bash
+      - -c
+      - >-
+        cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
+        cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+        make test-e2e-capz
+      securityContext:
+        privileged: true
+      env:
+      - name: TEST_CCM
+        value: "true"
+      - name: KUBERNETES_VERSION
+        value: 1.23.5
+      - name: GINKGO_ARGS
+        value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --test.parallel=30 --report-dir=/logs/artifacts --disable-log-dump=true
+      - name: CONTROL_PLANE_MACHINE_COUNT
+        value: "3"
+      - name: CLUSTER_TEMPLATE
+        value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss.yaml
+      - name: AZURE_LOADBALANCER_SKU
+        value: "Standard"
+  annotations:
+    testgrid-dashboards: provider-azure-cloud-provider-azure
+    testgrid-tab-name: cloud-provider-azure-conformance-vmss-capz
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
+    description: "Runs Kubernetes conformance tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on vmss."
+- interval: 24h
   # cloud-provider-azure-slow-vmss runs Kubernetes slow tests periodically on VMSS.
   name: cloud-provider-azure-slow-vmss
   decorate: true
@@ -849,6 +1013,66 @@ periodics:
     testgrid-tab-name: cloud-provider-azure-slow-vmss
     testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
     description: "Runs Kubernetes slow tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on VMSS."
+- interval: 24h
+  # cloud-provider-azure-slow-vmss-capz runs Kubernetes slow tests periodically.
+  name: cloud-provider-azure-slow-vmss-capz
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.3
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: true
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+    workdir: false
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: master
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220514-17efd5d2c3-master
+      command:
+      - runner.sh
+      args:
+      - ./scripts/ci-entrypoint.sh
+      - bash
+      - -c
+      - >-
+        cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
+        cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+        make test-e2e-capz
+      securityContext:
+        privileged: true
+      env:
+      - name: TEST_CCM
+        value: "true"
+      - name: KUBERNETES_VERSION
+        value: 1.23.5
+      - name: GINKGO_ARGS
+        value: --ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|In-tree.Volumes|should.be.able.to.create.an.internal.type.load.balancer --test.parallel=4 --report-dir=/logs/artifacts --disable-log-dump=true
+      - name: CONTROL_PLANE_MACHINE_COUNT
+        value: "3"
+      - name: CLUSTER_TEMPLATE
+        value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss.yaml
+      - name: AZURE_LOADBALANCER_SKU
+        value: "Standard"
+  annotations:
+    testgrid-dashboards: provider-azure-cloud-provider-azure
+    testgrid-tab-name: cloud-provider-azure-slow-vmss-capz
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
+    description: "Runs Kubernetes slow tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on vmss."
 - interval: 24h
   # cloud-provider-azure-multiple-zones runs Kubernetes multiple availability zones tests periodically.
   name: cloud-provider-azure-multiple-zones

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.0.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.0.yaml
@@ -141,6 +141,57 @@ presubmits:
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-1-21
         description: "Runs Azure specific tests with cloud-provider-azure release-1.0 (https://github.com/kubernetes-sigs/cloud-provider-azure)."
         testgrid-num-columns-recent: '30'
+    - name: pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-21
+      skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
+      always_run: false
+      optional: true
+      decorate: true
+      decoration_config:
+        timeout: 3h
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      branches:
+        - release-1.0
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+        preset-azure-cred-only: "true"
+        preset-azure-anonymous-pull: "true"
+      extra_refs:
+        - org: kubernetes-sigs
+          repo: cluster-api-provider-azure
+          base_ref: release-1.3
+          path_alias: sigs.k8s.io/cluster-api-provider-azure
+          workdir: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220514-17efd5d2c3-master
+            command:
+            - runner.sh
+            - ./scripts/ci-entrypoint.sh
+            args:
+            - bash
+            - -c
+            - >-
+              cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+              make test-ccm-e2e
+            securityContext:
+              privileged: true
+            env:
+              - name: TEST_CCM
+                value: "true"
+              - name: AZURE_LOADBALANCER_SKU
+                value: "Standard"
+              - name: KUBERNETES_VERSION
+                value: 1.21.5
+              - name: CONTROL_PLANE_MACHINE_COUNT
+                value: "3"
+              - name: CLUSTER_TEMPLATE
+                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss.yaml
+      annotations:
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-21-presubmit
+        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-capz-1-21
+        description: "Runs Azure specific tests with cloud-provider-azure release-1.0 (https://github.com/kubernetes-sigs/cloud-provider-azure) on vmss, using cluster-api-provider-azure."
+        testgrid-num-columns-recent: '30'
     # pull-cloud-provider-azure-e2e-capz-1-21 runs kubernetes conformance tests.
     - name: pull-cloud-provider-azure-e2e-capz-1-21
       skip_if_only_changed: "^docs/|^site/|^tests/e2e/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.1.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.1.yaml
@@ -141,6 +141,57 @@ presubmits:
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-1-22
         description: "Runs Azure specific tests with cloud-provider-azure release-1.1 (https://github.com/kubernetes-sigs/cloud-provider-azure)."
         testgrid-num-columns-recent: '30'
+    - name: pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-22
+      skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
+      always_run: false
+      optional: true
+      decorate: true
+      decoration_config:
+        timeout: 3h
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      branches:
+        - release-1.1
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+        preset-azure-cred-only: "true"
+        preset-azure-anonymous-pull: "true"
+      extra_refs:
+        - org: kubernetes-sigs
+          repo: cluster-api-provider-azure
+          base_ref: release-1.3
+          path_alias: sigs.k8s.io/cluster-api-provider-azure
+          workdir: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220514-17efd5d2c3-master
+            command:
+            - runner.sh
+            - ./scripts/ci-entrypoint.sh
+            args:
+            - bash
+            - -c
+            - >-
+              cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+              make test-ccm-e2e
+            securityContext:
+              privileged: true
+            env:
+              - name: TEST_CCM
+                value: "true"
+              - name: AZURE_LOADBALANCER_SKU
+                value: "Standard"
+              - name: KUBERNETES_VERSION
+                value: 1.22.2
+              - name: CONTROL_PLANE_MACHINE_COUNT
+                value: "3"
+              - name: CLUSTER_TEMPLATE
+                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss.yaml
+      annotations:
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-22-presubmit
+        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-capz-1-22
+        description: "Runs Azure specific tests with cloud-provider-azure release-1.1 (https://github.com/kubernetes-sigs/cloud-provider-azure) on vmss, using cluster-api-provider-azure."
+        testgrid-num-columns-recent: '30'
     # pull-cloud-provider-azure-e2e-capz-1-22 runs kubernetes conformance tests.
     - name: pull-cloud-provider-azure-e2e-capz-1-22
       skip_if_only_changed: "^docs/|^site/|^tests/e2e/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.23.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.23.yaml
@@ -141,6 +141,58 @@ presubmits:
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-1-23
         description: "Runs Azure specific tests with cloud-provider-azure release-1.23 (https://github.com/kubernetes-sigs/cloud-provider-azure)."
         testgrid-num-columns-recent: '30'
+    # pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-23
+    - name: pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-23
+      skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
+      always_run: false
+      optional: true
+      decorate: true
+      decoration_config:
+        timeout: 3h
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      branches:
+        - release-1.23
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+        preset-azure-cred-only: "true"
+        preset-azure-anonymous-pull: "true"
+      extra_refs:
+        - org: kubernetes-sigs
+          repo: cluster-api-provider-azure
+          base_ref: release-1.3
+          path_alias: sigs.k8s.io/cluster-api-provider-azure
+          workdir: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220514-17efd5d2c3-master
+            command:
+              - runner.sh
+              - ./scripts/ci-entrypoint.sh
+            args:
+              - bash
+              - -c
+              - >-
+                cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+                make test-ccm-e2e
+            securityContext:
+              privileged: true
+            env:
+              - name: TEST_CCM
+                value: "true"
+              - name: KUBERNETES_VERSION
+                value: 1.23.5
+              - name: CONTROL_PLANE_MACHINE_COUNT
+                value: "3"
+              - name: CLUSTER_TEMPLATE
+                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss.yaml
+              - name: AZURE_LOADBALANCER_SKU
+                value: "Standard"
+      annotations:
+        testgrid-dashboards: provider-azure-cloud-provider-azure-1-23-presubmit
+        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-capz-1-23
+        description: "Runs Azure specific tests with cloud-provider-azure release-1.23 (https://github.com/kubernetes-sigs/cloud-provider-azure) on vmss, using cluster-api-provider-azure."
+        testgrid-num-columns-recent: '30'
     # pull-cloud-provider-azure-e2e-capz-1-23 runs kubernetes conformance tests.
     - name: pull-cloud-provider-azure-e2e-capz-1-23
       skip_if_only_changed: "^docs/|^site/|^tests/e2e/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
@@ -197,7 +249,7 @@ presubmits:
         testgrid-tab-name: pr-cloud-provider-azure-e2e-capz-1-23
         description: "Runs Kubernetes conformance tests with cloud-provider-azure release-1.23 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
         testgrid-num-columns-recent: '30'
-    # pull-cloud-provider-azure-e2e-ccm-1-23
+    # pull-cloud-provider-azure-e2e-ccm-capz-1-23
     - name: pull-cloud-provider-azure-e2e-ccm-capz-1-23
       skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
       decorate: true

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.24.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.24.yaml
@@ -21,65 +21,57 @@ presubmits:
         testgrid-tab-name: pr-cloud-provider-azure-check-1-24
         description: "Run lint check tests for cloud-provider-azure release-1.24."
         testgrid-num-columns-recent: '30'
-    # pull-cloud-provider-azure-e2e-ccm-vmss-basic-lb-1-24 runs Azure specific e2e tests with VMSS and basic loadbalancer.
-    - name: pull-cloud-provider-azure-e2e-ccm-vmss-basic-lb-1-24
+    # pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-24
+    - name: pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-24
       skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
+      always_run: false
+      optional: true
       decorate: true
       decoration_config:
-        timeout: 5h
+        timeout: 3h
       path_alias: sigs.k8s.io/cloud-provider-azure
       branches:
         - release-1.24
       labels:
-        preset-service-account: "true"
-        preset-azure-cred: "true"
         preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+        preset-azure-cred-only: "true"
+        preset-azure-anonymous-pull: "true"
       extra_refs:
-        - org: kubernetes
-          repo: kubernetes
-          base_ref: release-1.24
-          path_alias: k8s.io/kubernetes
+        - org: kubernetes-sigs
+          repo: cluster-api-provider-azure
+          base_ref: release-1.3
+          path_alias: sigs.k8s.io/cluster-api-provider-azure
           workdir: true
       spec:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220514-17efd5d2c3-1.24
             command:
               - runner.sh
-              - kubetest
+              - ./scripts/ci-entrypoint.sh
             args:
-              # Generic e2e test args
-              - --test
-              - --up
-              - --down
-              - --build=quick
-              - --dump=$(ARTIFACTS)
-              # Azure-specific test args
-              - --provider=skeleton
-              - --deployment=aksengine
-              - --aksengine-agentpoolcount=2
-              - --aksengine-admin-username=azureuser
-              - --aksengine-creds=$(AZURE_CREDENTIALS)
-              - --aksengine-orchestratorRelease=1.24
-              - --aksengine-mastervmsize=Standard_DS2_v2
-              - --aksengine-agentvmsize=Standard_D4s_v3
-              - --aksengine-ccm
-              - --aksengine-cnm
-              - --aksengine-deploy-custom-k8s
-              - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
-              - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux-vmss-basic-lb.json
-              - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/nightly/aks-engine-nightly-linux-amd64.tar.gz
-              # Specific test args
-              - --test-ccm
-              - --ginkgo-parallel=30
+              - bash
+              - -c
+              - >-
+                cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+                make test-ccm-e2e
             securityContext:
               privileged: true
             env:
+              - name: TEST_CCM
+                value: "true"
+              - name: KUBERNETES_VERSION
+                value: 1.24.0
+              - name: CONTROL_PLANE_MACHINE_COUNT
+                value: "3"
+              - name: CLUSTER_TEMPLATE
+                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss.yaml
               - name: AZURE_LOADBALANCER_SKU
-                value: "basic"
+                value: "Standard"
       annotations:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-24-presubmit
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-basic-lb-1-24
-        description: "Runs Azure specific tests (VMSS + basic LB) with cloud-provider-azure release-1.24 (https://github.com/kubernetes-sigs/cloud-provider-azure)."
+        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-capz-1-24
+        description: "Runs Azure specific tests with cloud-provider-azure release-1.24 (https://github.com/kubernetes-sigs/cloud-provider-azure) on vmss, using cluster-api-provider-azure."
         testgrid-num-columns-recent: '30'
       # pull-cloud-provider-azure-e2e-ccm-vmss-1-24
     - name: pull-cloud-provider-azure-e2e-ccm-vmss-1-24


### PR DESCRIPTION
* Add vmss capz jobs for master and other release branches
* Remove vmss-basic-lb jobs on release-1.24 since basic lb
  aren't supported by capz
* Use k/k master branch for cloud-provider-azure master branch

related: https://github.com/kubernetes-sigs/cloud-provider-azure/issues/919

Signed-off-by: Zhecheng Li <zhechengli@microsoft.com>