### PR TITLE
update job timeout for 4h for post-k8sio-image-promo job

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -28,6 +28,8 @@ postsubmits:
   - name: post-k8sio-image-promo
     cluster: k8s-infra-prow-build-trusted
     decorate: true
+    decoration_config:
+      timeout: 4h
     run_if_changed: 'k8s.gcr.io/((images/.*/images\.yaml)|(manifests/.*/promoter-manifest\.yaml))'
     # Never run more than 1 job at a time. This is because we don't want to run
     # into a case where an older manifest PR merge gets run last (after a newer


### PR DESCRIPTION
the last k8s image promotion is running close to 2 hour so it will timeout soon for the next jobs

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-k8sio-image-promo/1529502808133341184

/assign @saschagrunert @Verolop @xmudrii @palnabarun 
cc @kubernetes/release-managers 