### PR TITLE
Fix running tests in transfigure.sh

### DIFF
--- a/testgrid/cmd/transfigure/transfigure.sh
+++ b/testgrid/cmd/transfigure/transfigure.sh
@@ -80,7 +80,7 @@ main() {
 
   echo "Running kubernetes/test-infra tests..."
 
-  ./hack/make-rules/go-run/arbitrary.sh test ./config/tests
+  ./hack/make-rules/go-run/arbitrary.sh test ./config/tests/...
   make verify-spelling
   echo "Tests successful!"
 


### PR DESCRIPTION
Fixes transfigure.sh which is broken since https://github.com/kubernetes/test-infra/commit/a18c28f2186ef5d2422e19a2ed83b15b50a94432


[Tests ](https://github.com/kubernetes/test-infra/blob/f2a2939508fa77af6e21196a700c5cf61ebdb756/testgrid/cmd/transfigure/transfigure.sh#L83)cannot be carried out.
```shell
cat: '': No such file or directory
Using user from GitHub: 
cat: '': No such file or directory
Using email from GitHub: 
Ensuring kubernetes/test-infra repo
Cloning into 'test-infra'...
Created temporary repository
Checking out transfigure-branch
Switched to a new branch 'transfigure-branch'
Generating testgrid yaml
Running kubernetes/test-infra tests...
go: downloading gotest.tools/gotestsum v1.7.0
go: downloading gotest.tools v2.2.0+incompatible
go: downloading github.com/fatih/color v1.13.0
go: downloading github.com/dnephin/pflag v1.0.7
go: downloading golang.org/x/tools v0.1.11-0.20220316014157-77aa08bb151a
go: downloading github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
go: downloading github.com/pkg/errors v0.9.1
go: downloading github.com/fsnotify/fsnotify v1.5.1
go: downloading github.com/jonboulle/clockwork v0.2.2
go: downloading golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8
go: downloading golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
go: downloading golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
go: downloading github.com/mattn/go-isatty v0.0.14
go: downloading github.com/mattn/go-colorable v0.1.12
go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
go: downloading golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3
+ go test ./config/tests
no Go files in /home/prow/go/src/github.com/gardener/ci-infra/test-infra/config/tests
Cleaning temporary repository at /home/prow/go/src/github.com/gardener/ci-infra/test-infra
time="2022-05-23T11:26:46Z" level=fatal error="exit status 1"
```