### PR TITLE
periodic-cluster-api-e2e-main workload identity setting on correct level

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -135,6 +135,8 @@ periodics:
 - name: periodic-cluster-api-e2e-main
   interval: 1h
   decorate: true
+  decoration_config:
+    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -148,8 +150,6 @@ periodics:
     base_ref: master
     path_alias: k8s.io/kubernetes
   spec:
-    decoration_config:
-      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
     serviceAccountName: prowjob-default-sa
     containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220514-17efd5d2c3-1.23


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/26357 switched this job to use workload identity, but placed the decoration config override on the wrong level, prow ignored the override as it didn't understand the name of the new field, so nothing had really changed. It should be fixed in this PR

/cc @cjwagner 
cc @killianmuldoon 