### PR TITLE
Fix version of clusterctl used in CAPZ upgrade jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -126,7 +126,7 @@ periodics:
           - ./scripts/ci-e2e.sh
         env:
           - name: INIT_WITH_BINARY
-            value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.23/clusterctl-{OS}-{ARCH}"
+            value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.8/clusterctl-{OS}-{ARCH}"
           - name: INIT_WITH_PROVIDERS_CONTRACT
             value: "v1alpha4"
           - name: INIT_WITH_KUBERNETES_VERSION

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -446,7 +446,7 @@ presubmits:
             - "./scripts/ci-e2e.sh"
           env:
             - name: INIT_WITH_BINARY
-              value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.23/clusterctl-{OS}-{ARCH}"
+              value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.8/clusterctl-{OS}-{ARCH}"
             - name: INIT_WITH_PROVIDERS_CONTRACT
               value: "v1alpha4"
             - name: INIT_WITH_KUBERNETES_VERSION

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -88,7 +88,7 @@ presubmits:
             - ./scripts/ci-e2e.sh
           env:
             - name: INIT_WITH_BINARY
-              value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.23/clusterctl-{OS}-{ARCH}"
+              value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.8/clusterctl-{OS}-{ARCH}"
             - name: INIT_WITH_PROVIDERS_CONTRACT
               value: "v1alpha4"
             - name: INIT_WITH_KUBERNETES_VERSION


### PR DESCRIPTION
Fixes an oversight in #26495 that led to this error:

```
current version of clusterctl is only compatible with v1alpha3 providers, detected v1alpha4 for provider cluster-api
```