### PR TITLE
kOps - Fix dependabot bot name

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -366,7 +366,7 @@ slack:
     - kops-dev
     exempt_users:
     - k8s-ci-robot
-    - dependabot
+    - dependabot[bot]
   - repos:
     - kubernetes/cluster-api-provider-aws
     channels:


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/26443 seems not to work yet:
https://kubernetes.slack.com/archives/C8MKE2G5P/p1653894020044159

/cc @olemarkus @rifelpet @cblecker 
/assign @cblecker 