### PR TITLE
add sig-testing email to send alerts for kubernetes-verify-go-licenses-periodical

### DIFF
--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -155,6 +155,7 @@ periodics:
   annotations:
     testgrid-create-test-group: "true"
     testgrid-dashboards: sig-testing-misc
+    testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com
     description: "Verify licences for the upstream Kubernetes Project's go-packages to the CNCF approved list of licences."
   extra_refs:
   - org: kubernetes


### PR DESCRIPTION
#### What this PR does / why we need it:

The PR updates the `kubernetes-verify-go-licenses-periodical` job to add a testgrid alert email for sig-testing.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of the fix for https://github.com/kubernetes/kubernetes/issues/108942

cc: @dims 