### PR TITLE
azure: set windows dockershim capz tests to optional

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1alpha4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1alpha4.yaml
@@ -99,7 +99,7 @@ presubmits:
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-e2e-windows-dockershim-v1alpha4
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
-    optional: false
+    optional: true
     decorate: true
     # please see: https://play.golang.org/p/JJSVylVPd53 for more insights
     run_if_changed: (^[^d].*$)|(^d$)|(^.[^o].*$)|(^do$)|(^..[^c].*$)|(^doc$)|(^...[^s].*$)|(^docs$)|(^....[^/].*$)|(^[^d][^o][^c][^s]/.*$)

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -139,7 +139,7 @@ presubmits:
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-e2e-windows-dockershim-v1beta1
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
-    optional: false
+    optional: true
     decorate: true
     # please see: https://play.golang.org/p/JJSVylVPd53 for more insights
     run_if_changed: (^[^d].*$)|(^d$)|(^.[^o].*$)|(^do$)|(^..[^c].*$)|(^doc$)|(^...[^s].*$)|(^docs$)|(^....[^/].*$)|(^[^d][^o][^c][^s]/.*$)


### PR DESCRIPTION
This PR retains the legacy Windows dockershim E2E test scenarios for v1alpha4 and v1beta of capz, but removes them as required presubmit tests.