### PR TITLE
Allow descheduler owners to rerun image push job

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-descheduler.yaml
+++ b/config/jobs/image-pushing/k8s-staging-descheduler.yaml
@@ -4,6 +4,12 @@ postsubmits:
   kubernetes-sigs/descheduler:
     # The name should be changed to match the repo name above
     - name: post-descheduler-push-images
+      rerun_auth_config:
+        # approvers from https://github.com/kubernetes-sigs/descheduler/blob/master/OWNERS
+        github_users:
+        - damemi
+        - ingvagabund
+        - seanmalloy
       cluster: k8s-infra-prow-build-trusted
       annotations:
         # This is the name of some testgrid dashboard to report to.


### PR DESCRIPTION
If an automated image build fails or times out, we need a way to manually retrigger it in order to promote release images. From what I can tell, this will allow that. I've chosen the current descheduler maintainers, and we should document that this list should be updated as maintainers are added/removed