### PR TITLE
KES is monitored from default namespace

### DIFF
--- a/config/prow/cluster/monitoring/prow_podmonitors_for_gmp.yaml
+++ b/config/prow/cluster/monitoring/prow_podmonitors_for_gmp.yaml
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/name: kubernetes-external-secrets
     app: kubernetes-external-secrets
   name: kubernetes-external-secrets
-  namespace: prow-monitoring
+  namespace: default
 spec:
   endpoints:
   - interval: 30s


### PR DESCRIPTION
PodMonitoring CR is meant to colocate with the resource being monitored, KES is deployed in default so the monitoring CR should also be