### PR TITLE
Enable cherrypick for the kubernetes-sigs/ibm-powervs-block-csi-driver

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1351,6 +1351,12 @@ external_plugins:
     - issue_comment
     - pull_request
     endpoint: http://cherrypicker
+  kubernetes-sigs/ibm-powervs-block-csi-driver:
+  - name: cherrypicker
+    events:
+      - issue_comment
+      - pull_request
+    endpoint: http://cherrypicker
   kubernetes-sigs/node-feature-discovery:
   - name: cherrypicker
     events:


### PR DESCRIPTION
This will enable the `/cherrypick` plugin for the https://github.com/kubernetes-sigs/ibm-powervs-block-csi-driver repository.