### PR TITLE
Configure periodic-cluster-api-e2e-mink8s-main to skip ClusterClass tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -201,7 +201,7 @@ periodics:
       - "./scripts/ci-e2e.sh"
       env:
       - name: GINKGO_SKIP
-        value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]"
+        value: "\\[Conformance\\] \\[K8s-Upgrade\\]|\\[IPv6\\]|\\[ClusterClass\\]"
       # This value determines the minimum Kubernetes
       # supported version for Cluster API management cluster.
       - name: KUBERNETES_VERSION_MANAGEMENT


### PR DESCRIPTION
ClusterClass will require Server-Side Apply which went to GA in v1.22.

Because of that and due to incompatibility to v1.20 this PR configures the test to skip tests which have the [ClusterClass] tag set.

xref to the PR which introduces Server-Side Apply for ClusterClass / topology controller: https://github.com/kubernetes-sigs/cluster-api/pull/6495 