### PR TITLE
Migrate periodic-cluster-api-e2e-mink8s-main to use workload identity

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -173,6 +173,8 @@ periodics:
 - name: periodic-cluster-api-e2e-mink8s-main
   interval: 1h
   decorate: true
+  decoration_config:
+    gcs_credentials_secret: "" # Use workload identity for uploading artifacts
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -186,6 +188,7 @@ periodics:
     base_ref: master
     path_alias: k8s.io/kubernetes
   spec:
+    serviceAccountName: prowjob-default-sa
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220514-17efd5d2c3-1.23
       args:


### PR DESCRIPTION
This will be served as an example of migrating a prow job to use workload identity, this is the most basic scenario where the job doesn't interact directly with GCP. The only place where the prow job pod need to access GCP is when the sidecar container from inside the test pod need to upload artifacts to GCS

/cc @cjwagner @killianmuldoon