### PR TITLE
add warnings to existing Prow docs

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -247,6 +247,13 @@ blockades:
   exceptionregexps:
   - ^README\.md$
   explanation: "We do not accept changes directly against this repository, unless the change is to the `README.md` itself. Please see `CONTRIBUTING.md` for information on where and how to contribute instead."
+- repos:
+  - kubernetes/test-infra
+  blockregexps:
+  - ^prow/.+\.md$
+  exceptionregexps:
+  - ^prow/README\.md$
+  explanation: "All Prow documentation (Markdown files) have moved to https://github.com/kubernetes-sigs/prow as part of https://github.com/kubernetes-sigs/prow/issues/4."
 
 blunderbuss:
   max_request_count: 2
@@ -973,6 +980,7 @@ plugins:
 
   kubernetes/test-infra:
     plugins:
+    - blockade
     - config-updater
     - milestone
     - override


### PR DESCRIPTION
Part of https://github.com/kubernetes-sigs/prow/issues/4.

This change just adds highly visible, almost obnoxious comments that are only visible to those who would like to make modifications to these files. The files now live in https://github.com/kubernetes-sigs/prow/pull/10 under the "Legacy Snapshot" subdirectory.

The next phase of this migration likely involves "promoting" each file out of the "Legacy Snapshot" directory there to a less "Legacy ..."-sounding path, and once that's done, deleting the original file here so as to force users to use docs.prow.k8s.io as the source of truth.

/assign @cjwagner 