### PR TITLE
Add header descriptors to Prow Status table

### DIFF
--- a/prow/cmd/deck/static/common/common.ts
+++ b/prow/cmd/deck/static/common/common.ts
@@ -44,7 +44,6 @@ export namespace cell {
       c.appendChild(document.createTextNode(""));
       return c;
     }
-    c.classList.add("icon-cell");
 
     let displayState = stateToAdj(s);
     displayState = displayState[0].toUpperCase() + displayState.slice(1);

--- a/prow/cmd/deck/static/spyglass/spyglass.ts
+++ b/prow/cmd/deck/static/spyglass/spyglass.ts
@@ -180,7 +180,6 @@ function handleRerunButton() {
   const r = document.getElementById("header-title")!;
   const c = document.createElement("div");
   c.appendChild(createRerunProwJobIcon(modal, rerunCommand, prowJobName, rerunCreatesJob, csrfToken));
-  c.classList.add("icon-cell");
   r.appendChild(c);
 
   if (rerunStatus === "gh_redirect") {

--- a/prow/cmd/deck/static/style.css
+++ b/prow/cmd/deck/static/style.css
@@ -136,9 +136,10 @@ th {
     color: #EF5350;
 }
 
-.icon-cell {
+.icon-cell-32 {
     width: 32px;
 }
+
 /**
  * ProwJob State style
  */

--- a/prow/cmd/deck/template/index.html
+++ b/prow/cmd/deck/template/index.html
@@ -63,13 +63,13 @@
       <table id="builds">
         <thead>
         <tr>
-          <th></th>
-          <th></th>
-          <th></th>
-          <th></th>
+          <th class="icon-cell-32">State</th>
+          <th class="icon-cell-32">Log</th>
+          <th class="icon-cell-32">Rerun</th>
+          <th>Job YML</th>
           <th>Repository</th>
           <th>Revision</th>
-          <th></th>
+          <th>Spyglass</th>
           <th>Job</th>
           <th>Started</th>
           <th>Duration</th>


### PR DESCRIPTION
This PR adds header descriptors to icons who previously did not have any. In addition this PR fills in empty spaces in the table with dashes.

![image](https://user-images.githubusercontent.com/55557781/172508118-90e8d5ad-824d-4fd3-849f-1bcc0b0aaa34.png)

/cc @chaodaiG @e-blackwelder 


