### PR TITLE
conformance-vmss-serial-capz don't use latest KUBERNETES_VERSION

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -1116,7 +1116,7 @@ periodics:
       - name: TEST_CCM
         value: "true"
       - name: KUBERNETES_VERSION
-        value: "latest"
+        value: "1.23.5"
       - name: GINKGO_ARGS
         # Check https://github.com/kubernetes-sigs/cloud-provider-azure/issues/224 for the status of each skipped test
         value: --ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]|regular.resource.usage.tracking.resource.tracking.for|validates.MaxPods.limit.number.of.pods.that.are.allowed.to.run --test.parallel=30 --report-dir=/logs/artifacts --disable-log-dump=true


### PR DESCRIPTION
This job is using external cluster template, which means it cannot
use latest KUBERNETES_VERSION now.

Signed-off-by: Zhecheng Li <zhechengli@microsoft.com>