### PR TITLE
Slack Client: fix double hashtag in log message

### DIFF
--- a/prow/slack/client.go
+++ b/prow/slack/client.go
@@ -147,7 +147,7 @@ func (sl *Client) WriteMessage(text, channel string) error {
 	uv.Add("text", text)
 
 	if err := sl.postMessage(chatPostMessage, uv); err != nil {
-		return fmt.Errorf("failed to post message to #%s: %w", channel, err)
+		return fmt.Errorf("failed to post message to %s: %w", channel, err)
 	}
 	return nil
 }


### PR DESCRIPTION
The `WriteMessage` method is logging the channel name with an extra '#'. The `channel` param already contains the '#' so no need to add it to the log output.

Example:
```
failed to post message to ##microshift-alerts: request failed: no_text
```