### PR TITLE
[bugzilla] allow bugs to hold extra groups than configured

### DIFF
--- a/prow/plugins/bugzilla/bugzilla.go
+++ b/prow/plugins/bugzilla/bugzilla.go
@@ -1251,18 +1251,5 @@ func isBugAllowed(bug *bugzilla.Bug, allowedGroups []string) bool {
 	if len(allowedGroups) == 0 {
 		return true
 	}
-
-	for _, group := range bug.Groups {
-		found := false
-		for _, allowed := range allowedGroups {
-			if group == allowed {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return false
-		}
-	}
-	return true
+	return sets.NewString(bug.Groups...).HasAll(allowedGroups...)
 }

--- a/prow/plugins/bugzilla/bugzilla_test.go
+++ b/prow/plugins/bugzilla/bugzilla_test.go
@@ -2311,9 +2311,17 @@ func TestIsBugAllowed(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "some but not all groups matching is not allowed",
+			name: "multiple groups in bug but with all allowed included is allowed",
 			bug: &bugzilla.Bug{
 				Groups: []string{"whoa", "really", "cool"},
+			},
+			groups:   []string{"whoa", "really"},
+			expected: true,
+		},
+		{
+			name: "multiple groups in bug but not all allowed included is not allowed",
+			bug: &bugzilla.Bug{
+				Groups: []string{"whoa", "cool"},
 			},
 			groups:   []string{"whoa", "really"},
 			expected: false,


### PR DESCRIPTION
Changes the way of validating if the bug is allowed based on the allowed groups that exist in the configuration. 

Before, we expect the bug groups to match exactly with the allowed groups, but with this change we allow the bug to contain extra groups rather than the allowed groups only.

/cc @alvaroaleman 


Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>