### PR TITLE
Add Prow Jobs to run `OWNERS_ALIASES`sync automation

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -772,3 +772,38 @@ periodics:
       - --warnings=duplicate-job-refs
   annotations:
     testgrid-dashboards: sig-testing-misc
+
+- interval: 24h
+  name: ci-org-owners-aliases-sync-kubernetes-client
+  annotations:
+    testgrid-dashboards: sig-contribex-org
+    testgrid-tab-name: ci-peribolos
+    testgrid-alert-email: kubernetes-github-managment-alerts@googlegroups.com, k8s-infra-oncall@google.com
+    testgrid-num-failures-to-alert: '1'
+  cluster: test-infra-trusted
+  decorate: true
+  max_concurrency: 1
+  extra_refs:
+  - org: kubernetes
+    repo: org
+    base_ref: main
+  spec:
+    containers:
+    - image: golang:1.17
+      command: ["/bin/bash", "-c"]
+      env:
+        - name: GITHUB_TOKEN_PATH
+          value: /etc/github-token/oauth
+      args:
+        - curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          apt update;
+          apt install gh;
+          ./admin/aliases-sync.sh kubernetes-client;
+      volumeMounts:
+      - name: github
+        mountPath: /etc/github-token
+    volumes:
+    - name: github
+      secret:
+        secretName: oauth-token

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -774,7 +774,7 @@ periodics:
     testgrid-dashboards: sig-testing-misc
 
 - interval: 24h
-  name: ci-org-owners-aliases-sync-kubernetes-client
+  name: ci-org-owners-aliases-sync-kubernetes
   annotations:
     testgrid-dashboards: sig-contribex-org
     testgrid-tab-name: ci-peribolos
@@ -795,11 +795,38 @@ periodics:
         - name: GITHUB_TOKEN_PATH
           value: /etc/github-token/oauth
       args:
-        - curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-          apt update;
-          apt install gh;
-          ./admin/aliases-sync.sh kubernetes-client;
+        - ./admin/aliases-sync.sh kubernetes;
+      volumeMounts:
+      - name: github
+        mountPath: /etc/github-token
+    volumes:
+    - name: github
+      secret:
+        secretName: oauth-token
+
+- interval: 24h
+  name: ci-org-owners-aliases-sync-kubernetes-sigs
+  annotations:
+    testgrid-dashboards: sig-contribex-org
+    testgrid-tab-name: ci-peribolos
+    testgrid-alert-email: kubernetes-github-managment-alerts@googlegroups.com, k8s-infra-oncall@google.com
+    testgrid-num-failures-to-alert: '1'
+  cluster: test-infra-trusted
+  decorate: true
+  max_concurrency: 1
+  extra_refs:
+  - org: kubernetes
+    repo: org
+    base_ref: main
+  spec:
+    containers:
+    - image: golang:1.17
+      command: ["/bin/bash", "-c"]
+      env:
+        - name: GITHUB_TOKEN_PATH
+          value: /etc/github-token/oauth
+      args:
+        - ./admin/aliases-sync.sh kubernetes-sigs;
       volumeMounts:
       - name: github
         mountPath: /etc/github-token

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -719,6 +719,11 @@ default:
       target: both
       prowPlugin: shrug
       addedBy: humans
+    - color: 0ffa16
+      description: Indicates a PR is trusted, used by tide for auto-merging PRs.
+      name: skip-review
+      target: prs
+      addedBy: autobump bot
 repos:
   kubernetes/community:
     labels:
@@ -1489,11 +1494,6 @@ repos:
           - name: area/release-infra
         target: both
         addedBy: label
-      - color: 0ffa16
-        description: Indicates a PR is trusted, used by tide for auto-merging PRs.
-        name: skip-review
-        target: prs
-        addedBy: autobump bot
       - color: f7c6c7
         description: Categorizes issue or PR as tracked by test-infra oncall.
         name: kind/oncall-hotlist


### PR DESCRIPTION
Part of https://github.com/kubernetes/release/issues/2175 and https://github.com/kubernetes/org/pull/3451

I'll be creating a prowjob for each organization. Lets start with the smallest organization.

/cc @saschagrunert 

