### PR TITLE
Sync CAPZ owners with Azure provider project

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/OWNERS
@@ -8,6 +8,7 @@ approvers:
 - shysank
 reviewers:
 - jackfrancis
+- Jont828
 - jsturtevant
 
 labels:


### PR DESCRIPTION
Adds @Jont828 to the local OWNERS file for CAPZ jobs. See kubernetes-sigs/cluster-api-provider-azure#2262.