### PR TITLE
Only build and push website preview container when required

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-sig-docs.yaml
+++ b/config/jobs/image-pushing/k8s-staging-sig-docs.yaml
@@ -6,6 +6,8 @@ postsubmits:
         testgrid-dashboards: sig-docs-website, sig-k8s-infra-gcb
         testgrid-tab-name: post-website-push-image-k8s-website-hugo
       decorate: true
+      run_if_changed: >-
+        ^(Dockerfile|Makefile|netlify\.toml|\.dockerignore)$
       branches:
         - ^main$
       spec:


### PR DESCRIPTION
For previewing changes to [k/website](https://github.com/kubernetes/website/), the project publishes a container images that developers can run locally.

The existing configuration pushes an updated image on ever push to the default branch (`main`) of [k/website](https://github.com/kubernetes/website/). Revise that to only push when a file involved in the build path has changed.