### PR TITLE
Remove cncf/apisnoop prow interactions apart from #sig-arch + #sig-release supporting jobs

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1251,6 +1251,10 @@ plugins:
     - size
     - welcome
 
+  cncf/apisnoop:
+    plugins:
+    - trigger # prow.k8s.io for #sig-arch + release-informing jobs... prow.cncf.io for cncf/k8s-conformance related jobs
+
 external_plugins:
   kubernetes:
   - name: needs-rebase

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1251,24 +1251,6 @@ plugins:
     - size
     - welcome
 
-  cncf/apisnoop:
-    plugins:
-    - wip
-    - trigger
-    - assign
-    - cla
-    - cat # /meow replies with cat pictures
-    - dog # /bark replies with dog pictures
-    - goose
-    - heart
-    - help
-    - hold
-    - label
-    - lgtm
-    - retitle
-    - shrug
-    - size
-
 external_plugins:
   kubernetes:
   - name: needs-rebase


### PR DESCRIPTION
Closes https://github.com/cncf/apisnoop/issues/548