### PR TITLE
azure: use latest k8s releases for cloud-provider-azure OOT + capz

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -183,7 +183,7 @@ presubmits:
             - name: CONTROL_PLANE_MACHINE_COUNT
               value: "3"
             - name: KUBERNETES_VERSION
-              value: 1.23.5
+              value: "latest"
             - name: CLUSTER_TEMPLATE
               value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss.yaml
             - name: AZURE_LOADBALANCER_SKU
@@ -215,7 +215,7 @@ presubmits:
         workdir: true
       - org: kubernetes
         repo: kubernetes
-        base_ref: release-1.23
+        base_ref: release-1.24
         path_alias: k8s.io/kubernetes
         workdir: false
     spec:
@@ -239,7 +239,7 @@ presubmits:
             - name: AZURE_LOADBALANCER_SKU
               value: "standard"
             - name: KUBERNETES_VERSION
-              value: 1.23.5
+              value: "latest"
             - name: GINKGO_ARGS
               value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --test.parallel=30 --report-dir=/logs/artifacts --disable-log-dump=true
             - name: CONTROL_PLANE_MACHINE_COUNT
@@ -291,7 +291,7 @@ presubmits:
             - name: CONTROL_PLANE_MACHINE_COUNT
               value: "3"
             - name: KUBERNETES_VERSION
-              value: 1.23.5
+              value: "latest"
     annotations:
       testgrid-dashboards: provider-azure-cloud-provider-azure
       testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-capz
@@ -363,7 +363,7 @@ periodics:
         - name: CONTROL_PLANE_MACHINE_COUNT
           value: "3"
         - name: KUBERNETES_VERSION
-          value: 1.23.5
+          value: "latest"
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
     testgrid-tab-name: cloud-provider-azure-master-capz
@@ -413,7 +413,7 @@ periodics:
         - name: CONTROL_PLANE_MACHINE_COUNT
           value: "3"
         - name: KUBERNETES_VERSION
-          value: 1.23.5
+          value: "latest"
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure
     testgrid-tab-name: cloud-provider-azure-master-capz-main
@@ -562,7 +562,7 @@ periodics:
     workdir: true
   - org: kubernetes
     repo: kubernetes
-    base_ref: release-1.23
+    base_ref: release-1.24
     path_alias: k8s.io/kubernetes
     workdir: false
   - org: kubernetes-sigs
@@ -591,7 +591,7 @@ periodics:
       - name: AZURE_LOADBALANCER_SKU
         value: "standard"
       - name: KUBERNETES_VERSION
-        value: 1.23.5
+        value: "latest"
       - name: GINKGO_ARGS
         value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --test.parallel=30 --report-dir=/logs/artifacts --disable-log-dump=true
       - name: CONTROL_PLANE_MACHINE_COUNT
@@ -620,7 +620,7 @@ periodics:
     workdir: true
   - org: kubernetes
     repo: kubernetes
-    base_ref: release-1.23
+    base_ref: release-1.24
     path_alias: k8s.io/kubernetes
     workdir: false
   - org: kubernetes-sigs
@@ -649,7 +649,7 @@ periodics:
       - name: AZURE_LOADBALANCER_SKU
         value: "standard"
       - name: KUBERNETES_VERSION
-        value: 1.23.5
+        value: "latest"
       - name: GINKGO_ARGS
         value: --ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|In-tree.Volumes|should.be.able.to.create.an.internal.type.load.balancer --test.parallel=4 --report-dir=/logs/artifacts --disable-log-dump=true
       - name: CONTROL_PLANE_MACHINE_COUNT
@@ -829,7 +829,7 @@ periodics:
         - name: CONTROL_PLANE_MACHINE_COUNT
           value: "3"
         - name: KUBERNETES_VERSION
-          value: 1.23.5
+          value: "latest"
         - name: CLUSTER_TEMPLATE
           value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss.yaml
         - name: AZURE_LOADBALANCER_SKU
@@ -942,7 +942,7 @@ periodics:
       - name: TEST_CCM
         value: "true"
       - name: KUBERNETES_VERSION
-        value: 1.23.5
+        value: "latest"
       - name: GINKGO_ARGS
         value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --test.parallel=30 --report-dir=/logs/artifacts --disable-log-dump=true
       - name: CONTROL_PLANE_MACHINE_COUNT
@@ -1059,7 +1059,7 @@ periodics:
       - name: TEST_CCM
         value: "true"
       - name: KUBERNETES_VERSION
-        value: 1.23.5
+        value: "latest"
       - name: GINKGO_ARGS
         value: --ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|In-tree.Volumes|should.be.able.to.create.an.internal.type.load.balancer --test.parallel=4 --report-dir=/logs/artifacts --disable-log-dump=true
       - name: CONTROL_PLANE_MACHINE_COUNT

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.0.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.0.yaml
@@ -182,7 +182,7 @@ presubmits:
               - name: AZURE_LOADBALANCER_SKU
                 value: "Standard"
               - name: KUBERNETES_VERSION
-                value: 1.21.5
+                value: "latest-1.21"
               - name: CONTROL_PLANE_MACHINE_COUNT
                 value: "3"
               - name: CLUSTER_TEMPLATE
@@ -238,7 +238,7 @@ presubmits:
               - name: AZURE_LOADBALANCER_SKU
                 value: "standard"
               - name: KUBERNETES_VERSION
-                value: 1.21.5
+                value: "latest-1.21"
               - name: GINKGO_ARGS
                 value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --test.parallel=30 --report-dir=/logs/artifacts --disable-log-dump=true
               - name: CONTROL_PLANE_MACHINE_COUNT
@@ -287,7 +287,7 @@ presubmits:
               - name: AZURE_LOADBALANCER_SKU
                 value: "standard"
               - name: KUBERNETES_VERSION
-                value: 1.21.5
+                value: "latest-1.21"
               - name: CONTROL_PLANE_MACHINE_COUNT
                 value: "3"
       annotations:

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.1.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.1.yaml
@@ -182,7 +182,7 @@ presubmits:
               - name: AZURE_LOADBALANCER_SKU
                 value: "Standard"
               - name: KUBERNETES_VERSION
-                value: 1.22.2
+                value: "latest-1.22"
               - name: CONTROL_PLANE_MACHINE_COUNT
                 value: "3"
               - name: CLUSTER_TEMPLATE
@@ -238,7 +238,7 @@ presubmits:
               - name: AZURE_LOADBALANCER_SKU
                 value: "standard"
               - name: KUBERNETES_VERSION
-                value: 1.22.2
+                value: "latest-1.22"
               - name: GINKGO_ARGS
                 value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --test.parallel=30 --report-dir=/logs/artifacts --disable-log-dump=true
               - name: CONTROL_PLANE_MACHINE_COUNT
@@ -287,7 +287,7 @@ presubmits:
               - name: AZURE_LOADBALANCER_SKU
                 value: "standard"
               - name: KUBERNETES_VERSION
-                value: 1.22.2
+                value: "latest-1.22"
               - name: CONTROL_PLANE_MACHINE_COUNT
                 value: "3"
       annotations:

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.23.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.23.yaml
@@ -181,7 +181,7 @@ presubmits:
               - name: TEST_CCM
                 value: "true"
               - name: KUBERNETES_VERSION
-                value: 1.23.5
+                value: "latest-1.23"
               - name: CONTROL_PLANE_MACHINE_COUNT
                 value: "3"
               - name: CLUSTER_TEMPLATE
@@ -239,7 +239,7 @@ presubmits:
               - name: AZURE_LOADBALANCER_SKU
                 value: "standard"
               - name: KUBERNETES_VERSION
-                value: 1.23.5
+                value: "latest-1.23"
               - name: GINKGO_ARGS
                 value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --test.parallel=30 --report-dir=/logs/artifacts --disable-log-dump=true
               - name: CONTROL_PLANE_MACHINE_COUNT
@@ -289,7 +289,7 @@ presubmits:
               - name: AZURE_LOADBALANCER_SKU
                 value: "standard"
               - name: KUBERNETES_VERSION
-                value: 1.23.5
+                value: "latest-1.23"
               - name: CONTROL_PLANE_MACHINE_COUNT
                 value: "3"
       annotations:

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.24.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.24.yaml
@@ -61,7 +61,7 @@ presubmits:
               - name: TEST_CCM
                 value: "true"
               - name: KUBERNETES_VERSION
-                value: 1.24.0
+                value: "latest-1.24"
               - name: CONTROL_PLANE_MACHINE_COUNT
                 value: "3"
               - name: CLUSTER_TEMPLATE
@@ -179,7 +179,7 @@ presubmits:
               - name: AZURE_LOADBALANCER_SKU
                 value: "standard"
               - name: KUBERNETES_VERSION
-                value: 1.24.0
+                value: "latest-1.24"
               - name: GINKGO_ARGS
                 value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --test.parallel=30 --report-dir=/logs/artifacts --disable-log-dump=true
               - name: CONTROL_PLANE_MACHINE_COUNT
@@ -229,7 +229,7 @@ presubmits:
               - name: AZURE_LOADBALANCER_SKU
                 value: "standard"
               - name: KUBERNETES_VERSION
-                value: 1.24.0
+                value: "latest-1.24"
               - name: CONTROL_PLANE_MACHINE_COUNT
                 value: "3"
       annotations:


### PR DESCRIPTION
This PR updates CI definitions for capz + out-of-tree cloud-provider-azure jobs so that they always use the latest released k8s bits.

This PR is now safe to merge as the required changes are live in capz @ release-1.3 branch:

https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2324