### PR TITLE
Fix typo in pr-history HTML

### DIFF
--- a/prow/cmd/deck/template/pr-history.html
+++ b/prow/cmd/deck/template/pr-history.html
@@ -38,7 +38,7 @@
       <tr>
         <td class="mdl-data-table__cell--non-numeric">{{if .Link}}<a href="{{.Link}}">{{.Name}}</a>{{else}}{{.Name}}{{end}}</td>
         {{range .Builds}}
-        <td class="mdl-data-table__cell--non-numeric {{if eq .Result "SUCCESS"}}run-success{{else if eq .Result "FAILURE"}}run-failure{{else if eq .Result "PENDING"}}run-pending{{else if eq .Result "ABORTED"}}run-aborted{{end}}">{{if .SpyglassLink}}<a href="{{.SpyglassLink}}">{{.ID}}</a>{{else}}{{.ID}}{{end}}</td>
+        <td class="mdl-data-table__cell--non-numeric {{if eq .Result "SUCCESS"}}run-success{{else if eq .Result "FAILURE"}}run-failure{{else if eq .Result "Pending"}}run-pending{{else if eq .Result "ABORTED"}}run-aborted{{end}}">{{if .SpyglassLink}}<a href="{{.SpyglassLink}}">{{.ID}}</a>{{else}}{{.ID}}{{end}}</td>
         {{end}}
       </tr>
       {{end}}


### PR DESCRIPTION
Small fix following f8da2a1b663690b5eee228895e8416da00728de4 - unlike
job history, in pr-history the result is `Pending` and not `PENDING`,
due to this line:

https://github.com/kubernetes/test-infra/blob/e7ccf79861d3c53dfaa6c784c0c8537922c4c0cc/prow/cmd/deck/job_history.go#L362