### PR TITLE
Tide caches prefetched HEAD OID while picking batches

### DIFF
--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -1123,9 +1123,14 @@ func (c *Controller) pickBatch(sp subpool, cc map[int]contextChecker, newBatchFu
 	sort.Slice(sp.prs, func(i, j int) bool { return sp.prs[i].Number < sp.prs[j].Number })
 
 	var candidates []PullRequest
-	for _, pr := range sp.prs {
-		if c.isRetestEligible(sp.log, &pr, cc[int(pr.Number)]) {
-			candidates = append(candidates, pr)
+	for i := range sp.prs {
+		// c.isRetestEligible appends `Commits` into the passed in PullRequest
+		// struct, which is used later to avoid repeatedly looking up on GitHub.
+		// So making sure that we are passing in the pointer from the slice
+		// instead of creating new instance of pr by `for _, pr := range sp.prs`.
+		ptrPr := &sp.prs[i]
+		if c.isRetestEligible(sp.log, ptrPr, cc[int(ptrPr.Number)]) {
+			candidates = append(candidates, *ptrPr)
 		}
 	}
 

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -4440,10 +4440,38 @@ func TestPickBatchPrefersBatchesWithPreexistingJobs(t *testing.T) {
 			name:    "Batch with pre-existing success jobs exists and is picked",
 			subpool: func(sp *subpool) {},
 			expectedPullRequests: []PullRequest{
-				{Number: githubql.Int(1), HeadRefOID: githubql.String("1")},
-				{Number: githubql.Int(2), HeadRefOID: githubql.String("2")},
-				{Number: githubql.Int(3), HeadRefOID: githubql.String("3")},
-				{Number: githubql.Int(4), HeadRefOID: githubql.String("4")},
+				{
+					Number:     githubql.Int(1),
+					HeadRefOID: githubql.String("1"),
+					Commits: struct{ Nodes []struct{ Commit Commit } }{
+						Nodes: []struct{ Commit Commit }{
+							{Commit: Commit{Status: CommitStatus{Contexts: []Context{}}, OID: "1"}}},
+					},
+				},
+				{
+					Number:     githubql.Int(2),
+					HeadRefOID: githubql.String("2"),
+					Commits: struct{ Nodes []struct{ Commit Commit } }{
+						Nodes: []struct{ Commit Commit }{
+							{Commit: Commit{Status: CommitStatus{Contexts: []Context{}}, OID: "2"}}},
+					},
+				},
+				{
+					Number:     githubql.Int(3),
+					HeadRefOID: githubql.String("3"),
+					Commits: struct{ Nodes []struct{ Commit Commit } }{
+						Nodes: []struct{ Commit Commit }{
+							{Commit: Commit{Status: CommitStatus{Contexts: []Context{}}, OID: "3"}}},
+					},
+				},
+				{
+					Number:     githubql.Int(4),
+					HeadRefOID: githubql.String("4"),
+					Commits: struct{ Nodes []struct{ Commit Commit } }{
+						Nodes: []struct{ Commit Commit }{
+							{Commit: Commit{Status: CommitStatus{Contexts: []Context{}}, OID: "4"}}},
+					},
+				},
 			},
 		},
 		{
@@ -4496,18 +4524,60 @@ func TestPickBatchPrefersBatchesWithPreexistingJobs(t *testing.T) {
 				sp.pjs[1].Spec.Refs.Pulls = []prowapi.Pull{{Number: 3, SHA: "3"}, {Number: 4, SHA: "4"}}
 			},
 			expectedPullRequests: []PullRequest{
-				{Number: githubql.Int(1), HeadRefOID: githubql.String("1")},
-				{Number: githubql.Int(2), HeadRefOID: githubql.String("2")},
+				{
+					Number:     githubql.Int(1),
+					HeadRefOID: githubql.String("1"),
+					Commits: struct{ Nodes []struct{ Commit Commit } }{
+						Nodes: []struct{ Commit Commit }{
+							{Commit: Commit{Status: CommitStatus{Contexts: []Context{}}, OID: "1"}}},
+					},
+				},
+				{
+					Number:     githubql.Int(2),
+					HeadRefOID: githubql.String("2"),
+					Commits: struct{ Nodes []struct{ Commit Commit } }{
+						Nodes: []struct{ Commit Commit }{
+							{Commit: Commit{Status: CommitStatus{Contexts: []Context{}}, OID: "2"}}},
+					},
+				},
 			},
 		},
 		{
 			name:    "Batch with pre-existing pending jobs exists and is picked",
 			subpool: func(sp *subpool) { sp.pjs[0].Status.State = prowapi.PendingState },
 			expectedPullRequests: []PullRequest{
-				{Number: githubql.Int(1), HeadRefOID: githubql.String("1")},
-				{Number: githubql.Int(2), HeadRefOID: githubql.String("2")},
-				{Number: githubql.Int(3), HeadRefOID: githubql.String("3")},
-				{Number: githubql.Int(4), HeadRefOID: githubql.String("4")},
+				{
+					Number:     githubql.Int(1),
+					HeadRefOID: githubql.String("1"),
+					Commits: struct{ Nodes []struct{ Commit Commit } }{
+						Nodes: []struct{ Commit Commit }{
+							{Commit: Commit{Status: CommitStatus{Contexts: []Context{}}, OID: "1"}}},
+					},
+				},
+				{
+					Number:     githubql.Int(2),
+					HeadRefOID: githubql.String("2"),
+					Commits: struct{ Nodes []struct{ Commit Commit } }{
+						Nodes: []struct{ Commit Commit }{
+							{Commit: Commit{Status: CommitStatus{Contexts: []Context{}}, OID: "2"}}},
+					},
+				},
+				{
+					Number:     githubql.Int(3),
+					HeadRefOID: githubql.String("3"),
+					Commits: struct{ Nodes []struct{ Commit Commit } }{
+						Nodes: []struct{ Commit Commit }{
+							{Commit: Commit{Status: CommitStatus{Contexts: []Context{}}, OID: "3"}}},
+					},
+				},
+				{
+					Number:     githubql.Int(4),
+					HeadRefOID: githubql.String("4"),
+					Commits: struct{ Nodes []struct{ Commit Commit } }{
+						Nodes: []struct{ Commit Commit }{
+							{Commit: Commit{Status: CommitStatus{Contexts: []Context{}}, OID: "4"}}},
+					},
+				},
 			},
 		},
 		{
@@ -4519,8 +4589,22 @@ func TestPickBatchPrefersBatchesWithPreexistingJobs(t *testing.T) {
 				sp.pjs[2].Spec.Refs.Pulls = []prowapi.Pull{{Number: 3, SHA: "3"}, {Number: 4, SHA: "4"}}
 			},
 			expectedPullRequests: []PullRequest{
-				{Number: githubql.Int(3), HeadRefOID: githubql.String("3")},
-				{Number: githubql.Int(4), HeadRefOID: githubql.String("4")},
+				{
+					Number:     githubql.Int(3),
+					HeadRefOID: githubql.String("3"),
+					Commits: struct{ Nodes []struct{ Commit Commit } }{
+						Nodes: []struct{ Commit Commit }{
+							{Commit: Commit{Status: CommitStatus{Contexts: []Context{}}, OID: "3"}}},
+					},
+				},
+				{
+					Number:     githubql.Int(4),
+					HeadRefOID: githubql.String("4"),
+					Commits: struct{ Nodes []struct{ Commit Commit } }{
+						Nodes: []struct{ Commit Commit }{
+							{Commit: Commit{Status: CommitStatus{Contexts: []Context{}}, OID: "4"}}},
+					},
+				},
 			},
 		},
 		{
@@ -4533,8 +4617,22 @@ func TestPickBatchPrefersBatchesWithPreexistingJobs(t *testing.T) {
 				sp.pjs[2].Spec.Refs.Pulls = []prowapi.Pull{{Number: 3, SHA: "3"}, {Number: 4, SHA: "4"}}
 			},
 			expectedPullRequests: []PullRequest{
-				{Number: githubql.Int(3), HeadRefOID: githubql.String("3")},
-				{Number: githubql.Int(4), HeadRefOID: githubql.String("4")},
+				{
+					Number:     githubql.Int(3),
+					HeadRefOID: githubql.String("3"),
+					Commits: struct{ Nodes []struct{ Commit Commit } }{
+						Nodes: []struct{ Commit Commit }{
+							{Commit: Commit{Status: CommitStatus{Contexts: []Context{}}, OID: "3"}}},
+					},
+				},
+				{
+					Number:     githubql.Int(4),
+					HeadRefOID: githubql.String("4"),
+					Commits: struct{ Nodes []struct{ Commit Commit } }{
+						Nodes: []struct{ Commit Commit }{
+							{Commit: Commit{Status: CommitStatus{Contexts: []Context{}}, OID: "4"}}},
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
The for loop passed in a copied value of PullRequest and cache only existed in the copy instead of original struct, feel like a bug.

/cc @cjwagner @alvaroaleman 