### PR TITLE
Adding periodic job to validate azurefile with windows/capz config

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -57,6 +57,13 @@ presets:
       value: "true"
     - name: WORKER_MACHINE_COUNT
       value: 0 # Don't create linux worker nodes
+- labels:
+    preset-capz-windows-azurefile: "true"
+  env:
+    - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS
+      value: "true"
+    - name: WORKER_MACHINE_COUNT
+      value: 0 # Don't create linux worker nodes
 periodics:
 - name: ci-kubernetes-e2e-capz-master-containerd-windows
   interval: 3h
@@ -236,6 +243,47 @@ periodics:
     testgrid-tab-name: capz-azuredisk-windows-2019
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure Disk e2e test in a CAPZ cluster on Windows 2019 nodes
+- name: ci-kubernetes-e2e-azurefile-capz-windows-2019
+  interval: 48h
+  decorate: true
+  decoration_config:
+    timeout: 2h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+    preset-capz-windows-ci-entrypoint-common-main: "true"
+    preset-capz-windows-azuredisk: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: true
+  - org: kubernetes-sigs
+    repo: azurefile-csi-driver
+    base_ref: master
+    path_alias: sigs.k8s.io/azurefile-csi-driver
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220523-f2a2939508-master
+        command:
+          - runner.sh
+          - ./scripts/ci-entrypoint.sh
+        args:
+          - bash
+          - -c
+          - >-
+            cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&
+            make e2e-test
+        securityContext:
+          privileged: true
+  annotations:
+    testgrid-dashboards: sig-windows-master-release
+    testgrid-tab-name: capz-azurefile-windows-2019
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    description: Run Azure File e2e test in a CAPZ cluster on Windows 2019 nodes
 - name: ci-kubernetes-e2e-capz-master-containerd-nightly-windows
   interval: 24h
   decorate: true


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

We have a PR job to that has many passes so this should be stable enough to enable the periodic job
https://testgrid.k8s.io/provider-azure-azurefile-csi-driver#pull-azurefile-csi-driver-e2e-capz-windows-2019

/assign @jsturtevant @andyzhangx 