### PR TITLE
chore: rename default branch for gateway-api

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-gateway-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-gateway-api.yaml
@@ -6,7 +6,7 @@ postsubmits:
         testgrid-dashboards: sig-network-gateway-api, sig-k8s-infra-gcb
       decorate: true
       branches:
-        - ^master$
+        - ^main$
         # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
         - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       spec:


### PR DESCRIPTION
As per the [default branch renaming instructions](https://www.kubernetes.dev/resources/rename/) and consequently with https://github.com/kubernetes-sigs/gateway-api/issues/1195 the purpose of this PR is to update the default branch for [Gateway API](https://github.com/kubernetes-sigs/gateway-api) in test-infra.