### PR TITLE
Bump CAPI mink8s version to 1.20.2

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -38,8 +38,13 @@ periodics:
       command:
       - "./scripts/ci-test.sh"
       env:
+      # This value determines the minimum Kubernetes
+      # supported version for Cluster API management cluster.
+      #
+      # To check the available envtest in Kubebuilder, please
+      # refer to https://github.com/kubernetes-sigs/kubebuilder/tree/tools-releases.
       - name: KUBEBUILDER_ENVTEST_KUBERNETES_VERSION
-        value: "1.19.2"
+        value: "1.20.2"
       resources:
         requests:
           cpu: 7300m
@@ -200,7 +205,7 @@ periodics:
       # This value determines the minimum Kubernetes
       # supported version for Cluster API management cluster.
       - name: KUBERNETES_VERSION_MANAGEMENT
-        value: "stable-1.19"
+        value: "stable-1.20"
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -101,7 +101,7 @@ presubmits:
         # To check the available envtest in Kubebuilder, please
         # refer to https://github.com/kubernetes-sigs/kubebuilder/tree/tools-releases.
         - name: KUBEBUILDER_ENVTEST_KUBERNETES_VERSION
-          value: "1.19.2"
+          value: "1.20.2"
         resources:
           requests:
             cpu: 7300m


### PR DESCRIPTION
In order to fix failures on https://github.com/kubernetes-sigs/cluster-api/pull/6495 I discovered that we need a fix for a SSA apply issue that merged in Kubernetes 1.20 (https://github.com/kubernetes/kubernetes/issues/95680), so bumping CAPI mink8s version to 1.20.2

/cc @sbueringer 