### PR TITLE
Add K8s feature gates

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -42,7 +42,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220523-f2a2939508-1.23
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220523-f2a2939508-master
         command:
         - runner.sh
         - kubetest
@@ -102,7 +102,7 @@ presubmits:
         workdir: true
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220523-f2a2939508-1.23
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220523-f2a2939508-master
           command:
             - runner.sh
             - kubetest
@@ -183,7 +183,7 @@ presubmits:
             - name: CONTROL_PLANE_MACHINE_COUNT
               value: "3"
             - name: KUBERNETES_VERSION
-              value: "1.23.5"
+              value: "1.24.1"
             - name: CLUSTER_TEMPLATE
               value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss.yaml
             - name: AZURE_LOADBALANCER_SKU
@@ -495,7 +495,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220523-f2a2939508-1.23
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220523-f2a2939508-master
       command:
       - runner.sh
       - kubetest
@@ -557,7 +557,7 @@ periodics:
       path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220523-f2a2939508-1.23
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220523-f2a2939508-master
       command:
       - runner.sh
       - kubetest
@@ -797,7 +797,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220523-f2a2939508-1.23
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220523-f2a2939508-master
       command:
       - runner.sh
       - kubetest
@@ -864,7 +864,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220523-f2a2939508-1.23
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220523-f2a2939508-master
       command:
       - runner.sh
       - kubetest
@@ -945,7 +945,7 @@ periodics:
         - name: CONTROL_PLANE_MACHINE_COUNT
           value: "3"
         - name: KUBERNETES_VERSION
-          value: "1.23.5"
+          value: "1.24.1"
         - name: CLUSTER_TEMPLATE
           value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss.yaml
         - name: AZURE_LOADBALANCER_SKU
@@ -976,7 +976,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220523-f2a2939508-1.23
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220523-f2a2939508-master
       command:
       - runner.sh
       - kubetest
@@ -1058,10 +1058,9 @@ periodics:
       - name: TEST_CCM
         value: "true"
       - name: KUBERNETES_VERSION
-        value: "1.23.5"
+        value: "1.24.1"
       - name: GINKGO_ARGS
-        # The 3 skipped testcases need k8s v1.24
-        value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\]|Kubelet.should.reject.pod.when.the.node.OS.doesn't.match.pod's.OS|Probing.container.should.be.restarted.with.a.GRPC.liveness.probe|CSIStorageCapacity.should.support.CSIStorageCapacities.API.operations --test.parallel=30 --report-dir=/logs/artifacts --disable-log-dump=true
+        value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --test.parallel=30 --report-dir=/logs/artifacts --disable-log-dump=true
       - name: CONTROL_PLANE_MACHINE_COUNT
         value: "3"
       - name: CLUSTER_TEMPLATE
@@ -1119,7 +1118,7 @@ periodics:
       - name: TEST_CCM
         value: "true"
       - name: KUBERNETES_VERSION
-        value: "1.23.5"
+        value: "1.24.1"
       - name: GINKGO_ARGS
         # Check https://github.com/kubernetes-sigs/cloud-provider-azure/issues/224 for the status of each skipped test
         value: --ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]|regular.resource.usage.tracking.resource.tracking.for|validates.MaxPods.limit.number.of.pods.that.are.allowed.to.run|In-tree.Volumes --test.parallel=30 --report-dir=/logs/artifacts --disable-log-dump=true
@@ -1180,7 +1179,7 @@ periodics:
       - name: TEST_CCM
         value: "true"
       - name: KUBERNETES_VERSION
-        value: "1.23.5"
+        value: "1.24.1"
       - name: GINKGO_ARGS
         # Check https://github.com/kubernetes-sigs/cloud-provider-azure/issues/224 for the status of each skipped test
         value: --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|Delete.Grace.Period|runs.ReplicaSets.to.verify.preemption.running.path|client.go.should.negotiate|should.contain.custom.columns.for.each.resource|Network.should.set.TCP.CLOSE_WAIT.timeout|PodSecurityPolicy|In-tree.Volumes --test.parallel=30 --report-dir=/logs/artifacts --disable-log-dump=true
@@ -1216,7 +1215,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220523-f2a2939508-1.23
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220523-f2a2939508-master
       command:
       - runner.sh
       - kubetest
@@ -1298,7 +1297,7 @@ periodics:
       - name: TEST_CCM
         value: "true"
       - name: KUBERNETES_VERSION
-        value: "1.23.5"
+        value: "1.24.1"
       - name: GINKGO_ARGS
         value: --ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|In-tree.Volumes|should.be.able.to.create.an.internal.type.load.balancer --test.parallel=4 --report-dir=/logs/artifacts --disable-log-dump=true
       - name: CONTROL_PLANE_MACHINE_COUNT
@@ -1333,7 +1332,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220523-f2a2939508-1.23
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220523-f2a2939508-master
       command:
       - runner.sh
       - kubetest

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.0.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.0.yaml
@@ -187,6 +187,8 @@ presubmits:
                 value: "3"
               - name: CLUSTER_TEMPLATE
                 value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss.yaml
+              - name: K8S_FEATURE_GATES
+                value: "MixedProtocolLBService=true"
       annotations:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-21-presubmit
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-capz-1-21
@@ -290,6 +292,8 @@ presubmits:
                 value: "latest-1.21"
               - name: CONTROL_PLANE_MACHINE_COUNT
                 value: "3"
+              - name: K8S_FEATURE_GATES
+                value: "MixedProtocolLBService=true"
       annotations:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-21-presubmit
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-capz-1-21

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.1.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.1.yaml
@@ -187,6 +187,8 @@ presubmits:
                 value: "3"
               - name: CLUSTER_TEMPLATE
                 value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss.yaml
+              - name: K8S_FEATURE_GATES
+                value: "MixedProtocolLBService=true"
       annotations:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-22-presubmit
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-capz-1-22
@@ -290,6 +292,8 @@ presubmits:
                 value: "latest-1.22"
               - name: CONTROL_PLANE_MACHINE_COUNT
                 value: "3"
+              - name: K8S_FEATURE_GATES
+                value: "MixedProtocolLBService=true"
       annotations:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-22-presubmit
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-capz-1-22

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.23.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.23.yaml
@@ -188,6 +188,8 @@ presubmits:
                 value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss.yaml
               - name: AZURE_LOADBALANCER_SKU
                 value: "Standard"
+              - name: K8S_FEATURE_GATES
+                value: "MixedProtocolLBService=true"
       annotations:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-23-presubmit
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-capz-1-23
@@ -292,6 +294,8 @@ presubmits:
                 value: "latest-1.23"
               - name: CONTROL_PLANE_MACHINE_COUNT
                 value: "3"
+              - name: K8S_FEATURE_GATES
+                value: "MixedProtocolLBService=true"
       annotations:
         testgrid-dashboards: provider-azure-cloud-provider-azure-1-23-presubmit
         testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-capz-1-23


### PR DESCRIPTION
* MixedProtocolLBService is enabled by default in v1.24
  so it is necessary to set it for older versions.
* Use kubekins-e2e master
* Set KUBERNETES_VERSION to 1.24 for vmss jobs

Signed-off-by: Zhecheng Li <zhechengli@microsoft.com>