### PR TITLE
Sync CAPZ owners with Azure provider project

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/OWNERS
@@ -4,10 +4,10 @@ approvers:
 - alexeldeib
 - CecileRobertMichon
 - devigned
+- jackfrancis
 - mboersma
 - shysank
 reviewers:
-- jackfrancis
 - Jont828
 - jsturtevant
 


### PR DESCRIPTION
Moves @jackfrancis to maintainer in the local OWNERS file for CAPZ jobs. See https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2348.