### PR TITLE
Rollout restart KES with namespace

### DIFF
--- a/config/prow/Makefile
+++ b/config/prow/Makefile
@@ -38,7 +38,7 @@ deploy-prow: get-cluster-credentials
 	# Temporary solution for working around the issue of KES being flaky, see
 	# https://github.com/kubernetes/test-infra/issues/24869#issuecomment-1147530320.
 	# TODO(chaodaiG): remove this once the above issue is fixed.
-	kubectl rollout restart deployment kubernetes-external-secrets
+	kubectl -n default rollout restart deployment kubernetes-external-secrets
 
 deploy-build: get-build-cluster-credentials
 	kubectl apply -f ./cluster/build/


### PR DESCRIPTION
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-test-infra-deploy-prow/1533867916477337600 failed saying 'Error from server (NotFound): deployments.apps kubernetes-external-secrets not found', could not repro locally, the closest guess is probably lack of namespace