### PR TITLE
fix: Fix K8s version for Windows 2019 tests

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-v2-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-v2-config.yaml
@@ -631,7 +631,7 @@ presubmits:
             - name: DISABLE_ZONE
               value: "true"
             - name: KUBERNETES_VERSION
-              value: "latest-1.3"
+              value: "latest-1.23"
             - name: WINDOWS_WORKER_MACHINE_COUNT
               value: "3" # Need at least three workers for replica testing.
             - name: WORKER_MACHINE_COUNT


### PR DESCRIPTION
Fix the version specification for the Windows 2019 e2e test.