### PR TITLE
cluster-api: fix clusterctl upgrade test (v1alpha3=>main)

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -77,7 +77,7 @@ periodics:
           - name: INIT_WITH_PROVIDERS_CONTRACT
             value: v1alpha3
           - name: INIT_WITH_KUBERNETES_VERSION
-            value: v1.21.10
+            value: v1.21.12
 
         # we need privileged mode in order to do docker in docker
         securityContext:

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-1-1.yaml
@@ -51,7 +51,7 @@ periodics:
           - name: INIT_WITH_PROVIDERS_CONTRACT
             value: v1alpha3
           - name: INIT_WITH_KUBERNETES_VERSION
-            value: v1.21.2
+            value: v1.21.12
 
         # we need privileged mode in order to do docker in docker
         securityContext:


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

Upgrades to an image which works with systemd cgroupDriver. Verified here: https://github.com/kubernetes-sigs/cluster-api/pull/6556 (the full test)

This might break release-1.1 until we cherry-pick the v1.24/systemd change to release-1.1. But I think it's fine as that's only a matter of hours and I don't want to coordinate another PR.