### PR TITLE
Add env variables to job pull-kubernetes-node-swap-fedora-serial

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1219,6 +1219,12 @@ presubmits:
           requests:
             cpu: 4
             memory: 6Gi
+        env:
+          - name: GOPATH
+            value: /go
+          - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
+            value: "1"
+
 
   - name: pull-kubernetes-node-kubelet-credential-provider
     cluster: k8s-infra-prow-build


### PR DESCRIPTION
As an attempt to address https://github.com/kubernetes/kubernetes/issues/110340, this PR adds an env variable present in the periodic job (which is passing).

/sig node
/triage accepted
/priority important-soon
/area test