### PR TITLE
[cloud-provider-azure] Copy kubeconfig for e2e-ccm capz tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -173,6 +173,7 @@ presubmits:
           - bash
           - -c
           - >-
+            cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
             cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
             make test-ccm-e2e
           securityContext:
@@ -279,6 +280,7 @@ presubmits:
           - bash
           - -c
           - >-
+            cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
             cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
             make test-ccm-e2e
           securityContext:
@@ -351,6 +353,7 @@ periodics:
         - bash
         - -c
         - >-
+          cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
           cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
           make test-ccm-e2e
         securityContext:
@@ -401,6 +404,7 @@ periodics:
         - bash
         - -c
         - >-
+          cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
           cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
           make test-ccm-e2e
         securityContext:
@@ -450,6 +454,7 @@ periodics:
         - bash
         - -c
         - >-
+          cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
           cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
           make test-ccm-e2e
         securityContext:
@@ -933,6 +938,7 @@ periodics:
         - bash
         - -c
         - >-
+          cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
           cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
           make test-ccm-e2e
         securityContext:
@@ -1119,7 +1125,7 @@ periodics:
         value: "1.23.5"
       - name: GINKGO_ARGS
         # Check https://github.com/kubernetes-sigs/cloud-provider-azure/issues/224 for the status of each skipped test
-        value: --ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]|regular.resource.usage.tracking.resource.tracking.for|validates.MaxPods.limit.number.of.pods.that.are.allowed.to.run --test.parallel=30 --report-dir=/logs/artifacts --disable-log-dump=true
+        value: --ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]|regular.resource.usage.tracking.resource.tracking.for|validates.MaxPods.limit.number.of.pods.that.are.allowed.to.run|In-tree.Volumes --test.parallel=30 --report-dir=/logs/artifacts --disable-log-dump=true
       - name: CONTROL_PLANE_MACHINE_COUNT
         value: "3"
       - name: CLUSTER_TEMPLATE

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.0.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.0.yaml
@@ -172,6 +172,7 @@ presubmits:
             - bash
             - -c
             - >-
+              cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
               cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
               make test-ccm-e2e
             securityContext:
@@ -277,6 +278,7 @@ presubmits:
             - bash
             - -c
             - >-
+              cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
               cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
               make test-ccm-e2e
             securityContext:

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.1.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.1.yaml
@@ -172,6 +172,7 @@ presubmits:
             - bash
             - -c
             - >-
+              cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
               cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
               make test-ccm-e2e
             securityContext:
@@ -277,6 +278,7 @@ presubmits:
             - bash
             - -c
             - >-
+              cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
               cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
               make test-ccm-e2e
             securityContext:

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.23.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.23.yaml
@@ -173,6 +173,7 @@ presubmits:
               - bash
               - -c
               - >-
+                cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
                 cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
                 make test-ccm-e2e
             securityContext:
@@ -279,6 +280,7 @@ presubmits:
               - bash
               - -c
               - >-
+                cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
                 cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
                 make test-ccm-e2e
             securityContext:

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.24.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.24.yaml
@@ -53,6 +53,7 @@ presubmits:
               - bash
               - -c
               - >-
+                cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
                 cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
                 make test-ccm-e2e
             securityContext:
@@ -219,6 +220,7 @@ presubmits:
               - bash
               - -c
               - >-
+                cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
                 cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
                 make test-ccm-e2e
             securityContext:


### PR DESCRIPTION
Also skip in-tree volumes tests for
cloud-provider-azure-conformance-vmss-serial-capz

Signed-off-by: Zhecheng Li <zhechengli@microsoft.com>