### PR TITLE
integration test: gerrit: fix panic from nil pointer dereference

### DIFF
--- a/prow/test/integration/test/gerrit_test.go
+++ b/prow/test/integration/test/gerrit_test.go
@@ -87,7 +87,7 @@ func TestGerrit(t *testing.T) {
 	resp, err := gerritClient.GetChange(gerritServer, "1")
 	if err != nil {
 		reset()
-		t.Errorf("Failed getting gerrit change: %v", err)
+		t.Fatalf("Failed getting gerrit change: %v", err)
 	}
 
 	if len(resp.Messages) < 2 {


### PR DESCRIPTION
This was encountered when running the integration tests. The `resp`
variable will be nil if there is an error, resulting in `resp.Messages`
becoming a nil pointer dereference.

    + mkdir -p /usr/local/google/home/linusa/go/src/k8s.io/test-infra/_output
    + /usr/local/google/home/linusa/go/src/k8s.io/test-infra/_bin/gotestsum --junitfile=/usr/local/google/home/linusa/go/src/k8s.io/test-infra/_output/junit-integration.xml -- ./prow/test/integration/test --run-integration-test
    ✖  prow/test/integration/test (15.187s)

    === Failed
    === FAIL: prow/test/integration/test TestGerrit (15.01s)
        gerrit_test.go:90: Failed getting gerrit change: error getting current change: API call to http://localhost/fakegerritserver/changes/1 failed: 421 Misdirected Request, response body: ""
    panic: runtime error: invalid memory address or nil pointer dereference [recovered]
            panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x270 pc=0x15956fa]

    goroutine 72 [running]:
    testing.tRunner.func1.2({0x171ac40, 0x283fc70})
            /usr/local/google/home/linusa/.gimme/versions/go1.18.linux.amd64/src/testing/testing.go:1389 +0x24e
    testing.tRunner.func1()
            /usr/local/google/home/linusa/.gimme/versions/go1.18.linux.amd64/src/testing/testing.go:1392 +0x39f
    panic({0x171ac40, 0x283fc70})
            /usr/local/google/home/linusa/.gimme/versions/go1.18.linux.amd64/src/runtime/panic.go:838 +0x207
    k8s.io/test-infra/prow/test/integration/test.TestGerrit(0xc0004c4b60)
            /usr/local/google/home/linusa/go/src/k8s.io/test-infra/prow/test/integration/test/gerrit_test.go:93 +0x83a
    testing.tRunner(0xc0004c4b60, 0x1a2c438)
            /usr/local/google/home/linusa/.gimme/versions/go1.18.linux.amd64/src/testing/testing.go:1439 +0x102
    created by testing.(*T).Run
            /usr/local/google/home/linusa/.gimme/versions/go1.18.linux.amd64/src/testing/testing.go:1486 +0x35f

/assign @mpherman2 