### PR TITLE
Add Windows Server 2022 test

### DIFF
--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -100,6 +100,55 @@ periodics:
     testgrid-dashboards: sig-windows-gce
     testgrid-tab-name: gce-windows-2019-containerd-master
     description: Runs tests on a Kubernetes cluster with Windows containerd nodes on GCE
+- name: ci-kubernetes-e2e-windows-win2022-containerd-gce-master
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  extra_refs:
+  - base_ref: master
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/windows-testing
+    repo: windows-testing
+  interval: 4h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+    preset-common-gce-windows: "true"
+    preset-e2e-gce-windows: "true"
+    preset-e2e-gce-windows-containerd: "true"
+    preset-windows-repo-list-master: "true"
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --cluster=
+      - --extract=ci/latest
+      - --gcp-zone=us-west1-b
+      - --provider=gce
+      - --gcp-nodes=2
+      - --test=false
+      - --test-cmd=$GOPATH/src/sigs.k8s.io/windows-testing/gce/run-e2e.sh
+      - --test_args=--node-os-distro=windows -prepull-images=true --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[Feature:Windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[alpha\]|\[Slow\]|\[GMSA\]|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|\[sig-api-machinery\].Aggregator|\[Driver:.windows-gcepd\]
+      - --test-cmd-args=--node-os-distro=windows -prepull-images=true --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[Feature:Windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[alpha\]|\[Slow\]|\[GMSA\]|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|\[sig-api-machinery\].Aggregator|\[Driver:.windows-gcepd\]
+      - --ginkgo-parallel=4
+      - --timeout=230m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      env:
+      - name: NO_LINUX_POOL_TAINT
+        value: "true"
+      - name: WINDOWS_NODE_OS_DISTRIBUTION
+        value: "win2022"
+      - name: NODE_SIZE
+        value: "n1-standard-4"
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220523-f2a2939508-master
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-windows-gce
+    testgrid-tab-name: gce-windows-2022-containerd-master
+    description: Runs tests on a Kubernetes cluster with Windows Server 2022 containerd nodes on GCE
 - name: ci-kubernetes-e2e-windows-20h2-containerd-gce-master
   decorate: true
   decoration_config:


### PR DESCRIPTION
We added a test in the master branch to run e2e test on Windows Server 2022 Image for containerd. This will ensure any future changes on OSS repo will work with the new Windows Server 2022 Image

/assign @ibabou 