### PR TITLE
jira: add GetIssueWithOptions client and fake client methods

### DIFF
--- a/prow/jira/fakejira/fake.go
+++ b/prow/jira/fakejira/fake.go
@@ -31,14 +31,15 @@ import (
 )
 
 type FakeClient struct {
-	Issues          []*jira.Issue
-	ExistingLinks   map[string][]jira.RemoteLink
-	NewLinks        []jira.RemoteLink
-	IssueLinks      []*jira.IssueLink
-	GetIssueError   error
-	Transitions     []jira.Transition
-	Users           []*jira.User
-	SearchResponses map[SearchRequest]SearchResponse
+	Issues            []*jira.Issue
+	ExistingLinks     map[string][]jira.RemoteLink
+	NewLinks          []jira.RemoteLink
+	IssueLinks        []*jira.IssueLink
+	GetIssueError     error
+	Transitions       []jira.Transition
+	Users             []*jira.User
+	SearchResponses   map[SearchRequest]SearchResponse
+	GetIssueResponses map[GetIssueRequest]GetIssueResponse
 }
 
 func (f *FakeClient) ListProjects() (*jira.ProjectList, error) {
@@ -55,6 +56,24 @@ func (f *FakeClient) GetIssue(id string) (*jira.Issue, error) {
 		}
 	}
 	return nil, jiraclient.NewNotFoundError(fmt.Errorf("No issue %s found", id))
+}
+
+type GetIssueRequest struct {
+	issueID string
+	options *jira.GetQueryOptions
+}
+
+type GetIssueResponse struct {
+	issue *jira.Issue
+	error error
+}
+
+func (f *FakeClient) GetIssueWithOptions(id string, options *jira.GetQueryOptions) (*jira.Issue, error) {
+	resp, expected := f.GetIssueResponses[GetIssueRequest{issueID: id, options: options}]
+	if !expected {
+		return nil, fmt.Errorf("the filtering query: %v for the issue with ID: %s is not registered", options, id)
+	}
+	return resp.issue, resp.error
 }
 
 func (f *FakeClient) GetRemoteLinks(id string) ([]jira.RemoteLink, error) {

--- a/prow/jira/jira.go
+++ b/prow/jira/jira.go
@@ -51,6 +51,7 @@ const (
 )
 
 type Client interface {
+	GetIssueWithOptions(id string, options *jira.GetQueryOptions) (*jira.Issue, error)
 	GetIssue(id string) (*jira.Issue, error)
 	// SearchWithContext will search for tickets according to the jql
 	// Jira API docs: https://developer.atlassian.com/jiradev/jira-apis/jira-rest-apis/jira-rest-api-tutorials/jira-rest-api-example-query-issues
@@ -223,8 +224,8 @@ func (jc *client) JiraClient() *jira.Client {
 	return jc.upstream
 }
 
-func (jc *client) GetIssue(id string) (*jira.Issue, error) {
-	issue, response, err := jc.upstream.Issue.Get(id, &jira.GetQueryOptions{})
+func (jc *client) GetIssueWithOptions(id string, options *jira.GetQueryOptions) (*jira.Issue, error) {
+	issue, response, err := jc.upstream.Issue.Get(id, options)
 	if err != nil {
 		if response != nil && response.StatusCode == http.StatusNotFound {
 			return nil, NotFoundError{err}
@@ -233,6 +234,10 @@ func (jc *client) GetIssue(id string) (*jira.Issue, error) {
 	}
 
 	return issue, nil
+}
+
+func (jc *client) GetIssue(id string) (*jira.Issue, error) {
+	return jc.GetIssueWithOptions(id, &jira.GetQueryOptions{})
 }
 
 func (jc *client) ListProjects() (*jira.ProjectList, error) {


### PR DESCRIPTION
The added method (`GetIssueWithOptions`) returns a full representation of the issue for the given issue key/ID and query options (`GetQueryOptions`).
The fake client method is based on a static approach (following the standard of `SearchWithContext`)