### PR TITLE
releng: update kubekins/krte to go1.18.3 and go1.17.11

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.18.2
+    GO_VERSION: 1.18.3
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
@@ -9,7 +9,7 @@ variants:
     UPGRADE_DOCKER: 'true'
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.18.2
+    GO_VERSION: 1.18.3
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
@@ -22,31 +22,31 @@ variants:
     KIND_VERSION: 0.10.0
   master:
     CONFIG: master
-    GO_VERSION: 1.18.2
+    GO_VERSION: 1.18.3
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   main:
     CONFIG: main
-    GO_VERSION: 1.18.2
+    GO_VERSION: 1.18.3
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.25':
     CONFIG: '1.25'
-    GO_VERSION: 1.18.2
+    GO_VERSION: 1.18.3
     K8S_RELEASE: latest-1.25
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.24':
     CONFIG: '1.24'
-    GO_VERSION: 1.18.2
+    GO_VERSION: 1.18.3
     K8S_RELEASE: latest-1.24
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.23':
     CONFIG: '1.23'
-    GO_VERSION: 1.17.10
+    GO_VERSION: 1.17.11
     K8S_RELEASE: stable-1.23
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
releng: update kubekins/krte to go1.18.3 and go1.17.11

xref https://github.com/kubernetes/release/issues/2541


/assign @saschagrunert @puerco @justaugustus @BenTheElder @dims 
cc @kubernetes/release-engineering 