### PR TITLE
Revert "[bugzilla] allow bugs to hold extra groups than configured"

### DIFF
--- a/prow/plugins/bugzilla/bugzilla.go
+++ b/prow/plugins/bugzilla/bugzilla.go
@@ -1251,5 +1251,18 @@ func isBugAllowed(bug *bugzilla.Bug, allowedGroups []string) bool {
 	if len(allowedGroups) == 0 {
 		return true
 	}
-	return sets.NewString(bug.Groups...).HasAll(allowedGroups...)
+
+	for _, group := range bug.Groups {
+		found := false
+		for _, allowed := range allowedGroups {
+			if group == allowed {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }

--- a/prow/plugins/bugzilla/bugzilla_test.go
+++ b/prow/plugins/bugzilla/bugzilla_test.go
@@ -2311,17 +2311,9 @@ func TestIsBugAllowed(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "multiple groups in bug but with all allowed included is allowed",
+			name: "some but not all groups matching is not allowed",
 			bug: &bugzilla.Bug{
 				Groups: []string{"whoa", "really", "cool"},
-			},
-			groups:   []string{"whoa", "really"},
-			expected: true,
-		},
-		{
-			name: "multiple groups in bug but not all allowed included is not allowed",
-			bug: &bugzilla.Bug{
-				Groups: []string{"whoa", "cool"},
 			},
 			groups:   []string{"whoa", "really"},
 			expected: false,


### PR DESCRIPTION
This reverts commit ab4e5df53478f2f6b1be0b8f729261bf91f82361.

With the above, bugs must always have all allowed groups, which doesn't
really make sense.