### PR TITLE
Use FindIssuesWithOrg to cope with GitHub Apps

### DIFF
--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -613,8 +613,13 @@ func (f *FakeClient) RemoveLabel(owner, repo string, number int, label string) e
 	return fmt.Errorf("cannot remove %v from %s/%s/#%d", label, owner, repo, number)
 }
 
-// FindIssues returns f.Issues
+// FindIssues returns the same results as FindIssuesWithOrg
 func (f *FakeClient) FindIssues(query, sort string, asc bool) ([]github.Issue, error) {
+	return f.FindIssuesWithOrg("", query, sort, asc)
+}
+
+// FindIssuesWithOrg returns f.Issues
+func (f *FakeClient) FindIssuesWithOrg(org, query, sort string, asc bool) ([]github.Issue, error) {
 	f.lock.RLock()
 	defer f.lock.RUnlock()
 	var issues []github.Issue

--- a/prow/plugins/welcome/welcome.go
+++ b/prow/plugins/welcome/welcome.go
@@ -82,7 +82,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) 
 
 type githubClient interface {
 	CreateComment(owner, repo string, number int, comment string) error
-	FindIssues(query, sort string, asc bool) ([]github.Issue, error)
+	FindIssuesWithOrg(org, query, sort string, asc bool) ([]github.Issue, error)
 	IsCollaborator(org, repo, user string) (bool, error)
 	IsMember(org, user string) (bool, error)
 	BotUserChecker() (func(candidate string) bool, error)
@@ -131,7 +131,7 @@ func handlePR(c client, t plugins.Trigger, pre github.PullRequestEvent, welcomeT
 
 	// search for PRs from the author in this repo
 	query := fmt.Sprintf("is:pr repo:%s/%s author:%s", org, repo, user)
-	issues, err := c.GitHubClient.FindIssues(query, "", false)
+	issues, err := c.GitHubClient.FindIssuesWithOrg(org, query, "", false)
 	if err != nil {
 		return err
 	}

--- a/prow/plugins/welcome/welcome_test.go
+++ b/prow/plugins/welcome/welcome_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package welcome
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"regexp"
@@ -126,9 +127,12 @@ func (fc *fakeClient) ClearPRs() {
 	fc.prs = make(map[string]sets.Int)
 }
 
-// FindIssues fails if the query does not match the expected query regex and
+// FindIssuesWithOrg fails if the query does not match the expected query regex and
 // looks up issues based on parsing the expected query format
-func (fc *fakeClient) FindIssues(query, sort string, asc bool) ([]github.Issue, error) {
+func (fc *fakeClient) FindIssuesWithOrg(org, query, sort string, asc bool) ([]github.Issue, error) {
+	if org == "" {
+		return nil, errors.New("passing an empty organization is highly discouraged, as it's incompatible with GitHub Apps")
+	}
 	fields := expectedQueryRegex.FindStringSubmatch(query)
 	if fields == nil || len(fields) != 4 {
 		return nil, fmt.Errorf("invalid query: `%s` does not match expected regex `%s`", query, expectedQueryRegex.String())


### PR DESCRIPTION
Setting up welcome plugin in our setup seems broken, yields the following error:
```
Get
"http://ghproxy/search/issues?per_page=100&q=is%3Apr+repo%3A<org>%2F<repo>+author%3A<author>":
BUG apps auth requested but empty org, please report this to the
test-infra repo. Stack: goroutine 174392 [running]:
runtime/debug.Stack()
runtime/debug/stack.go:24 +0x65
k8s.io/test-infra/prow/github.(*appsRoundTripper).addAppInstallationAuth(0x1dc2ea0?,
0xc00380de00)
k8s.io/test-infra/prow/github/app_auth_roundtripper.go:152 +0xae
k8s.io/test-infra/prow/github.(*appsRoundTripper).RoundTrip(0xc0284e4460,
0xc00380de00)
k8s.io/test-infra/prow/github/app_auth_roundtripper.go:99 +0x10a
net/http.send(0xc00380dd00, {0x24c2cc0, 0xc0284e4460}, {0x2075740?,
0x4beb01?, 0x34c9440?})
net/http/client.go:252 +0x5d8
net/http.(*Client).send(0xc04632f4a0, 0xc00380dd00, {0x20302d?,
0xc0b534a230?, 0x34c9440?})
net/http/client.go:176 +0x9b
net/http.(*Client).do(0xc04632f4a0, 0xc00380dd00)
net/http/client.go:725 +0x8f5
net/http.(*Client).Do(0xc0b506a690?, 0xc003b0b708?)
net/http/client.go:593 +0x19
k8s.io/test-infra/prow/github.(*client).doRequest(0xc0b7fdc180,
{0x24dc3a0?, 0xc000056030?}, {0x20e03f7?, 0x8?}, {0xc035918d00?,
0x1000000000000?}, {0x0, 0x0}, {0x0, ...}, ...)
k8s.io/test-infra/prow/github/client.go:1199 +0xa08
k8s.io/test-infra/prow/github.(*client).requestRetryWithContext(0xc0b7fdc180,
{0x24dc3a0, 0xc000056030}, {0x20e03f7, 0x3}, {0xc035918c80, 0x71}, {0x0,
0x0}, {0x0, ...}, ...)
k8s.io/test-infra/prow/github/client.go:1054 +0x267
k8s.io/test-infra/prow/github.(*client).readPaginatedResultsWithValuesWithContext(0x0?,
{0x24dc3a0, 0xc000056030}, {0xc06e7b4dc0?, 0xe?}, 0xb2173e?, {0x0, 0x0},
{0x0, 0x0}, ...)
k8s.io/test-infra/prow/github/client.go:1990 +0x187
k8s.io/test-infra/prow/github.(*client).readPaginatedResultsWithValues(...)
k8s.io/test-infra/prow/github/client.go:1981
k8s.io/test-infra/prow/github.(*client).FindIssuesWithOrg(0xc003b0c930?,
{0x0, 0x0}, {0xc03b7de5a0, 0x4b}, {0x0, 0x0}, 0x0)
k8s.io/test-infra/prow/github/client.go:3501 +0x465
k8s.io/test-infra/prow/github.(*client).FindIssues(0xc003b0ca88?,
{0xc03b7de5a0?, 0x3?}, {0x0?, 0xc03b7de5a0?}, 0x20?)
k8s.io/test-infra/prow/github/client.go:3470 +0x36
k8s.io/test-infra/prow/plugins/welcome.handlePR({{_, _}, _}, {{0x0, 0x0,
0x0}, {0x0, 0x0, 0x0}, {0x0, ...}, ...}, ...)
k8s.io/test-infra/prow/plugins/welcome/welcome.go:134 +0x2bd
k8s.io/test-infra/prow/plugins/welcome.handlePullRequest({{0x24f5530,
0xc04c774100}, {0x24e48d0, 0xc0466776e0}, {0x24ef430, 0xc04633fa20},
0xc0466892f0, {0x24dacd0, 0xc02e750e68}, 0xc046677700, ...}, ...)
k8s.io/test-infra/prow/plugins/welcome/welcome.go:106 +0x1cb
k8s.io/test-infra/prow/hook.(*Server).handlePullRequestEvent.func1.1()
k8s.io/test-infra/prow/hook/events.go:210 +0x79
k8s.io/test-infra/prow/hook.errorOnPanic(0xc003889de8?)
k8s.io/test-infra/prow/hook/events.go:470 +0x62
k8s.io/test-infra/prow/hook.(*Server).handlePullRequestEvent.func1({0xc0327e5240,
0x7}, 0x2202d20)
k8s.io/test-infra/prow/hook/events.go:210 +0x1ee
created by k8s.io/test-infra/prow/hook.(*Server).handlePullRequestEvent
k8s.io/test-infra/prow/hook/events.go:201 +0x4f7
```

Seeing it's originating from usage of the [FindIssues](https://github.com/kubernetes/test-infra/blob/ca70c964e2ea2de803474a60a5f3bdb3cf11fe74/prow/github/client.go#L3469) function, I read function documentation which says it's not working in contexts where "github-app-id" is set. Instead, we can make use of [FindIssuesWithOrg](https://github.com/kubernetes/test-infra/blob/ca70c964e2ea2de803474a60a5f3bdb3cf11fe74/prow/github/client.go#L3481) which should work in those cases.

I've changed usage to consist on ``FindIssuesWithOrg`` alone (with no fallback logic) because it doesn't seem like using ``FindIssues`` has any advantage on cases you already have the org.

Many thanks for @droslean for pointing me to the right direction :)