### PR TITLE
Job History page: Use an orange color for error result

### DIFF
--- a/prow/cmd/deck/static/job-history/job-history.ts
+++ b/prow/cmd/deck/static/job-history/job-history.ts
@@ -17,6 +17,9 @@ window.onload = (): void => {
       case "FAILURE":
         className = "run-failure";
         break;
+      case "error":
+        className = "run-error";
+        break;
       case "ABORTED":
         className = "run-aborted";
         break;

--- a/prow/cmd/deck/template/job-history.html
+++ b/prow/cmd/deck/template/job-history.html
@@ -12,6 +12,9 @@
   .run-failure {
     background-color: rgba(255, 0, 0, 0.3);
   }
+  .run-error {
+    background-color: rgba(255, 100, 0, 0.3);
+  }
   .run-pending {
     background-color: rgba(255, 255, 0, 0.3);
   }


### PR DESCRIPTION
# Background

A job may end with result `error`, which is different from `FAILURE`,
and I believe indicates a general issue with running the job.

Here is an example of a job run with an "error" result:

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/openshift-kubernetes-1252-ci-4.11-e2e-azure-upgrade-single-node/1528156495684833280

(see `finished.json` artifact to see the `error` result)

# Issue

This `error` result was not accounted for when determining the CSS class
for that job and as a result it defaulted to the "pending" color
(yellow) which made it seem like jobs in the error state are still
running.

# Fix

Add a new CSS class for jobs with an `error` result and give it an
orange color to make is distinct from pending jobs and from FAILURE
jobs

Before:
![image](https://user-images.githubusercontent.com/10882062/170445039-457db70e-c989-4e66-bedf-35f10d4e035e.png)


After:
![image](https://user-images.githubusercontent.com/10882062/170444930-ddb9b2a1-7949-4954-83eb-fb8acc04ac12.png)
