### PR TITLE
Correct halogen service type

### DIFF
--- a/config/prow/cluster/halogen.yaml
+++ b/config/prow/cluster/halogen.yaml
@@ -62,4 +62,4 @@ spec:
   # name: metrics
   # port: 9090
   # protocol: TCP
-  type: ClusterIP
+  type: NodePort


### PR DESCRIPTION
`NodePort` is required for external services: https://cloud.google.com/kubernetes-engine/docs/how-to/load-balance-ingress#creating_a_service