### PR TITLE
Adding logs to prow's welcome plugin

### DIFF
--- a/prow/plugins/welcome/welcome_test.go
+++ b/prow/plugins/welcome/welcome_test.go
@@ -325,11 +325,12 @@ func TestHandlePR(t *testing.T) {
 		},
 	}
 
-	c := client{
-		GitHubClient: fc,
-		Logger:       &logrus.Entry{},
-	}
 	for _, tc := range testCases {
+		c := client{
+			GitHubClient: fc,
+			Logger:       logrus.WithField("testcase", tc.name),
+		}
+
 		// clear out comments from the last test case
 		fc.ClearComments()
 


### PR DESCRIPTION
Currently this plugin lacks some logs to be able to track down how it behaves.
This change adds a couple of log lines mainly for the different branches in code.