### PR TITLE
git base image: install git-daemon package

### DIFF
--- a/images/git/Dockerfile
+++ b/images/git/Dockerfile
@@ -17,7 +17,7 @@ FROM gcr.io/k8s-prow/alpine:v20211015-92dc282
 ARG IMAGE_ARG
 ENV IMAGE=${IMAGE_ARG}
 
-RUN apk add --no-cache git openssh
+RUN apk add --no-cache git git-daemon openssh
 
 COPY github-known-hosts /github_known_hosts
 COPY ssh-config /etc/ssh/ssh_config


### PR DESCRIPTION
The `git-http-backend` script does not come pre-installed with the basic
`git` package in Alpine Linux. The `git-daemon` package provides it.

This way, we can use this image as a base image for creating a Fake Git
Server image for integration tests, as described in the design doc [1]
[2].

[1]: https://docs.google.com/document/d/1StDoe894gxCnpkgkXwI-q2YxeNduGEYHeu_gJ7PonaI/edit?usp=sharing_eip_m&resourcekey=0-pQ0xkNAAXJ33CGs9y6FQ3g&ts=6282efde
[2]: https://groups.google.com/g/kubernetes-sig-testing/c/-eQ27NLdyb8.

/cc @cjwagner @chaodaiG @mpherman2 