### PR TITLE
jira FlagUtil: make bearerTokenFile exportable

### DIFF
--- a/prow/flagutil/jira.go
+++ b/prow/flagutil/jira.go
@@ -30,14 +30,14 @@ type JiraOptions struct {
 	endpoint        string
 	username        string
 	passwordFile    string
-	bearerTokenFile string
+	BearerTokenFile string
 }
 
 func (o *JiraOptions) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&o.endpoint, "jira-endpoint", "", "The Jira endpoint to use")
 	fs.StringVar(&o.username, "jira-username", "", "The username to use for Jira basic auth")
 	fs.StringVar(&o.passwordFile, "jira-password-file", "", "Location to a file containing the Jira basic auth password")
-	fs.StringVar(&o.bearerTokenFile, "jira-bearer-token-file", "", "Location to a file containing the Jira bearer authorization token")
+	fs.StringVar(&o.BearerTokenFile, "jira-bearer-token-file", "", "Location to a file containing the Jira bearer authorization token")
 
 }
 
@@ -54,11 +54,11 @@ func (o *JiraOptions) Validate(_ bool) error {
 		return errors.New("--jira-username and --jira-password-file must be specified together")
 	}
 
-	if o.bearerTokenFile != "" && o.username != "" {
+	if o.BearerTokenFile != "" && o.username != "" {
 		return errors.New("--jira-bearer-token-file and --jira-username are mutually exclusive")
 	}
 
-	if o.bearerTokenFile != "" && o.passwordFile != "" {
+	if o.BearerTokenFile != "" && o.passwordFile != "" {
 		return errors.New("--jira-bearer-token-file and --jira-password-file are mutually exclusive")
 	}
 
@@ -80,12 +80,12 @@ func (o *JiraOptions) Client() (jira.Client, error) {
 		}))
 	}
 
-	if o.bearerTokenFile != "" {
-		if err := secret.Add(o.bearerTokenFile); err != nil {
+	if o.BearerTokenFile != "" {
+		if err := secret.Add(o.BearerTokenFile); err != nil {
 			return nil, fmt.Errorf("failed to get --jira-bearer-token-file: %w", err)
 		}
 		opts = append(opts, jira.WithBearerAuth(func() string {
-			return string(secret.GetSecret(o.bearerTokenFile))
+			return string(secret.GetSecret(o.BearerTokenFile))
 		}))
 	}
 


### PR DESCRIPTION
Export the `bearerTokenFile` key (`JiraOptions` type) . It is necessary for some use-cases. 