### PR TITLE
Officially stop supporting owners_dir_blacklist

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -188,6 +188,8 @@ state and no claims of backwards compatibility are made for any external API.
 Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
+ - *May 27th, 2022* The `owners_dir_blacklist` field in prow config is removed
+   in favor of `owners_dir_denylist`.
  - *February 22nd, 2022* Since prow version `v20220222-acb5731b85`, the
    entrypoint container in a prow job will run as `--copy-mode-only`, instead of
    `/bin/cp /entrypoint /tools/entrypoint`. Entrypoint images before the mentioned version

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -212,17 +212,8 @@ func main() {
 		// OwnersDirDenylist struct contains some defaults that's required by all
 		// repos, so this function cannot return nil
 		res := &config.OwnersDirDenylist{}
-		deprecated := configAgent.Config().OwnersDirBlacklist
 		if l := configAgent.Config().OwnersDirDenylist; l != nil {
 			res = l
-		}
-		if deprecated != nil {
-			logrus.Warn("owners_dir_blacklist will be deprecated after October 2021, use owners_dir_denylist instead")
-			if res != nil {
-				logrus.Warn("Both owners_dir_blacklist and owners_dir_denylist are provided, owners_dir_blacklist is discarded")
-			} else {
-				res = deprecated
-			}
 		}
 		return res
 	}

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -171,10 +171,6 @@ type ProwConfig struct {
 	// to ignore when searching for OWNERS{,_ALIAS} files in a repo.
 	OwnersDirDenylist *OwnersDirDenylist `json:"owners_dir_denylist,omitempty"`
 
-	// OwnersDirBlacklist is deprecated, use OwnersDirDenylist instead
-	// TODO(chaodaiG, November 2021): Removed after October 2021
-	OwnersDirBlacklist *OwnersDirDenylist `json:"owners_dir_blacklist,omitempty"`
-
 	// Pub/Sub Subscriptions that we want to listen to
 	PubSubSubscriptions PubsubSubscriptions `json:"pubsub_subscriptions,omitempty"`
 

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -524,25 +524,6 @@ managed_webhooks:
     respect_legacy_global_token: false
 
 
-# OwnersDirBlacklist is deprecated, use OwnersDirDenylist instead
-owners_dir_blacklist:
-    # Default configures a default denylist for all repos (or orgs).
-    # Some directories like ".git", "_output" and "vendor/.*/OWNERS"
-    # are already preconfigured to be denylisted, and need not be included here.
-    default:
-      - ""
-
-    # By default, some directories like ".git", "_output" and "vendor/.*/OWNERS"
-    # are preconfigured to be denylisted.
-    # If set, IgnorePreconfiguredDefaults will not add these preconfigured directories
-    # to the denylist.
-    ignore_preconfigured_defaults: true
-
-    # Repos configures a directory denylist per repo (or org)
-    repos:
-        "": null
-
-
 # OwnersDirDenylist is used to configure regular expressions matching directories
 # to ignore when searching for OWNERS{,_ALIAS} files in a repo.
 owners_dir_denylist:


### PR DESCRIPTION
It was announced to be removed by October 2021, should be safe to remove now