### PR TITLE
cluster-api: bump release-1.1 upgrade presubmit to v1.24=>v1.25

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-1-1.yaml
@@ -259,7 +259,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.1
       testgrid-tab-name: capi-pr-e2e-full-release-1-1
-  - name: pull-cluster-api-e2e-workload-upgrade-1-23-latest-release-1-1
+  - name: pull-cluster-api-e2e-workload-upgrade-1-24-latest-release-1-1
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -283,9 +283,9 @@ presubmits:
           - "./scripts/ci-e2e.sh"
         env:
           - name: KUBERNETES_VERSION_UPGRADE_FROM
-            value: "stable-1.23"
+            value: "stable-1.24"
           - name: KUBERNETES_VERSION_UPGRADE_TO
-            value: "ci/latest-1.24"
+            value: "ci/latest-1.25"
           - name: ETCD_VERSION_UPGRADE_TO
             value: "3.5.3-0"
           - name: COREDNS_VERSION_UPGRADE_TO
@@ -300,4 +300,4 @@ presubmits:
             cpu: 7300m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.1
-      testgrid-tab-name: capi-pr-e2e-release-1-1-1-23-latest
+      testgrid-tab-name: capi-pr-e2e-release-1-1-1-24-latest


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com