### PR TITLE
prow/plugin: Extends label plugin to use Unique Prefixes 

### DIFF
--- a/prow/plugins/config_test.go
+++ b/prow/plugins/config_test.go
@@ -104,6 +104,35 @@ func TestValidateExternalPlugins(t *testing.T) {
 	}
 }
 
+func TestValidateUniquePrefixes(t *testing.T) {
+	testCases := []struct {
+		name           string
+		uniquePrefixes []string
+		isErrorNil     bool
+	}{
+		{
+			name:           "non-zero length prefixes",
+			uniquePrefixes: []string{"prefix1/", "prefix2"},
+			isErrorNil:     true,
+		},
+		{
+			name:           "zero length prefixes",
+			uniquePrefixes: []string{"", "prefix2"},
+			isErrorNil:     false,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.name, func(t *testing.T) {
+			err := validateUniquePrefixes(tC.uniquePrefixes)
+			if tC.isErrorNil && err != nil {
+				t.Errorf("expected nil error got %s", err)
+			} else if !tC.isErrorNil && err == nil {
+				t.Errorf("expected non nil error, got nil")
+			}
+		})
+	}
+}
+
 func TestSetDefault_Maps(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/prow/plugins/plugin-config-documented.yaml
+++ b/prow/plugins/plugin-config-documented.yaml
@@ -487,6 +487,11 @@ label:
     # or a repo in org/repo notation.
     restricted_labels:
         "": null
+
+    # UniquePrefixes is the list of label prefixes that can only exist
+    # once per issue.
+    unique_prefixes:
+      - ""
 lgtm:
   - # Repos is either of the form org/repos or just org.
     repos:


### PR DESCRIPTION
Ref: https://github.com/kubernetes/test-infra/issues/6095

This commit takes care of label prefixes that can only exist once per issue. This is done by using a list of unique prefixes to create a map that maps these prefixes to existing labels that match the prefix. When a new label is needed to be added that matches a unique prefix, the pre-existing labels in this map that match the same prefix are removed and then the new label is added.