### PR TITLE
jira: implement bug lifecycle management for OCPBUGS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -82,6 +82,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	github.com/tektoncd/pipeline v0.14.1-0.20200710073957-5eeb17f81999
+	github.com/trivago/tgo v1.0.7
 	go.uber.org/zap v1.19.0
 	go4.org v0.0.0-20201209231011-d4a079459e60
 	gocloud.dev v0.19.0
@@ -182,7 +183,6 @@ require (
 	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f // indirect
-	github.com/trivago/tgo v1.0.7 // indirect
 	github.com/xanzy/ssh-agent v0.3.0 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect

--- a/prow/jira/fakejira/fake.go
+++ b/prow/jira/fakejira/fake.go
@@ -31,14 +31,17 @@ import (
 )
 
 type FakeClient struct {
-	Issues          []*jira.Issue
-	ExistingLinks   map[string][]jira.RemoteLink
-	NewLinks        []jira.RemoteLink
-	IssueLinks      []*jira.IssueLink
-	GetIssueError   error
-	Transitions     []jira.Transition
-	Users           []*jira.User
-	SearchResponses map[SearchRequest]SearchResponse
+	Issues           []*jira.Issue
+	ExistingLinks    map[string][]jira.RemoteLink
+	NewLinks         []jira.RemoteLink
+	RemovedLinks     []jira.RemoteLink
+	IssueLinks       []*jira.IssueLink
+	GetIssueError    map[string]error
+	CreateIssueError map[string]error
+	UpdateIssueError map[string]error
+	Transitions      []jira.Transition
+	Users            []*jira.User
+	SearchResponses  map[SearchRequest]SearchResponse
 }
 
 func (f *FakeClient) ListProjects() (*jira.ProjectList, error) {
@@ -47,7 +50,9 @@ func (f *FakeClient) ListProjects() (*jira.ProjectList, error) {
 
 func (f *FakeClient) GetIssue(id string) (*jira.Issue, error) {
 	if f.GetIssueError != nil {
-		return nil, f.GetIssueError
+		if err, ok := f.GetIssueError[id]; ok {
+			return nil, err
+		}
 	}
 	for _, existingIssue := range f.Issues {
 		if existingIssue.ID == id || existingIssue.Key == id {
@@ -58,7 +63,11 @@ func (f *FakeClient) GetIssue(id string) (*jira.Issue, error) {
 }
 
 func (f *FakeClient) GetRemoteLinks(id string) ([]jira.RemoteLink, error) {
-	return f.ExistingLinks[id], nil
+	issue, err := f.GetIssue(id)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get issue when chekcing from remote links: %+v", err)
+	}
+	return append(f.ExistingLinks[issue.ID], f.ExistingLinks[issue.Key]...), nil
 }
 
 func (f *FakeClient) AddRemoteLink(id string, link *jira.RemoteLink) (*jira.RemoteLink, error) {
@@ -107,6 +116,13 @@ func (f *FakeClient) AddComment(issueID string, comment *jira.Comment) (*jira.Co
 	if err != nil {
 		return nil, fmt.Errorf("Issue %s not found: %v", issueID, err)
 	}
+	// make sure the fields exist
+	if issue.Fields == nil {
+		issue.Fields = &jira.IssueFields{}
+	}
+	if issue.Fields.Comments == nil {
+		issue.Fields.Comments = &jira.Comments{}
+	}
 	issue.Fields.Comments.Comments = append(issue.Fields.Comments.Comments, comment)
 	return comment, nil
 }
@@ -116,18 +132,25 @@ func (f *FakeClient) CreateIssueLink(link *jira.IssueLink) error {
 	if err != nil {
 		return fmt.Errorf("failed to get outward link issue: %v", err)
 	}
-	outward.Fields.IssueLinks = append(outward.Fields.IssueLinks, link)
+	// links in an issue struct do not include the short definition of the the issue they are part of.
+	//This behavior is used by the jira hook plugin to identify which direction a clone happened,
+	// so it needs to be replicated in the fake client
+	linkForOutward := *link
+	linkForOutward.OutwardIssue = nil
+	outward.Fields.IssueLinks = append(outward.Fields.IssueLinks, &linkForOutward)
 	inward, err := f.GetIssue(link.InwardIssue.ID)
 	if err != nil {
 		return fmt.Errorf("failed to get inward link issue: %v", err)
 	}
-	inward.Fields.IssueLinks = append(inward.Fields.IssueLinks, link)
+	linkForInward := *link
+	linkForInward.InwardIssue = nil
+	inward.Fields.IssueLinks = append(inward.Fields.IssueLinks, &linkForInward)
 	f.IssueLinks = append(f.IssueLinks, link)
 	return nil
 }
 
 func (f *FakeClient) CloneIssue(issue *jira.Issue) (*jira.Issue, error) {
-	// create deep copy of parent so we can modify key and id for child
+	// create deep copy of parent so we can use updateIssueIDAndKey to get new ID and Key for child
 	data, err := json.Marshal(issue)
 	if err != nil {
 		return nil, err
@@ -139,11 +162,21 @@ func (f *FakeClient) CloneIssue(issue *jira.Issue) (*jira.Issue, error) {
 	}
 	// set ID and Key to unused id and key
 	f.updateIssueIDAndKey(issueCopy)
-	// run generic cloning function
-	return jiraclient.CloneIssue(f, issueCopy)
+	clonedIssue, err := jiraclient.CloneIssue(f, issue, issueCopy.ID, issueCopy.Key)
+	if err != nil {
+		return clonedIssue, err
+	}
+	// comments are unset during a clone on a real jira server; unset them here to replicate behavior
+	clonedIssue.Fields.Comments = nil
+	return clonedIssue, nil
 }
 
 func (f *FakeClient) CreateIssue(issue *jira.Issue) (*jira.Issue, error) {
+	if f.CreateIssueError != nil {
+		if err, ok := f.CreateIssueError[issue.Key]; ok {
+			return nil, err
+		}
+	}
 	// check that there are no ID collisions
 	for _, currIssue := range f.Issues {
 		if currIssue.ID == issue.ID {
@@ -153,7 +186,9 @@ func (f *FakeClient) CreateIssue(issue *jira.Issue) (*jira.Issue, error) {
 			return nil, fmt.Errorf("Issue key %s already exists", issue.Key)
 		}
 	}
-	f.updateIssueIDAndKey(issue)
+	if err := f.updateIssueIDAndKey(issue); err != nil {
+		return nil, err
+	}
 	f.Issues = append(f.Issues, issue)
 	return issue, nil
 }
@@ -211,13 +246,19 @@ func (f *FakeClient) DeleteLink(id string) error {
 func (f *FakeClient) DeleteRemoteLink(issueID string, linkID int) error {
 	for index, remoteLink := range f.ExistingLinks[issueID] {
 		if remoteLink.ID == linkID {
-			f.ExistingLinks[issueID] = append(f.ExistingLinks[issueID][:index], f.ExistingLinks[issueID][index+1:]...)
+			f.RemovedLinks = append(f.RemovedLinks, remoteLink)
+			if len(f.ExistingLinks[issueID]) == index+1 {
+				f.ExistingLinks[issueID] = f.ExistingLinks[issueID][:index]
+			} else {
+				f.ExistingLinks[issueID] = append(f.ExistingLinks[issueID][:index], f.ExistingLinks[issueID][index+1:]...)
+			}
+			return nil
 		}
 	}
 	return fmt.Errorf("failed to find link id %d in issue %s", linkID, issueID)
 }
 
-func (f *FakeClient) DeleteRemoteLinkViaURL(issueID, url string) error {
+func (f *FakeClient) DeleteRemoteLinkViaURL(issueID, url string) (bool, error) {
 	return jiraclient.DeleteRemoteLinkViaURL(f, issueID, url)
 }
 
@@ -254,7 +295,7 @@ func (f *FakeClient) updateIssueIDAndKey(newIssue *jira.Issue) error {
 			}
 		}
 	}
-	newIssue.Key = fmt.Sprintf("%s%d", keyPrefix, highestKeyID)
+	newIssue.Key = fmt.Sprintf("%s%d", keyPrefix, highestKeyID+1)
 	return nil
 }
 
@@ -306,11 +347,20 @@ func (f *FakeClient) GetIssueQaContact(issue *jira.Issue) (*jira.User, error) {
 	return jiraclient.GetIssueQaContact(issue)
 }
 
-func (f *FakeClient) GetIssueTargetVersion(issue *jira.Issue) (*[]*jira.Version, error) {
+func (f *FakeClient) GetIssueTargetVersion(issue *jira.Issue) ([]*jira.Version, error) {
 	return jiraclient.GetIssueTargetVersion(issue)
 }
 
+func (f *FakeClient) GetIssueSeverity(issue *jira.Issue) (*jiraclient.Severity, error) {
+	return jiraclient.GetIssueSeverity(issue)
+}
+
 func (f *FakeClient) UpdateIssue(issue *jira.Issue) (*jira.Issue, error) {
+	if f.UpdateIssueError != nil {
+		if err, ok := f.UpdateIssueError[issue.ID]; ok {
+			return nil, err
+		}
+	}
 	retrievedIssue, err := f.GetIssue(issue.ID)
 	if err != nil {
 		return nil, fmt.Errorf("unable to find issue to update: %v", err)
@@ -339,11 +389,11 @@ func (f *FakeClient) UpdateIssue(issue *jira.Issue) (*jira.Issue, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error converting updated issue to json: %v", err)
 	}
-	var newFields *jira.IssueFields
-	if err := json.Unmarshal(updatedIssueBytes, newFields); err != nil {
+	var newFields jira.IssueFields
+	if err := json.Unmarshal(updatedIssueBytes, &newFields); err != nil {
 		return nil, fmt.Errorf("failed converting updated issue to struct: %v", err)
 	}
-	retrievedIssue.Fields = newFields
+	retrievedIssue.Fields = &newFields
 	return retrievedIssue, nil
 }
 

--- a/prow/labels/labels.go
+++ b/prow/labels/labels.go
@@ -53,4 +53,11 @@ const (
 	TriageAccepted              = "triage/accepted"
 	WorkInProgress              = "do-not-merge/work-in-progress"
 	ValidBug                    = "bugzilla/valid-bug"
+	JiraValidBug                = "jira/valid-bug"
+	JiraInvalidBug              = "jira/invalid-bug"
+	JiraSeverityCritical        = "jira/severity-critical"
+	JiraSeverityImportant       = "jira/severity-important"
+	JiraSeverityModerate        = "jira/severity-moderate"
+	JiraSeverityLow             = "jira/severity-low"
+	JiraSeverityInformational   = "jira/severity-informational"
 )

--- a/prow/plugins/config_test.go
+++ b/prow/plugins/config_test.go
@@ -446,6 +446,59 @@ func TestSetCherryPickUnapprovedDefaults(t *testing.T) {
 	}
 }
 
+func TestJiraOptionsForItem(t *testing.T) {
+	open := true
+	one, two := "v1", "v2"
+	var testCases = []struct {
+		name     string
+		item     string
+		config   map[string]JiraBranchOptions
+		expected JiraBranchOptions
+	}{
+		{
+			name:     "no config means no options",
+			item:     "item",
+			config:   map[string]JiraBranchOptions{},
+			expected: JiraBranchOptions{},
+		},
+		{
+			name:     "unrelated config means no options",
+			item:     "item",
+			config:   map[string]JiraBranchOptions{"other": {IsOpen: &open, TargetVersion: &one}},
+			expected: JiraBranchOptions{},
+		},
+		{
+			name:     "global config resolves to options",
+			item:     "item",
+			config:   map[string]JiraBranchOptions{"*": {IsOpen: &open, TargetVersion: &one}},
+			expected: JiraBranchOptions{IsOpen: &open, TargetVersion: &one},
+		},
+		{
+			name:     "specific config resolves to options",
+			item:     "item",
+			config:   map[string]JiraBranchOptions{"item": {IsOpen: &open, TargetVersion: &one}},
+			expected: JiraBranchOptions{IsOpen: &open, TargetVersion: &one},
+		},
+		{
+			name: "global and specific config resolves to options that favor specificity",
+			item: "item",
+			config: map[string]JiraBranchOptions{
+				"*":    {IsOpen: &open, TargetVersion: &one},
+				"item": {TargetVersion: &two},
+			},
+			expected: JiraBranchOptions{IsOpen: &open, TargetVersion: &two},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if actual, expected := JiraOptionsForItem(testCase.item, testCase.config), testCase.expected; !reflect.DeepEqual(actual, expected) {
+				t.Errorf("%s: got incorrect options for item %q: %v", testCase.name, testCase.item, diff.ObjectReflectDiff(actual, expected))
+			}
+		})
+	}
+}
+
 func TestOptionsForItem(t *testing.T) {
 	open := true
 	one, two := "v1", "v2"
@@ -494,6 +547,239 @@ func TestOptionsForItem(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			if actual, expected := OptionsForItem(testCase.item, testCase.config), testCase.expected; !reflect.DeepEqual(actual, expected) {
 				t.Errorf("%s: got incorrect options for item %q: %v", testCase.name, testCase.item, diff.ObjectReflectDiff(actual, expected))
+			}
+		})
+	}
+}
+
+func TestResolveJiraOptions(t *testing.T) {
+	open, closed := true, false
+	yes, no := true, false
+	one, two := "v1", "v2"
+	modified, verified, post, pre := "MODIFIED", "VERIFIED", "POST", "PRE"
+	modifiedState := JiraBugState{Status: modified}
+	verifiedState := JiraBugState{Status: verified}
+	postState := JiraBugState{Status: post}
+	preState := JiraBugState{Status: pre}
+	var testCases = []struct {
+		name          string
+		parent, child JiraBranchOptions
+		expected      JiraBranchOptions
+	}{
+		{
+			name: "no parent or child means no output",
+		},
+		{
+			name:   "no child means a copy of parent is the output",
+			parent: JiraBranchOptions{ValidateByDefault: &yes, IsOpen: &open, TargetVersion: &one, ValidStates: &[]JiraBugState{modifiedState}, DependentBugStates: &[]JiraBugState{verifiedState}, DependentBugTargetVersions: &[]string{one}, StateAfterValidation: &postState},
+			expected: JiraBranchOptions{
+				ValidateByDefault:          &yes,
+				IsOpen:                     &open,
+				TargetVersion:              &one,
+				ValidStates:                &[]JiraBugState{modifiedState},
+				DependentBugStates:         &[]JiraBugState{verifiedState},
+				DependentBugTargetVersions: &[]string{one},
+				StateAfterValidation:       &postState,
+			},
+		},
+		{
+			name:  "no parent means a copy of child is the output",
+			child: JiraBranchOptions{ValidateByDefault: &yes, IsOpen: &open, TargetVersion: &one, ValidStates: &[]JiraBugState{modifiedState}, DependentBugStates: &[]JiraBugState{verifiedState}, DependentBugTargetVersions: &[]string{one}, StateAfterValidation: &postState},
+			expected: JiraBranchOptions{
+				ValidateByDefault:          &yes,
+				IsOpen:                     &open,
+				TargetVersion:              &one,
+				ValidStates:                &[]JiraBugState{modifiedState},
+				DependentBugStates:         &[]JiraBugState{verifiedState},
+				DependentBugTargetVersions: &[]string{one},
+				StateAfterValidation:       &postState,
+			},
+		},
+		{
+			name:     "child overrides parent on IsOpen",
+			parent:   JiraBranchOptions{IsOpen: &open, TargetVersion: &one, ValidStates: &[]JiraBugState{modifiedState}, StateAfterValidation: &postState},
+			child:    JiraBranchOptions{IsOpen: &closed},
+			expected: JiraBranchOptions{IsOpen: &closed, TargetVersion: &one, ValidStates: &[]JiraBugState{modifiedState}, StateAfterValidation: &postState},
+		},
+		{
+			name:     "child overrides parent on target release",
+			parent:   JiraBranchOptions{IsOpen: &open, TargetVersion: &one, ValidStates: &[]JiraBugState{modifiedState}, StateAfterValidation: &postState},
+			child:    JiraBranchOptions{TargetVersion: &two},
+			expected: JiraBranchOptions{IsOpen: &open, TargetVersion: &two, ValidStates: &[]JiraBugState{modifiedState}, StateAfterValidation: &postState},
+		},
+		{
+			name:     "child overrides parent on states",
+			parent:   JiraBranchOptions{IsOpen: &open, TargetVersion: &one, ValidStates: &[]JiraBugState{modifiedState}, StateAfterValidation: &postState},
+			child:    JiraBranchOptions{ValidStates: &[]JiraBugState{verifiedState}},
+			expected: JiraBranchOptions{IsOpen: &open, TargetVersion: &one, ValidStates: &[]JiraBugState{verifiedState}, StateAfterValidation: &postState},
+		},
+		{
+			name:     "child overrides parent on state after validation",
+			parent:   JiraBranchOptions{IsOpen: &open, TargetVersion: &one, ValidStates: &[]JiraBugState{modifiedState}, StateAfterValidation: &postState},
+			child:    JiraBranchOptions{StateAfterValidation: &preState},
+			expected: JiraBranchOptions{IsOpen: &open, TargetVersion: &one, ValidStates: &[]JiraBugState{modifiedState}, StateAfterValidation: &preState},
+		},
+		{
+			name:     "child overrides parent on validation by default",
+			parent:   JiraBranchOptions{IsOpen: &open, TargetVersion: &one, ValidStates: &[]JiraBugState{modifiedState}, StateAfterValidation: &postState},
+			child:    JiraBranchOptions{ValidateByDefault: &yes},
+			expected: JiraBranchOptions{ValidateByDefault: &yes, IsOpen: &open, TargetVersion: &one, ValidStates: &[]JiraBugState{modifiedState}, StateAfterValidation: &postState},
+		},
+		{
+			name:   "child overrides parent on dependent bug states",
+			parent: JiraBranchOptions{IsOpen: &open, TargetVersion: &one, ValidStates: &[]JiraBugState{modifiedState}, DependentBugStates: &[]JiraBugState{verifiedState}, StateAfterValidation: &postState},
+			child:  JiraBranchOptions{DependentBugStates: &[]JiraBugState{modifiedState}},
+			expected: JiraBranchOptions{
+				IsOpen:               &open,
+				TargetVersion:        &one,
+				ValidStates:          &[]JiraBugState{modifiedState},
+				DependentBugStates:   &[]JiraBugState{modifiedState},
+				StateAfterValidation: &postState,
+			},
+		},
+		{
+			name:     "child overrides parent on dependent bug target releases",
+			parent:   JiraBranchOptions{IsOpen: &open, TargetVersion: &one, ValidStates: &[]JiraBugState{modifiedState}, StateAfterValidation: &postState, DependentBugTargetVersions: &[]string{one}},
+			child:    JiraBranchOptions{DependentBugTargetVersions: &[]string{two}},
+			expected: JiraBranchOptions{IsOpen: &open, TargetVersion: &one, ValidStates: &[]JiraBugState{modifiedState}, StateAfterValidation: &postState, DependentBugTargetVersions: &[]string{two}},
+		},
+		{
+			name:   "child overrides parent on state after merge",
+			parent: JiraBranchOptions{IsOpen: &open, TargetVersion: &one, ValidStates: &[]JiraBugState{modifiedState}, StateAfterValidation: &postState, StateAfterMerge: &postState},
+			child:  JiraBranchOptions{StateAfterMerge: &preState},
+			expected: JiraBranchOptions{
+				IsOpen:               &open,
+				TargetVersion:        &one,
+				ValidStates:          &[]JiraBugState{modifiedState},
+				StateAfterValidation: &postState,
+				StateAfterMerge:      &preState,
+			},
+		},
+		{
+			name:   "child overrides parent on all fields",
+			parent: JiraBranchOptions{ValidateByDefault: &yes, IsOpen: &open, TargetVersion: &one, ValidStates: &[]JiraBugState{verifiedState}, DependentBugStates: &[]JiraBugState{verifiedState}, DependentBugTargetVersions: &[]string{one}, StateAfterValidation: &postState, StateAfterMerge: &postState},
+			child:  JiraBranchOptions{ValidateByDefault: &no, IsOpen: &closed, TargetVersion: &two, ValidStates: &[]JiraBugState{modifiedState}, DependentBugStates: &[]JiraBugState{modifiedState}, DependentBugTargetVersions: &[]string{two}, StateAfterValidation: &preState, StateAfterMerge: &preState},
+			expected: JiraBranchOptions{
+				ValidateByDefault:          &no,
+				IsOpen:                     &closed,
+				TargetVersion:              &two,
+				ValidStates:                &[]JiraBugState{modifiedState},
+				DependentBugStates:         &[]JiraBugState{modifiedState},
+				DependentBugTargetVersions: &[]string{two},
+				StateAfterValidation:       &preState,
+				StateAfterMerge:            &preState,
+			},
+		},
+		{
+			name:     "parent target release is excluded on child",
+			parent:   JiraBranchOptions{TargetVersion: &one},
+			child:    JiraBranchOptions{ExcludeDefaults: &yes},
+			expected: JiraBranchOptions{ExcludeDefaults: &yes},
+		},
+		{
+			name:     "parent target release is excluded on child with other options",
+			parent:   JiraBranchOptions{DependentBugTargetVersions: &[]string{one}},
+			child:    JiraBranchOptions{TargetVersion: &one, ExcludeDefaults: &yes},
+			expected: JiraBranchOptions{TargetVersion: &one, ExcludeDefaults: &yes},
+		},
+		{
+			name:     "parent exclude merges with child options",
+			parent:   JiraBranchOptions{DependentBugTargetVersions: &[]string{one}, ExcludeDefaults: &yes},
+			child:    JiraBranchOptions{TargetVersion: &one},
+			expected: JiraBranchOptions{DependentBugTargetVersions: &[]string{one}, TargetVersion: &one, ExcludeDefaults: &yes},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if actual, expected := ResolveJiraOptions(testCase.parent, testCase.child), testCase.expected; !reflect.DeepEqual(actual, expected) {
+				t.Errorf("%s: resolved incorrect options for parent and child: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
+			}
+		})
+	}
+
+	var i int = 0
+	managedCol1 := ManagedColumn{ID: &i, Name: "col1", State: "open", Labels: []string{"area/conformance", "area/testing"}, Org: "org1"}
+	managedCol3 := ManagedColumn{ID: &i, Name: "col2", State: "open", Labels: []string{}, Org: "org2"}
+	managedColx := ManagedColumn{ID: &i, Name: "col2", State: "open", Labels: []string{"area/conformance", "area/testing"}, Org: "org2"}
+	invalidCol := ManagedColumn{State: "open", Labels: []string{"area/conformance", "area/testing2"}, Org: "org2"}
+	invalidOrg := ManagedColumn{Name: "col1", State: "open", Labels: []string{"area/conformance", "area/testing2"}, Org: ""}
+	managedProj2 := ManagedProject{Columns: []ManagedColumn{managedCol3}}
+	managedProjx := ManagedProject{Columns: []ManagedColumn{managedCol1, managedColx}}
+	managedOrgRepo2 := ManagedOrgRepo{Projects: map[string]ManagedProject{"project1": managedProj2}}
+	managedOrgRepox := ManagedOrgRepo{Projects: map[string]ManagedProject{"project1": managedProjx}}
+
+	projectManagerTestcases := []struct {
+		name        string
+		config      *Configuration
+		expectedErr string
+	}{
+		{
+			name: "No projects configured in a repo",
+			config: &Configuration{
+				ProjectManager: ProjectManager{
+					OrgRepos: map[string]ManagedOrgRepo{"org1": {Projects: map[string]ManagedProject{}}},
+				},
+			},
+			expectedErr: fmt.Sprintf("Org/repo: %s, has no projects configured", "org1"),
+		},
+		{
+			name: "No columns configured for a project",
+			config: &Configuration{
+				ProjectManager: ProjectManager{
+					OrgRepos: map[string]ManagedOrgRepo{"org1": {Projects: map[string]ManagedProject{"project1": {Columns: []ManagedColumn{}}}}},
+				},
+			},
+			expectedErr: fmt.Sprintf("Org/repo: %s, project %s, has no columns configured", "org1", "project1"),
+		},
+		{
+			name: "Columns does not have name or ID",
+			config: &Configuration{
+				ProjectManager: ProjectManager{
+					OrgRepos: map[string]ManagedOrgRepo{"org1": {Projects: map[string]ManagedProject{"project1": {Columns: []ManagedColumn{invalidCol}}}}},
+				},
+			},
+			expectedErr: fmt.Sprintf("Org/repo: %s, project %s, column %v, has no name/id configured", "org1", "project1", invalidCol),
+		},
+		{
+			name: "Columns does not have owner Org/repo",
+			config: &Configuration{
+				ProjectManager: ProjectManager{
+					OrgRepos: map[string]ManagedOrgRepo{"org1": {Projects: map[string]ManagedProject{"project1": {Columns: []ManagedColumn{invalidOrg}}}}},
+				},
+			},
+			expectedErr: fmt.Sprintf("Org/repo: %s, project %s, column %s, has no org configured", "org1", "project1", "col1"),
+		},
+		{
+			name: "No Labels specified in the column of the project",
+			config: &Configuration{
+				ProjectManager: ProjectManager{
+					OrgRepos: map[string]ManagedOrgRepo{"org1": managedOrgRepo2},
+				},
+			},
+			expectedErr: fmt.Sprintf("Org/repo: %s, project %s, column %s, has no labels configured", "org1", "project1", "col2"),
+		},
+		{
+			name: "Same Label specified to multiple column in a project",
+			config: &Configuration{
+				ProjectManager: ProjectManager{
+					OrgRepos: map[string]ManagedOrgRepo{"org1": managedOrgRepox},
+				},
+			},
+			expectedErr: fmt.Sprintf("Org/repo: %s, project %s, column %s has same labels configured as another column", "org1", "project1", "col2"),
+		},
+	}
+
+	for _, c := range projectManagerTestcases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateProjectManager(c.config.ProjectManager)
+			if err != nil && len(c.expectedErr) == 0 {
+				t.Fatalf("config validation error: %v", err)
+			}
+			if err == nil && len(c.expectedErr) > 0 {
+				t.Fatalf("config validation error: %v but expecting %v", err, c.expectedErr)
+			}
+			if err != nil && c.expectedErr != err.Error() {
+				t.Fatalf("Error running the test %s, \nexpected: %s, \nreceived: %s", c.name, c.expectedErr, err.Error())
 			}
 		})
 	}
@@ -770,6 +1056,229 @@ func TestResolveBugzillaOptions(t *testing.T) {
 	}
 }
 
+func TestJiraOptionsForBranch(t *testing.T) {
+	open, closed := true, false
+	yes, no := true, false
+	globalDefault, globalBranchDefault, orgDefault, orgBranchDefault, repoDefault, repoBranch := "global-default", "global-branch-default", "my-org-default", "my-org-branch-default", "my-repo-default", "my-repo-branch"
+	post, pre, release, notabug, new, reset := "POST", "PRE", "RELEASE_PENDING", "NOTABUG", "NEW", "RESET"
+	verifiedState, modifiedState := JiraBugState{Status: "VERIFIED"}, JiraBugState{Status: "MODIFIED"}
+	postState, preState, releaseState, notabugState, newState, resetState := JiraBugState{Status: post}, JiraBugState{Status: pre}, JiraBugState{Status: release}, JiraBugState{Status: notabug}, JiraBugState{Status: new}, JiraBugState{Status: reset}
+	closedErrata := JiraBugState{Status: "CLOSED", Resolution: "ERRATA"}
+	orgAllowedSecurityLevels, repoAllowedSecurityLevels := []string{"test"}, []string{"security", "test"}
+
+	rawConfig := `default:
+  "*":
+    target_version: global-default
+  "global-branch":
+    is_open: false
+    target_version: global-branch-default
+orgs:
+  my-org:
+    default:
+      "*":
+        is_open: true
+        target_version: my-org-default
+        state_after_validation:
+          status: "PRE"
+        state_after_close:
+          status: "NEW"
+        allowed_security_levels:
+        - test
+      "my-org-branch":
+        target_version: my-org-branch-default
+        state_after_validation:
+          status: "POST"
+    repos:
+      my-repo:
+        branches:
+          "*":
+            is_open: false
+            target_version: my-repo-default
+            valid_states:
+            - status: VERIFIED
+            validate_by_default: false
+            state_after_merge:
+              status: RELEASE_PENDING
+          "my-repo-branch":
+            target_version: my-repo-branch
+            valid_states:
+            - status: MODIFIED
+            - status: CLOSED
+              resolution: ERRATA
+            validate_by_default: true
+            state_after_merge:
+              status: NOTABUG
+            state_after_close:
+              status: RESET
+            allowed_security_levels:
+            - security
+          "my-special-branch":
+            exclude_defaults: true
+            validate_by_default: false
+      another-repo:
+        branches:
+          "*":
+            exclude_defaults: true
+          "my-org-branch":
+            target_version: my-repo-branch`
+	var config Jira
+	if err := yaml.Unmarshal([]byte(rawConfig), &config); err != nil {
+		t.Fatalf("couldn't unmarshal config: %v", err)
+	}
+
+	var testCases = []struct {
+		name              string
+		org, repo, branch string
+		expected          JiraBranchOptions
+	}{
+		{
+			name:     "unconfigured branch gets global default",
+			org:      "some-org",
+			repo:     "some-repo",
+			branch:   "some-branch",
+			expected: JiraBranchOptions{TargetVersion: &globalDefault},
+		},
+		{
+			name:     "branch on unconfigured org/repo gets global default",
+			org:      "some-org",
+			repo:     "some-repo",
+			branch:   "global-branch",
+			expected: JiraBranchOptions{IsOpen: &closed, TargetVersion: &globalBranchDefault},
+		},
+		{
+			name:     "branch on configured org but not repo gets org default",
+			org:      "my-org",
+			repo:     "some-repo",
+			branch:   "some-branch",
+			expected: JiraBranchOptions{IsOpen: &open, TargetVersion: &orgDefault, StateAfterValidation: &preState, AllowedSecurityLevels: orgAllowedSecurityLevels, StateAfterClose: &newState},
+		},
+		{
+			name:     "branch on configured org but not repo gets org branch default",
+			org:      "my-org",
+			repo:     "some-repo",
+			branch:   "my-org-branch",
+			expected: JiraBranchOptions{IsOpen: &open, TargetVersion: &orgBranchDefault, StateAfterValidation: &postState, AllowedSecurityLevels: orgAllowedSecurityLevels, StateAfterClose: &newState},
+		},
+		{
+			name:     "branch on configured org and repo gets repo default",
+			org:      "my-org",
+			repo:     "my-repo",
+			branch:   "some-branch",
+			expected: JiraBranchOptions{ValidateByDefault: &no, IsOpen: &closed, TargetVersion: &repoDefault, ValidStates: &[]JiraBugState{verifiedState}, StateAfterValidation: &preState, StateAfterMerge: &releaseState, AllowedSecurityLevels: orgAllowedSecurityLevels, StateAfterClose: &newState},
+		},
+		{
+			name:     "branch on configured org and repo gets branch config",
+			org:      "my-org",
+			repo:     "my-repo",
+			branch:   "my-repo-branch",
+			expected: JiraBranchOptions{ValidateByDefault: &yes, IsOpen: &closed, TargetVersion: &repoBranch, ValidStates: &[]JiraBugState{modifiedState, closedErrata}, StateAfterValidation: &preState, StateAfterMerge: &notabugState, AllowedSecurityLevels: repoAllowedSecurityLevels, StateAfterClose: &resetState},
+		},
+		{
+			name:     "exclude branch on configured org and repo gets branch config",
+			org:      "my-org",
+			repo:     "my-repo",
+			branch:   "my-special-branch",
+			expected: JiraBranchOptions{ValidateByDefault: &no, ExcludeDefaults: &yes},
+		},
+		{
+			name:     "exclude branch on repo cascades to branch config",
+			org:      "my-org",
+			repo:     "another-repo",
+			branch:   "my-org-branch",
+			expected: JiraBranchOptions{TargetVersion: &repoBranch, ExcludeDefaults: &yes},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if actual, expected := config.OptionsForBranch(testCase.org, testCase.repo, testCase.branch), testCase.expected; !reflect.DeepEqual(actual, expected) {
+				t.Errorf("%s: resolved incorrect options for %s/%s#%s: %v", testCase.name, testCase.org, testCase.repo, testCase.branch, diff.ObjectReflectDiff(actual, expected))
+			}
+		})
+	}
+
+	var repoTestCases = []struct {
+		name      string
+		org, repo string
+		expected  map[string]JiraBranchOptions
+	}{
+		{
+			name: "unconfigured repo gets global default",
+			org:  "some-org",
+			repo: "some-repo",
+			expected: map[string]JiraBranchOptions{
+				"*":             {TargetVersion: &globalDefault},
+				"global-branch": {IsOpen: &closed, TargetVersion: &globalBranchDefault},
+			},
+		},
+		{
+			name: "repo in configured org gets org default",
+			org:  "my-org",
+			repo: "some-repo",
+			expected: map[string]JiraBranchOptions{
+				"*":             {IsOpen: &open, TargetVersion: &orgDefault, StateAfterValidation: &preState, AllowedSecurityLevels: orgAllowedSecurityLevels, StateAfterClose: &newState},
+				"my-org-branch": {IsOpen: &open, TargetVersion: &orgBranchDefault, StateAfterValidation: &postState, AllowedSecurityLevels: orgAllowedSecurityLevels, StateAfterClose: &newState},
+			},
+		},
+		{
+			name: "configured repo gets repo config",
+			org:  "my-org",
+			repo: "my-repo",
+			expected: map[string]JiraBranchOptions{
+				"*": {
+					ValidateByDefault:     &no,
+					IsOpen:                &closed,
+					TargetVersion:         &repoDefault,
+					ValidStates:           &[]JiraBugState{verifiedState},
+					StateAfterValidation:  &preState,
+					StateAfterMerge:       &releaseState,
+					AllowedSecurityLevels: orgAllowedSecurityLevels,
+					StateAfterClose:       &newState,
+				},
+				"my-repo-branch": {
+					ValidateByDefault:     &yes,
+					IsOpen:                &closed,
+					TargetVersion:         &repoBranch,
+					ValidStates:           &[]JiraBugState{modifiedState, closedErrata},
+					StateAfterValidation:  &preState,
+					StateAfterMerge:       &notabugState,
+					AllowedSecurityLevels: repoAllowedSecurityLevels,
+					StateAfterClose:       &resetState,
+				},
+				"my-org-branch": {
+					ValidateByDefault:     &no,
+					IsOpen:                &closed,
+					TargetVersion:         &repoDefault,
+					ValidStates:           &[]JiraBugState{verifiedState},
+					StateAfterValidation:  &postState,
+					StateAfterMerge:       &releaseState,
+					AllowedSecurityLevels: orgAllowedSecurityLevels,
+					StateAfterClose:       &newState,
+				},
+				"my-special-branch": {
+					ValidateByDefault: &no,
+					ExcludeDefaults:   &yes,
+				},
+			},
+		},
+		{
+			name: "excluded repo gets no defaults",
+			org:  "my-org",
+			repo: "another-repo",
+			expected: map[string]JiraBranchOptions{
+				"*":             {ExcludeDefaults: &yes},
+				"my-org-branch": {ExcludeDefaults: &yes, TargetVersion: &repoBranch},
+			},
+		},
+	}
+	for _, testCase := range repoTestCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if actual, expected := config.OptionsForRepo(testCase.org, testCase.repo), testCase.expected; !reflect.DeepEqual(actual, expected) {
+				t.Errorf("%s: resolved incorrect options for %s/%s: %v", testCase.name, testCase.org, testCase.repo, diff.ObjectReflectDiff(actual, expected))
+			}
+		})
+	}
+}
+
 func TestOptionsForBranch(t *testing.T) {
 	open, closed := true, false
 	yes, no := true, false
@@ -1013,6 +1522,43 @@ orgs:
 	}
 }
 
+func TestJiraBugState_String(t *testing.T) {
+	testCases := []struct {
+		name     string
+		state    *JiraBugState
+		expected string
+	}{
+		{
+			name:     "empty struct",
+			state:    &JiraBugState{},
+			expected: "",
+		},
+		{
+			name:     "only status",
+			state:    &JiraBugState{Status: "CLOSED"},
+			expected: "CLOSED",
+		},
+		{
+			name:     "only resolution",
+			state:    &JiraBugState{Resolution: "NOTABUG"},
+			expected: "any status with resolution NOTABUG",
+		},
+		{
+			name:     "status and resolution",
+			state:    &JiraBugState{Status: "CLOSED", Resolution: "NOTABUG"},
+			expected: "CLOSED (NOTABUG)",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.state.String()
+			if actual != tc.expected {
+				t.Errorf("%s: expected %q, got %q", tc.name, tc.expected, actual)
+			}
+		})
+	}
+}
+
 func TestBugzillaBugState_String(t *testing.T) {
 	testCases := []struct {
 		name     string
@@ -1180,6 +1726,66 @@ func TestBugzillaBugState_AsBugUpdate(t *testing.T) {
 	}
 }
 
+func TestJiraBugStateSet_Has(t *testing.T) {
+	bugInProgress := JiraBugState{Status: "MODIFIED"}
+	bugErrata := JiraBugState{Status: "CLOSED", Resolution: "ERRATA"}
+	bugWontfix := JiraBugState{Status: "CLOSED", Resolution: "WONTFIX"}
+
+	testCases := []struct {
+		name   string
+		states []JiraBugState
+		state  JiraBugState
+
+		expectedLength int
+		expectedHas    bool
+	}{
+		{
+			name:           "empty set",
+			state:          bugInProgress,
+			expectedLength: 0,
+			expectedHas:    false,
+		},
+		{
+			name:           "membership",
+			states:         []JiraBugState{bugInProgress},
+			state:          bugInProgress,
+			expectedLength: 1,
+			expectedHas:    true,
+		},
+		{
+			name:           "non-membership",
+			states:         []JiraBugState{bugInProgress, bugErrata},
+			state:          bugWontfix,
+			expectedLength: 2,
+			expectedHas:    false,
+		},
+		{
+			name:           "actually a set",
+			states:         []JiraBugState{bugInProgress, bugInProgress, bugInProgress},
+			state:          bugInProgress,
+			expectedLength: 1,
+			expectedHas:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			set := NewJiraBugStateSet(tc.states)
+			if len(set) != tc.expectedLength {
+				t.Errorf("%s: expected set to have %d members, it has %d", tc.name, tc.expectedLength, len(set))
+			}
+			var not string
+			if !tc.expectedHas {
+				not = "not "
+			}
+			has := set.Has(tc.state)
+			if has != tc.expectedHas {
+				t.Errorf("%s: expected set to %scontain %v", tc.name, not, tc.state)
+			}
+		})
+	}
+}
+
 func TestBugzillaBugStateSet_Has(t *testing.T) {
 	bugInProgress := BugzillaBugState{Status: "MODIFIED"}
 	bugErrata := BugzillaBugState{Status: "CLOSED", Resolution: "ERRATA"}
@@ -1235,6 +1841,65 @@ func TestBugzillaBugStateSet_Has(t *testing.T) {
 			has := set.Has(tc.state)
 			if has != tc.expectedHas {
 				t.Errorf("%s: expected set to %scontain %v", tc.name, not, tc.state)
+			}
+		})
+	}
+}
+
+func TestJiraStatesMatch(t *testing.T) {
+	modified := JiraBugState{Status: "MODIFIED"}
+	errata := JiraBugState{Status: "CLOSED", Resolution: "ERRATA"}
+	wontfix := JiraBugState{Status: "CLOSED", Resolution: "WONTFIX"}
+	testCases := []struct {
+		name          string
+		first, second []JiraBugState
+		expected      bool
+	}{
+		{
+			name:     "empty slices match",
+			expected: true,
+		},
+		{
+			name:  "one empty, one non-empty do not match",
+			first: []JiraBugState{modified},
+		},
+		{
+			name:     "identical slices match",
+			first:    []JiraBugState{modified},
+			second:   []JiraBugState{modified},
+			expected: true,
+		},
+		{
+			name:     "ordering does not matter",
+			first:    []JiraBugState{modified, errata},
+			second:   []JiraBugState{errata, modified},
+			expected: true,
+		},
+		{
+			name:     "different slices do not match",
+			first:    []JiraBugState{modified, errata},
+			second:   []JiraBugState{modified, wontfix},
+			expected: false,
+		},
+		{
+			name:     "suffix in first operand is not ignored",
+			first:    []JiraBugState{modified, errata},
+			second:   []JiraBugState{modified},
+			expected: false,
+		},
+		{
+			name:     "suffix in second operand is not ignored",
+			first:    []JiraBugState{modified},
+			second:   []JiraBugState{modified, errata},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := jiraStatesMatch(tc.first, tc.second)
+			if actual != tc.expected {
+				t.Errorf("%s: expected %t, got %t", tc.name, tc.expected, actual)
 			}
 		})
 	}
@@ -1534,7 +2199,7 @@ func TestConfigMergingProperties(t *testing.T) {
 		{
 			name: "Plugins config",
 			makeMergeable: func(c *Configuration) {
-				*c = Configuration{Plugins: c.Plugins, Bugzilla: c.Bugzilla}
+				*c = Configuration{Plugins: c.Plugins, Bugzilla: c.Bugzilla, Jira: c.Jira}
 			},
 		},
 	}
@@ -1571,6 +2236,12 @@ func TestConfigMergingProperties(t *testing.T) {
 				for org, val := range fuzzedMergeableConfig.Bugzilla.Orgs {
 					if reflect.DeepEqual(val, BugzillaOrgOptions{}) {
 						delete(fuzzedMergeableConfig.Bugzilla.Orgs, org)
+					}
+				}
+				// An empty jira org config does nothing, so clean those.
+				for org, val := range fuzzedMergeableConfig.Jira.Orgs {
+					if reflect.DeepEqual(val, JiraOrgOptions{}) {
+						delete(fuzzedMergeableConfig.Jira.Orgs, org)
 					}
 				}
 				// An exception to the rule is merging an empty config into itself, that is valid and will just do nothing.
@@ -1659,6 +2330,327 @@ func TestPluginsMergeFrom(t *testing.T) {
 			}
 			if tc.expectedErrMsg != errMsg {
 				t.Fatalf("expected error message %q, got %s", tc.expectedErrMsg, errMsg)
+			}
+			if err != nil {
+				return
+			}
+
+			if diff := cmp.Diff(tc.expected, tc.to); diff != "" {
+				t.Errorf("expexcted config differs from actual: %s", diff)
+			}
+		})
+	}
+}
+
+func TestJiraMergeFrom(t *testing.T) {
+	t.Parallel()
+
+	yes := true
+	targetVersion1 := "target-version-1"
+	targetVersion2 := "target-version-2"
+
+	testCases := []struct {
+		name string
+
+		from *Jira
+		to   *Jira
+
+		expected       *Jira
+		expectedErrMsg string
+	}{
+		{
+			name: "Merging for two different repos",
+
+			from: &Jira{Orgs: map[string]JiraOrgOptions{
+				"org": {
+					Repos: map[string]JiraRepoOptions{
+						"repo-1": {
+							Branches: map[string]JiraBranchOptions{
+								"master": {
+									IsOpen:        &yes,
+									TargetVersion: &targetVersion1,
+								},
+							},
+						},
+					},
+				},
+			}},
+			to: &Jira{Orgs: map[string]JiraOrgOptions{
+				"org": {
+					Repos: map[string]JiraRepoOptions{
+						"repo-2": {
+							Branches: map[string]JiraBranchOptions{
+								"master": {
+									IsOpen:        &yes,
+									TargetVersion: &targetVersion2,
+								},
+							},
+						},
+					},
+				},
+			}},
+
+			expected: &Jira{Orgs: map[string]JiraOrgOptions{
+				"org": {
+					Repos: map[string]JiraRepoOptions{
+						"repo-1": {
+							Branches: map[string]JiraBranchOptions{
+								"master": {
+									IsOpen:        &yes,
+									TargetVersion: &targetVersion1,
+								},
+							},
+						},
+						"repo-2": {
+							Branches: map[string]JiraBranchOptions{
+								"master": {
+									IsOpen:        &yes,
+									TargetVersion: &targetVersion2,
+								},
+							},
+						},
+					},
+				},
+			}},
+		},
+		{
+			name: "Merging organization defaults and repo in org",
+
+			from: &Jira{Orgs: map[string]JiraOrgOptions{
+				"org": {
+					Repos: map[string]JiraRepoOptions{
+						"repo-2": {
+							Branches: map[string]JiraBranchOptions{
+								"master": {
+									IsOpen:        &yes,
+									TargetVersion: &targetVersion2,
+								},
+							},
+						},
+					},
+				},
+			}},
+			to: &Jira{Orgs: map[string]JiraOrgOptions{
+				"org": {
+					Default: map[string]JiraBranchOptions{
+						"master": {
+							IsOpen:        &yes,
+							TargetVersion: &targetVersion1,
+						},
+					},
+				},
+			}},
+
+			expected: &Jira{Orgs: map[string]JiraOrgOptions{
+				"org": {
+					Default: map[string]JiraBranchOptions{
+						"master": {
+							IsOpen:        &yes,
+							TargetVersion: &targetVersion1,
+						},
+					},
+					Repos: map[string]JiraRepoOptions{
+						"repo-2": {
+							Branches: map[string]JiraBranchOptions{
+								"master": {
+									IsOpen:        &yes,
+									TargetVersion: &targetVersion2,
+								},
+							},
+						},
+					},
+				},
+			}},
+		},
+		{
+			name: "Merging 2 organizations",
+
+			from: &Jira{Orgs: map[string]JiraOrgOptions{
+				"org": {
+					Repos: map[string]JiraRepoOptions{
+						"repo-1": {
+							Branches: map[string]JiraBranchOptions{
+								"master": {
+									IsOpen:        &yes,
+									TargetVersion: &targetVersion1,
+								},
+							},
+						},
+					},
+				},
+			}},
+			to: &Jira{Orgs: map[string]JiraOrgOptions{
+				"org-2": {
+					Repos: map[string]JiraRepoOptions{
+						"repo-1": {
+							Branches: map[string]JiraBranchOptions{
+								"master": {
+									IsOpen:        &yes,
+									TargetVersion: &targetVersion2,
+								},
+							},
+						},
+					},
+				},
+			}},
+
+			expected: &Jira{Orgs: map[string]JiraOrgOptions{
+				"org": {
+					Repos: map[string]JiraRepoOptions{
+						"repo-1": {
+							Branches: map[string]JiraBranchOptions{
+								"master": {
+									IsOpen:        &yes,
+									TargetVersion: &targetVersion1,
+								},
+							},
+						},
+					}},
+				"org-2": {
+					Repos: map[string]JiraRepoOptions{
+						"repo-1": {
+							Branches: map[string]JiraBranchOptions{
+								"master": {
+									IsOpen:        &yes,
+									TargetVersion: &targetVersion2,
+								},
+							},
+						},
+					},
+				},
+			}},
+		},
+		{
+			name: "Merging global defaults succeeds",
+
+			from: &Jira{Default: map[string]JiraBranchOptions{
+				"master": {
+					IsOpen:        &yes,
+					TargetVersion: &targetVersion1,
+				},
+			}},
+			to: &Jira{Orgs: map[string]JiraOrgOptions{
+				"org": {
+					Repos: map[string]JiraRepoOptions{
+						"repo-1": {
+							Branches: map[string]JiraBranchOptions{
+								"master": {
+									IsOpen:        &yes,
+									TargetVersion: &targetVersion1,
+								},
+							},
+						},
+					},
+				},
+			}},
+			expected: &Jira{Default: map[string]JiraBranchOptions{
+				"master": {
+					IsOpen:        &yes,
+					TargetVersion: &targetVersion1,
+				},
+			}, Orgs: map[string]JiraOrgOptions{
+				"org": {
+					Repos: map[string]JiraRepoOptions{
+						"repo-1": {
+							Branches: map[string]JiraBranchOptions{
+								"master": {
+									IsOpen:        &yes,
+									TargetVersion: &targetVersion1,
+								},
+							},
+						},
+					},
+				},
+			}},
+		},
+		{
+			name: "Merging multiple global defaults fails",
+
+			from: &Jira{Default: map[string]JiraBranchOptions{
+				"master": {
+					IsOpen:        &yes,
+					TargetVersion: &targetVersion1,
+				},
+			}},
+			to: &Jira{Default: map[string]JiraBranchOptions{
+				"master": {
+					IsOpen:        &yes,
+					TargetVersion: &targetVersion2,
+				},
+			}},
+			expectedErrMsg: "configuration of global default defined in multiple places",
+		},
+		{
+			name: "Merging same organization defaults fails",
+
+			from: &Jira{Orgs: map[string]JiraOrgOptions{
+				"org": {
+					Default: map[string]JiraBranchOptions{
+						"master": {
+							IsOpen:        &yes,
+							TargetVersion: &targetVersion1,
+						},
+					},
+				},
+			}},
+			to: &Jira{Orgs: map[string]JiraOrgOptions{
+				"org": {
+					Default: map[string]JiraBranchOptions{
+						"master": {
+							IsOpen:        &yes,
+							TargetVersion: &targetVersion2,
+						},
+					},
+				},
+			}},
+
+			expectedErrMsg: "found duplicate organization config for jira.org",
+		},
+		{
+			name: "Merging same repository fails",
+
+			from: &Jira{Orgs: map[string]JiraOrgOptions{
+				"org": {
+					Repos: map[string]JiraRepoOptions{
+						"repo-1": {
+							Branches: map[string]JiraBranchOptions{
+								"master": {
+									IsOpen:        &yes,
+									TargetVersion: &targetVersion1,
+								},
+							},
+						},
+					},
+				},
+			}},
+			to: &Jira{Orgs: map[string]JiraOrgOptions{
+				"org": {
+					Repos: map[string]JiraRepoOptions{
+						"repo-1": {
+							Branches: map[string]JiraBranchOptions{
+								"master": {
+									IsOpen:        &yes,
+									TargetVersion: &targetVersion2,
+								},
+							},
+						},
+					},
+				},
+			}},
+
+			expectedErrMsg: "found duplicate repository config for jira.org/repo-1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var errMsg string
+			err := tc.to.mergeFrom(tc.from)
+			if err != nil {
+				errMsg = err.Error()
+			}
+			if tc.expectedErrMsg != errMsg {
+				t.Fatalf("expected error message %q, got %q", tc.expectedErrMsg, errMsg)
 			}
 			if err != nil {
 				return
@@ -1999,10 +2991,11 @@ func TestHasConfigFor(t *testing.T) {
 		resultGenerator func(fuzzedConfig *Configuration) (toCheck *Configuration, expectGlobal bool, expectOrgs sets.String, expectRepos sets.String)
 	}{
 		{
-			name: "Any non-empty config with empty Plugins and Bugzilla is considered to be global",
+			name: "Any non-empty config with empty Plugins, Bugzilla, and Jira is considered to be global",
 			resultGenerator: func(fuzzedConfig *Configuration) (toCheck *Configuration, expectGlobal bool, expectOrgs sets.String, expectRepos sets.String) {
 				fuzzedConfig.Plugins = nil
 				fuzzedConfig.Bugzilla = Bugzilla{}
+				fuzzedConfig.Jira = Jira{}
 				fuzzedConfig.Approve = nil
 				fuzzedConfig.Label.RestrictedLabels = nil
 				fuzzedConfig.Lgtm = nil
@@ -2043,6 +3036,23 @@ func TestHasConfigFor(t *testing.T) {
 					}
 				}
 				return fuzzedConfig, len(fuzzedConfig.Bugzilla.Default) > 0, expectOrgs, expectRepos
+			},
+		},
+		{
+			name: "Any config with jira is considered to be for the orgs and repos references there",
+			resultGenerator: func(fuzzedConfig *Configuration) (toCheck *Configuration, expectGlobal bool, expectOrgs sets.String, expectRepos sets.String) {
+				// exclude non-plugins configs to test jira specifically
+				fuzzedConfig = &Configuration{Jira: fuzzedConfig.Jira}
+				expectOrgs, expectRepos = sets.String{}, sets.String{}
+				for org, orgConfig := range fuzzedConfig.Jira.Orgs {
+					if orgConfig.Default != nil {
+						expectOrgs.Insert(org)
+					}
+					for repo := range orgConfig.Repos {
+						expectRepos.Insert(org + "/" + repo)
+					}
+				}
+				return fuzzedConfig, (len(fuzzedConfig.Jira.Default) > 0 || len(fuzzedConfig.Jira.DisabledJiraProjects) > 0), expectOrgs, expectRepos
 			},
 		},
 		{
@@ -2176,7 +3186,7 @@ func TestHasConfigFor(t *testing.T) {
 				actualIsGlobal, actualOrgs, actualRepos := fuzzedAndManipulatedConfig.HasConfigFor()
 
 				if expectIsGlobal != actualIsGlobal {
-					t.Errorf("exepcted isGlobal: %t, got: %t", expectIsGlobal, actualIsGlobal)
+					t.Errorf("expected isGlobal: %t, got: %t", expectIsGlobal, actualIsGlobal)
 				}
 
 				if diff := cmp.Diff(expectOrgs, actualOrgs); diff != "" {

--- a/prow/plugins/jira/jira.go
+++ b/prow/plugins/jira/jira.go
@@ -17,26 +17,45 @@ limitations under the License.
 package jira
 
 import (
-	"errors"
+	"context"
+	"encoding/json"
 	"fmt"
 	"regexp"
+	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/andygrunwald/go-jira"
+	githubql "github.com/shurcooL/githubv4"
 	"github.com/sirupsen/logrus"
+	"github.com/trivago/tgo/tcontainer"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	jiraclient "k8s.io/test-infra/prow/jira"
+	"k8s.io/test-infra/prow/labels"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
 )
 
 const (
-	PluginName = "jira"
+	PluginName            = "jira"
+	bugLink               = `[Jira Issue %s](%s/browse/%s)`
+	criticalSeverity      = "Critical"
+	importantSeverity     = "Important"
+	moderateSeverity      = "Moderate"
+	lowSeverity           = "Low"
+	informationalSeverity = "Informational"
+)
+
+var (
+	titleMatch           = regexp.MustCompile(`(?i)OCPBUGS-([0-9]+):`)
+	refreshCommandMatch  = regexp.MustCompile(`(?mi)^/jira refresh\s*$`)
+	qaReviewCommandMatch = regexp.MustCompile(`(?mi)^/jira cc-qa\s*$`)
+	cherrypickPRMatch    = regexp.MustCompile(`This is an automated cherry-pick of #([0-9]+)`)
 )
 
 var (
@@ -61,13 +80,242 @@ func extractCandidatesFromText(t string) []string {
 
 func init() {
 	plugins.RegisterGenericCommentHandler(PluginName, handleGenericComment, helpProvider)
+	plugins.RegisterPullRequestHandler(PluginName, handlePullRequest, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
-	// The Config field is omitted because this plugin is not configurable.
-	pluginHelp := &pluginhelp.PluginHelp{
-		Description: "The Jira plugin links Pull Requests and Issues to Jira issues",
+func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
+	configInfo := make(map[string]string)
+	for _, repo := range enabledRepos {
+		opts := config.Jira.OptionsForRepo(repo.Org, repo.Repo)
+		if len(opts) == 0 {
+			continue
+		}
+		// we need to make sure the order of this help is consistent for page reloads and testing
+		var branches []string
+		for branch := range opts {
+			branches = append(branches, branch)
+		}
+		sort.Strings(branches)
+		var configInfoStrings []string
+		configInfoStrings = append(configInfoStrings, "The plugin has the following configuration:<ul>")
+		for _, branch := range branches {
+			var message string
+			if branch == plugins.JiraOptionsWildcard {
+				message = "by default, "
+			} else {
+				message = fmt.Sprintf("on the %q branch, ", branch)
+			}
+			message += "valid bugs must "
+			var conditions []string
+			if opts[branch].IsOpen != nil {
+				if *opts[branch].IsOpen {
+					conditions = append(conditions, "be open")
+				} else {
+					conditions = append(conditions, "be closed")
+				}
+			}
+			if opts[branch].TargetVersion != nil {
+				conditions = append(conditions, fmt.Sprintf("target the %q version", *opts[branch].TargetVersion))
+			}
+			if opts[branch].ValidStates != nil && len(*opts[branch].ValidStates) > 0 {
+				pretty := strings.Join(prettyStates(*opts[branch].ValidStates), ", ")
+				conditions = append(conditions, fmt.Sprintf("be in one of the following states: %s", pretty))
+			}
+			if opts[branch].DependentBugStates != nil || opts[branch].DependentBugTargetVersions != nil {
+				conditions = append(conditions, "depend on at least one other bug")
+			}
+			if opts[branch].DependentBugStates != nil {
+				pretty := strings.Join(prettyStates(*opts[branch].DependentBugStates), ", ")
+				conditions = append(conditions, fmt.Sprintf("have all dependent bugs in one of the following states: %s", pretty))
+			}
+			if opts[branch].DependentBugTargetVersions != nil {
+				conditions = append(conditions, fmt.Sprintf("have all dependent bugs in one of the following target versions: %s", strings.Join(*opts[branch].DependentBugTargetVersions, ", ")))
+			}
+			switch len(conditions) {
+			case 0:
+				message += "exist"
+			case 1:
+				message += conditions[0]
+			case 2:
+				message += fmt.Sprintf("%s and %s", conditions[0], conditions[1])
+			default:
+				conditions[len(conditions)-1] = fmt.Sprintf("and %s", conditions[len(conditions)-1])
+				message += strings.Join(conditions, ", ")
+			}
+			var updates []string
+			if opts[branch].StateAfterValidation != nil {
+				updates = append(updates, fmt.Sprintf("moved to the %s state", opts[branch].StateAfterValidation))
+			}
+			if opts[branch].AddExternalLink != nil && *opts[branch].AddExternalLink {
+				updates = append(updates, "updated to refer to the pull request using the external bug tracker")
+			}
+			if opts[branch].StateAfterMerge != nil {
+				updates = append(updates, fmt.Sprintf("moved to the %s state when all linked pull requests are merged", opts[branch].StateAfterMerge))
+			}
+
+			if len(updates) > 0 {
+				message += ". After being linked to a pull request, bugs will be "
+			}
+			switch len(updates) {
+			case 0:
+			case 1:
+				message += updates[0]
+			case 2:
+				message += fmt.Sprintf("%s and %s", updates[0], updates[1])
+			default:
+				updates[len(updates)-1] = fmt.Sprintf("and %s", updates[len(updates)-1])
+				message += strings.Join(updates, ", ")
+			}
+			configInfoStrings = append(configInfoStrings, "<li>"+message+".</li>")
+		}
+		configInfoStrings = append(configInfoStrings, "</ul>")
+
+		configInfo[repo.String()] = strings.Join(configInfoStrings, "\n")
 	}
+	str := func(s string) *string { return &s }
+	yes := true
+	no := false
+	yamlSnippet, err := plugins.CommentMap.GenYaml(&plugins.Configuration{
+		Jira: plugins.Jira{
+			Default: map[string]plugins.JiraBranchOptions{
+				"*": {
+					ValidateByDefault: &yes,
+					IsOpen:            &yes,
+					TargetVersion:     str("version1"),
+					ValidStates: &[]plugins.JiraBugState{
+						{
+							Status: "MODIFIED",
+						},
+						{
+							Status:     "CLOSED",
+							Resolution: "ERRATA",
+						},
+					},
+					DependentBugStates: &[]plugins.JiraBugState{
+						{
+							Status: "MODIFIED",
+						},
+					},
+					DependentBugTargetVersions: &[]string{"version1", "version2"},
+					StateAfterValidation: &plugins.JiraBugState{
+						Status: "VERIFIED",
+					},
+					AddExternalLink: &no,
+					StateAfterMerge: &plugins.JiraBugState{
+						Status:     "RELEASE_PENDING",
+						Resolution: "RESOLVED",
+					},
+					StateAfterClose: &plugins.JiraBugState{
+						Status:     "RESET",
+						Resolution: "FIXED",
+					},
+					AllowedSecurityLevels: []string{"group1", "groups2"},
+				},
+			},
+			Orgs: map[string]plugins.JiraOrgOptions{
+				"org": {
+					Default: map[string]plugins.JiraBranchOptions{
+						"*": {
+							ExcludeDefaults:   &yes,
+							ValidateByDefault: &yes,
+							IsOpen:            &yes,
+							TargetVersion:     str("version1"),
+							ValidStates: &[]plugins.JiraBugState{
+								{
+									Status: "MODIFIED",
+								},
+								{
+									Status:     "CLOSED",
+									Resolution: "ERRATA",
+								},
+							},
+							DependentBugStates: &[]plugins.JiraBugState{
+								{
+									Status: "MODIFIED",
+								},
+							},
+							DependentBugTargetVersions: &[]string{"version1", "version2"},
+							StateAfterValidation: &plugins.JiraBugState{
+								Status: "VERIFIED",
+							},
+							AddExternalLink: &no,
+							StateAfterMerge: &plugins.JiraBugState{
+								Status:     "RELEASE_PENDING",
+								Resolution: "RESOLVED",
+							},
+							StateAfterClose: &plugins.JiraBugState{
+								Status:     "RESET",
+								Resolution: "FIXED",
+							},
+							AllowedSecurityLevels: []string{"group1", "groups2"},
+						},
+					},
+					Repos: map[string]plugins.JiraRepoOptions{
+						"repo": {
+							Branches: map[string]plugins.JiraBranchOptions{
+								"branch": {
+									ExcludeDefaults:   &no,
+									ValidateByDefault: &yes,
+									IsOpen:            &yes,
+									TargetVersion:     str("version1"),
+									ValidStates: &[]plugins.JiraBugState{
+										{
+											Status: "MODIFIED",
+										},
+										{
+											Status:     "CLOSED",
+											Resolution: "ERRATA",
+										},
+									},
+									DependentBugStates: &[]plugins.JiraBugState{
+										{
+											Status: "MODIFIED",
+										},
+									},
+									DependentBugTargetVersions: &[]string{"version1", "version2"},
+									StateAfterValidation: &plugins.JiraBugState{
+										Status: "VERIFIED",
+									},
+									AddExternalLink: &no,
+									StateAfterMerge: &plugins.JiraBugState{
+										Status:     "RELEASE_PENDING",
+										Resolution: "RESOLVED",
+									},
+									StateAfterClose: &plugins.JiraBugState{
+										Status:     "RESET",
+										Resolution: "FIXED",
+									},
+									AllowedSecurityLevels: []string{"group1", "groups2"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		logrus.WithError(err).Warnf("cannot generate comments for %s plugin", PluginName)
+	}
+	pluginHelp := &pluginhelp.PluginHelp{
+		Description: "The jira plugin ensures that pull requests reference a valid Jira bug in their title.",
+		Config:      configInfo,
+		Snippet:     yamlSnippet,
+	}
+	pluginHelp.AddCommand(pluginhelp.Command{
+		Usage:       "/jira refresh",
+		Description: "Check Jira for a valid bug referenced in the PR title",
+		Featured:    false,
+		WhoCanUse:   "Anyone",
+		Examples:    []string{"/jira refresh"},
+	})
+	pluginHelp.AddCommand(pluginhelp.Command{
+		Usage:       "/jira cc-qa",
+		Description: "Request PR review from QA contact specified in Jira",
+		Featured:    false,
+		WhoCanUse:   "Anyone",
+		Examples:    []string{"/jira cc-qa"},
+	})
 	return pluginHelp, nil
 }
 
@@ -75,13 +323,33 @@ type githubClient interface {
 	EditComment(org, repo string, id int, comment string) error
 	GetIssue(org, repo string, number int) (*github.Issue, error)
 	EditIssue(org, repo string, number int, issue *github.Issue) (*github.Issue, error)
+	GetPullRequest(org, repo string, number int) (*github.PullRequest, error)
+	CreateComment(owner, repo string, number int, comment string) error
+	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
+	AddLabel(owner, repo string, number int, label string) error
+	RemoveLabel(owner, repo string, number int, label string) error
+	WasLabelAddedByHuman(org, repo string, num int, label string) (bool, error)
+	Query(ctx context.Context, q interface{}, vars map[string]interface{}) error
 }
 
-func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
-	return handle(pc.JiraClient, pc.GitHubClient, pc.PluginConfig.Jira, pc.Logger, &e)
+func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("recovered panic in jira plugin: %v", r)
+		}
+	}()
+	event, err := digestComment(pc.GitHubClient, pc.Logger, e)
+	if err != nil {
+		return err
+	}
+	if event != nil {
+		options := pc.PluginConfig.Jira.OptionsForBranch(event.org, event.repo, event.baseRef)
+		return handle(pc.JiraClient, pc.GitHubClient, pc.PluginConfig.Jira.DisabledJiraProjects, options, pc.Logger, *event, pc.Config.AllRepos)
+	}
+	return nil
 }
 
-func handle(jc jiraclient.Client, ghc githubClient, cfg *plugins.Jira, log *logrus.Entry, e *github.GenericCommentEvent) error {
+func handle(jc jiraclient.Client, ghc githubClient, disabledJiraProjects []string, options plugins.JiraBranchOptions, log *logrus.Entry, e event, allRepos sets.String) error {
 	if projectCache.entryCount() == 0 {
 		projects, err := jc.ListProjects()
 		if err != nil {
@@ -94,78 +362,346 @@ func handle(jc jiraclient.Client, ghc githubClient, cfg *plugins.Jira, log *logr
 		projectCache.insert(projectNames...)
 	}
 
-	return handleWithProjectCache(jc, ghc, cfg, log, e, projectCache)
+	return handleWithProjectCache(jc, ghc, disabledJiraProjects, options, log, e, allRepos, projectCache)
 }
 
-func handleWithProjectCache(jc jiraclient.Client, ghc githubClient, cfg *plugins.Jira, log *logrus.Entry, e *github.GenericCommentEvent, projectCache *threadsafeSet) error {
-	// Nothing to do on deletion
-	if e.Action == github.GenericCommentActionDeleted {
-		return nil
-	}
-
+func handleWithProjectCache(jc jiraclient.Client, gc githubClient, disabledJiraProjects []string, options plugins.JiraBranchOptions, log *logrus.Entry, e event, allRepos sets.String, projectCache *threadsafeSet) error {
 	jc = &projectCachingJiraClient{jc, projectCache}
 
-	issueCandidateNames := extractCandidatesFromText(e.Body)
-	issueCandidateNames = append(issueCandidateNames, extractCandidatesFromText(e.IssueTitle)...)
-	issueCandidateNames = filterOutDisabledJiraProjects(issueCandidateNames, cfg)
-	if len(issueCandidateNames) == 0 {
+	// if this is a comment, linkify the comment and add remote link for non-bug type issues
+	if e.isComment {
+		issueCandidateNames := extractCandidatesFromText(e.body)
+		issueCandidateNames = append(issueCandidateNames, extractCandidatesFromText(e.title)...)
+		issueCandidateNames = filterOutDisabledJiraProjects(issueCandidateNames, disabledJiraProjects)
+		if len(issueCandidateNames) == 0 {
+			return nil
+		}
+
+		var errs []error
+		referencedIssues := sets.String{}
+		for _, match := range issueCandidateNames {
+			if referencedIssues.Has(match) {
+				continue
+			}
+			_, err := jc.GetIssue(match)
+			if err != nil {
+				if !jiraclient.IsNotFound(err) {
+					errs = append(errs, fmt.Errorf("failed to get issue %s: %w", match, err))
+				}
+				continue
+			}
+			referencedIssues.Insert(match)
+		}
+
+		wg := &sync.WaitGroup{}
+		for _, issue := range referencedIssues.List() {
+			// don't handle bug (i.e. OCPBUGS issues); those are handled separately
+			if strings.HasPrefix(issue, "OCPBUGS-") {
+				continue
+			}
+			wg.Add(1)
+			go func(issue string) {
+				defer wg.Done()
+				if _, err := upsertGitHubLinkToIssue(log, issue, jc, e); err != nil {
+					log.WithField("Issue", issue).WithError(err).Error("Failed to ensure GitHub link on Jira issue")
+				}
+			}(issue)
+		}
+
+		if err := updateComment(e, referencedIssues.UnsortedList(), jc.JiraURL(), gc); err != nil {
+			errs = append(errs, fmt.Errorf("failed to update comment: %w", err))
+		}
+		wg.Wait()
+		if len(errs) != 0 {
+			return utilerrors.NewAggregate(errs)
+		}
+	}
+
+	if e.key == "" || !strings.HasPrefix(e.key, "OCPBUGS-") {
 		return nil
 	}
 
-	var errs []error
-	referencedIssues := sets.String{}
-	for _, match := range issueCandidateNames {
-		if referencedIssues.Has(match) {
-			continue
+	comment := e.comment(gc)
+	// check if bug is part of a restricted security level
+	if !e.missing {
+		bug, err := getBug(jc, e.key, log, comment)
+		if err != nil || bug == nil {
+			return err
 		}
-		_, err := jc.GetIssue(match)
+		bugAllowed, err := isBugAllowed(bug, options.AllowedSecurityLevels)
 		if err != nil {
-			if !jiraclient.IsNotFound(err) {
-				errs = append(errs, fmt.Errorf("failed to get issue %s: %w", match, err))
-			}
-			continue
+			return err
 		}
-		referencedIssues.Insert(match)
-	}
-
-	wg := &sync.WaitGroup{}
-	for _, issue := range referencedIssues.List() {
-		wg.Add(1)
-		go func(issue string) {
-			defer wg.Done()
-			if err := upsertGitHubLinkToIssue(log, issue, jc, e); err != nil {
-				log.WithField("Issue", issue).WithError(err).Error("Failed to ensure GitHub link on Jira issue")
+		if !bugAllowed {
+			// ignore bugs that are in non-allowed security levels for this repo
+			if e.opened || refreshCommandMatch.MatchString(e.body) {
+				response := fmt.Sprintf(bugLink+" is in a security level that is not in the allowed security levels for this repo.", e.key, jc.JiraURL(), e.key)
+				if len(options.AllowedSecurityLevels) > 0 {
+					response += "\nAllowed security levels for this repo are:"
+					for _, group := range options.AllowedSecurityLevels {
+						response += "\n- " + group
+					}
+				} else {
+					response += " There are no allowed security levels configured for this repo."
+				}
+				return comment(response)
 			}
-		}(issue)
+			return nil
+		}
+	}
+	// merges follow a different pattern from the normal validation
+	if e.merged {
+		return handleMerge(e, gc, jc, options, log, allRepos)
+	}
+	// close events follow a different pattern from the normal validation
+	if e.closed && !e.merged {
+		return handleClose(e, gc, jc, options, log)
+	}
+	// cherrypicks follow a different pattern than normal validation
+	if e.cherrypick {
+		return handleCherrypick(e, gc, jc, options, log)
 	}
 
-	if err := updateComment(e, referencedIssues.UnsortedList(), jc.JiraURL(), ghc); err != nil {
-		errs = append(errs, fmt.Errorf("failed to update comment: %w", err))
-	}
-	wg.Wait()
+	var needsValidLabel, needsInvalidLabel bool
+	var response, severityLabel string
+	if e.missing {
+		log.WithField("bugMissing", true)
+		log.Debug("No bug referenced.")
+		needsValidLabel, needsInvalidLabel = false, false
+		response = `No Jira bug is referenced in the title of this pull request.
+To reference a bug, add 'OCPBUGS-XXX:' to the title of this pull request and request another bug refresh with <code>/jira refresh</code>.`
+	} else {
+		log = log.WithField("bugKey", e.key)
 
-	return utilerrors.NewAggregate(errs)
+		bug, err := getBug(jc, e.key, log, comment)
+		if err != nil || bug == nil {
+			return err
+		}
+
+		severity, err := getSimplifiedSeverity(bug)
+		if err != nil {
+			return err
+		}
+
+		severityLabel = getSeverityLabel(severity)
+
+		var dependents []*jira.Issue
+		if options.DependentBugStates != nil || options.DependentBugTargetVersions != nil {
+			for _, link := range bug.Fields.IssueLinks {
+				// identify if bug depends on this link; multiple different types of links may be blocker types; more can be added as they are identified
+				dependsOn := false
+				dependsOn = dependsOn || (link.InwardIssue != nil && link.Type.Name == "Blocks" && link.Type.Inward == "is blocked by")
+				dependsOn = dependsOn || (link.InwardIssue != nil && link.Type.Name == "Cloners" && link.Type.Inward == "is cloned by")
+				if !dependsOn {
+					continue
+				}
+				// link may be either an outward or inward issue; depends on the link type
+				linkIssue := link.InwardIssue
+				if linkIssue == nil {
+					linkIssue = link.OutwardIssue
+				}
+				// the issue in the link is very trimmed down; get full link for dependent list
+				dependent, err := jc.GetIssue(linkIssue.Key)
+				if err != nil {
+					return comment(formatError(fmt.Sprintf("searching for dependent bug %s", linkIssue.Key), jc.JiraURL(), e.key, err))
+				}
+				dependents = append(dependents, dependent)
+			}
+		}
+
+		valid, validationsRun, why := validateBug(bug, dependents, options, jc.JiraURL())
+		needsValidLabel, needsInvalidLabel = valid, !valid
+		if valid {
+			log.Debug("Valid bug found.")
+			response = fmt.Sprintf(`This pull request references `+bugLink+`, which is valid.`, e.key, jc.JiraURL(), e.key)
+			// if configured, move the bug to the new state
+			if options.StateAfterValidation != nil {
+				if options.StateAfterValidation.Status != "" && (bug.Fields.Status == nil || options.StateAfterValidation.Status != bug.Fields.Status.Name) {
+					if err := jc.UpdateStatus(bug.ID, options.StateAfterValidation.Status); err != nil {
+						log.WithError(err).Warn("Unexpected error updating jira issue.")
+						return comment(formatError(fmt.Sprintf("updating to the %s state", options.StateAfterValidation.Status), jc.JiraURL(), e.key, err))
+					}
+					if options.StateAfterValidation.Resolution != "" && (bug.Fields.Resolution == nil || options.StateAfterValidation.Resolution != bug.Fields.Resolution.Name) {
+						updateIssue := jira.Issue{ID: bug.ID, Fields: &jira.IssueFields{Resolution: &jira.Resolution{Name: options.StateAfterValidation.Resolution}}}
+						if _, err := jc.UpdateIssue(&updateIssue); err != nil {
+							log.WithError(err).Warn("Unexpected error updating jira issue.")
+							return comment(formatError(fmt.Sprintf("updating to the %s resolution", options.StateAfterValidation.Resolution), jc.JiraURL(), e.key, err))
+						}
+					}
+					response += fmt.Sprintf(" The bug has been moved to the %s state.", options.StateAfterValidation)
+				}
+			}
+			if options.AddExternalLink != nil && *options.AddExternalLink {
+				changed, err := upsertGitHubLinkToIssue(log, bug.ID, jc, e)
+				if err != nil {
+					log.WithError(err).Warn("Unexpected error adding external tracker bug to Jira bug.")
+					return comment(formatError("adding this pull request to the external tracker bugs", jc.JiraURL(), e.key, err))
+				}
+				if changed {
+					response += " The bug has been updated to refer to the pull request using the external bug tracker."
+				}
+			}
+
+			response += "\n\n<details>"
+			if len(validationsRun) == 0 {
+				response += "<summary>No validations were run on this bug</summary>"
+			} else {
+				response += fmt.Sprintf("<summary>%d validation(s) were run on this bug</summary>\n", len(validationsRun))
+			}
+			for _, validation := range validationsRun {
+				response += fmt.Sprint("\n* ", validation)
+			}
+			response += "</details>"
+
+			qaContactDetail, err := jc.GetIssueQaContact(bug)
+			if err != nil {
+				return comment(formatError("processing qa contact information for the bug", jc.JiraURL(), e.key, err))
+			}
+			if qaContactDetail == nil {
+				if e.cc {
+					response += fmt.Sprintf(bugLink+" does not have a QA contact, skipping assignment", e.key, jc.JiraURL(), e.key)
+				}
+			} else if qaContactDetail.EmailAddress == "" {
+				if e.cc {
+					response += fmt.Sprintf("QA contact for "+bugLink+" does not have a listed email, skipping assignment", e.key, jc.JiraURL(), e.key)
+				}
+			} else {
+				query := &emailToLoginQuery{}
+				email := qaContactDetail.EmailAddress
+				queryVars := map[string]interface{}{
+					"email": githubql.String(email),
+				}
+				err := gc.Query(context.Background(), query, queryVars)
+				if err != nil {
+					log.WithError(err).Error("Failed to run graphql github query")
+					return comment(formatError(fmt.Sprintf("querying GitHub for users with public email (%s)", email), jc.JiraURL(), e.key, err))
+				}
+				response += fmt.Sprint("\n\n", processQuery(query, email, log))
+			}
+		} else {
+			log.Debug("Invalid bug found.")
+			var formattedReasons string
+			for _, reason := range why {
+				formattedReasons += fmt.Sprintf(" - %s\n", reason)
+			}
+			response = fmt.Sprintf(`This pull request references `+bugLink+`, which is invalid:
+%s
+Comment <code>/jira refresh</code> to re-evaluate validity if changes to the Jira bug are made, or edit the title of this pull request to link to a different bug.`, e.key, jc.JiraURL(), e.key, formattedReasons)
+		}
+	}
+
+	// ensure label state is correct. Do not propagate errors
+	// as it is more important to report to the user than to
+	// fail early on a label check.
+	currentLabels, err := gc.GetIssueLabels(e.org, e.repo, e.number)
+	if err != nil {
+		log.WithError(err).Warn("Could not list labels on PR")
+	}
+	var hasValidLabel, hasInvalidLabel bool
+	var severityLabelToRemove string
+	for _, l := range currentLabels {
+		if l.Name == labels.JiraValidBug {
+			hasValidLabel = true
+		}
+		if l.Name == labels.JiraInvalidBug {
+			hasInvalidLabel = true
+		}
+		if l.Name == labels.JiraSeverityCritical ||
+			l.Name == labels.JiraSeverityImportant ||
+			l.Name == labels.JiraSeverityModerate ||
+			l.Name == labels.JiraSeverityLow ||
+			l.Name == labels.JiraSeverityInformational {
+			severityLabelToRemove = l.Name
+		}
+	}
+
+	if severityLabelToRemove != "" && severityLabel != severityLabelToRemove {
+		if err := gc.RemoveLabel(e.org, e.repo, e.number, severityLabelToRemove); err != nil {
+			log.WithError(err).Error("Failed to remove severity bug label.")
+		}
+	}
+	if severityLabel != "" && severityLabel != severityLabelToRemove {
+		if err := gc.AddLabel(e.org, e.repo, e.number, severityLabel); err != nil {
+			log.WithError(err).Error("Failed to add severity bug label.")
+		}
+	}
+
+	if hasValidLabel && !needsValidLabel {
+		humanLabelled, err := gc.WasLabelAddedByHuman(e.org, e.repo, e.number, labels.JiraValidBug)
+		if err != nil {
+			// Return rather than potentially doing the wrong thing. The user can re-trigger us.
+			return fmt.Errorf("failed to check if %s label was added by a human: %w", labels.JiraValidBug, err)
+		}
+		if humanLabelled {
+			// This will make us remove the invalid label if it exists but saves us another check if it was
+			// added by a human. It is reasonable to assume that it should be absent if the valid label was
+			// manually added.
+			needsInvalidLabel = false
+			needsValidLabel = true
+			response += fmt.Sprintf("\n\nRetaining the %s label as it was manually added.", labels.JiraValidBug)
+		}
+	}
+
+	if needsValidLabel && !hasValidLabel {
+		if err := gc.AddLabel(e.org, e.repo, e.number, labels.JiraValidBug); err != nil {
+			log.WithError(err).Error("Failed to add valid bug label.")
+		}
+	} else if !needsValidLabel && hasValidLabel {
+		if err := gc.RemoveLabel(e.org, e.repo, e.number, labels.JiraValidBug); err != nil {
+			log.WithError(err).Error("Failed to remove valid bug label.")
+		}
+	}
+
+	if needsInvalidLabel && !hasInvalidLabel {
+		if err := gc.AddLabel(e.org, e.repo, e.number, labels.JiraInvalidBug); err != nil {
+			log.WithError(err).Error("Failed to add invalid bug label.")
+		}
+	} else if !needsInvalidLabel && hasInvalidLabel {
+		if err := gc.RemoveLabel(e.org, e.repo, e.number, labels.JiraInvalidBug); err != nil {
+			log.WithError(err).Error("Failed to remove invalid bug label.")
+		}
+	}
+
+	return comment(response)
 }
 
-func updateComment(e *github.GenericCommentEvent, validIssues []string, jiraBaseURL string, ghc githubClient) error {
-	withLinks := insertLinksIntoComment(e.Body, validIssues, jiraBaseURL)
-	if withLinks == e.Body {
+// getSimplifiedSeverity retrieves the severity of the issue and trims the image tags that precede
+// the name of the severity, which are a nuisance for automation
+func getSimplifiedSeverity(issue *jira.Issue) (string, error) {
+	severity, err := jiraclient.GetIssueSeverity(issue)
+	if err != nil {
+		return "", fmt.Errorf("Failed to get severity of issue %s", issue.Key)
+	}
+	if severity == nil {
+		return "unset", nil
+	}
+	// the values of the severity fields in redhat jira have an image before them
+	// (ex: <img alt=\"\" src=\"/images/icons/priorities/medium.svg\" width=\"16\" height=\"16\"> Medium)
+	// we need to trim that off before returning. There is always a space between the image and the text,
+	// so we can split on spaces and take the last element
+	splitSeverity := strings.Split(severity.Value, " ")
+	return splitSeverity[len(splitSeverity)-1], nil
+}
+
+func updateComment(e event, validIssues []string, jiraBaseURL string, ghc githubClient) error {
+	withLinks := insertLinksIntoComment(e.body, validIssues, jiraBaseURL)
+	if withLinks == e.body {
 		return nil
 	}
-	if e.CommentID != nil {
-		return ghc.EditComment(e.Repo.Owner.Login, e.Repo.Name, *e.CommentID, withLinks)
+	if e.commentID != nil {
+		return ghc.EditComment(e.org, e.repo, *e.commentID, withLinks)
 	}
 
-	issue, err := ghc.GetIssue(e.Repo.Owner.Login, e.Repo.Name, e.Number)
+	issue, err := ghc.GetIssue(e.org, e.repo, e.number)
 	if err != nil {
-		return fmt.Errorf("failed to get issue %s/%s#%d: %w", e.Repo.Owner.Login, e.Repo.Name, e.Number, err)
+		return fmt.Errorf("failed to get issue %s/%s#%d: %w", e.org, e.repo, e.number, err)
 	}
 
-	// Check for the diff on the issues body in case the even't didn't have a commentID but did not originate
+	// Check for the diff on the issues body in case the event didn't have a commentID but did not originate
 	// in issue creation, e.G. PRReviewEvent
 	if withLinks := insertLinksIntoComment(issue.Body, validIssues, jiraBaseURL); withLinks != issue.Body {
 		issue.Body = withLinks
-		_, err := ghc.EditIssue(e.Repo.Owner.Login, e.Repo.Name, e.Number, issue)
+		_, err := ghc.EditIssue(e.org, e.repo, e.number, issue)
 		return err
 	}
 
@@ -225,7 +761,6 @@ func insertLinksIntoLine(line string, issueNames []string, jiraBaseURL string) s
 // * `/` which we use as heuristic for "Part of a link in a previous replacement",
 // * ``` (backtick) which we use as heuristic for "Inline code".
 // If golang would support back-references in regex replacements, this would have been a lot
-// simpler.
 func replaceStringIfNeeded(text, old, new string) string {
 	if old == "" {
 		return text
@@ -265,18 +800,24 @@ func replaceStringIfNeeded(text, old, new string) string {
 	return result
 }
 
-func upsertGitHubLinkToIssue(log *logrus.Entry, issueID string, jc jiraclient.Client, e *github.GenericCommentEvent) error {
+func prURLFromCommentURL(url string) string {
+	newURL := url
+	if idx := strings.Index(url, "#"); idx != -1 {
+		newURL = newURL[:idx]
+	}
+	return newURL
+}
+
+// upsertGitHubLinkToIssue adds a remote link to the github issue on the jira issue. It returns a bool indicating whether or not the
+// remote link changed or was created, and an error.
+func upsertGitHubLinkToIssue(log *logrus.Entry, issueID string, jc jiraclient.Client, e event) (bool, error) {
 	links, err := jc.GetRemoteLinks(issueID)
 	if err != nil {
-		return fmt.Errorf("failed to get remote links: %w", err)
+		return false, fmt.Errorf("failed to get remote links: %w", err)
 	}
 
-	url := e.HTMLURL
-	if idx := strings.Index(url, "#"); idx != -1 {
-		url = url[:idx]
-	}
-
-	title := fmt.Sprintf("%s#%d: %s", e.Repo.FullName, e.Number, e.IssueTitle)
+	url := prURLFromCommentURL(e.htmlUrl)
+	title := fmt.Sprintf("%s/%s#%d: %s", e.org, e.repo, e.number, e.title)
 	var existingLink *jira.RemoteLink
 
 	// Check if the same link exists already. We consider two links to be the same if the have the same URL.
@@ -285,7 +826,7 @@ func upsertGitHubLinkToIssue(log *logrus.Entry, issueID string, jc jiraclient.Cl
 	for _, link := range links {
 		if link.Object.URL == url {
 			if title == link.Object.Title {
-				return nil
+				return false, nil
 			}
 			link := link
 			existingLink = &link
@@ -307,26 +848,26 @@ func upsertGitHubLinkToIssue(log *logrus.Entry, issueID string, jc jiraclient.Cl
 	if existingLink != nil {
 		existingLink.Object = link.Object
 		if err := jc.UpdateRemoteLink(issueID, existingLink); err != nil {
-			return fmt.Errorf("failed to update remote link: %w", err)
+			return false, fmt.Errorf("failed to update remote link: %w", err)
 		}
 		log.Info("Updated jira link")
 	} else {
 		if _, err := jc.AddRemoteLink(issueID, link); err != nil {
-			return fmt.Errorf("failed to add remote link: %w", err)
+			return false, fmt.Errorf("failed to add remote link: %w", err)
 		}
 		log.Info("Created jira link")
 	}
 
-	return nil
+	return true, nil
 }
 
-func filterOutDisabledJiraProjects(candidateNames []string, cfg *plugins.Jira) []string {
-	if cfg == nil {
+func filterOutDisabledJiraProjects(candidateNames []string, disabledProjects []string) []string {
+	if len(disabledProjects) == 0 {
 		return candidateNames
 	}
 
 	var result []string
-	for _, excludedProject := range cfg.DisabledJiraProjects {
+	for _, excludedProject := range disabledProjects {
 		for _, candidate := range candidateNames {
 			if strings.HasPrefix(strings.ToLower(candidate), strings.ToLower(excludedProject)) {
 				continue
@@ -348,7 +889,7 @@ type projectCachingJiraClient struct {
 func (c *projectCachingJiraClient) GetIssue(id string) (*jira.Issue, error) {
 	projectName := strings.ToLower(strings.Split(id, "-")[0])
 	if !c.cache.has(projectName) {
-		return nil, jiraclient.NewNotFoundError(errors.New("404 from cache"))
+		return nil, jiraclient.NewNotFoundError(fmt.Errorf("404 from cache for key %s, project name %s", id, projectName))
 	}
 	result, err := c.Client.GetIssue(id)
 	if err != nil {
@@ -378,4 +919,797 @@ func (s *threadsafeSet) entryCount() int {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	return len(s.data)
+}
+
+func handlePullRequest(pc plugins.Agent, pre github.PullRequestEvent) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("recovered panic in jira plugin: %v", r)
+		}
+	}()
+	options := pc.PluginConfig.Jira.OptionsForBranch(pre.PullRequest.Base.Repo.Owner.Login, pre.PullRequest.Base.Repo.Name, pre.PullRequest.Base.Ref)
+	event, err := digestPR(pc.Logger, pre, options.ValidateByDefault)
+	if err != nil {
+		return err
+	}
+	if event != nil {
+		return handle(pc.JiraClient, pc.GitHubClient, pc.PluginConfig.Jira.DisabledJiraProjects, options, pc.Logger, *event, pc.Config.AllRepos)
+	}
+	return nil
+}
+
+func getCherryPickMatch(pre github.PullRequestEvent) (bool, int, string, error) {
+	cherrypickMatch := cherrypickPRMatch.FindStringSubmatch(pre.PullRequest.Body)
+	if cherrypickMatch != nil {
+		cherrypickOf, err := strconv.Atoi(cherrypickMatch[1])
+		if err != nil {
+			// should be impossible based on the regex
+			return false, 0, "", fmt.Errorf("Failed to parse cherrypick jira issue - is the regex correct? Err: %w", err)
+		}
+		return true, cherrypickOf, pre.PullRequest.Base.Ref, nil
+	}
+	return false, 0, "", nil
+}
+
+// digestPR determines if any action is necessary and creates the objects for handle() if it is
+func digestPR(log *logrus.Entry, pre github.PullRequestEvent, validateByDefault *bool) (*event, error) {
+	// These are the only actions indicating the PR title may have changed or that the PR merged or was closed
+	if pre.Action != github.PullRequestActionOpened &&
+		pre.Action != github.PullRequestActionReopened &&
+		pre.Action != github.PullRequestActionEdited &&
+		pre.Action != github.PullRequestActionClosed {
+		return nil, nil
+	}
+
+	var (
+		org     = pre.PullRequest.Base.Repo.Owner.Login
+		repo    = pre.PullRequest.Base.Repo.Name
+		baseRef = pre.PullRequest.Base.Ref
+		number  = pre.PullRequest.Number
+		title   = pre.PullRequest.Title
+		body    = pre.PullRequest.Body
+	)
+
+	e := &event{org: org, repo: repo, baseRef: baseRef, number: number, merged: pre.PullRequest.Merged, closed: pre.Action == github.PullRequestActionClosed, opened: pre.Action == github.PullRequestActionOpened, state: pre.PullRequest.State, body: body, title: title, htmlUrl: pre.PullRequest.HTMLURL, login: pre.PullRequest.User.Login}
+	// Make sure the PR title is referencing a bug
+	var err error
+	e.key, e.missing, err = bugKeyFromTitle(title)
+	// in the case that the title used to reference a bug and no longer does we
+	// want to handle this to remove labels
+	if err != nil {
+		log.WithError(err).Debug("Failed to get bug ID from title")
+		return nil, err
+	}
+
+	// Check if PR is a cherrypick
+	cherrypick, cherrypickFromPRNum, cherrypickTo, err := getCherryPickMatch(pre)
+	if err != nil {
+		log.WithError(err).Debug("Failed to identify if PR is a cherrypick")
+		return nil, err
+	} else if cherrypick {
+		if pre.Action == github.PullRequestActionOpened {
+			e.cherrypick = true
+			e.cherrypickFromPRNum = cherrypickFromPRNum
+			e.cherrypickTo = cherrypickTo
+			return e, nil
+		}
+	}
+
+	if e.closed && !e.merged {
+		// if the PR was closed, we do not need to check for any other
+		// conditions like cherry-picks or title edits and can just
+		// handle it
+		return e, nil
+	}
+
+	// when exiting early from errors trying to find out if the PR previously referenced a bug,
+	// we want to handle the event only if a bug is currently referenced or we are validating by
+	// default
+	var intermediate *event
+	if !e.missing || (validateByDefault != nil && *validateByDefault) {
+		intermediate = e
+	}
+
+	// Check if the previous version of the title referenced a bug.
+	var changes struct {
+		Title struct {
+			From string `json:"from"`
+		} `json:"title"`
+	}
+	if err := json.Unmarshal(pre.Changes, &changes); err != nil {
+		// we're detecting this best-effort so we can handle it anyway
+		return intermediate, nil
+	}
+	prevId, missing, err := bugKeyFromTitle(changes.Title.From)
+	if missing {
+		// title did not previously reference a bug
+		return intermediate, nil
+	} else if err != nil {
+		// should be impossible based on the regex, ignore err as this is best-effort
+		log.WithError(err).Debug("Failed get previous bug ID")
+		return intermediate, nil
+	}
+
+	// if the referenced bug has not changed in the update, ignore it
+	if prevId == e.key {
+		logrus.Debugf("Referenced OCPBUGS story (%s) has not changed, not handling event.", e.key)
+		return nil, nil
+	}
+
+	// we know the PR previously referenced a bug, so whether
+	// it currently does or does not reference a bug, we should
+	// handle the event
+	return e, nil
+}
+
+// digestComment determines if any action is necessary and creates the objects for handle() if it is
+func digestComment(gc githubClient, log *logrus.Entry, gce github.GenericCommentEvent) (*event, error) {
+	// Only consider new comments.
+	if gce.Action != github.GenericCommentActionCreated {
+		return nil, nil
+	}
+	// Make sure they are requesting a valid command
+	var cc bool
+	switch {
+	case refreshCommandMatch.MatchString(gce.Body):
+		// continue without updating bool values
+	case qaReviewCommandMatch.MatchString(gce.Body):
+		cc = true
+	default:
+		return nil, nil
+	}
+	var (
+		org    = gce.Repo.Owner.Login
+		repo   = gce.Repo.Name
+		number = gce.Number
+	)
+
+	// We don't support linking issues to Bugs
+	if !gce.IsPR {
+		log.Debug("Jira bug command requested on an issue, ignoring")
+		return nil, gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(gce.Body, gce.HTMLURL, gce.User.Login, `Jira bug referencing is only supported for Pull Requests, not issues.`))
+	}
+
+	// Make sure the PR title is referencing a bug
+	pr, err := gc.GetPullRequest(org, repo, number)
+	if err != nil {
+		return nil, err
+	}
+
+	e := &event{org: org, repo: repo, baseRef: pr.Base.Ref, number: number, merged: pr.Merged, state: pr.State, body: gce.Body, title: gce.IssueTitle, htmlUrl: gce.HTMLURL, login: gce.User.Login, cc: cc, isComment: true, commentID: gce.CommentID}
+	e.key, e.missing, err = bugKeyFromTitle(pr.Title)
+	if err != nil {
+		// should be impossible based on the regex
+		log.WithError(err).Debug("Failed to get Jira bug ID from PR title")
+		return nil, err
+	}
+
+	return e, nil
+}
+
+type event struct {
+	org, repo, baseRef              string
+	number                          int
+	key                             string
+	missing, merged, closed, opened bool
+	isComment                       bool
+	commentID                       *int
+	state                           string
+	body, title, htmlUrl, login     string
+	cc                              bool
+	cherrypick                      bool
+	cherrypickFromPRNum             int
+	cherrypickTo                    string
+}
+
+func (e *event) comment(gc githubClient) func(body string) error {
+	return func(body string) error {
+		return gc.CreateComment(e.org, e.repo, e.number, plugins.FormatResponseRaw(e.body, e.htmlUrl, e.login, body))
+	}
+}
+
+type queryUser struct {
+	Login githubql.String
+}
+
+type queryNode struct {
+	User queryUser `graphql:"... on User"`
+}
+
+type queryEdge struct {
+	Node queryNode
+}
+
+type querySearch struct {
+	Edges []queryEdge
+}
+
+/* emailToLoginQuery is a graphql query struct that should result in this graphql query:
+   {
+     search(type: USER, query: "email", first: 5) {
+       edges {
+         node {
+           ... on User {
+             login
+           }
+         }
+       }
+     }
+   }
+*/
+type emailToLoginQuery struct {
+	Search querySearch `graphql:"search(type:USER query:$email first:5)"`
+}
+
+// processQueryResult generates a response based on a populated emailToLoginQuery
+func processQuery(query *emailToLoginQuery, email string, log *logrus.Entry) string {
+	switch len(query.Search.Edges) {
+	case 0:
+		return fmt.Sprintf("No GitHub users were found matching the public email listed for the QA contact in Jira (%s), skipping review request.", email)
+	case 1:
+		return fmt.Sprintf("Requesting review from QA contact:\n/cc @%s", query.Search.Edges[0].Node.User.Login)
+	default:
+		response := fmt.Sprintf("Multiple GitHub users were found matching the public email listed for the QA contact in Jira (%s), skipping review request. List of users with matching email:", email)
+		for _, edge := range query.Search.Edges {
+			response += fmt.Sprintf("\n\t- %s", edge.Node.User.Login)
+		}
+		return response
+	}
+}
+
+func getSeverityLabel(severity string) string {
+	switch severity {
+	case criticalSeverity:
+		return labels.JiraSeverityCritical
+	case importantSeverity:
+		return labels.JiraSeverityImportant
+	case moderateSeverity:
+		return labels.JiraSeverityModerate
+	case lowSeverity:
+		return labels.JiraSeverityLow
+	case informationalSeverity:
+		return labels.JiraSeverityInformational
+	}
+	//If we don't understand the severity, don't set it but don't error.
+	return ""
+}
+
+func bugMatchesStates(bug *jira.Issue, states []plugins.JiraBugState) bool {
+	if bug == nil {
+		return false
+	}
+	for _, state := range states {
+		if ((state.Status != "" && state.Status == bug.Fields.Status.Name) || state.Status == "") &&
+			((state.Resolution != "" && state.Resolution == bug.Fields.Resolution.Name) || state.Resolution == "") {
+			return true
+		}
+	}
+	return false
+}
+
+func prettyStates(statuses []plugins.JiraBugState) []string {
+	pretty := make([]string, 0, len(statuses))
+	for _, status := range statuses {
+		pretty = append(pretty, jiraclient.PrettyStatus(status.Status, status.Resolution))
+	}
+	return pretty
+}
+
+// validateBug determines if the bug matches the options and returns a description of why not
+func validateBug(bug *jira.Issue, dependents []*jira.Issue, options plugins.JiraBranchOptions, endpoint string) (bool, []string, []string) {
+	valid := true
+	var errors []string
+	var validations []string
+	if options.IsOpen != nil && (bug.Fields == nil || bug.Fields.Status == nil || *options.IsOpen != (bug.Fields.Status.Name != jiraclient.StatusClosed)) {
+		valid = false
+		not := ""
+		was := "isn't"
+		if !*options.IsOpen {
+			not = "not "
+			was = "is"
+		}
+		errors = append(errors, fmt.Sprintf("expected the bug to %sbe open, but it %s", not, was))
+	} else if options.IsOpen != nil {
+		expected := "open"
+		if !*options.IsOpen {
+			expected = "not open"
+		}
+		was := "isn't"
+		if bug.Fields.Status.Name != jiraclient.StatusClosed {
+			was = "is"
+		}
+		validations = append(validations, fmt.Sprintf("bug %s open, matching expected state (%s)", was, expected))
+	}
+
+	if options.TargetVersion != nil {
+		targetVersion, err := jiraclient.GetIssueTargetVersion(bug)
+		if err != nil {
+			valid = false
+			errors = append(errors, fmt.Sprintf("failed to get target version for bug: %v", err))
+		} else {
+			if len(targetVersion) == 0 {
+				valid = false
+				errors = append(errors, fmt.Sprintf("expected the bug to target the %q version, but no target version was set", *options.TargetVersion))
+			} else if len(targetVersion) > 1 {
+				valid = false
+				errors = append(errors, fmt.Sprintf("expected the bug to target only the %q version, but multiple target versions were set", *options.TargetVersion))
+			} else if *options.TargetVersion != targetVersion[0].Name {
+				valid = false
+				errors = append(errors, fmt.Sprintf("expected the bug to target the %q version, but it targets %q instead", *options.TargetVersion, targetVersion[0].Name))
+			} else {
+				validations = append(validations, fmt.Sprintf("bug target version (%s) matches configured target version for branch (%s)", targetVersion[0].Name, *options.TargetVersion))
+			}
+		}
+	}
+
+	if options.ValidStates != nil {
+		var allowed []plugins.JiraBugState
+		allowed = append(allowed, *options.ValidStates...)
+		if options.StateAfterValidation != nil {
+			allowed = append(allowed, *options.StateAfterValidation)
+		}
+		var status, resolution string
+		if bug.Fields.Status != nil {
+			status = bug.Fields.Status.Name
+		}
+		if bug.Fields.Resolution != nil {
+			resolution = bug.Fields.Resolution.Name
+		}
+		if !bugMatchesStates(bug, allowed) {
+			valid = false
+			errors = append(errors, fmt.Sprintf("expected the bug to be in one of the following states: %s, but it is %s instead", strings.Join(prettyStates(allowed), ", "), jiraclient.PrettyStatus(status, resolution)))
+		} else {
+			validations = append(validations, fmt.Sprintf("bug is in the state %s, which is one of the valid states (%s)", jiraclient.PrettyStatus(status, resolution), strings.Join(prettyStates(allowed), ", ")))
+		}
+	}
+
+	if options.DependentBugStates != nil {
+		for _, bug := range dependents {
+			var status, resolution string
+			if bug.Fields.Status != nil {
+				status = bug.Fields.Status.Name
+			}
+			if bug.Fields.Resolution != nil {
+				resolution = bug.Fields.Resolution.Name
+			}
+			if !bugMatchesStates(bug, *options.DependentBugStates) {
+				valid = false
+				expected := strings.Join(prettyStates(*options.DependentBugStates), ", ")
+				actual := jiraclient.PrettyStatus(status, resolution)
+				errors = append(errors, fmt.Sprintf("expected dependent "+bugLink+" to be in one of the following states: %s, but it is %s instead", bug.Key, endpoint, bug.Key, expected, actual))
+			} else {
+				validations = append(validations, fmt.Sprintf("dependent bug "+bugLink+" is in the state %s, which is one of the valid states (%s)", bug.Key, endpoint, bug.Key, jiraclient.PrettyStatus(status, resolution), strings.Join(prettyStates(*options.DependentBugStates), ", ")))
+			}
+		}
+	}
+
+	if options.DependentBugTargetVersions != nil {
+		for _, bug := range dependents {
+			targetVersion, err := jiraclient.GetIssueTargetVersion(bug)
+			if err != nil {
+				valid = false
+				errors = append(errors, fmt.Sprintf("failed to get target version for bug: %v", err))
+			} else {
+				if len(targetVersion) == 0 {
+					valid = false
+					errors = append(errors, fmt.Sprintf("expected dependent "+bugLink+" to target a version in %s, but no target version was set", bug.Key, endpoint, bug.Key, strings.Join(*options.DependentBugTargetVersions, ", ")))
+				} else if len(targetVersion) > 1 {
+					valid = false
+					errors = append(errors, fmt.Sprintf("expected dependent "+bugLink+" to target a version in %s, but it has multiple target versions", bug.Key, endpoint, bug.Key, strings.Join(*options.DependentBugTargetVersions, ", ")))
+				} else if sets.NewString(*options.DependentBugTargetVersions...).Has(targetVersion[0].Name) {
+					validations = append(validations, fmt.Sprintf("dependent "+bugLink+" targets the %q version, which is one of the valid target versions: %s", bug.Key, endpoint, bug.Key, targetVersion[0].Name, strings.Join(*options.DependentBugTargetVersions, ", ")))
+				} else {
+					valid = false
+					errors = append(errors, fmt.Sprintf("expected dependent "+bugLink+" to target a version in %s, but it targets %q instead", bug.Key, endpoint, bug.Key, strings.Join(*options.DependentBugTargetVersions, ", "), targetVersion[0].Name))
+				}
+			}
+		}
+	}
+
+	if len(dependents) == 0 {
+		switch {
+		case options.DependentBugStates != nil && options.DependentBugTargetVersions != nil:
+			valid = false
+			expected := strings.Join(prettyStates(*options.DependentBugStates), ", ")
+			errors = append(errors, fmt.Sprintf("expected "+bugLink+" to depend on a bug targeting a version in %s and in one of the following states: %s, but no dependents were found", bug.Key, endpoint, bug.Key, strings.Join(*options.DependentBugTargetVersions, ", "), expected))
+		case options.DependentBugStates != nil:
+			valid = false
+			expected := strings.Join(prettyStates(*options.DependentBugStates), ", ")
+			errors = append(errors, fmt.Sprintf("expected "+bugLink+" to depend on a bug in one of the following states: %s, but no dependents were found", bug.Key, endpoint, bug.Key, expected))
+		case options.DependentBugTargetVersions != nil:
+			valid = false
+			errors = append(errors, fmt.Sprintf("expected "+bugLink+" to depend on a bug targeting a version in %s, but no dependents were found", bug.Key, endpoint, bug.Key, strings.Join(*options.DependentBugTargetVersions, ", ")))
+		default:
+		}
+	} else {
+		validations = append(validations, "bug has dependents")
+	}
+
+	return valid, validations, errors
+}
+
+type prParts struct {
+	Org  string
+	Repo string
+	Num  int
+}
+
+func handleMerge(e event, gc githubClient, jc jiraclient.Client, options plugins.JiraBranchOptions, log *logrus.Entry, allRepos sets.String) error {
+	comment := e.comment(gc)
+
+	if options.StateAfterMerge == nil {
+		return nil
+	}
+	if e.missing {
+		return nil
+	}
+	bug, err := getBug(jc, e.key, log, comment)
+	if err != nil || bug == nil {
+		return err
+	}
+	if options.ValidStates != nil || options.StateAfterValidation != nil {
+		// we should only migrate if we can be fairly certain that the bug
+		// is not in a state that required human intervention to get to.
+		// For instance, if a bug is closed after a PR merges it should not
+		// be possible for /jira refresh to move it back to the post-merge
+		// state.
+		var allowed []plugins.JiraBugState
+		if options.ValidStates != nil {
+			allowed = append(allowed, *options.ValidStates...)
+		}
+
+		if options.StateAfterValidation != nil {
+			allowed = append(allowed, *options.StateAfterValidation)
+		}
+		if !bugMatchesStates(bug, allowed) {
+			return comment(fmt.Sprintf(bugLink+" is in an unrecognized state (%s) and will not be moved to the %s state.", e.key, jc.JiraURL(), e.key, bug.Fields.Status.Name, options.StateAfterMerge))
+		}
+	}
+
+	links, err := jc.GetRemoteLinks(bug.ID)
+	if err != nil {
+		log.WithError(err).Warn("Unexpected error listing external tracker bugs for Jira bug.")
+		return comment(formatError("searching for external tracker bugs", jc.JiraURL(), e.key, err))
+	}
+	shouldMigrate := true
+	var mergedPRs []prParts
+	unmergedPrStates := map[prParts]string{}
+	for _, link := range links {
+		identifier := strings.TrimPrefix(link.Object.URL, "https://github.com/")
+		parts := strings.Split(identifier, "/")
+		if len(parts) >= 3 && parts[2] != "pull" {
+			// this is not a github link
+			continue
+		}
+		if len(parts) != 4 && !(len(parts) == 5 && (parts[4] == "" || parts[4] == "files")) && !(len(parts) == 6 && (parts[4] == "files" && parts[5] == "")) {
+			log.WithError(err).Warn("Unexpected error splitting github URL for Jira external link.")
+			return comment(formatError(fmt.Sprintf("invalid pull identifier with %d parts: %q", len(parts), identifier), jc.JiraURL(), e.key, err))
+		}
+		number, err := strconv.Atoi(parts[3])
+		if err != nil {
+			log.WithError(err).Warn("Unexpected error splitting github URL for Jira external link.")
+			return comment(formatError(fmt.Sprintf("invalid pull identifier: could not parse %s as number", parts[3]), jc.JiraURL(), e.key, err))
+		}
+		item := prParts{
+			Org:  parts[0],
+			Repo: parts[1],
+			Num:  number,
+		}
+		var merged bool
+		var state string
+		if e.org == item.Org && e.repo == item.Repo && e.number == item.Num {
+			merged = e.merged
+			state = e.state
+		} else {
+			// This could be literally anything, only process PRs in repos that are mentioned in our config, otherwise this will potentially
+			// fail.
+			if !allRepos.Has(item.Org + "/" + item.Repo) {
+				logrus.WithField("pr", item.Org+"/"+item.Repo+"#"+strconv.Itoa(item.Num)).Debug("Not processing PR from third-party repo")
+				continue
+			}
+			pr, err := gc.GetPullRequest(item.Org, item.Repo, item.Num)
+			if err != nil {
+				log.WithError(err).Warn("Unexpected error checking merge state of related pull request.")
+				return comment(formatError(fmt.Sprintf("checking the state of a related pull request at https://github.com/%s/%s/pull/%d", item.Org, item.Repo, item.Num), jc.JiraURL(), e.key, err))
+			}
+			merged = pr.Merged
+			state = pr.State
+		}
+		if merged {
+			mergedPRs = append(mergedPRs, item)
+		} else {
+			unmergedPrStates[item] = state
+		}
+		// only update Jira bug status if all PRs have merged
+		shouldMigrate = shouldMigrate && merged
+		if !shouldMigrate {
+			// we could give more complete feedback to the user by checking all PRs
+			// but we save tokens by exiting when we find an unmerged one, so we
+			// prefer to do that
+			break
+		}
+	}
+
+	link := func(pr prParts) string {
+		return fmt.Sprintf("[%s/%s#%d](https://github.com/%s/%s/pull/%d)", pr.Org, pr.Repo, pr.Num, pr.Org, pr.Repo, pr.Num)
+	}
+
+	mergedMessage := func(statement string) string {
+		var links []string
+		for _, bug := range mergedPRs {
+			links = append(links, fmt.Sprintf(" * %s", link(bug)))
+		}
+		return fmt.Sprintf(`%s pull requests linked via external trackers have merged:
+%s
+
+`, statement, strings.Join(links, "\n"))
+	}
+
+	var statements []string
+	for bug, state := range unmergedPrStates {
+		statements = append(statements, fmt.Sprintf(" * %s is %s", link(bug), state))
+	}
+	unmergedMessage := fmt.Sprintf(`The following pull requests linked via external trackers have not merged:
+%s
+
+These pull request must merge or be unlinked from the Jira bug in order for it to move to the next state. Once unlinked, request a bug refresh with <code>/jira refresh</code>.
+
+`, strings.Join(statements, "\n"))
+
+	outcomeMessage := func(action string) string {
+		return fmt.Sprintf(bugLink+" has %sbeen moved to the %s state.", e.key, jc.JiraURL(), e.key, action, options.StateAfterMerge)
+	}
+
+	if shouldMigrate {
+		if options.StateAfterMerge != nil {
+			if options.StateAfterMerge.Status != "" && (bug.Fields.Status == nil || options.StateAfterMerge.Status != bug.Fields.Status.Name) {
+				if err := jc.UpdateStatus(e.key, options.StateAfterMerge.Status); err != nil {
+					log.WithError(err).Warn("Unexpected error updating jira issue.")
+					return comment(formatError(fmt.Sprintf("updating to the %s state", options.StateAfterMerge.Status), jc.JiraURL(), e.key, err))
+				}
+				if options.StateAfterMerge.Resolution != "" && (bug.Fields.Resolution == nil || options.StateAfterMerge.Resolution != bug.Fields.Resolution.Name) {
+					updateIssue := jira.Issue{ID: bug.ID, Fields: &jira.IssueFields{Resolution: &jira.Resolution{Name: options.StateAfterMerge.Resolution}}}
+					if _, err := jc.UpdateIssue(&updateIssue); err != nil {
+						log.WithError(err).Warn("Unexpected error updating jira issue.")
+						return comment(formatError(fmt.Sprintf("updating to the %s resolution", options.StateAfterMerge.Resolution), jc.JiraURL(), e.key, err))
+					}
+				}
+			}
+		}
+		return comment(fmt.Sprintf("%s%s", mergedMessage("All"), outcomeMessage("")))
+	}
+	return comment(fmt.Sprintf("%s%s%s", mergedMessage("Some"), unmergedMessage, outcomeMessage("not ")))
+}
+
+func identifyClones(issue *jira.Issue) []*jira.Issue {
+	var clones []*jira.Issue
+	for _, link := range issue.Fields.IssueLinks {
+		// the inward issue of the Cloners type is always the clone of the provided; if it is unset (nil), then
+		// the issue being linked is being cloned by the provided issue
+		if link.Type.Name == "Cloners" && link.InwardIssue != nil {
+			clones = append(clones, link.InwardIssue)
+		}
+	}
+	return clones
+}
+
+func handleCherrypick(e event, gc githubClient, jc jiraclient.Client, options plugins.JiraBranchOptions, log *logrus.Entry) error {
+	comment := e.comment(gc)
+	// get the info for the PR being cherrypicked from
+	pr, err := gc.GetPullRequest(e.org, e.repo, e.cherrypickFromPRNum)
+	if err != nil {
+		log.WithError(err).Warn("Unexpected error getting title of pull request being cherrypicked from.")
+		return comment(fmt.Sprintf("Error creating a cherry-pick bug in Jira: failed to check the state of cherrypicked pull request at https://github.com/%s/%s/pull/%d: %v.\nPlease contact an administrator to resolve this issue, then request a bug refresh with <code>/jira refresh</code>.", e.org, e.repo, e.cherrypickFromPRNum, err))
+	}
+	// Attempt to identify bug from PR title
+	bugKey, bugMissing, err := bugKeyFromTitle(pr.Title)
+	if err != nil {
+		// should be impossible based on the regex
+		log.WithError(err).Debugf("Failed to get bug ID from PR title \"%s\"", pr.Title)
+		return comment(fmt.Sprintf("Error creating a cherry-pick bug in Jira: could not get bug ID from PR title \"%s\": %v", pr.Title, err))
+	} else if bugMissing {
+		log.Debugf("Parent PR %d doesn't have associated bug; not creating cherrypicked bug", pr.Number)
+		// if there is no jira bug, we should simply ignore this PR
+		return nil
+	}
+	// Since getBug generates a comment itself, we have to add a prefix explaining that this was a cherrypick attempt to the comment
+	commentWithPrefix := func(body string) error {
+		return comment(fmt.Sprintf("Failed to create a cherry-pick bug in Jira: %s", body))
+	}
+	bug, err := getBug(jc, bugKey, log, commentWithPrefix)
+	if err != nil || bug == nil {
+		return err
+	}
+	allowed, err := isBugAllowed(bug, options.AllowedSecurityLevels)
+	if err != nil {
+		return fmt.Errorf("failed to check is issue is in allowed security level: %w", err)
+	}
+	if !allowed {
+		// ignore bugs that are in non-allowed groups for this repo
+		return nil
+	}
+	clones := identifyClones(bug)
+	oldLink := fmt.Sprintf(bugLink, bugKey, jc.JiraURL(), bugKey)
+	if options.TargetVersion == nil {
+		return comment(fmt.Sprintf("Could not make automatic cherrypick of %s for this PR as the target version is not set for this branch in the jira plugin config. Running refresh:\n/jira refresh", oldLink))
+	}
+	targetRelease := *options.TargetVersion
+	for _, baseClone := range clones {
+		// get full issue struct
+		clone, err := jc.GetIssue(baseClone.Key)
+		if err != nil {
+			return fmt.Errorf("failed to get %s, which is a clone of %s: %w", baseClone.Key, bug.Key, err)
+		}
+		targetVersion, err := jiraclient.GetIssueTargetVersion(clone)
+		if err != nil {
+			return comment(formatError(fmt.Sprintf("getting the target version for clone %s", clone.Key), jc.JiraURL(), bug.Key, err))
+		}
+		if len(targetVersion) == 1 && targetVersion[0].Name == targetRelease {
+			newTitle := strings.Replace(e.title, bugKey, clone.Key, 1)
+			return comment(fmt.Sprintf("Detected clone of %s with correct target version. Retitling PR to link to clone:\n/retitle %s", oldLink, newTitle))
+		}
+	}
+	clone, err := jc.CloneIssue(bug)
+	if err != nil {
+		log.WithError(err).Debugf("Failed to clone bug %s", bugKey)
+		return comment(formatError("cloning bug for cherrypick", jc.JiraURL(), bug.Key, err))
+	}
+	cloneLink := fmt.Sprintf(bugLink, clone.Key, jc.JiraURL(), clone.Key)
+	// Update the version of the bug to the target release
+	update := jira.Issue{
+		ID: clone.ID,
+		Fields: &jira.IssueFields{
+			Unknowns: tcontainer.MarshalMap{
+				"customfield_12319940": []*jira.Version{{Name: targetRelease}},
+			},
+		},
+	}
+	_, err = jc.UpdateIssue(&update)
+	if err != nil {
+		log.WithError(err).Debugf("Unable to update target version and dependencies for bug %s", clone.Key)
+		return comment(formatError(fmt.Sprintf("updating cherry-pick bug in Jira: Created cherrypick %s, but encountered error updating target version", cloneLink), jc.JiraURL(), clone.Key, err))
+	}
+	// Replace old bugID in title with new cloneID
+	newTitle := strings.ReplaceAll(e.title, bugKey, clone.Key)
+	response := fmt.Sprintf("%s has been cloned as %s. Retitling PR to link against new bug.\n/retitle %s", oldLink, cloneLink, newTitle)
+	return comment(response)
+}
+
+func bugKeyFromTitle(title string) (string, bool, error) {
+	mat := titleMatch.FindStringSubmatch(title)
+	if mat == nil {
+		return "", true, nil
+	}
+	return strings.TrimSuffix(mat[0], ":"), false, nil
+}
+
+func getBug(jc jiraclient.Client, bugKey string, log *logrus.Entry, comment func(string) error) (*jira.Issue, error) {
+	bug, err := jc.GetIssue(bugKey)
+	if err != nil && !jiraclient.IsNotFound(err) {
+		log.WithError(err).Warn("Unexpected error searching for Jira bug.")
+		return nil, comment(formatError("searching", jc.JiraURL(), bugKey, err))
+	}
+	if jiraclient.IsNotFound(err) || bug == nil {
+		log.Debug("No bug found.")
+		return nil, comment(fmt.Sprintf(`No Jira issue with key %s exists in the tracker at %s.
+Once a valid bug is referenced in the title of this pull request, request a bug refresh with <code>/jira refresh</code>.`,
+			bugKey, jc.JiraURL()))
+	}
+	return bug, nil
+}
+
+func formatError(action, endpoint, bugKey string, err error) string {
+	knownErrors := map[string]string{
+		// TODO: Most of this code is copied from the bugzilla client. If Jira rate limits us the same way, this could come in handy. We will keep this for now in case it is needed
+		//"There was an error reported for a GitHub REST call": "The Bugzilla server failed to load data from GitHub when creating the bug. This is usually caused by rate-limiting, please try again later.",
+	}
+	var applicable []string
+	for key, value := range knownErrors {
+		if strings.Contains(err.Error(), key) {
+			applicable = append(applicable, value)
+
+		}
+	}
+	digest := "No known errors were detected, please see the full error message for details."
+	if len(applicable) > 0 {
+		digest = "We were able to detect the following conditions from the error:\n\n"
+		for _, item := range applicable {
+			digest = fmt.Sprintf("%s- %s\n", digest, item)
+		}
+	}
+	return fmt.Sprintf(`An error was encountered %s for bug %s on the Jira server at %s. %s
+
+<details><summary>Full error message.</summary>
+
+<code>
+%v
+</code>
+
+</details>
+
+Please contact an administrator to resolve this issue, then request a bug refresh with <code>/jira refresh</code>.`,
+		action, bugKey, endpoint, digest, err)
+}
+
+var PrivateVisibility = jira.CommentVisibility{Type: "group", Value: "Red Hat Employee"}
+
+func handleClose(e event, gc githubClient, jc jiraclient.Client, options plugins.JiraBranchOptions, log *logrus.Entry) error {
+	comment := e.comment(gc)
+	if e.missing {
+		return nil
+	}
+	if options.AddExternalLink != nil && *options.AddExternalLink {
+		response := fmt.Sprintf(`This pull request references `+bugLink+`. The bug has been updated to no longer refer to the pull request using the external bug tracker.`, e.key, jc.JiraURL(), e.key)
+		changed, err := jc.DeleteRemoteLinkViaURL(e.key, prURLFromCommentURL(e.htmlUrl))
+		if err != nil {
+			log.WithError(err).Warn("Unexpected error removing external tracker bug from Jira bug.")
+			return comment(formatError("removing this pull request from the external tracker bugs", jc.JiraURL(), e.key, err))
+		}
+		if options.StateAfterClose != nil {
+			issue, err := jc.GetIssue(e.key)
+			if err != nil {
+				log.WithError(err).Warn("Unexpected error getting Jira issue.")
+				return comment(formatError("getting issue", jc.JiraURL(), e.key, err))
+			}
+			if issue.Fields.Status.Name != "CLOSED" {
+				links, err := jc.GetRemoteLinks(issue.ID)
+				if err != nil {
+					log.WithError(err).Warn("Unexpected error getting remote links for Jira issue.")
+					return comment(formatError("getting remote links", jc.JiraURL(), e.key, err))
+				}
+				if len(links) == 0 {
+					bug, err := getBug(jc, e.key, log, comment)
+					if err != nil || bug == nil {
+						return err
+					}
+					if options.StateAfterClose.Status != "" && (bug.Fields.Status == nil || options.StateAfterClose.Status != bug.Fields.Status.Name) {
+						if err := jc.UpdateStatus(issue.ID, options.StateAfterClose.Status); err != nil {
+							log.WithError(err).Warn("Unexpected error updating jira issue.")
+							return comment(formatError(fmt.Sprintf("updating to the %s state", options.StateAfterClose.Status), jc.JiraURL(), e.key, err))
+						}
+						if options.StateAfterClose.Resolution != "" && (bug.Fields.Resolution == nil || options.StateAfterClose.Resolution != bug.Fields.Resolution.Name) {
+							updateIssue := jira.Issue{ID: bug.ID, Fields: &jira.IssueFields{Resolution: &jira.Resolution{Name: options.StateAfterClose.Resolution}}}
+							if _, err := jc.UpdateIssue(&updateIssue); err != nil {
+								log.WithError(err).Warn("Unexpected error updating jira issue.")
+								return comment(formatError(fmt.Sprintf("updating to the %s resolution", options.StateAfterClose.Resolution), jc.JiraURL(), e.key, err))
+							}
+						}
+						response += fmt.Sprintf(" All external bug links have been closed. The bug has been moved to the %s state.", options.StateAfterClose)
+					}
+					jiraComment := &jira.Comment{Body: fmt.Sprintf("Bug status changed to %s as previous linked PR https://github.com/%s/%s/pull/%d has been closed", options.StateAfterClose.Status, e.org, e.repo, e.number), Visibility: PrivateVisibility}
+					if _, err := jc.AddComment(bug.ID, jiraComment); err != nil {
+						response += "\nWarning: Failed to comment on Jira bug with reason for changed state."
+					}
+				}
+			}
+		}
+		if changed {
+			return comment(response)
+		}
+	}
+	return nil
+}
+
+func isBugAllowed(issue *jira.Issue, allowedSecurityLevel []string) (bool, error) {
+	// if no allowed visibilities are listed, assume all visibilities are allowed
+	if len(allowedSecurityLevel) == 0 {
+		return true, nil
+	}
+
+	level, err := jiraclient.GetIssueSecurityLevel(issue)
+	if err != nil {
+		return false, fmt.Errorf("failed to get security level: %w", err)
+	}
+	if level == nil {
+		// default security level is empty; make a temporary "default" security level for this check
+		level = &jiraclient.SecurityLevel{Name: "default"}
+	}
+	found := false
+	for _, allowed := range allowedSecurityLevel {
+		if level.Name == allowed {
+			found = true
+			break
+		}
+	}
+	return found, nil
 }

--- a/prow/plugins/jira/jira_test.go
+++ b/prow/plugins/jira/jira_test.go
@@ -25,14 +25,21 @@ import (
 	"github.com/andygrunwald/go-jira"
 	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
+	"github.com/trivago/tgo/tcontainer"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/yaml"
 
+	prowconfig "k8s.io/test-infra/prow/config"
+	cherrypicker "k8s.io/test-infra/prow/external-plugins/cherrypicker/lib"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/github/fakegithub"
 	jiraclient "k8s.io/test-infra/prow/jira"
 	"k8s.io/test-infra/prow/jira/fakejira"
+	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
 )
+
+var allowEventAndDate = cmp.AllowUnexported(event{}, jira.Date{})
 
 func TestRegex(t *testing.T) {
 	t.Parallel()
@@ -123,33 +130,145 @@ func (f *fakeGitHubClient) EditIssue(org, repo string, number int, issue *github
 
 func TestHandle(t *testing.T) {
 	t.Parallel()
-	testCases := []struct {
-		name                   string
-		event                  github.GenericCommentEvent
-		cfg                    *plugins.Jira
-		projectCache           *threadsafeSet
-		getIssueClientError    error
-		existingIssues         []jira.Issue
-		existingLinks          map[string][]jira.RemoteLink
-		expectedNewLinks       []jira.RemoteLink
+	yes := true
+	open := true
+	v1Str := "v1"
+	v2Str := "v2"
+	v1 := []*jira.Version{{Name: v1Str}}
+	v2 := []*jira.Version{{Name: v2Str}}
+	v3 := []*jira.Version{{Name: "v3"}}
+	updated := plugins.JiraBugState{Status: "UPDATED"}
+	modified := plugins.JiraBugState{Status: "MODIFIED"}
+	verified := []plugins.JiraBugState{{Status: "VERIFIED"}}
+	jiraTransitions := []jira.Transition{
+		{
+			ID:   "1",
+			Name: "NEW",
+			To: jira.Status{
+				Name: "NEW",
+			},
+		},
+		{
+			ID:   "2",
+			Name: "MODIFIED",
+			To: jira.Status{
+				Name: "MODIFIED",
+			},
+		},
+		{
+			ID:   "3",
+			Name: "UPDATED",
+			To: jira.Status{
+				Name: "UPDATED",
+			},
+		},
+		{
+			ID:   "4",
+			Name: "VERIFIED",
+			To: jira.Status{
+				Name: "VERIFIED",
+			},
+		},
+		{
+			ID:   "5",
+			Name: "CLOSED",
+			To: jira.Status{
+				Name: "CLOSED",
+			},
+		},
+	}
+	severityCritical := struct {
+		Value string
+	}{Value: "<img alt=\"\" src=\"/images/icons/priorities/critical.svg\" width=\"16\" height=\"16\"> Critical"}
+	severityImportant := struct {
+		Value string
+	}{Value: "<img alt=\"\" src=\"/images/icons/priorities/important.svg\" width=\"16\" height=\"16\"> Important"}
+	severityModerate := struct {
+		Value string
+	}{Value: "<img alt=\"\" src=\"/images/icons/priorities/moderate.svg\" width=\"16\" height=\"16\"> Moderate"}
+	severityLow := struct {
+		Value string
+	}{Value: "<img alt=\"\" src=\"/images/icons/priorities/low.svg\" width=\"16\" height=\"16\"> Low"}
+	fieldLinkTo123 := jira.IssueLink{
+		Type: jira.IssueLinkType{
+			Name:    "Cloners",
+			Inward:  "is cloned by",
+			Outward: "clones",
+		},
+		OutwardIssue: &jira.Issue{ID: "1"},
+	}
+	fieldLinkTo124 := jira.IssueLink{
+		Type: jira.IssueLinkType{
+			Name:    "Cloners",
+			Inward:  "is cloned by",
+			Outward: "clone",
+		},
+		InwardIssue: &jira.Issue{ID: "2", Key: "OCPBUGS-124"},
+	}
+	linkBetween123to124 := jira.IssueLink{
+		Type: jira.IssueLinkType{
+			Name:    "Cloners",
+			Inward:  "is cloned by",
+			Outward: "clones",
+		},
+		InwardIssue:  &jira.Issue{ID: "2"},
+		OutwardIssue: &jira.Issue{ID: "1"},
+	}
+	base := &event{
+		org: "org", repo: "repo", baseRef: "branch", number: 1, key: "OCPBUGS-123", body: "This PR fixes OCPBUGS-123", title: "OCPBUGS-123: fixed it!", htmlUrl: "https://github.com/org/repo/pull/1", login: "user",
+	}
+	var testCases = []struct {
+		name                       string
+		labels                     []string
+		humanLabelled              bool
+		missing                    bool
+		merged                     bool
+		closed                     bool
+		opened                     bool
+		cherryPick                 bool
+		cherryPickFromPRNum        int
+		cherryPickTo               string
+		body                       string
+		title                      string
+		remoteLinks                map[string][]jira.RemoteLink
+		prs                        []github.PullRequest
+		issues                     []jira.Issue
+		issueGetErrors             map[string]error
+		issueCreateErrors          map[string]error
+		issueUpdateErrors          map[string]error
+		options                    plugins.JiraBranchOptions
+		expectedLabels             []string
+		expectedComment            string
+		expectedIssue              *jira.Issue
+		expectedNewRemoteLinks     []jira.RemoteLink
+		expectedRemovedRemoteLinks []jira.RemoteLink
+		projectCache               *threadsafeSet
+		isComment                  bool
+		existingIssueLinks         []*jira.IssueLink
+		// most of the tests can be handled by a single event struct with small modifications; for tests with more extensive differences, allow override
+		overrideEvent          *event
+		disabledProjects       []string
 		expectedCommentUpdates []string
 	}{
 		{
-			name: "No issue referenced, nothing to do",
+			name:          "No issue referenced, nothing to do",
+			overrideEvent: &event{org: "org", repo: "repo", baseRef: "branch", number: 1, title: "Not a jira bugfix", htmlUrl: "http.com", login: "user"},
 		},
 		{
-			name: "Link is created based on body",
-			event: github.GenericCommentEvent{
-				CommentID:  intPtr(1),
-				HTMLURL:    "https://github.com/org/repo/issues/3",
-				IssueTitle: "Some issue",
-				Body:       "Some text and also ABC-123",
-				Repo:       github.Repo{FullName: "org/repo", Owner: github.User{Login: "org"}, Name: "repo"},
-				Number:     3,
+			name:         "Link is created based on body",
+			projectCache: &threadsafeSet{data: sets.NewString("abc")},
+			overrideEvent: &event{
+				isComment: true,
+				commentID: intPtr(1),
+				htmlUrl:   "https://github.com/org/repo/issues/3",
+				title:     "Some issue",
+				body:      "Some text and also ABC-123",
+				org:       "org",
+				repo:      "repo",
+				number:    3,
 			},
-			projectCache:   &threadsafeSet{data: sets.NewString("abc")},
-			existingIssues: []jira.Issue{{ID: "ABC-123"}},
-			expectedNewLinks: []jira.RemoteLink{{Object: &jira.RemoteLinkObject{
+			issues: []jira.Issue{{ID: "ABC-123"}},
+			expectedNewRemoteLinks: []jira.RemoteLink{{Object: &jira.RemoteLinkObject{
 				URL:   "https://github.com/org/repo/issues/3",
 				Title: "org/repo#3: Some issue",
 				Icon: &jira.RemoteLinkIcon{
@@ -161,18 +280,20 @@ func TestHandle(t *testing.T) {
 			expectedCommentUpdates: []string{"org/repo#1:Some text and also [ABC-123](https://my-jira.com/browse/ABC-123)"},
 		},
 		{
-			name: "Link is created based on body with pasted link",
-			event: github.GenericCommentEvent{
-				CommentID:  intPtr(1),
-				HTMLURL:    "https://github.com/org/repo/issues/3",
-				IssueTitle: "Some issue",
-				Body:       "Some text and also https://my-jira.com/browse/ABC-123",
-				Repo:       github.Repo{FullName: "org/repo", Owner: github.User{Login: "org"}, Name: "repo"},
-				Number:     3,
+			name:         "Link is created based on body with pasted link",
+			projectCache: &threadsafeSet{data: sets.NewString("abc")},
+			overrideEvent: &event{
+				isComment: true,
+				commentID: intPtr(1),
+				htmlUrl:   "https://github.com/org/repo/issues/3",
+				title:     "Some issue",
+				body:      "Some text and also https://my-jira.com/browse/ABC-123",
+				org:       "org",
+				repo:      "repo",
+				number:    3,
 			},
-			projectCache:   &threadsafeSet{data: sets.NewString("abc")},
-			existingIssues: []jira.Issue{{ID: "ABC-123"}},
-			expectedNewLinks: []jira.RemoteLink{{Object: &jira.RemoteLinkObject{
+			issues: []jira.Issue{{ID: "ABC-123"}},
+			expectedNewRemoteLinks: []jira.RemoteLink{{Object: &jira.RemoteLinkObject{
 				URL:   "https://github.com/org/repo/issues/3",
 				Title: "org/repo#3: Some issue",
 				Icon: &jira.RemoteLinkIcon{
@@ -183,18 +304,20 @@ func TestHandle(t *testing.T) {
 			}},
 		},
 		{
-			name: "Link is created based on body and issuecomment suffix is removed from url",
-			event: github.GenericCommentEvent{
-				CommentID:  intPtr(1),
-				HTMLURL:    "https://github.com/org/repo/issues/3#issuecomment-705743977",
-				IssueTitle: "Some issue",
-				Body:       "Some text and also ABC-123",
-				Repo:       github.Repo{FullName: "org/repo", Owner: github.User{Login: "org"}, Name: "repo"},
-				Number:     3,
+			name:         "Link is created based on body and issuecomment suffix is removed from url",
+			projectCache: &threadsafeSet{data: sets.NewString("abc")},
+			overrideEvent: &event{
+				isComment: true,
+				commentID: intPtr(1),
+				htmlUrl:   "https://github.com/org/repo/issues/3#issuecomment-705743977",
+				title:     "Some issue",
+				body:      "Some text and also ABC-123",
+				org:       "org",
+				repo:      "repo",
+				number:    3,
 			},
-			projectCache:   &threadsafeSet{data: sets.NewString("abc")},
-			existingIssues: []jira.Issue{{ID: "ABC-123"}},
-			expectedNewLinks: []jira.RemoteLink{{Object: &jira.RemoteLinkObject{
+			issues: []jira.Issue{{ID: "ABC-123"}},
+			expectedNewRemoteLinks: []jira.RemoteLink{{Object: &jira.RemoteLinkObject{
 				URL:   "https://github.com/org/repo/issues/3",
 				Title: "org/repo#3: Some issue",
 				Icon: &jira.RemoteLinkIcon{
@@ -206,17 +329,19 @@ func TestHandle(t *testing.T) {
 			expectedCommentUpdates: []string{"org/repo#1:Some text and also [ABC-123](https://my-jira.com/browse/ABC-123)"},
 		},
 		{
-			name: "Link is created based on title",
-			event: github.GenericCommentEvent{
-				HTMLURL:    "https://github.com/org/repo/issues/3",
-				IssueTitle: "ABC-123: Some issue",
-				Body:       "Some text",
-				Repo:       github.Repo{FullName: "org/repo"},
-				Number:     3,
+			name:         "Link is created based on title",
+			projectCache: &threadsafeSet{data: sets.NewString("abc")},
+			overrideEvent: &event{
+				isComment: true,
+				htmlUrl:   "https://github.com/org/repo/issues/3",
+				title:     "ABC-123: Some issue",
+				body:      "Some text",
+				org:       "org",
+				repo:      "repo",
+				number:    3,
 			},
-			projectCache:   &threadsafeSet{data: sets.NewString("abc")},
-			existingIssues: []jira.Issue{{ID: "ABC-123"}},
-			expectedNewLinks: []jira.RemoteLink{{Object: &jira.RemoteLinkObject{
+			issues: []jira.Issue{{ID: "ABC-123"}},
+			expectedNewRemoteLinks: []jira.RemoteLink{{Object: &jira.RemoteLinkObject{
 				URL:   "https://github.com/org/repo/issues/3",
 				Title: "org/repo#3: ABC-123: Some issue",
 				Icon: &jira.RemoteLinkIcon{
@@ -227,18 +352,20 @@ func TestHandle(t *testing.T) {
 			}},
 		},
 		{
-			name: "Multiple references for issue, one link is created",
-			event: github.GenericCommentEvent{
-				CommentID:  intPtr(1),
-				HTMLURL:    "https://github.com/org/repo/issues/3",
-				IssueTitle: "Some issue",
-				Body:       "Some text and also ABC-123 and again ABC-123",
-				Repo:       github.Repo{FullName: "org/repo", Owner: github.User{Login: "org"}, Name: "repo"},
-				Number:     3,
+			name:         "Multiple references for issue, one link is created",
+			projectCache: &threadsafeSet{data: sets.NewString("abc")},
+			overrideEvent: &event{
+				isComment: true,
+				commentID: intPtr(1),
+				htmlUrl:   "https://github.com/org/repo/issues/3",
+				title:     "Some issue",
+				body:      "Some text and also ABC-123 and again ABC-123",
+				org:       "org",
+				repo:      "repo",
+				number:    3,
 			},
-			projectCache:   &threadsafeSet{data: sets.NewString("abc")},
-			existingIssues: []jira.Issue{{ID: "ABC-123"}},
-			expectedNewLinks: []jira.RemoteLink{{Object: &jira.RemoteLinkObject{
+			issues: []jira.Issue{{ID: "ABC-123"}},
+			expectedNewRemoteLinks: []jira.RemoteLink{{Object: &jira.RemoteLinkObject{
 				URL:   "https://github.com/org/repo/issues/3",
 				Title: "org/repo#3: Some issue",
 				Icon: &jira.RemoteLinkIcon{
@@ -250,41 +377,47 @@ func TestHandle(t *testing.T) {
 			expectedCommentUpdates: []string{"org/repo#1:Some text and also [ABC-123](https://my-jira.com/browse/ABC-123) and again [ABC-123](https://my-jira.com/browse/ABC-123)"},
 		},
 		{
-			name: "Referenced issue doesn't exist, nothing to do",
-			event: github.GenericCommentEvent{
-				HTMLURL:    "https://github.com/org/repo/issues/3#issuecomment-705743977",
-				IssueTitle: "Some issue",
-				Body:       "Some text and also ABC-123",
-				Repo:       github.Repo{FullName: "org/repo"},
-				Number:     3,
-			},
+			name:         "Referenced issue doesn't exist, nothing to do",
 			projectCache: &threadsafeSet{data: sets.NewString("abc")},
+			overrideEvent: &event{
+				isComment: true,
+				htmlUrl:   "https://github.com/org/repo/issues/3#issuecomment-705743977",
+				title:     "Some issue",
+				body:      "Some text and also ABC-123",
+				org:       "org",
+				repo:      "repo",
+				number:    3,
+			},
 		},
 		{
-			name: "Link already exists, nothing to do",
-			event: github.GenericCommentEvent{
-				HTMLURL:    "https://github.com/org/repo/issues/3",
-				IssueTitle: "Some issue",
-				Body:       "Some text and also [ABC-123](https://my-jira.com/browse/ABC-123)",
-				Repo:       github.Repo{FullName: "org/repo"},
-				Number:     3,
+			name:         "Link already exists, nothing to do",
+			projectCache: &threadsafeSet{data: sets.NewString("abc")},
+			overrideEvent: &event{
+				isComment: true,
+				htmlUrl:   "https://github.com/org/repo/issues/3",
+				title:     "Some issue",
+				body:      "Some text and also [ABC-123](https://my-jira.com/browse/ABC-123)",
+				org:       "org",
+				repo:      "repo",
+				number:    3,
 			},
-			projectCache:   &threadsafeSet{data: sets.NewString("abc")},
-			existingIssues: []jira.Issue{{ID: "ABC-123"}},
-			existingLinks:  map[string][]jira.RemoteLink{"ABC-123": {{Object: &jira.RemoteLinkObject{URL: "https://github.com/org/repo/issues/3", Title: "Some issue"}}}},
+			issues:      []jira.Issue{{ID: "ABC-123"}},
+			remoteLinks: map[string][]jira.RemoteLink{"ABC-123": {{ID: 1, Object: &jira.RemoteLinkObject{URL: "https://github.com/org/repo/issues/3", Title: "Some issue"}}}},
 		},
 		{
-			name: "Link exists but title is different, replacing it",
-			event: github.GenericCommentEvent{
-				HTMLURL:    "https://github.com/org/repo/issues/3",
-				IssueTitle: "Some issue NEW",
-				Body:       "Some text and also [ABC-123:](https://my-jira.com/browse/ABC-123)",
-				Repo:       github.Repo{FullName: "org/repo"},
-				Number:     3,
+			name:         "Link exists but title is different, replacing it",
+			projectCache: &threadsafeSet{data: sets.NewString("abc")},
+			overrideEvent: &event{
+				isComment: true,
+				htmlUrl:   "https://github.com/org/repo/issues/3",
+				title:     "Some issue NEW",
+				body:      "Some text and also [ABC-123:](https://my-jira.com/browse/ABC-123)",
+				org:       "org",
+				repo:      "repo",
+				number:    3,
 			},
-			projectCache:   &threadsafeSet{data: sets.NewString("abc")},
-			existingIssues: []jira.Issue{{ID: "ABC-123"}},
-			existingLinks: map[string][]jira.RemoteLink{
+			issues: []jira.Issue{{ID: "ABC-123"}},
+			remoteLinks: map[string][]jira.RemoteLink{
 				"ABC-123": {
 					{
 						Object: &jira.RemoteLinkObject{
@@ -295,7 +428,7 @@ func TestHandle(t *testing.T) {
 					},
 				},
 			},
-			expectedNewLinks: []jira.RemoteLink{
+			expectedNewRemoteLinks: []jira.RemoteLink{
 				{
 					Object: &jira.RemoteLinkObject{
 						URL:   "https://github.com/org/repo/issues/3",
@@ -306,60 +439,1392 @@ func TestHandle(t *testing.T) {
 			},
 		},
 		{
-			name: "Valid issue in disabled project, case insensitive matching and no link",
-			event: github.GenericCommentEvent{
-				HTMLURL:    "https://github.com/org/repo/issues/3",
-				IssueTitle: "Some issue",
-				Body:       "Some text and also ENTERPRISE-4",
-				Repo:       github.Repo{FullName: "org/repo"},
-				Number:     3,
+			name:         "Valid issue in disabled project, case insensitive matching and no link",
+			projectCache: &threadsafeSet{data: sets.NewString("enterprise")},
+			overrideEvent: &event{
+				isComment: true,
+				htmlUrl:   "https://github.com/org/repo/issues/3",
+				title:     "Some issue",
+				body:      "Some text and also ENTERPRISE-4",
+				org:       "org",
+				repo:      "repo",
+				number:    3,
 			},
-			projectCache:   &threadsafeSet{data: sets.NewString("enterprise")},
-			cfg:            &plugins.Jira{DisabledJiraProjects: []string{"Enterprise"}},
-			existingIssues: []jira.Issue{{ID: "ENTERPRISE-4"}},
+			disabledProjects: []string{"Enterprise"},
+			issues:           []jira.Issue{{ID: "ENTERPRISE-4"}},
 		},
 		{
-			name: "Project 404 gets served from cache, nothing happens",
-			event: github.GenericCommentEvent{
-				HTMLURL:    "https://github.com/org/repo/issues/3",
-				IssueTitle: "Some issue",
-				Body:       "ABC-123",
-				Repo:       github.Repo{FullName: "org/repo"},
-				Number:     3,
+			name:         "Project 404 gets served from cache, nothing happens",
+			projectCache: &threadsafeSet{},
+			overrideEvent: &event{
+				isComment: true,
+				htmlUrl:   "https://github.com/org/repo/issues/3",
+				title:     "Some issue",
+				body:      "ABC-123",
+				org:       "org",
+				repo:      "repo",
+				number:    3,
 			},
-			projectCache:        &threadsafeSet{},
-			getIssueClientError: errors.New("error: didn't serve 404 from cache"),
+			issueGetErrors: map[string]error{"ABC-123": errors.New("error: didn't serve 404 from cache")},
+		},
+		{
+			name:         "no bug found leaves a comment",
+			projectCache: &threadsafeSet{data: sets.NewString("ocpbugs")},
+			expectedComment: `org/repo#1:@user: No Jira issue with key OCPBUGS-123 exists in the tracker at https://my-jira.com.
+Once a valid bug is referenced in the title of this pull request, request a bug refresh with <code>/jira refresh</code>.
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		},
+		{
+			name:           "error fetching bug leaves a comment",
+			projectCache:   &threadsafeSet{data: sets.NewString("ocpbugs")},
+			issueGetErrors: map[string]error{"OCPBUGS-123": errors.New("injected error getting bug")},
+			expectedComment: `org/repo#1:@user: An error was encountered searching for bug OCPBUGS-123 on the Jira server at https://my-jira.com. No known errors were detected, please see the full error message for details.
+
+<details><summary>Full error message.</summary>
+
+<code>
+injected error getting bug
+</code>
+
+</details>
+
+Please contact an administrator to resolve this issue, then request a bug refresh with <code>/jira refresh</code>.
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		},
+		{
+			name:           "valid bug removes invalid label, adds valid/severity labels and comments",
+			projectCache:   &threadsafeSet{data: sets.NewString("ocpbugs")},
+			issues:         []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{Unknowns: tcontainer.MarshalMap{"customfield_12316142": severityCritical}}}},
+			options:        plugins.JiraBranchOptions{}, // no requirements --> always valid
+			labels:         []string{"jira/invalid-bug"},
+			expectedLabels: []string{"jira/valid-bug", "jira/severity-critical"},
+			expectedComment: `org/repo#1:@user: This pull request references [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123), which is valid.
+
+<details><summary>No validations were run on this bug</summary></details>
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		},
+		{
+			name:           "invalid bug adds invalid label, removes valid label and comments",
+			projectCache:   &threadsafeSet{data: sets.NewString("ocpbugs")},
+			issues:         []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{Unknowns: tcontainer.MarshalMap{"customfield_12316142": severityImportant}}}},
+			options:        plugins.JiraBranchOptions{IsOpen: &open},
+			labels:         []string{"jira/valid-bug", "jira/severity-critical"},
+			expectedLabels: []string{"jira/invalid-bug", "jira/severity-important"},
+			expectedComment: `org/repo#1:@user: This pull request references [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123), which is invalid:
+ - expected the bug to be open, but it isn't
+
+Comment <code>/jira refresh</code> to re-evaluate validity if changes to the Jira bug are made, or edit the title of this pull request to link to a different bug.
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		},
+		{
+			name:           "invalid bug adds keeps human-added valid bug label",
+			projectCache:   &threadsafeSet{data: sets.NewString("ocpbugs")},
+			issues:         []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{Unknowns: tcontainer.MarshalMap{"customfield_12316142": severityImportant}}}},
+			options:        plugins.JiraBranchOptions{IsOpen: &open},
+			humanLabelled:  true,
+			labels:         []string{"jira/valid-bug", "jira/severity-critical"},
+			expectedLabels: []string{"jira/valid-bug", "jira/severity-important"},
+			expectedComment: `org/repo#1:@user: This pull request references [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123), which is invalid:
+ - expected the bug to be open, but it isn't
+
+Comment <code>/jira refresh</code> to re-evaluate validity if changes to the Jira bug are made, or edit the title of this pull request to link to a different bug.
+
+Retaining the jira/valid-bug label as it was manually added.
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		},
+		{
+			name:         "no bug removes all labels and comments",
+			projectCache: &threadsafeSet{data: sets.NewString("ocpbugs")},
+			missing:      true,
+			labels:       []string{"jira/valid-bug", "jira/invalid-bug"},
+			expectedComment: `org/repo#1:@user: No Jira bug is referenced in the title of this pull request.
+To reference a bug, add 'OCPBUGS-XXX:' to the title of this pull request and request another bug refresh with <code>/jira refresh</code>.
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		},
+		{
+			name:         "valid bug with status update removes invalid label, adds valid label, comments and updates status",
+			projectCache: &threadsafeSet{data: sets.NewString("ocpbugs")},
+			issues:       []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{Unknowns: tcontainer.MarshalMap{"customfield_12316142": severityModerate}}}},
+			remoteLinks: map[string][]jira.RemoteLink{"OCPBUGS-123": {{ID: 1, Object: &jira.RemoteLinkObject{
+				URL:   "https://github.com/org/repo/pull/1",
+				Title: "org/repo#1: OCPBUGS-123: fixed it!",
+				Icon: &jira.RemoteLinkIcon{
+					Url16x16: "https://github.com/favicon.ico",
+					Title:    "GitHub",
+				},
+			}},
+			}},
+			options:        plugins.JiraBranchOptions{StateAfterValidation: &updated}, // no requirements --> always valid
+			labels:         []string{"jira/invalid-bug"},
+			expectedLabels: []string{"jira/valid-bug", "jira/severity-moderate"},
+			expectedComment: `org/repo#1:@user: This pull request references [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123), which is valid. The bug has been moved to the UPDATED state.
+
+<details><summary>No validations were run on this bug</summary></details>
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+			expectedIssue: &jira.Issue{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
+				Status:   &jira.Status{Name: "UPDATED"},
+				Unknowns: tcontainer.MarshalMap{"customfield_12316142": severityModerate},
+			}},
+		},
+		{
+			name:           "valid bug with status update removes invalid label, adds valid label, comments and updates status with resolution",
+			projectCache:   &threadsafeSet{data: sets.NewString("ocpbugs")},
+			issues:         []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{Unknowns: tcontainer.MarshalMap{"customfield_12316142": severityLow}}}},
+			options:        plugins.JiraBranchOptions{StateAfterValidation: &plugins.JiraBugState{Status: "CLOSED", Resolution: "VALIDATED"}}, // no requirements --> always valid
+			labels:         []string{"jira/invalid-bug"},
+			expectedLabels: []string{"jira/valid-bug", "jira/severity-low"},
+			expectedComment: `org/repo#1:@user: This pull request references [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123), which is valid. The bug has been moved to the CLOSED (VALIDATED) state.
+
+<details><summary>No validations were run on this bug</summary></details>
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+			expectedIssue: &jira.Issue{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
+				Status: &jira.Status{
+					Name: "CLOSED",
+				},
+				Resolution: &jira.Resolution{
+					Name: "VALIDATED",
+				},
+				// due to the way `Unknowns` works, this has to be provided as a map[string]interface{}
+				Unknowns: tcontainer.MarshalMap{"customfield_12316142": map[string]interface{}{"Value": string(`<img alt="" src="/images/icons/priorities/low.svg" width="16" height="16"> Low`)}},
+			},
+			},
+		},
+		{
+			name:           "valid bug with status update removes invalid label, adds valid label, comments and does not update status when it is already correct",
+			projectCache:   &threadsafeSet{data: sets.NewString("ocpbugs")},
+			issues:         []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{Status: &jira.Status{Name: "UPDATED"}}}},
+			options:        plugins.JiraBranchOptions{StateAfterValidation: &updated}, // no requirements --> always valid
+			labels:         []string{"jira/invalid-bug"},
+			expectedLabels: []string{"jira/valid-bug"},
+			expectedComment: `org/repo#1:@user: This pull request references [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123), which is valid.
+
+<details><summary>No validations were run on this bug</summary></details>
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+			expectedIssue: &jira.Issue{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{Status: &jira.Status{Name: "UPDATED"}}},
+		},
+		{
+			name:           "valid bug with external link removes invalid label, adds valid label, comments, makes an external bug link",
+			projectCache:   &threadsafeSet{data: sets.NewString("ocpbugs")},
+			issues:         []jira.Issue{{ID: "1", Key: "OCPBUGS-123"}},
+			options:        plugins.JiraBranchOptions{AddExternalLink: &yes}, // no requirements --> always valid
+			labels:         []string{"jira/invalid-bug"},
+			expectedLabels: []string{"jira/valid-bug"},
+			expectedComment: `org/repo#1:@user: This pull request references [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123), which is valid. The bug has been updated to refer to the pull request using the external bug tracker.
+
+<details><summary>No validations were run on this bug</summary></details>
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+			expectedIssue: &jira.Issue{ID: "1", Key: "OCPBUGS-123"},
+			expectedNewRemoteLinks: []jira.RemoteLink{{Object: &jira.RemoteLinkObject{
+				URL:   "https://github.com/org/repo/pull/1",
+				Title: "org/repo#1: OCPBUGS-123: fixed it!",
+				Icon: &jira.RemoteLinkIcon{
+					Url16x16: "https://github.com/favicon.ico",
+					Title:    "GitHub",
+				},
+			},
+			}},
+		},
+		{
+			name:         "valid bug with already existing external link removes invalid label, adds valid label, comments to say nothing changed",
+			projectCache: &threadsafeSet{data: sets.NewString("ocpbugs")},
+			issues:       []jira.Issue{{ID: "1", Key: "OCPBUGS-123"}},
+			remoteLinks: map[string][]jira.RemoteLink{"OCPBUGS-123": {{ID: 1, Object: &jira.RemoteLinkObject{
+				URL:   "https://github.com/org/repo/pull/1",
+				Title: "org/repo#1: OCPBUGS-123: fixed it!",
+				Icon: &jira.RemoteLinkIcon{
+					Url16x16: "https://github.com/favicon.ico",
+					Title:    "GitHub",
+				},
+			}},
+			}},
+			options:        plugins.JiraBranchOptions{AddExternalLink: &yes}, // no requirements --> always valid
+			labels:         []string{"jira/invalid-bug"},
+			expectedLabels: []string{"jira/valid-bug"},
+			expectedComment: `org/repo#1:@user: This pull request references [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123), which is valid.
+
+<details><summary>No validations were run on this bug</summary></details>
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+			expectedIssue: &jira.Issue{ID: "1", Key: "OCPBUGS-123"},
+		},
+		{
+			name:         "failure to fetch dependent bug results in a comment",
+			projectCache: &threadsafeSet{data: sets.NewString("ocpbugs")},
+			issues: []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
+				IssueLinks: []*jira.IssueLink{&fieldLinkTo124},
+			}}},
+			existingIssueLinks: []*jira.IssueLink{&linkBetween123to124},
+			issueGetErrors:     map[string]error{"OCPBUGS-124": errors.New("injected error getting bug")},
+			options:            plugins.JiraBranchOptions{DependentBugStates: &verified},
+			expectedComment: `org/repo#1:@user: An error was encountered searching for dependent bug OCPBUGS-124 for bug OCPBUGS-123 on the Jira server at https://my-jira.com. No known errors were detected, please see the full error message for details.
+
+<details><summary>Full error message.</summary>
+
+<code>
+injected error getting bug
+</code>
+
+</details>
+
+Please contact an administrator to resolve this issue, then request a bug refresh with <code>/jira refresh</code>.
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		},
+		{
+			name:         "valid bug with dependent bugs removes invalid label, adds valid label, comments",
+			projectCache: &threadsafeSet{data: sets.NewString("ocpbugs")},
+			issues: []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
+				Status:     &jira.Status{Name: "MODIFIED"},
+				IssueLinks: []*jira.IssueLink{&fieldLinkTo124},
+				Unknowns: tcontainer.MarshalMap{
+					"customfield_12319940": &v1,
+				},
+			},
+			}, {ID: "2", Key: "OCPBUGS-124", Fields: &jira.IssueFields{
+				Status:     &jira.Status{Name: "VERIFIED"},
+				IssueLinks: []*jira.IssueLink{&fieldLinkTo123},
+				Unknowns: tcontainer.MarshalMap{
+					"customfield_12319940": &v2,
+				},
+			}}},
+			existingIssueLinks: []*jira.IssueLink{&linkBetween123to124},
+			options:            plugins.JiraBranchOptions{IsOpen: &yes, TargetVersion: &v1Str, DependentBugStates: &verified, DependentBugTargetVersions: &[]string{v2Str}},
+			labels:             []string{"jira/invalid-bug"},
+			expectedLabels:     []string{"jira/valid-bug"},
+			expectedComment: `org/repo#1:@user: This pull request references [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123), which is valid.
+
+<details><summary>5 validation(s) were run on this bug</summary>
+
+* bug is open, matching expected state (open)
+* bug target version (v1) matches configured target version for branch (v1)
+* dependent bug [Jira Issue OCPBUGS-124](https://my-jira.com/browse/OCPBUGS-124) is in the state VERIFIED, which is one of the valid states (VERIFIED)
+* dependent [Jira Issue OCPBUGS-124](https://my-jira.com/browse/OCPBUGS-124) targets the "v2" version, which is one of the valid target versions: v2
+* bug has dependents</details>
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		},
+		{
+			name:         "valid bug on merged PR with one external link migrates to new state with resolution and comments",
+			projectCache: &threadsafeSet{data: sets.NewString("ocpbugs")},
+			merged:       true,
+			issues: []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
+				Status: &jira.Status{Name: "MODIFIED"},
+			}}},
+			remoteLinks: map[string][]jira.RemoteLink{"OCPBUGS-123": {{ID: 1, Object: &jira.RemoteLinkObject{
+				URL:   "https://github.com/org/repo/pull/1",
+				Title: "org/repo#1: OCPBUGS-123: fixed it!",
+				Icon: &jira.RemoteLinkIcon{
+					Url16x16: "https://github.com/favicon.ico",
+					Title:    "GitHub",
+				},
+			}},
+			}},
+			prs:     []github.PullRequest{{Number: base.number, Merged: true}},
+			options: plugins.JiraBranchOptions{StateAfterMerge: &plugins.JiraBugState{Status: "CLOSED", Resolution: "MERGED"}}, // no requirements --> always valid
+			expectedComment: `org/repo#1:@user: All pull requests linked via external trackers have merged:
+ * [org/repo#1](https://github.com/org/repo/pull/1)
+
+[Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123) has been moved to the CLOSED (MERGED) state.
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+			expectedIssue: &jira.Issue{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
+				Status:     &jira.Status{Name: "CLOSED"},
+				Resolution: &jira.Resolution{Name: "MERGED"},
+				Unknowns:   tcontainer.MarshalMap{},
+			}},
+		},
+		{
+			name:         "valid bug on merged PR with one external link migrates to new state and comments",
+			projectCache: &threadsafeSet{data: sets.NewString("ocpbugs")},
+			merged:       true,
+			issues:       []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{}}},
+			remoteLinks: map[string][]jira.RemoteLink{"OCPBUGS-123": {{ID: 1, Object: &jira.RemoteLinkObject{
+				URL:   "https://github.com/org/repo/pull/1",
+				Title: "org/repo#1: OCPBUGS-123: fixed it!",
+				Icon: &jira.RemoteLinkIcon{
+					Url16x16: "https://github.com/favicon.ico",
+					Title:    "GitHub",
+				},
+			}},
+			}},
+			prs:     []github.PullRequest{{Number: base.number, Merged: true}},
+			options: plugins.JiraBranchOptions{StateAfterMerge: &modified}, // no requirements --> always valid
+			expectedComment: `org/repo#1:@user: All pull requests linked via external trackers have merged:
+ * [org/repo#1](https://github.com/org/repo/pull/1)
+
+[Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123) has been moved to the MODIFIED state.
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+			expectedIssue: &jira.Issue{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{Status: &jira.Status{Name: "MODIFIED"}}},
+		},
+		{
+			name:         "valid bug on merged PR with many external links migrates to new state and comments",
+			projectCache: &threadsafeSet{data: sets.NewString("ocpbugs")},
+			merged:       true,
+			issues:       []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{}}},
+			remoteLinks: map[string][]jira.RemoteLink{"OCPBUGS-123": {{
+				ID: 1,
+				Object: &jira.RemoteLinkObject{
+					URL:   "https://github.com/org/repo/pull/1",
+					Title: "org/repo#1: OCPBUGS-123: fixed it!",
+					Icon: &jira.RemoteLinkIcon{
+						Url16x16: "https://github.com/favicon.ico",
+						Title:    "GitHub",
+					},
+				},
+			}, {
+				ID: 2,
+				Object: &jira.RemoteLinkObject{
+					URL:   "https://github.com/org/repo/pull/22",
+					Title: "org/repo#22: OCPBUGS-123: fixed it!",
+					Icon: &jira.RemoteLinkIcon{
+						Url16x16: "https://github.com/favicon.ico",
+						Title:    "GitHub",
+					},
+				},
+			},
+			}},
+			prs:     []github.PullRequest{{Number: base.number, Merged: true}, {Number: 22, Merged: true}},
+			options: plugins.JiraBranchOptions{StateAfterMerge: &modified}, // no requirements --> always valid
+			expectedComment: `org/repo#1:@user: All pull requests linked via external trackers have merged:
+ * [org/repo#1](https://github.com/org/repo/pull/1)
+ * [org/repo#22](https://github.com/org/repo/pull/22)
+
+[Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123) has been moved to the MODIFIED state.
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+			expectedIssue: &jira.Issue{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{Status: &jira.Status{Name: "MODIFIED"}}},
+		},
+		{
+			name:         "valid bug on merged PR with unmerged external links does nothing",
+			projectCache: &threadsafeSet{data: sets.NewString("ocpbugs")},
+			merged:       true,
+			issues:       []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{}}},
+			remoteLinks: map[string][]jira.RemoteLink{"OCPBUGS-123": {{
+				ID: 1,
+				Object: &jira.RemoteLinkObject{
+					URL:   "https://github.com/org/repo/pull/1",
+					Title: "org/repo#1: OCPBUGS-123: fixed it!",
+					Icon: &jira.RemoteLinkIcon{
+						Url16x16: "https://github.com/favicon.ico",
+						Title:    "GitHub",
+					},
+				},
+			}, {
+				ID: 2,
+				Object: &jira.RemoteLinkObject{
+					URL:   "https://github.com/org/repo/pull/22",
+					Title: "org/repo#22: OCPBUGS-123: fixed it!",
+					Icon: &jira.RemoteLinkIcon{
+						Url16x16: "https://github.com/favicon.ico",
+						Title:    "GitHub",
+					},
+				},
+			},
+			}},
+			prs:           []github.PullRequest{{Number: base.number, Merged: true}, {Number: 22, Merged: false, State: "open"}},
+			options:       plugins.JiraBranchOptions{StateAfterMerge: &modified}, // no requirements --> always valid
+			expectedIssue: &jira.Issue{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{}},
+			expectedComment: `org/repo#1:@user: Some pull requests linked via external trackers have merged:
+ * [org/repo#1](https://github.com/org/repo/pull/1)
+
+The following pull requests linked via external trackers have not merged:
+ * [org/repo#22](https://github.com/org/repo/pull/22) is open
+
+These pull request must merge or be unlinked from the Jira bug in order for it to move to the next state. Once unlinked, request a bug refresh with <code>/jira refresh</code>.
+
+[Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123) has not been moved to the MODIFIED state.
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		},
+		{
+			name:         "External bug on rep that is not in our config is ignored, bug gets set to MODIFIED",
+			projectCache: &threadsafeSet{data: sets.NewString("ocpbugs")},
+			merged:       true,
+			issues:       []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{}}},
+			remoteLinks: map[string][]jira.RemoteLink{"OCPBUGS-123": {{ID: 1, Object: &jira.RemoteLinkObject{
+				URL:   "https://github.com/unreferenced/repo/pull/22",
+				Title: "unreferenced/repo#22: OCPBUGS-123: fixed it!",
+				Icon: &jira.RemoteLinkIcon{
+					Url16x16: "https://github.com/favicon.ico",
+					Title:    "GitHub",
+				},
+			}},
+			}},
+			prs:           []github.PullRequest{{Number: 22, Merged: false, State: "open"}},
+			options:       plugins.JiraBranchOptions{StateAfterMerge: &modified}, // no requirements --> always valid
+			expectedIssue: &jira.Issue{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{Status: &jira.Status{Name: "MODIFIED"}}},
+			expectedComment: `org/repo#1:@user: All pull requests linked via external trackers have merged:
+
+
+[Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123) has been moved to the MODIFIED state.
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		},
+		{
+			name:         "valid bug on merged PR with one external link but no status after merge configured does nothing",
+			projectCache: &threadsafeSet{data: sets.NewString("ocpbugs")},
+			merged:       true,
+			issues:       []jira.Issue{{ID: "1", Key: "OCPBUGS-123"}},
+			remoteLinks: map[string][]jira.RemoteLink{"OCPBUGS-123": {{ID: 1, Object: &jira.RemoteLinkObject{
+				URL:   "https://github.com/org/repo/pull/1",
+				Title: "org/repo#1: OCPBUGS-123: fixed it!",
+				Icon: &jira.RemoteLinkIcon{
+					Url16x16: "https://github.com/favicon.ico",
+					Title:    "GitHub",
+				},
+			}},
+			}},
+			prs:           []github.PullRequest{{Number: base.number, Merged: true}},
+			options:       plugins.JiraBranchOptions{}, // no requirements --> always valid
+			expectedIssue: &jira.Issue{ID: "1", Key: "OCPBUGS-123"},
+		},
+		{
+			name:         "valid bug on merged PR with one external link but no referenced bug in the title does nothing",
+			projectCache: &threadsafeSet{data: sets.NewString("ocpbugs")},
+			merged:       true,
+			missing:      true,
+			issues:       []jira.Issue{{ID: "1", Key: "OCPBUGS-123"}},
+			remoteLinks: map[string][]jira.RemoteLink{"OCPBUGS-123": {{ID: 1, Object: &jira.RemoteLinkObject{
+				URL:   "https://github.com/org/repo/pull/1",
+				Title: "org/repo#1: OCPBUGS-123: fixed it!",
+				Icon: &jira.RemoteLinkIcon{
+					Url16x16: "https://github.com/favicon.ico",
+					Title:    "GitHub",
+				},
+			}},
+			}},
+			prs:           []github.PullRequest{{Number: base.number, Merged: true}},
+			options:       plugins.JiraBranchOptions{StateAfterMerge: &modified}, // no requirements --> always valid
+			expectedIssue: &jira.Issue{ID: "1", Key: "OCPBUGS-123"},
+		},
+		{
+			name:           "valid bug on merged PR with one external link fails to update bug and comments",
+			projectCache:   &threadsafeSet{data: sets.NewString("ocpbugs")},
+			merged:         true,
+			issues:         []jira.Issue{{ID: "1", Key: "OCPBUGS-123"}},
+			issueGetErrors: map[string]error{"OCPBUGS-123": errors.New("injected error getting bug")},
+			remoteLinks: map[string][]jira.RemoteLink{"OCPBUGS-123": {{ID: 1, Object: &jira.RemoteLinkObject{
+				URL:   "https://github.com/org/repo/pull/1",
+				Title: "org/repo#1: OCPBUGS-123: fixed it!",
+				Icon: &jira.RemoteLinkIcon{
+					Url16x16: "https://github.com/favicon.ico",
+					Title:    "GitHub",
+				},
+			}},
+			}},
+			prs:     []github.PullRequest{{Number: base.number, Merged: true}},
+			options: plugins.JiraBranchOptions{StateAfterMerge: &modified}, // no requirements --> always valid
+			expectedComment: `org/repo#1:@user: An error was encountered searching for bug OCPBUGS-123 on the Jira server at https://my-jira.com. No known errors were detected, please see the full error message for details.
+
+<details><summary>Full error message.</summary>
+
+<code>
+injected error getting bug
+</code>
+
+</details>
+
+Please contact an administrator to resolve this issue, then request a bug refresh with <code>/jira refresh</code>.
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+			expectedIssue: &jira.Issue{ID: "1", Key: "OCPBUGS-123"},
+		},
+		{
+			name:         "valid bug on merged PR with merged external links but unknown status does not migrate to new state and comments",
+			projectCache: &threadsafeSet{data: sets.NewString("ocpbugs")},
+			merged:       true,
+			issues: []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
+				Status: &jira.Status{Name: "CLOSED"},
+				Unknowns: tcontainer.MarshalMap{
+					"customfield_12316142": severityCritical,
+				},
+			}}},
+			remoteLinks: map[string][]jira.RemoteLink{"OCPBUGS-123": {{ID: 1, Object: &jira.RemoteLinkObject{
+				URL:   "https://github.com/org/repo/pull/1",
+				Title: "org/repo#1: OCPBUGS-123: fixed it!",
+				Icon: &jira.RemoteLinkIcon{
+					Url16x16: "https://github.com/favicon.ico",
+					Title:    "GitHub",
+				},
+			}},
+			}},
+			prs:     []github.PullRequest{{Number: base.number, Merged: true}},
+			options: plugins.JiraBranchOptions{StateAfterValidation: &updated, StateAfterMerge: &modified}, // no requirements --> always valid
+			expectedComment: `org/repo#1:@user: [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123) is in an unrecognized state (CLOSED) and will not be moved to the MODIFIED state.
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+
+			expectedIssue: &jira.Issue{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
+				Status: &jira.Status{Name: "CLOSED"},
+				Unknowns: tcontainer.MarshalMap{
+					"customfield_12316142": severityCritical,
+				},
+			}},
+		},
+		{
+			name:         "closed PR removes link and comments",
+			projectCache: &threadsafeSet{data: sets.NewString("ocpbugs")},
+			merged:       false,
+			closed:       true,
+			issues: []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
+				Status: &jira.Status{Name: "CLOSED"},
+				Unknowns: tcontainer.MarshalMap{
+					"customfield_12316142": severityCritical,
+				},
+			}}},
+			remoteLinks: map[string][]jira.RemoteLink{"OCPBUGS-123": {{ID: 1, Object: &jira.RemoteLinkObject{
+				URL:   "https://github.com/org/repo/pull/1",
+				Title: "org/repo#1: OCPBUGS-123: fixed it!",
+				Icon: &jira.RemoteLinkIcon{
+					Url16x16: "https://github.com/favicon.ico",
+					Title:    "GitHub",
+				},
+			}},
+			}},
+			prs:     []github.PullRequest{{Number: base.number, Merged: false}},
+			options: plugins.JiraBranchOptions{AddExternalLink: &yes},
+			expectedComment: `org/repo#1:@user: This pull request references [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123). The bug has been updated to no longer refer to the pull request using the external bug tracker.
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+			expectedIssue: &jira.Issue{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
+				Status: &jira.Status{Name: "CLOSED"},
+				Unknowns: tcontainer.MarshalMap{
+					"customfield_12316142": severityCritical,
+				},
+			}},
+			expectedRemovedRemoteLinks: []jira.RemoteLink{{ID: 1, Object: &jira.RemoteLinkObject{
+				URL:   "https://github.com/org/repo/pull/1",
+				Title: "org/repo#1: OCPBUGS-123: fixed it!",
+				Icon: &jira.RemoteLinkIcon{
+					Url16x16: "https://github.com/favicon.ico",
+					Title:    "GitHub",
+				},
+			}},
+			},
+		},
+		{
+			name:         "closed PR without a link does nothing",
+			projectCache: &threadsafeSet{data: sets.NewString("ocpbugs")},
+			merged:       false,
+			closed:       true,
+			issues: []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
+				Status: &jira.Status{Name: "CLOSED"},
+				Unknowns: tcontainer.MarshalMap{
+					"customfield_12316142": severityCritical,
+				},
+			}}},
+			prs:     []github.PullRequest{{Number: base.number, Merged: false}},
+			options: plugins.JiraBranchOptions{AddExternalLink: &yes},
+			expectedIssue: &jira.Issue{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
+				Status: &jira.Status{Name: "CLOSED"},
+				Unknowns: tcontainer.MarshalMap{
+					"customfield_12316142": severityCritical,
+				},
+			}},
+		},
+		{
+			name:         "closed PR removes link, changes bug state, and comments",
+			projectCache: &threadsafeSet{data: sets.NewString("ocpbugs")},
+			merged:       false,
+			closed:       true,
+			issues: []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
+				Comments: &jira.Comments{Comments: []*jira.Comment{{
+					Body: "This is a bug",
+				}}},
+				Status: &jira.Status{Name: "POST"},
+				Unknowns: tcontainer.MarshalMap{
+					"customfield_12316142": severityCritical,
+				},
+			}}},
+			remoteLinks: map[string][]jira.RemoteLink{"OCPBUGS-123": {{ID: 1, Object: &jira.RemoteLinkObject{
+				URL:   "https://github.com/org/repo/pull/1",
+				Title: "org/repo#1: OCPBUGS-123: fixed it!",
+				Icon: &jira.RemoteLinkIcon{
+					Url16x16: "https://github.com/favicon.ico",
+					Title:    "GitHub",
+				},
+			}},
+			}},
+			prs:     []github.PullRequest{{Number: base.number, Merged: false}},
+			options: plugins.JiraBranchOptions{AddExternalLink: &yes, StateAfterClose: &plugins.JiraBugState{Status: "NEW"}},
+			expectedComment: `org/repo#1:@user: This pull request references [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123). The bug has been updated to no longer refer to the pull request using the external bug tracker. All external bug links have been closed. The bug has been moved to the NEW state.
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+			expectedIssue: &jira.Issue{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
+				Status: &jira.Status{Name: "NEW"},
+				Comments: &jira.Comments{Comments: []*jira.Comment{{
+					Body: "This is a bug",
+				}, {
+					Body:       "Bug status changed to NEW as previous linked PR https://github.com/org/repo/pull/1 has been closed",
+					Visibility: PrivateVisibility,
+				}}},
+				Unknowns: tcontainer.MarshalMap{
+					"customfield_12316142": severityCritical,
+				},
+			}},
+			expectedRemovedRemoteLinks: []jira.RemoteLink{{ID: 1, Object: &jira.RemoteLinkObject{
+				URL:   "https://github.com/org/repo/pull/1",
+				Title: "org/repo#1: OCPBUGS-123: fixed it!",
+				Icon: &jira.RemoteLinkIcon{
+					Url16x16: "https://github.com/favicon.ico",
+					Title:    "GitHub",
+				},
+			}},
+			},
+		},
+		{
+			name:         "closed PR with missing bug does nothing",
+			projectCache: &threadsafeSet{data: sets.NewString("ocpbugs")},
+			merged:       false,
+			closed:       true,
+			missing:      true,
+			issues:       []jira.Issue{},
+			prs:          []github.PullRequest{{Number: base.number, Merged: false}},
+			options:      plugins.JiraBranchOptions{AddExternalLink: &yes, StateAfterClose: &plugins.JiraBugState{Status: "NEW"}},
+		},
+		{
+			name:         "closed PR with multiple external links removes link, does not change bug state, and comments",
+			projectCache: &threadsafeSet{data: sets.NewString("ocpbugs")},
+			merged:       false,
+			closed:       true,
+			issues: []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
+				Status: &jira.Status{Name: "POST"},
+				Unknowns: tcontainer.MarshalMap{
+					"customfield_12316142": severityCritical,
+				},
+			}}},
+			remoteLinks: map[string][]jira.RemoteLink{"OCPBUGS-123": {{
+				ID: 1,
+				Object: &jira.RemoteLinkObject{
+					URL:   "https://github.com/org/repo/pull/1",
+					Title: "org/repo#1: OCPBUGS-123: fixed it!",
+					Icon: &jira.RemoteLinkIcon{
+						Url16x16: "https://github.com/favicon.ico",
+						Title:    "GitHub",
+					},
+				},
+			}, {
+				ID: 2,
+				Object: &jira.RemoteLinkObject{
+					URL:   "https://github.com/org/repo/issues/42",
+					Title: "org/repo#42: OCPBUGS-123: fixed it!",
+					Icon: &jira.RemoteLinkIcon{
+						Url16x16: "https://github.com/favicon.ico",
+						Title:    "GitHub",
+					},
+				}},
+			}},
+			prs:     []github.PullRequest{{Number: base.number, Merged: false}},
+			options: plugins.JiraBranchOptions{AddExternalLink: &yes, StateAfterClose: &plugins.JiraBugState{Status: "NEW"}},
+			expectedComment: `org/repo#1:@user: This pull request references [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123). The bug has been updated to no longer refer to the pull request using the external bug tracker.
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+			expectedIssue: &jira.Issue{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
+				Status: &jira.Status{Name: "POST"},
+				Unknowns: tcontainer.MarshalMap{
+					"customfield_12316142": severityCritical,
+				},
+			}},
+			expectedRemovedRemoteLinks: []jira.RemoteLink{{ID: 1, Object: &jira.RemoteLinkObject{
+				URL:   "https://github.com/org/repo/pull/1",
+				Title: "org/repo#1: OCPBUGS-123: fixed it!",
+				Icon: &jira.RemoteLinkIcon{
+					Url16x16: "https://github.com/favicon.ico",
+					Title:    "GitHub",
+				},
+			}},
+			},
+		},
+		{
+			name:         "Cherrypick PR results in cloned bug creation",
+			projectCache: &threadsafeSet{data: sets.NewString("ocpbugs")},
+			issues: []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
+				Status: &jira.Status{Name: "CLOSED"},
+				Comments: &jira.Comments{Comments: []*jira.Comment{{
+					Body: "This is a bug",
+				}}},
+				Unknowns: tcontainer.MarshalMap{
+					"customfield_12316142": severityCritical,
+					"customfield_12319940": &v2,
+				},
+			}}},
+			prs:                 []github.PullRequest{{Number: base.number, Body: base.body, Title: base.title}, {Number: 2, Body: "This is an automated cherry-pick of #1.\n\n/assign user", Title: "[v1] " + base.title}},
+			title:               "[v1] " + base.title,
+			cherryPick:          true,
+			cherryPickFromPRNum: 1,
+			cherryPickTo:        "v1",
+			options:             plugins.JiraBranchOptions{TargetVersion: &v1Str},
+			expectedComment: `org/repo#1:@user: [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123) has been cloned as [Jira Issue OCPBUGS-124](https://my-jira.com/browse/OCPBUGS-124). Retitling PR to link against new bug.
+/retitle [v1] OCPBUGS-124: fixed it!
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+			expectedIssue: &jira.Issue{ID: "2", Key: "OCPBUGS-124", Fields: &jira.IssueFields{
+				Description: "This is a clone of issue OCPBUGS-123. The following is the description of the original issue: \n---\n",
+				Status:      &jira.Status{Name: "CLOSED"}, // during a clone on a real jira server, this field would get unset/reset; the fake client copies
+				IssueLinks:  []*jira.IssueLink{&fieldLinkTo123},
+				Unknowns: tcontainer.MarshalMap{
+					"customfield_12316142": map[string]interface{}{"Value": `<img alt="" src="/images/icons/priorities/critical.svg" width="16" height="16"> Critical`},
+					"customfield_12319940": []interface{}{map[string]interface{}{"name": v1Str}},
+				},
+			}},
+		},
+		{
+			name:         "parent PR of cherrypick not existing results in error",
+			projectCache: &threadsafeSet{data: sets.NewString("ocpbugs")},
+			issues: []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
+				Status: &jira.Status{Name: "CLOSED"},
+				Comments: &jira.Comments{Comments: []*jira.Comment{{
+					Body: "This is a bug",
+				}}},
+				Unknowns: tcontainer.MarshalMap{
+					"customfield_12316142": severityCritical,
+					"customfield_12319940": &v2,
+				},
+			}}},
+			prs:                 []github.PullRequest{{Number: 2, Body: "This is an automated cherry-pick of #1.\n\n/assign user", Title: "[v1] " + base.title}},
+			title:               "[v1] " + base.title,
+			cherryPick:          true,
+			cherryPickFromPRNum: 1,
+			cherryPickTo:        "v1",
+			options:             plugins.JiraBranchOptions{TargetVersion: &v1Str},
+			expectedComment: `org/repo#1:@user: Error creating a cherry-pick bug in Jira: failed to check the state of cherrypicked pull request at https://github.com/org/repo/pull/1: pull request number 1 does not exist.
+Please contact an administrator to resolve this issue, then request a bug refresh with <code>/jira refresh</code>.
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		},
+		{
+			name:         "failure to obtain parent bug for cherrypick results in error",
+			projectCache: &threadsafeSet{data: sets.NewString("ocpbugs")},
+			issues: []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
+				Status: &jira.Status{Name: "CLOSED"},
+				Comments: &jira.Comments{Comments: []*jira.Comment{{
+					Body: "This is a bug",
+				}}},
+				Unknowns: tcontainer.MarshalMap{
+					"customfield_12316142": severityCritical,
+					"customfield_12319940": &v2,
+				},
+			}}},
+			issueGetErrors:      map[string]error{"OCPBUGS-123": errors.New("injected error getting bug")},
+			prs:                 []github.PullRequest{{Number: base.number, Body: base.body, Title: base.title}, {Number: 2, Body: "This is an automated cherry-pick of #1.\n\n/assign user", Title: "[v1] " + base.title}},
+			title:               "[v1] " + base.title,
+			cherryPick:          true,
+			cherryPickFromPRNum: 1,
+			cherryPickTo:        "v1",
+			options:             plugins.JiraBranchOptions{TargetVersion: &v1Str},
+			expectedComment: `org/repo#1:@user: An error was encountered searching for bug OCPBUGS-123 on the Jira server at https://my-jira.com. No known errors were detected, please see the full error message for details.
+
+<details><summary>Full error message.</summary>
+
+<code>
+injected error getting bug
+</code>
+
+</details>
+
+Please contact an administrator to resolve this issue, then request a bug refresh with <code>/jira refresh</code>.
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		}, {
+			name:         "failure to clone bug for cherrypick results in error",
+			projectCache: &threadsafeSet{data: sets.NewString("ocpbugs")},
+			issues: []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
+				Status: &jira.Status{Name: "CLOSED"},
+				Comments: &jira.Comments{Comments: []*jira.Comment{{
+					Body: "This is a bug",
+				}}},
+				Unknowns: tcontainer.MarshalMap{
+					"customfield_12316142": severityCritical,
+					"customfield_12319940": &v2,
+				},
+			}}},
+			issueCreateErrors:   map[string]error{"OCPBUGS-124": errors.New("injected error creating OCPBUGS-124")},
+			prs:                 []github.PullRequest{{Number: base.number, Body: base.body, Title: base.title}, {Number: 2, Body: "This is an automated cherry-pick of #1.\n\n/assign user", Title: "[v1] " + base.title}},
+			title:               "[v1] " + base.title,
+			cherryPick:          true,
+			cherryPickFromPRNum: 1,
+			cherryPickTo:        "v1",
+			options:             plugins.JiraBranchOptions{TargetVersion: &v1Str},
+			expectedComment: `org/repo#1:@user: An error was encountered cloning bug for cherrypick for bug OCPBUGS-123 on the Jira server at https://my-jira.com. No known errors were detected, please see the full error message for details.
+
+<details><summary>Full error message.</summary>
+
+<code>
+injected error creating OCPBUGS-124
+</code>
+
+</details>
+
+Please contact an administrator to resolve this issue, then request a bug refresh with <code>/jira refresh</code>.
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		}, {
+			name:         "failure to update bug for results in error",
+			projectCache: &threadsafeSet{data: sets.NewString("ocpbugs")},
+			issues: []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
+				Status: &jira.Status{Name: "CLOSED"},
+				Comments: &jira.Comments{Comments: []*jira.Comment{{
+					Body: "This is a bug",
+				}}},
+				Unknowns: tcontainer.MarshalMap{
+					"customfield_12316142": severityCritical,
+					"customfield_12319940": &v2,
+				},
+			}}},
+			issueUpdateErrors:   map[string]error{"2": errors.New("injected error updating bug")},
+			prs:                 []github.PullRequest{{Number: base.number, Body: base.body, Title: base.title}, {Number: 2, Body: "This is an automated cherry-pick of #1.\n\n/assign user", Title: "[v1] " + base.title}},
+			title:               "[v1] " + base.title,
+			cherryPick:          true,
+			cherryPickFromPRNum: 1,
+			cherryPickTo:        "v1",
+			options:             plugins.JiraBranchOptions{TargetVersion: &v1Str},
+			expectedComment: `org/repo#1:@user: An error was encountered updating cherry-pick bug in Jira: Created cherrypick [Jira Issue OCPBUGS-124](https://my-jira.com/browse/OCPBUGS-124), but encountered error updating target version for bug OCPBUGS-124 on the Jira server at https://my-jira.com. No known errors were detected, please see the full error message for details.
+
+<details><summary>Full error message.</summary>
+
+<code>
+injected error updating bug
+</code>
+
+</details>
+
+Please contact an administrator to resolve this issue, then request a bug refresh with <code>/jira refresh</code>.
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		}, {
+			name:         "If bug clone with correct target version already exists, just retitle PR",
+			projectCache: &threadsafeSet{data: sets.NewString("ocpbugs")},
+			issues: []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
+				IssueLinks: []*jira.IssueLink{&fieldLinkTo124},
+				Status:     &jira.Status{Name: "CLOSED"},
+				Comments: &jira.Comments{Comments: []*jira.Comment{{
+					Body: "This is a bug",
+				}}},
+				Unknowns: tcontainer.MarshalMap{
+					"customfield_12316142": severityCritical,
+					"customfield_12319940": &v2,
+				},
+			}}, {ID: "2", Key: "OCPBUGS-124", Fields: &jira.IssueFields{
+				IssueLinks: []*jira.IssueLink{&fieldLinkTo123},
+				Status:     &jira.Status{Name: "NEW"},
+				Unknowns: tcontainer.MarshalMap{
+					"customfield_12316142": severityCritical,
+					"customfield_12319940": &v1,
+				},
+			}},
+			},
+			prs:                 []github.PullRequest{{Number: base.number, Body: base.body, Title: base.title}, {Number: 2, Body: "This is an automated cherry-pick of #1.\n\n/assign user", Title: "[v1] " + base.title}},
+			title:               "[v1] " + base.title,
+			cherryPick:          true,
+			cherryPickFromPRNum: 1,
+			cherryPickTo:        "v1",
+			options:             plugins.JiraBranchOptions{TargetVersion: &v1Str},
+			expectedComment: `org/repo#1:@user: Detected clone of [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123) with correct target version. Retitling PR to link to clone:
+/retitle [v1] OCPBUGS-124: fixed it!
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		}, {
+			name:         "Clone for different version does not block creation of new clone",
+			projectCache: &threadsafeSet{data: sets.NewString("ocpbugs")},
+			issues: []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
+				Status: &jira.Status{Name: "CLOSED"},
+				Comments: &jira.Comments{Comments: []*jira.Comment{{
+					Body: "This is a bug",
+				}}},
+				Unknowns: tcontainer.MarshalMap{
+					"customfield_12316142": severityCritical,
+					"customfield_12319940": &v2,
+				},
+			}}, {ID: "2", Key: "OCPBUGS-124", Fields: &jira.IssueFields{
+				Status: &jira.Status{Name: "NEW"},
+				Unknowns: tcontainer.MarshalMap{
+					"customfield_12316142": severityCritical,
+					"customfield_12319940": &v3,
+				},
+			}},
+			},
+			prs:                 []github.PullRequest{{Number: base.number, Body: base.body, Title: base.title}, {Number: 2, Body: "This is an automated cherry-pick of #1.\n\n/assign user", Title: "[v1] " + base.title}},
+			title:               "[v1] " + base.title,
+			cherryPick:          true,
+			cherryPickFromPRNum: 1,
+			cherryPickTo:        "v1",
+			options:             plugins.JiraBranchOptions{TargetVersion: &v1Str},
+			expectedComment: `org/repo#1:@user: [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123) has been cloned as [Jira Issue OCPBUGS-125](https://my-jira.com/browse/OCPBUGS-125). Retitling PR to link against new bug.
+/retitle [v1] OCPBUGS-125: fixed it!
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+			expectedIssue: &jira.Issue{ID: "3", Key: "OCPBUGS-125", Fields: &jira.IssueFields{
+				Description: "This is a clone of issue OCPBUGS-123. The following is the description of the original issue: \n---\n",
+				Status:      &jira.Status{Name: "CLOSED"}, // during a clone on a real jira server, this field would get unset/reset; the fake client copies
+				IssueLinks:  []*jira.IssueLink{&fieldLinkTo123},
+				Unknowns: tcontainer.MarshalMap{
+					"customfield_12316142": map[string]interface{}{"Value": `<img alt="" src="/images/icons/priorities/critical.svg" width="16" height="16"> Critical`},
+					"customfield_12319940": []interface{}{map[string]interface{}{"name": v1Str}},
+				},
+			}},
+		}, {
+			name:         "Bug with non-allowed security level is ignored",
+			projectCache: &threadsafeSet{data: sets.NewString("ocpbugs")},
+			issues:       []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{Unknowns: tcontainer.MarshalMap{"security": jiraclient.SecurityLevel{Name: "security"}}}}},
+			options:      plugins.JiraBranchOptions{AllowedSecurityLevels: []string{"internal"}},
+			prs:          []github.PullRequest{{Number: base.number, Body: base.body, Title: base.title}},
+			// there should be no comment returned in this test case
+		}, {
+			name:           "Bug with security level on repo with no allowed security levels results in comment on /jira refresh",
+			projectCache:   &threadsafeSet{data: sets.NewString("ocpbugs")},
+			issues:         []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{Unknowns: tcontainer.MarshalMap{"security": jiraclient.SecurityLevel{Name: "security"}}}}},
+			prs:            []github.PullRequest{{Number: base.number, Body: base.body, Title: base.title}},
+			body:           "/jira refresh",
+			isComment:      true,
+			expectedLabels: []string{"jira/valid-bug"},
+			expectedComment: `org/repo#1:@user: This pull request references [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123), which is valid.
+
+<details><summary>No validations were run on this bug</summary></details>
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>/jira refresh
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		}, {
+			name:         "Bug with non-allowed security level results in comment on /jira refresh",
+			projectCache: &threadsafeSet{data: sets.NewString("ocpbugs")},
+			issues:       []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{Unknowns: tcontainer.MarshalMap{"security": jiraclient.SecurityLevel{Name: "security"}}}}},
+			prs:          []github.PullRequest{{Number: base.number, Body: base.body, Title: base.title}},
+			body:         "/jira refresh",
+			isComment:    true,
+			options:      plugins.JiraBranchOptions{AllowedSecurityLevels: []string{"internal"}},
+			expectedComment: `org/repo#1:@user: [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123) is in a security level that is not in the allowed security levels for this repo.
+Allowed security levels for this repo are:
+- internal
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>/jira refresh
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		}, {
+			name:         "Bug with non-allowed security level results in comment on PR creation",
+			projectCache: &threadsafeSet{data: sets.NewString("ocpbugs")},
+			issues:       []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{Unknowns: tcontainer.MarshalMap{"security": jiraclient.SecurityLevel{Name: "security"}}}}},
+			prs:          []github.PullRequest{{Number: base.number, Body: base.body, Title: base.title}},
+			body:         "/jira refresh",
+			isComment:    true,
+			opened:       true,
+			options:      plugins.JiraBranchOptions{AllowedSecurityLevels: []string{"internal"}},
+			expectedComment: `org/repo#1:@user: [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123) is in a security level that is not in the allowed security levels for this repo.
+Allowed security levels for this repo are:
+- internal
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>/jira refresh
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		}, {
+			name:         "Bug with allowed group is properly handled",
+			projectCache: &threadsafeSet{data: sets.NewString("ocpbugs")},
+			issues: []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{Unknowns: tcontainer.MarshalMap{
+				"security":             jiraclient.SecurityLevel{Name: "security"},
+				"customfield_12316142": severityModerate,
+			}}}},
+			options:        plugins.JiraBranchOptions{StateAfterValidation: &updated, AllowedSecurityLevels: []string{"security"}},
+			labels:         []string{"jira/invalid-bug"},
+			expectedLabels: []string{"jira/valid-bug", "jira/severity-moderate"},
+			expectedComment: `org/repo#1:@user: This pull request references [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123), which is valid. The bug has been moved to the UPDATED state.
+
+<details><summary>No validations were run on this bug</summary></details>
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+			expectedIssue: &jira.Issue{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
+				Unknowns: tcontainer.MarshalMap{
+					"security":             jiraclient.SecurityLevel{Name: "security"},
+					"customfield_12316142": severityModerate,
+				}, Status: &jira.Status{Name: "UPDATED"},
+			}},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// convert []jira.Issue to []*jira.Issue
 			var ptrIssues []*jira.Issue
-			for index := range tc.existingIssues {
-				ptrIssues = append(ptrIssues, &tc.existingIssues[index])
+			for index := range tc.issues {
+				ptrIssues = append(ptrIssues, &tc.issues[index])
 			}
 			jiraClient := &fakejira.FakeClient{
-				Issues:        ptrIssues,
-				ExistingLinks: tc.existingLinks,
-				GetIssueError: tc.getIssueClientError,
+				Issues:           ptrIssues,
+				ExistingLinks:    tc.remoteLinks,
+				GetIssueError:    tc.issueGetErrors,
+				CreateIssueError: tc.issueCreateErrors,
+				UpdateIssueError: tc.issueUpdateErrors,
+				Transitions:      jiraTransitions,
 			}
-			githubClient := fakegithub.NewFakeClient()
-
-			if err := handleWithProjectCache(jiraClient, githubClient, tc.cfg, logrus.NewEntry(logrus.New()), &tc.event, tc.projectCache); err != nil {
+			var testEvent event // copy so parallel tests don't collide
+			if tc.overrideEvent != nil {
+				testEvent = *tc.overrideEvent
+			} else {
+				testEvent = *base // copy so parallel tests don't collide
+			}
+			testEvent.missing = tc.missing
+			testEvent.merged = tc.merged
+			testEvent.closed = tc.closed || tc.merged
+			testEvent.opened = tc.opened
+			testEvent.cherrypick = tc.cherryPick
+			testEvent.cherrypickFromPRNum = tc.cherryPickFromPRNum
+			testEvent.cherrypickTo = tc.cherryPickTo
+			if tc.body != "" {
+				testEvent.body = tc.body
+			}
+			if tc.title != "" {
+				testEvent.title = tc.title
+			}
+			gc := fakegithub.NewFakeClient()
+			gc.IssueLabelsExisting = []string{}
+			gc.IssueComments = map[int][]github.IssueComment{}
+			gc.PullRequests = map[int]*github.PullRequest{}
+			gc.WasLabelAddedByHumanVal = tc.humanLabelled
+			for _, label := range tc.labels {
+				gc.IssueLabelsExisting = append(gc.IssueLabelsExisting, fmt.Sprintf("%s/%s#%d:%s", testEvent.org, testEvent.repo, testEvent.number, label))
+			}
+			for _, pr := range tc.prs {
+				pr := pr
+				gc.PullRequests[pr.Number] = &pr
+			}
+			if err := handleWithProjectCache(jiraClient, gc, tc.disabledProjects, tc.options, logrus.WithField("testCase", tc.name), testEvent, sets.NewString("org/repo"), tc.projectCache); err != nil {
 				t.Fatalf("handle failed: %v", err)
 			}
 
-			if diff := cmp.Diff(jiraClient.NewLinks, tc.expectedNewLinks); diff != "" {
+			if diff := cmp.Diff(jiraClient.NewLinks, tc.expectedNewRemoteLinks); diff != "" {
 				t.Errorf("new links differs from expected new links: %s", diff)
 			}
 
-			if diff := cmp.Diff(githubClient.IssueCommentsEdited, tc.expectedCommentUpdates); diff != "" {
+			if diff := cmp.Diff(jiraClient.RemovedLinks, tc.expectedRemovedRemoteLinks); diff != "" {
+				t.Errorf("removed links differs from expected removed links: %s", diff)
+			}
+
+			if diff := cmp.Diff(gc.IssueCommentsEdited, tc.expectedCommentUpdates); diff != "" {
 				t.Errorf("comment updates differ from expected: %s", diff)
+			}
+
+			checkComments(gc, tc.name, tc.expectedComment, t)
+
+			expected := sets.NewString()
+			for _, label := range tc.expectedLabels {
+				expected.Insert(fmt.Sprintf("%s/%s#%d:%s", testEvent.org, testEvent.repo, testEvent.number, label))
+			}
+
+			actual := sets.NewString(gc.IssueLabelsExisting...)
+			actual.Insert(gc.IssueLabelsAdded...)
+			actual.Delete(gc.IssueLabelsRemoved...)
+
+			if missing := expected.Difference(actual); missing.Len() > 0 {
+				t.Errorf("%s: missing expected labels: %v", tc.name, missing.List())
+			}
+			if extra := actual.Difference(expected); extra.Len() > 0 {
+				t.Errorf("%s: unexpected labels: %v", tc.name, extra.List())
+			}
+
+			// reset errors on client for verification
+			jiraClient.CreateIssueError = nil
+			jiraClient.GetIssueError = nil
+			if tc.expectedIssue != nil {
+				actual, err := jiraClient.GetIssue(tc.expectedIssue.ID)
+				if err != nil {
+					t.Errorf("%s: failed to get expected bug during test: %v", tc.name, err)
+				}
+				if !reflect.DeepEqual(actual, tc.expectedIssue) {
+					t.Errorf("%s: got incorrect bug after update: %s", tc.name, cmp.Diff(actual, tc.expectedIssue, allowEventAndDate))
+				}
 			}
 		})
 	}
+}
 
+func checkComments(client *fakegithub.FakeClient, name, expectedComment string, t *testing.T) {
+	wantedComments := 0
+	if expectedComment != "" {
+		wantedComments = 1
+	}
+	if len(client.IssueCommentsAdded) != wantedComments {
+		t.Errorf("%s: wanted %d comment, got %d: %v", name, wantedComments, len(client.IssueCommentsAdded), client.IssueCommentsAdded)
+	}
+
+	if expectedComment != "" && len(client.IssueCommentsAdded) == 1 {
+		if expectedComment != client.IssueCommentsAdded[0] {
+			t.Errorf("%s: got incorrect comment: %v", name, cmp.Diff(expectedComment, client.IssueCommentsAdded[0]))
+		}
+	}
 }
 
 func intPtr(i int) *int {
@@ -493,7 +1958,7 @@ func TestProjectCachingJiraClient(t *testing.T) {
 			client:         &fakejira.FakeClient{},
 			issueToRequest: "issue-123",
 			cache:          &threadsafeSet{data: sets.String{}},
-			expectedError:  jiraclient.NewNotFoundError(errors.New("404 from cache")),
+			expectedError:  jiraclient.NewNotFoundError(errors.New("404 from cache for key issue-123, project name issue")),
 		},
 		{
 			name:           "Success",
@@ -521,5 +1986,1234 @@ func TestProjectCachingJiraClient(t *testing.T) {
 				t.Fatalf("expected error differs from expected: %s", diff)
 			}
 		})
+	}
+}
+
+func TestHelpProvider(t *testing.T) {
+	rawConfig := `disabled_jira_projects:
+- "private-project"
+default:
+  "*":
+    target_version: global-default
+  "global-branch":
+    is_open: false
+    target_version: global-branch-default
+orgs:
+  my-org:
+    default:
+      "*":
+        is_open: true
+        target_version: my-org-default
+        state_after_validation:
+          status: "PRE"
+      "my-org-branch":
+        target_version: my-org-branch-default
+        state_after_validation:
+          status: "POST"
+        add_external_link: true
+    repos:
+      my-repo:
+        branches:
+          "*":
+            is_open: false
+            target_version: my-repo-default
+            valid_states:
+            - status: VALIDATED
+          "my-repo-branch":
+            target_version: my-repo-branch
+            valid_states:
+            - status: MODIFIED
+            add_external_link: true
+            state_after_merge:
+              status: MODIFIED
+            allowed_security_levels:
+            - default
+          "branch-that-likes-closed-bugs":
+            valid_states:
+            - status: VERIFIED
+            - status: CLOSED
+              resolution: ERRATA
+            dependent_bug_states:
+            - status: CLOSED
+              resolution: ERRATA
+            state_after_merge:
+              status: CLOSED
+              resolution: FIXED
+            state_after_validation:
+              status: CLOSED
+              resolution: VALIDATED`
+
+	var config plugins.Jira
+	if err := yaml.Unmarshal([]byte(rawConfig), &config); err != nil {
+		t.Fatalf("couldn't unmarshal config: %v", err)
+	}
+
+	pc := &plugins.Configuration{Jira: config}
+	enabledRepos := []prowconfig.OrgRepo{
+		{Org: "some-org", Repo: "some-repo"},
+		{Org: "my-org", Repo: "some-repo"},
+		{Org: "my-org", Repo: "my-repo"},
+	}
+	help, err := helpProvider(pc, enabledRepos)
+	if err != nil {
+		t.Fatalf("unexpected error creating help provider: %v", err)
+	}
+	// don't check snippet
+	help.Snippet = ""
+
+	expected := &pluginhelp.PluginHelp{
+		Description: "The jira plugin ensures that pull requests reference a valid Jira bug in their title.",
+		Config: map[string]string{
+			"some-org/some-repo": `The plugin has the following configuration:<ul>
+<li>by default, valid bugs must target the "global-default" version.</li>
+<li>on the "global-branch" branch, valid bugs must be closed and target the "global-branch-default" version.</li>
+</ul>`,
+			"my-org/some-repo": `The plugin has the following configuration:<ul>
+<li>by default, valid bugs must be open and target the "my-org-default" version. After being linked to a pull request, bugs will be moved to the PRE state.</li>
+<li>on the "my-org-branch" branch, valid bugs must be open and target the "my-org-branch-default" version. After being linked to a pull request, bugs will be moved to the POST state and updated to refer to the pull request using the external bug tracker.</li>
+</ul>`,
+			"my-org/my-repo": `The plugin has the following configuration:<ul>
+<li>by default, valid bugs must be closed, target the "my-repo-default" version, and be in one of the following states: VALIDATED. After being linked to a pull request, bugs will be moved to the PRE state.</li>
+<li>on the "branch-that-likes-closed-bugs" branch, valid bugs must be closed, target the "my-repo-default" version, be in one of the following states: VERIFIED, CLOSED (ERRATA), depend on at least one other bug, and have all dependent bugs in one of the following states: CLOSED (ERRATA). After being linked to a pull request, bugs will be moved to the CLOSED (VALIDATED) state and moved to the CLOSED (FIXED) state when all linked pull requests are merged.</li>
+<li>on the "my-org-branch" branch, valid bugs must be closed, target the "my-repo-default" version, and be in one of the following states: VALIDATED. After being linked to a pull request, bugs will be moved to the POST state and updated to refer to the pull request using the external bug tracker.</li>
+<li>on the "my-repo-branch" branch, valid bugs must be closed, target the "my-repo-branch" version, and be in one of the following states: MODIFIED. After being linked to a pull request, bugs will be moved to the PRE state, updated to refer to the pull request using the external bug tracker, and moved to the MODIFIED state when all linked pull requests are merged.</li>
+</ul>`,
+		},
+		Commands: []pluginhelp.Command{
+			{
+				Usage:       "/jira refresh",
+				Description: "Check Jira for a valid bug referenced in the PR title",
+				Featured:    false,
+				WhoCanUse:   "Anyone",
+				Examples:    []string{"/jira refresh"},
+			}, {
+				Usage:       "/jira cc-qa",
+				Description: "Request PR review from QA contact specified in Jira",
+				Featured:    false,
+				WhoCanUse:   "Anyone",
+				Examples:    []string{"/jira cc-qa"},
+			},
+		},
+	}
+
+	if actual := help; !reflect.DeepEqual(actual, expected) {
+		t.Errorf("resolved incorrect plugin help: %v", cmp.Diff(actual, expected, allowEventAndDate))
+	}
+}
+
+func TestDigestPR(t *testing.T) {
+	yes := true
+	var testCases = []struct {
+		name              string
+		pre               github.PullRequestEvent
+		validateByDefault *bool
+		expected          *event
+		expectedErr       bool
+	}{
+		{
+			name: "unrelated event gets ignored",
+			pre: github.PullRequestEvent{
+				Action: github.PullRequestFileAdded,
+				PullRequest: github.PullRequest{
+					Base: github.PullRequestBranch{
+						Repo: github.Repo{
+							Owner: github.User{
+								Login: "org",
+							},
+							Name: "repo",
+						},
+						Ref: "branch",
+					},
+					Number: 1,
+					Title:  "OCPBUGS-123: fixed it!",
+					State:  "open",
+				},
+			},
+		},
+		{
+			name: "unrelated title gets ignored",
+			pre: github.PullRequestEvent{
+				Action: github.PullRequestActionOpened,
+				PullRequest: github.PullRequest{
+					Base: github.PullRequestBranch{
+						Repo: github.Repo{
+							Owner: github.User{
+								Login: "org",
+							},
+							Name: "repo",
+						},
+						Ref: "branch",
+					},
+					Number: 1,
+					Title:  "fixing a typo",
+					State:  "open",
+				},
+			},
+		},
+		{
+			name: "unrelated title gets handled when validating by default",
+			pre: github.PullRequestEvent{
+				Action: github.PullRequestActionOpened,
+				PullRequest: github.PullRequest{
+					Base: github.PullRequestBranch{
+						Repo: github.Repo{
+							Owner: github.User{
+								Login: "org",
+							},
+							Name: "repo",
+						},
+						Ref: "branch",
+					},
+					Number:  1,
+					Title:   "fixing a typo",
+					State:   "open",
+					HTMLURL: "http.com",
+					User: github.User{
+						Login: "user",
+					},
+				},
+			},
+			validateByDefault: &yes,
+			expected: &event{
+				org: "org", repo: "repo", baseRef: "branch", number: 1, state: "open", missing: true, opened: true, key: "", title: "fixing a typo", htmlUrl: "http.com", login: "user",
+			},
+		},
+		{
+			name: "title referencing bug gets an event",
+			pre: github.PullRequestEvent{
+				Action: github.PullRequestActionOpened,
+				PullRequest: github.PullRequest{
+					Base: github.PullRequestBranch{
+						Repo: github.Repo{
+							Owner: github.User{
+								Login: "org",
+							},
+							Name: "repo",
+						},
+						Ref: "branch",
+					},
+					Number:  1,
+					Title:   "OCPBUGS-123: fixed it!",
+					State:   "open",
+					HTMLURL: "http.com",
+					User: github.User{
+						Login: "user",
+					},
+				},
+			},
+			expected: &event{
+				org: "org", repo: "repo", baseRef: "branch", number: 1, state: "open", opened: true, key: "OCPBUGS-123", title: "OCPBUGS-123: fixed it!", htmlUrl: "http.com", login: "user",
+			},
+		},
+		{
+			name: "title referencing bug gets an event on PR merge",
+			pre: github.PullRequestEvent{
+				Action: github.PullRequestActionClosed,
+				PullRequest: github.PullRequest{
+					Merged: true,
+					Base: github.PullRequestBranch{
+						Repo: github.Repo{
+							Owner: github.User{
+								Login: "org",
+							},
+							Name: "repo",
+						},
+						Ref: "branch",
+					},
+					Number:  1,
+					Title:   "OCPBUGS-123: fixed it!",
+					HTMLURL: "http.com",
+					User: github.User{
+						Login: "user",
+					},
+				},
+			},
+			expected: &event{
+				org: "org", repo: "repo", baseRef: "branch", number: 1, merged: true, closed: true, key: "OCPBUGS-123", title: "OCPBUGS-123: fixed it!", htmlUrl: "http.com", login: "user",
+			},
+		},
+		{
+			name: "title referencing bug gets an event on PR close",
+			pre: github.PullRequestEvent{
+				Action: github.PullRequestActionClosed,
+				PullRequest: github.PullRequest{
+					Base: github.PullRequestBranch{
+						Repo: github.Repo{
+							Owner: github.User{
+								Login: "org",
+							},
+							Name: "repo",
+						},
+						Ref: "branch",
+					},
+					Number:  1,
+					Title:   "OCPBUGS-123: fixed it!",
+					HTMLURL: "http.com",
+					User: github.User{
+						Login: "user",
+					},
+				},
+			},
+			expected: &event{
+				org: "org", repo: "repo", baseRef: "branch", number: 1, merged: false, closed: true, key: "OCPBUGS-123", title: "OCPBUGS-123: fixed it!", htmlUrl: "http.com", login: "user",
+			},
+		},
+		{
+			name: "non-jira cherrypick PR sets e.missing to true",
+			pre: github.PullRequestEvent{
+				Action: github.PullRequestActionOpened,
+				PullRequest: github.PullRequest{
+					Base: github.PullRequestBranch{
+						Repo: github.Repo{
+							Owner: github.User{
+								Login: "org",
+							},
+							Name: "repo",
+						},
+						Ref: "release-4.4",
+					},
+					Number:  3,
+					Title:   "[release-4.4] fixing a typo",
+					HTMLURL: "http.com",
+					User: github.User{
+						Login: "user",
+					},
+					Body: `This is an automated cherry-pick of #2
+
+/assign user`,
+				},
+			},
+			expected: &event{
+				org: "org", repo: "repo", baseRef: "release-4.4", number: 3, opened: true, body: "This is an automated cherry-pick of #2\n\n/assign user", title: "[release-4.4] fixing a typo", htmlUrl: "http.com", login: "user", cherrypick: true, cherrypickFromPRNum: 2, cherrypickTo: "release-4.4", missing: true,
+			},
+		},
+		{
+			name: "cherrypicked PR gets cherrypick event",
+			pre: github.PullRequestEvent{
+				Action: github.PullRequestActionOpened,
+				PullRequest: github.PullRequest{
+					Base: github.PullRequestBranch{
+						Repo: github.Repo{
+							Owner: github.User{
+								Login: "org",
+							},
+							Name: "repo",
+						},
+						Ref: "release-4.4",
+					},
+					Number:  3,
+					Title:   "[release-4.4] OCPBUGS-123: fixed it!",
+					HTMLURL: "http.com",
+					User: github.User{
+						Login: "user",
+					},
+					Body: `This is an automated cherry-pick of #2
+
+/assign user`,
+				},
+			},
+			expected: &event{
+				org: "org", repo: "repo", baseRef: "release-4.4", number: 3, opened: true, body: "This is an automated cherry-pick of #2\n\n/assign user", title: "[release-4.4] OCPBUGS-123: fixed it!", htmlUrl: "http.com", login: "user", cherrypick: true, cherrypickFromPRNum: 2, cherrypickTo: "release-4.4", key: "OCPBUGS-123",
+			},
+		},
+		{
+			name: "edited cherrypicked PR gets normal event",
+			pre: github.PullRequestEvent{
+				Action: github.PullRequestActionEdited,
+				PullRequest: github.PullRequest{
+					Base: github.PullRequestBranch{
+						Repo: github.Repo{
+							Owner: github.User{
+								Login: "org",
+							},
+							Name: "repo",
+						},
+						Ref: "release-4.4",
+					},
+					Number:  3,
+					Title:   "[release-4.4] OCPBUGS-123: fixed it!",
+					HTMLURL: "http.com",
+					User: github.User{
+						Login: "user",
+					},
+					Body: `This is an automated cherry-pick of #2
+
+/assign user`,
+				},
+			},
+			expected: &event{
+				org: "org", repo: "repo", baseRef: "release-4.4", number: 3, key: "OCPBUGS-123", body: "This is an automated cherry-pick of #2\n\n/assign user", title: "[release-4.4] OCPBUGS-123: fixed it!", htmlUrl: "http.com", login: "user",
+			},
+		},
+		{
+			name: "title change referencing same bug gets no event",
+			pre: github.PullRequestEvent{
+				Action: github.PullRequestActionOpened,
+				PullRequest: github.PullRequest{
+					Base: github.PullRequestBranch{
+						Repo: github.Repo{
+							Owner: github.User{
+								Login: "org",
+							},
+							Name: "repo",
+						},
+						Ref: "branch",
+					},
+					Number:  1,
+					Title:   "OCPBUGS-123: fixed it!",
+					HTMLURL: "http.com",
+					User: github.User{
+						Login: "user",
+					},
+				},
+				Changes: []byte(`{"title":{"from":"OCPBUGS-123: fixed it! (WIP)"}}`),
+			},
+		},
+		{
+			name: "title change referencing new bug gets event",
+			pre: github.PullRequestEvent{
+				Action: github.PullRequestActionOpened,
+				PullRequest: github.PullRequest{
+					Base: github.PullRequestBranch{
+						Repo: github.Repo{
+							Owner: github.User{
+								Login: "org",
+							},
+							Name: "repo",
+						},
+						Ref: "branch",
+					},
+					Number:  1,
+					Title:   "OCPBUGS-123: fixed it!",
+					HTMLURL: "http.com",
+					User: github.User{
+						Login: "user",
+					},
+				},
+				Changes: []byte(`{"title":{"from":"fixed it! (WIP)"}}`),
+			},
+			expected: &event{
+				org: "org", repo: "repo", baseRef: "branch", number: 1, opened: true, key: "OCPBUGS-123", title: "OCPBUGS-123: fixed it!", htmlUrl: "http.com", login: "user",
+			},
+		},
+		{
+			name: "title change dereferencing bug gets event",
+			pre: github.PullRequestEvent{
+				Action: github.PullRequestActionOpened,
+				PullRequest: github.PullRequest{
+					Base: github.PullRequestBranch{
+						Repo: github.Repo{
+							Owner: github.User{
+								Login: "org",
+							},
+							Name: "repo",
+						},
+						Ref: "branch",
+					},
+					Number:  1,
+					Title:   "fixed it!",
+					HTMLURL: "http.com",
+					User: github.User{
+						Login: "user",
+					},
+				},
+				Changes: []byte(`{"title":{"from":"OCPBUGS-123: fixed it! (WIP)"}}`),
+			},
+			expected: &event{
+				org: "org", repo: "repo", baseRef: "branch", number: 1, opened: true, missing: true, title: "fixed it!", htmlUrl: "http.com", login: "user",
+			},
+		},
+		{
+			name: "title change to no bug with unrelated changes gets no event",
+			pre: github.PullRequestEvent{
+				Action: github.PullRequestActionOpened,
+				PullRequest: github.PullRequest{
+					Base: github.PullRequestBranch{
+						Repo: github.Repo{
+							Owner: github.User{
+								Login: "org",
+							},
+							Name: "repo",
+						},
+						Ref: "branch",
+					},
+					Number:  1,
+					Title:   "fixed it!",
+					HTMLURL: "http.com",
+					User: github.User{
+						Login: "user",
+					},
+				},
+				Changes: []byte(`{"oops":{"doops":"payload"}}`),
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			event, err := digestPR(logrus.WithField("testCase", testCase.name), testCase.pre, testCase.validateByDefault)
+			if err == nil && testCase.expectedErr {
+				t.Errorf("%s: expected an error but got none", testCase.name)
+			}
+			if err != nil && !testCase.expectedErr {
+				t.Errorf("%s: expected no error but got one: %v", testCase.name, err)
+			}
+
+			if actual, expected := event, testCase.expected; !reflect.DeepEqual(actual, expected) {
+				t.Errorf("%s: did not get correct event: %v", testCase.name, cmp.Diff(actual, expected, allowEventAndDate))
+			}
+		})
+	}
+}
+
+func TestDigestComment(t *testing.T) {
+	var testCases = []struct {
+		name            string
+		e               github.GenericCommentEvent
+		title           string
+		merged          bool
+		expected        *event
+		expectedComment string
+		expectedErr     bool
+	}{
+		{
+			name: "unrelated event gets ignored",
+			e: github.GenericCommentEvent{
+				Action: github.GenericCommentActionDeleted,
+				IsPR:   true,
+				Body:   "/jira refresh",
+				Repo: github.Repo{
+					Owner: github.User{
+						Login: "org",
+					},
+					Name: "repo",
+				},
+				Number: 1,
+			},
+			title: "OCPBUGS-123: oopsie doopsie",
+		},
+		{
+			name: "unrelated title gets an event saying so",
+			e: github.GenericCommentEvent{
+				Action: github.GenericCommentActionCreated,
+				IsPR:   true,
+				Body:   "/jira refresh",
+				Repo: github.Repo{
+					Owner: github.User{
+						Login: "org",
+					},
+					Name: "repo",
+				},
+				Number: 1,
+				User: github.User{
+					Login: "user",
+				},
+				HTMLURL: "www.com",
+			},
+			title: "cole, please review this typo fix",
+			expected: &event{
+				org: "org", repo: "repo", baseRef: "branch", number: 1, missing: true, body: "/jira refresh", htmlUrl: "www.com", login: "user", cc: false, isComment: true,
+			},
+		},
+		{
+			name: "comment on issue gets no event but a comment",
+			e: github.GenericCommentEvent{
+				Action: github.GenericCommentActionCreated,
+				IsPR:   false,
+				Body:   "/jira refresh",
+				Repo: github.Repo{
+					Owner: github.User{
+						Login: "org",
+					},
+					Name: "repo",
+				},
+				Number: 1,
+			},
+			title: "someone misspelled words in this repo",
+			expectedComment: `org/repo#1:@: Jira bug referencing is only supported for Pull Requests, not issues.
+
+<details>
+
+In response to [this]():
+
+>/jira refresh
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		},
+		{
+			name: "title referencing bug gets an event",
+			e: github.GenericCommentEvent{
+				Action: github.GenericCommentActionCreated,
+				IsPR:   true,
+				Body:   "/jira refresh",
+				Repo: github.Repo{
+					Owner: github.User{
+						Login: "org",
+					},
+					Name: "repo",
+				},
+				Number: 1,
+				User: github.User{
+					Login: "user",
+				},
+				HTMLURL: "www.com",
+			},
+			title: "OCPBUGS-123: oopsie doopsie",
+			expected: &event{
+				org: "org", repo: "repo", baseRef: "branch", number: 1, key: "OCPBUGS-123", body: "/jira refresh", htmlUrl: "www.com", login: "user", cc: false, isComment: true,
+			},
+		},
+		{
+			name: "title referencing bug in a merged PR gets an event",
+			e: github.GenericCommentEvent{
+				Action: github.GenericCommentActionCreated,
+				IsPR:   true,
+				Body:   "/jira refresh",
+				Repo: github.Repo{
+					Owner: github.User{
+						Login: "org",
+					},
+					Name: "repo",
+				},
+				Number: 1,
+				User: github.User{
+					Login: "user",
+				},
+				HTMLURL: "www.com",
+			},
+			title:  "OCPBUGS-123: oopsie doopsie",
+			merged: true,
+			expected: &event{
+				org: "org", repo: "repo", baseRef: "branch", number: 1, key: "OCPBUGS-123", merged: true, body: "/jira refresh", htmlUrl: "www.com", login: "user", cc: false, isComment: true,
+			},
+		},
+		{
+			name: "cc-qa comment event has cc bool set to true",
+			e: github.GenericCommentEvent{
+				Action: github.GenericCommentActionCreated,
+				IsPR:   true,
+				Body:   "/jira cc-qa",
+				Repo: github.Repo{
+					Owner: github.User{
+						Login: "org",
+					},
+					Name: "repo",
+				},
+				Number: 1,
+				User: github.User{
+					Login: "user",
+				},
+				HTMLURL: "www.com",
+			},
+			title: "OCPBUGS-123: oopsie doopsie",
+			expected: &event{
+				org: "org", repo: "repo", baseRef: "branch", number: 1, key: "OCPBUGS-123", body: "/jira cc-qa", htmlUrl: "www.com", login: "user", cc: true, isComment: true,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			client := fakegithub.NewFakeClient()
+			client.PullRequests = map[int]*github.PullRequest{
+				1: {Base: github.PullRequestBranch{Ref: "branch"}, Title: testCase.title, Merged: testCase.merged},
+			}
+			event, err := digestComment(client, logrus.WithField("testCase", testCase.name), testCase.e)
+			if err == nil && testCase.expectedErr {
+				t.Errorf("%s: expected an error but got none", testCase.name)
+			}
+			if err != nil && !testCase.expectedErr {
+				t.Errorf("%s: expected no error but got one: %v", testCase.name, err)
+			}
+
+			if actual, expected := event, testCase.expected; !reflect.DeepEqual(actual, expected) {
+				t.Errorf("%s: did not get correct event: %v", testCase.name, cmp.Diff(actual, expected, allowEventAndDate))
+			}
+
+			checkComments(client, testCase.name, testCase.expectedComment, t)
+		})
+	}
+}
+
+func TestBugKeyFromTitle(t *testing.T) {
+	var testCases = []struct {
+		title            string
+		expectedKey      string
+		expectedNotFound bool
+	}{
+		{
+			title:            "no match",
+			expectedKey:      "",
+			expectedNotFound: true,
+		},
+		{
+			title:       "OCPBUGS-12: Canonical",
+			expectedKey: "OCPBUGS-12",
+		},
+		{
+			title:            "OCPBUGS-12 : Space before colon",
+			expectedKey:      "",
+			expectedNotFound: true,
+		},
+		{
+			title:       "[rebase release-1.0] OCPBUGS-12: Prefix",
+			expectedKey: "OCPBUGS-12",
+		},
+		{
+			title:       "Revert: \"OCPBUGS-12: Revert default\"",
+			expectedKey: "OCPBUGS-12",
+		},
+		{
+			title:       "OCPBUGS-34: Revert: \"OCPBUGS-12: Revert default\"",
+			expectedKey: "OCPBUGS-34",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.title, func(t *testing.T) {
+			key, notFound, err := bugKeyFromTitle(testCase.title)
+			if err != nil {
+				t.Errorf("%s: Unexpected error: %v", testCase.title, err)
+			}
+			if key != testCase.expectedKey {
+				t.Errorf("%s: unexpected %s != %s", testCase.title, key, testCase.expectedKey)
+			}
+			if notFound != testCase.expectedNotFound {
+				t.Errorf("%s: unexpected %t != %t", testCase.title, notFound, testCase.expectedNotFound)
+			}
+		})
+	}
+}
+
+func TestValidateBug(t *testing.T) {
+	open, closed := true, false
+	oneStr, twoStr := "v1", "v2"
+	one := []*jira.Version{{Name: "v1"}}
+	two := []*jira.Version{{Name: "v2"}}
+	verified := []plugins.JiraBugState{{Status: "VERIFIED"}}
+	modified := []plugins.JiraBugState{{Status: "MODIFIED"}}
+	updated := plugins.JiraBugState{Status: "UPDATED"}
+	var testCases = []struct {
+		name        string
+		issue       *jira.Issue
+		dependents  []*jira.Issue
+		options     plugins.JiraBranchOptions
+		valid       bool
+		validations []string
+		why         []string
+	}{
+		{
+			name:    "no requirements means a valid bug",
+			issue:   &jira.Issue{Fields: &jira.IssueFields{}},
+			options: plugins.JiraBranchOptions{},
+			valid:   true,
+		},
+		{
+			name:        "matching open requirement means a valid bug",
+			issue:       &jira.Issue{Fields: &jira.IssueFields{Status: &jira.Status{Name: "NEW"}}},
+			options:     plugins.JiraBranchOptions{IsOpen: &open},
+			valid:       true,
+			validations: []string{"bug is open, matching expected state (open)"},
+		},
+		{
+			name:        "matching closed requirement means a valid bug",
+			issue:       &jira.Issue{Fields: &jira.IssueFields{Status: &jira.Status{Name: "CLOSED"}}},
+			options:     plugins.JiraBranchOptions{IsOpen: &closed},
+			valid:       true,
+			validations: []string{"bug isn't open, matching expected state (not open)"},
+		},
+		{
+			name:    "not matching open requirement means an invalid bug",
+			issue:   &jira.Issue{Fields: &jira.IssueFields{Status: &jira.Status{Name: "CLOSED"}}},
+			options: plugins.JiraBranchOptions{IsOpen: &open},
+			valid:   false,
+			why:     []string{"expected the bug to be open, but it isn't"},
+		},
+		{
+			name:    "not matching closed requirement means an invalid bug",
+			issue:   &jira.Issue{Fields: &jira.IssueFields{Status: &jira.Status{Name: "NEW"}}},
+			options: plugins.JiraBranchOptions{IsOpen: &closed},
+			valid:   false,
+			why:     []string{"expected the bug to not be open, but it is"},
+		},
+		{
+			name: "matching target version requirement means a valid bug",
+			issue: &jira.Issue{Fields: &jira.IssueFields{
+				Unknowns: tcontainer.MarshalMap{
+					"customfield_12319940": &one,
+				},
+			}},
+			options:     plugins.JiraBranchOptions{TargetVersion: &oneStr},
+			valid:       true,
+			validations: []string{"bug target version (v1) matches configured target version for branch (v1)"},
+		},
+		{
+			name: "not matching target version requirement means an invalid bug",
+			issue: &jira.Issue{Fields: &jira.IssueFields{
+				Unknowns: tcontainer.MarshalMap{
+					"customfield_12319940": &two,
+				},
+			}},
+			options: plugins.JiraBranchOptions{TargetVersion: &oneStr},
+			valid:   false,
+			why:     []string{"expected the bug to target the \"v1\" version, but it targets \"v2\" instead"},
+		},
+		{
+			name:    "not setting target version requirement means an invalid bug",
+			issue:   &jira.Issue{Fields: &jira.IssueFields{}},
+			options: plugins.JiraBranchOptions{TargetVersion: &oneStr},
+			valid:   false,
+			why:     []string{"expected the bug to target the \"v1\" version, but no target version was set"},
+		},
+		{
+			name:        "matching status requirement means a valid bug",
+			issue:       &jira.Issue{Fields: &jira.IssueFields{Status: &jira.Status{Name: "MODIFIED"}}},
+			options:     plugins.JiraBranchOptions{ValidStates: &modified},
+			valid:       true,
+			validations: []string{"bug is in the state MODIFIED, which is one of the valid states (MODIFIED)"},
+		},
+		{
+			name:        "matching status requirement by being in the migrated state means a valid bug",
+			issue:       &jira.Issue{Fields: &jira.IssueFields{Status: &jira.Status{Name: "UPDATED"}}},
+			options:     plugins.JiraBranchOptions{ValidStates: &modified, StateAfterValidation: &updated},
+			valid:       true,
+			validations: []string{"bug is in the state UPDATED, which is one of the valid states (MODIFIED, UPDATED)"},
+		},
+		{
+			name:    "not matching status requirement means an invalid bug",
+			issue:   &jira.Issue{Fields: &jira.IssueFields{Status: &jira.Status{Name: "MODIFIED"}}},
+			options: plugins.JiraBranchOptions{ValidStates: &verified},
+			valid:   false,
+			why:     []string{"expected the bug to be in one of the following states: VERIFIED, but it is MODIFIED instead"},
+		},
+		{
+			name:    "dependent status requirement with no dependent bugs means a valid bug",
+			issue:   &jira.Issue{Key: "OCPBUGS-123", Fields: &jira.IssueFields{}},
+			options: plugins.JiraBranchOptions{DependentBugStates: &verified},
+			valid:   false,
+			why:     []string{"expected [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123) to depend on a bug in one of the following states: VERIFIED, but no dependents were found"},
+		},
+		{
+			name: "not matching dependent bug status requirement means an invalid bug",
+			issue: &jira.Issue{Fields: &jira.IssueFields{
+				IssueLinks: []*jira.IssueLink{{
+					Type: jira.IssueLinkType{
+						Name:    "Cloners",
+						Inward:  "is cloned by",
+						Outward: "clones",
+					},
+					OutwardIssue: &jira.Issue{ID: "2", Key: "OCPBUGS-124"},
+				}},
+			}},
+			dependents:  []*jira.Issue{{ID: "2", Key: "OCPBUGS-124", Fields: &jira.IssueFields{Status: &jira.Status{Name: "MODIFIED"}}}},
+			options:     plugins.JiraBranchOptions{DependentBugStates: &verified},
+			valid:       false,
+			validations: []string{"bug has dependents"},
+			why:         []string{"expected dependent [Jira Issue OCPBUGS-124](https://my-jira.com/browse/OCPBUGS-124) to be in one of the following states: VERIFIED, but it is MODIFIED instead"},
+		},
+		{
+			name: "not matching dependent bug target version requirement means an invalid bug",
+			issue: &jira.Issue{Fields: &jira.IssueFields{
+				IssueLinks: []*jira.IssueLink{{
+					Type: jira.IssueLinkType{
+						Name:    "Cloners",
+						Inward:  "is cloned by",
+						Outward: "clones",
+					},
+					OutwardIssue: &jira.Issue{ID: "2", Key: "OCPBUGS-124"},
+				}},
+			}},
+			dependents: []*jira.Issue{{ID: "2", Key: "OCPBUGS-124", Fields: &jira.IssueFields{
+				Status: &jira.Status{Name: "MODIFIED"},
+				Unknowns: tcontainer.MarshalMap{
+					"customfield_12319940": &two,
+				},
+			}}},
+			options:     plugins.JiraBranchOptions{DependentBugTargetVersions: &[]string{oneStr}},
+			valid:       false,
+			validations: []string{"bug has dependents"},
+			why:         []string{"expected dependent [Jira Issue OCPBUGS-124](https://my-jira.com/browse/OCPBUGS-124) to target a version in v1, but it targets \"v2\" instead"},
+		},
+		{
+			name: "not having a dependent bug target version means an invalid bug",
+			issue: &jira.Issue{Fields: &jira.IssueFields{
+				IssueLinks: []*jira.IssueLink{{
+					Type: jira.IssueLinkType{
+						Name:    "Cloners",
+						Inward:  "is cloned by",
+						Outward: "clones",
+					},
+					OutwardIssue: &jira.Issue{ID: "2", Key: "OCPBUGS-124"},
+				}},
+			}},
+			dependents:  []*jira.Issue{{ID: "2", Key: "OCPBUGS-124", Fields: &jira.IssueFields{Status: &jira.Status{Name: "MODIFIED"}}}},
+			options:     plugins.JiraBranchOptions{DependentBugTargetVersions: &[]string{oneStr}},
+			valid:       false,
+			validations: []string{"bug has dependents"},
+			why:         []string{"expected dependent [Jira Issue OCPBUGS-124](https://my-jira.com/browse/OCPBUGS-124) to target a version in v1, but no target version was set"},
+		},
+		{
+			name: "matching all requirements means a valid bug",
+			issue: &jira.Issue{Fields: &jira.IssueFields{
+				Status: &jira.Status{Name: "MODIFIED"},
+				IssueLinks: []*jira.IssueLink{{
+					Type: jira.IssueLinkType{
+						Name:    "Cloners",
+						Inward:  "is cloned by",
+						Outward: "clones",
+					},
+					OutwardIssue: &jira.Issue{ID: "2", Key: "OCPBUGS-124"},
+				}},
+				Unknowns: tcontainer.MarshalMap{
+					"customfield_12319940": &one,
+				},
+			}},
+			dependents: []*jira.Issue{{ID: "2", Key: "OCPBUGS-124", Fields: &jira.IssueFields{
+				Status: &jira.Status{Name: "MODIFIED"},
+				Unknowns: tcontainer.MarshalMap{
+					"customfield_12319940": &two,
+				},
+			}}},
+			options: plugins.JiraBranchOptions{IsOpen: &open, TargetVersion: &oneStr, ValidStates: &modified, DependentBugStates: &modified, DependentBugTargetVersions: &[]string{twoStr}},
+			validations: []string{`bug is open, matching expected state (open)`,
+				`bug target version (v1) matches configured target version for branch (v1)`,
+				"bug is in the state MODIFIED, which is one of the valid states (MODIFIED)",
+				"dependent bug [Jira Issue OCPBUGS-124](https://my-jira.com/browse/OCPBUGS-124) is in the state MODIFIED, which is one of the valid states (MODIFIED)",
+				`dependent [Jira Issue OCPBUGS-124](https://my-jira.com/browse/OCPBUGS-124) targets the "v2" version, which is one of the valid target versions: v2`,
+				"bug has dependents"},
+			valid: true,
+		},
+		{
+			name: "matching no requirements means an invalid bug",
+			issue: &jira.Issue{Fields: &jira.IssueFields{
+				Status: &jira.Status{Name: "CLOSED"},
+				IssueLinks: []*jira.IssueLink{{
+					Type: jira.IssueLinkType{
+						Name:    "Cloners",
+						Inward:  "is cloned by",
+						Outward: "clones",
+					},
+					OutwardIssue: &jira.Issue{ID: "2", Key: "OCPBUGS-124"},
+				}},
+				Unknowns: tcontainer.MarshalMap{
+					"customfield_12319940": &one,
+				},
+			}},
+			dependents:  []*jira.Issue{{ID: "2", Key: "OCPBUGS-124", Fields: &jira.IssueFields{Status: &jira.Status{Name: "MODIFIED"}}}},
+			options:     plugins.JiraBranchOptions{IsOpen: &open, TargetVersion: &twoStr, ValidStates: &verified, DependentBugStates: &verified},
+			valid:       false,
+			validations: []string{"bug has dependents"},
+			why: []string{"expected the bug to be open, but it isn't",
+				"expected the bug to target the \"v2\" version, but it targets \"v1\" instead",
+				"expected the bug to be in one of the following states: VERIFIED, but it is CLOSED instead",
+				"expected dependent [Jira Issue OCPBUGS-124](https://my-jira.com/browse/OCPBUGS-124) to be in one of the following states: VERIFIED, but it is MODIFIED instead",
+			},
+		},
+		{
+			name: "matching status means a valid bug when resolution is not required",
+			issue: &jira.Issue{Fields: &jira.IssueFields{
+				Status:     &jira.Status{Name: "CLOSED"},
+				Resolution: &jira.Resolution{Name: "LOL_GO_AWAY"},
+			}},
+			options:     plugins.JiraBranchOptions{ValidStates: &[]plugins.JiraBugState{{Status: "CLOSED"}}},
+			valid:       true,
+			validations: []string{"bug is in the state CLOSED (LOL_GO_AWAY), which is one of the valid states (CLOSED)"},
+		},
+		{
+			name: "matching just status means an invalid bug when resolution does not match",
+			issue: &jira.Issue{Fields: &jira.IssueFields{
+				Status:     &jira.Status{Name: "CLOSED"},
+				Resolution: &jira.Resolution{Name: "LOL_GO_AWAY"},
+			}},
+			options: plugins.JiraBranchOptions{ValidStates: &[]plugins.JiraBugState{{Status: "CLOSED", Resolution: "ERRATA"}}},
+			valid:   false,
+			why: []string{
+				"expected the bug to be in one of the following states: CLOSED (ERRATA), but it is CLOSED (LOL_GO_AWAY) instead",
+			},
+		},
+		{
+			name: "matching status and resolution means a valid bug when both are required",
+			issue: &jira.Issue{Fields: &jira.IssueFields{
+				Status:     &jira.Status{Name: "CLOSED"},
+				Resolution: &jira.Resolution{Name: "ERRATA"},
+			}},
+			options:     plugins.JiraBranchOptions{ValidStates: &[]plugins.JiraBugState{{Status: "CLOSED", Resolution: "ERRATA"}}},
+			valid:       true,
+			validations: []string{"bug is in the state CLOSED (ERRATA), which is one of the valid states (CLOSED (ERRATA))"},
+		},
+		{
+			name: "matching resolution means a valid bug when status is not required",
+			issue: &jira.Issue{Fields: &jira.IssueFields{
+				Status:     &jira.Status{Name: "CLOSED"},
+				Resolution: &jira.Resolution{Name: "ERRATA"},
+			}},
+			options:     plugins.JiraBranchOptions{ValidStates: &[]plugins.JiraBugState{{Resolution: "ERRATA"}}},
+			valid:       true,
+			validations: []string{"bug is in the state CLOSED (ERRATA), which is one of the valid states (any status with resolution ERRATA)"},
+		},
+		{
+			name: "matching just resolution means an invalid bug when status does not match",
+			issue: &jira.Issue{Fields: &jira.IssueFields{
+				Status:     &jira.Status{Name: "CLOSED"},
+				Resolution: &jira.Resolution{Name: "ERRATA"},
+			}},
+			options: plugins.JiraBranchOptions{ValidStates: &[]plugins.JiraBugState{{Status: "RESOLVED", Resolution: "ERRATA"}}},
+			valid:   false,
+			why: []string{
+				"expected the bug to be in one of the following states: RESOLVED (ERRATA), but it is CLOSED (ERRATA) instead",
+			},
+		},
+		{
+			name: "matching status on dependent bug means a valid bug when resolution is not required",
+			issue: &jira.Issue{Fields: &jira.IssueFields{
+				Status:     &jira.Status{Name: "CLOSED"},
+				Resolution: &jira.Resolution{Name: "LOL_GO_AWAY"},
+				IssueLinks: []*jira.IssueLink{{
+					Type: jira.IssueLinkType{
+						Name:    "Cloners",
+						Inward:  "is cloned by",
+						Outward: "clones",
+					},
+					OutwardIssue: &jira.Issue{ID: "2", Key: "OCPBUGS-124"},
+				}},
+			}},
+			dependents: []*jira.Issue{{ID: "2", Key: "OCPBUGS-124", Fields: &jira.IssueFields{
+				Status:     &jira.Status{Name: "CLOSED"},
+				Resolution: &jira.Resolution{Name: "LOL_GO_AWAY"},
+			}}},
+			options:     plugins.JiraBranchOptions{DependentBugStates: &[]plugins.JiraBugState{{Status: "CLOSED"}}},
+			valid:       true,
+			validations: []string{"dependent bug [Jira Issue OCPBUGS-124](https://my-jira.com/browse/OCPBUGS-124) is in the state CLOSED (LOL_GO_AWAY), which is one of the valid states (CLOSED)", "bug has dependents"},
+		},
+		{
+			name: "matching just status on dependent bug means an invalid bug when resolution does not match",
+			issue: &jira.Issue{Fields: &jira.IssueFields{
+				Status:     &jira.Status{Name: "CLOSED"},
+				Resolution: &jira.Resolution{Name: "LOL_GO_AWAY"},
+				IssueLinks: []*jira.IssueLink{{
+					Type: jira.IssueLinkType{
+						Name:    "Cloners",
+						Inward:  "is cloned by",
+						Outward: "clones",
+					},
+					OutwardIssue: &jira.Issue{ID: "2", Key: "OCPBUGS-124"},
+				}},
+			}},
+			dependents: []*jira.Issue{{ID: "2", Key: "OCPBUGS-124", Fields: &jira.IssueFields{
+				Status:     &jira.Status{Name: "CLOSED"},
+				Resolution: &jira.Resolution{Name: "LOL_GO_AWAY"},
+			}}},
+			options:     plugins.JiraBranchOptions{DependentBugStates: &[]plugins.JiraBugState{{Status: "CLOSED", Resolution: "ERRATA"}}},
+			valid:       false,
+			validations: []string{"bug has dependents"},
+			why: []string{
+				"expected dependent [Jira Issue OCPBUGS-124](https://my-jira.com/browse/OCPBUGS-124) to be in one of the following states: CLOSED (ERRATA), but it is CLOSED (LOL_GO_AWAY) instead",
+			},
+		},
+		{
+			name: "matching status and resolution on dependent bug means a valid bug when both are required",
+			issue: &jira.Issue{Fields: &jira.IssueFields{
+				Status:     &jira.Status{Name: "CLOSED"},
+				Resolution: &jira.Resolution{Name: "ERRATA"},
+				IssueLinks: []*jira.IssueLink{{
+					Type: jira.IssueLinkType{
+						Name:    "Cloners",
+						Inward:  "is cloned by",
+						Outward: "clones",
+					},
+					OutwardIssue: &jira.Issue{ID: "2", Key: "OCPBUGS-124"},
+				}},
+			}},
+			dependents: []*jira.Issue{{ID: "2", Key: "OCPBUGS-124", Fields: &jira.IssueFields{
+				Status:     &jira.Status{Name: "CLOSED"},
+				Resolution: &jira.Resolution{Name: "ERRATA"},
+			}}},
+			options:     plugins.JiraBranchOptions{DependentBugStates: &[]plugins.JiraBugState{{Status: "CLOSED", Resolution: "ERRATA"}}},
+			valid:       true,
+			validations: []string{"dependent bug [Jira Issue OCPBUGS-124](https://my-jira.com/browse/OCPBUGS-124) is in the state CLOSED (ERRATA), which is one of the valid states (CLOSED (ERRATA))", "bug has dependents"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			valid, validations, why := validateBug(testCase.issue, testCase.dependents, testCase.options, "https://my-jira.com")
+			if valid != testCase.valid {
+				t.Errorf("%s: didn't validate bug correctly, expected %t got %t", testCase.name, testCase.valid, valid)
+			}
+			if !reflect.DeepEqual(validations, testCase.validations) {
+				t.Errorf("%s: didn't get correct validations: %v", testCase.name, cmp.Diff(testCase.validations, validations, allowEventAndDate))
+			}
+			if !reflect.DeepEqual(why, testCase.why) {
+				t.Errorf("%s: didn't get correct reasons why: %v", testCase.name, cmp.Diff(testCase.why, why, allowEventAndDate))
+			}
+		})
+	}
+}
+
+func TestProcessQuery(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		query    emailToLoginQuery
+		email    string
+		expected string
+	}{
+		{
+			name: "single login returns cc",
+			query: emailToLoginQuery{
+				Search: querySearch{
+					Edges: []queryEdge{{
+						Node: queryNode{
+							User: queryUser{
+								Login: "ValidLogin",
+							},
+						},
+					}},
+				},
+			},
+			email:    "qa_tester@example.com",
+			expected: "Requesting review from QA contact:\n/cc @ValidLogin",
+		}, {
+			name: "no login returns not found error",
+			query: emailToLoginQuery{
+				Search: querySearch{
+					Edges: []queryEdge{},
+				},
+			},
+			email:    "qa_tester@example.com",
+			expected: "No GitHub users were found matching the public email listed for the QA contact in Jira (qa_tester@example.com), skipping review request.",
+		}, {
+			name: "multiple logins returns multiple results error",
+			query: emailToLoginQuery{
+				Search: querySearch{
+					Edges: []queryEdge{{
+						Node: queryNode{
+							User: queryUser{
+								Login: "Login1",
+							},
+						},
+					}, {
+						Node: queryNode{
+							User: queryUser{
+								Login: "Login2",
+							},
+						},
+					}},
+				},
+			},
+			email:    "qa_tester@example.com",
+			expected: "Multiple GitHub users were found matching the public email listed for the QA contact in Jira (qa_tester@example.com), skipping review request. List of users with matching email:\n\t- Login1\n\t- Login2",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			response := processQuery(&testCase.query, testCase.email, logrus.WithField("testCase", testCase.name))
+			if response != testCase.expected {
+				t.Errorf("%s: Expected \"%s\", got \"%s\"", testCase.name, testCase.expected, response)
+			}
+		})
+	}
+}
+
+func TestGetCherrypickPRMatch(t *testing.T) {
+	var prNum = 123
+	var branch = "v2"
+	var testCases = []struct {
+		name      string
+		requestor string
+		note      string
+	}{{
+		name: "No requestor or string",
+	}, {
+		name:      "Include requestor",
+		requestor: "user",
+	}, {
+		name: "Include note",
+		note: "this is a test",
+	}, {
+		name:      "Include requestor and note",
+		requestor: "user",
+		note:      "this is a test",
+	}}
+	var pr = &github.PullRequestEvent{
+		PullRequest: github.PullRequest{
+			Base: github.PullRequestBranch{
+				Ref: branch,
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		testPR := *pr
+		testPR.PullRequest.Body = cherrypicker.CreateCherrypickBody(prNum, testCase.requestor, testCase.note)
+		cherrypick, cherrypickOfPRNum, cherrypickTo, err := getCherryPickMatch(testPR)
+		if err != nil {
+			t.Fatalf("%s: Got error but did not expect one: %v", testCase.name, err)
+		}
+		if !cherrypick {
+			t.Errorf("%s: Expected cherrypick to be true, but got false", testCase.name)
+		}
+		if cherrypickOfPRNum != prNum {
+			t.Errorf("%s: Got incorrect PR num: Expected %d, got %d", testCase.name, prNum, cherrypickOfPRNum)
+		}
+		if cherrypickTo != "v2" {
+			t.Errorf("%s: Got incorrect cherrypick to branch: Expected %s, got %s", testCase.name, branch, cherrypickTo)
+		}
+	}
+}
+
+func TestIsBugAllowed(t *testing.T) {
+	testCases := []struct {
+		name           string
+		bug            *jira.Issue
+		securityLevels []string
+		expected       bool
+	}{
+		{
+			name:           "no groups configured means always allowed",
+			securityLevels: []string{},
+			expected:       true,
+		},
+		{
+			name: "matching one level is allowed",
+			bug: &jira.Issue{Fields: &jira.IssueFields{
+				Unknowns: tcontainer.MarshalMap{
+					"security": jiraclient.SecurityLevel{Name: "whoa"},
+				},
+			}},
+			securityLevels: []string{"whoa", "really", "cool"},
+			expected:       true,
+		},
+		{
+			name: "no levels matching is not allowed",
+			bug: &jira.Issue{Fields: &jira.IssueFields{
+				Unknowns: tcontainer.MarshalMap{
+					"security": jiraclient.SecurityLevel{Name: "whoa"},
+				},
+			}},
+			securityLevels: []string{"other"},
+			expected:       false,
+		},
+		{
+			name:           "no level set in bug is equal to level default",
+			bug:            &jira.Issue{Fields: &jira.IssueFields{}},
+			securityLevels: []string{"default"},
+			expected:       true,
+		},
+		{
+			name:           "default level is not set",
+			bug:            &jira.Issue{Fields: &jira.IssueFields{}},
+			securityLevels: []string{"internal"},
+			expected:       false,
+		},
+	}
+	for _, testCase := range testCases {
+		actual, err := isBugAllowed(testCase.bug, testCase.securityLevels)
+		if err != nil {
+			// this error should never occur when run against a real jira server, so no need to test error handling
+			t.Fatalf("%s: unexpected error: %v", testCase.name, err)
+		}
+		if actual != testCase.expected {
+			t.Errorf("%s: isBugAllowed returned %v incorrectly", testCase.name, actual)
+		}
 	}
 }

--- a/prow/plugins/plugin-config-documented.yaml
+++ b/prow/plugins/plugin-config-documented.yaml
@@ -455,11 +455,191 @@ help:
     # The default value is "https://git.k8s.io/community/contributors/guide/help-wanted.md".
     help_guidelines_url: ' '
 jira:
+    # Default settings mapped by branch in any repo in any org.
+    # The `*` wildcard will apply to all branches.
+    default:
+        "":
+            # AddExternalLink determines whether the pull request will be added to the Jira
+            # bug using the ExternalBug tracker API after being validated
+            add_external_link: false
+
+            # AllowedSecurityLevels is a list of the name of jira issue security levels that the jira plugin can
+            # link to in PRs. If an issue has a security level that is not in this list, the jira
+            # plugin will not link the issue to the PR.
+            allowed_security_levels:
+              - ""
+
+            # DependentBugStates determine states in which a bug's dependents bugs may be
+            # to deem the child bug valid. If set, all blockers must have a valid state.
+            dependent_bug_states: null
+
+            # DependentBugTargetVersions determines the set of valid target
+            # versions for dependent bugs. If set, all blockers must have a
+            # valid target version.
+            dependent_bug_target_versions: null
+
+            # ExcludeDefaults excludes defaults from more generic Jira configurations.
+            exclude_defaults: false
+
+            # IsOpen determines whether a bug needs to be open to be valid
+            is_open: false
+
+            # StateAfterClose is the state to which the bug will be moved if all pull requests
+            # in the external bug tracker have been closed.
+            state_after_close:
+                resolution: ' '
+                status: ' '
+
+            # StateAfterMerge is the state to which the bug will be moved after all pull requests
+            # in the external bug tracker have been merged.
+            state_after_merge:
+                resolution: ' '
+                status: ' '
+
+            # StateAfterValidation is the state to which the bug will be moved after being
+            # deemed valid and linked to a PR. Will implicitly be considered a part of `ValidStates`
+            # if others are set.
+            state_after_validation:
+                resolution: ' '
+                status: ' '
+
+            # TargetVersion determines which release a bug needs to target to be valid
+            target_version: ""
+
+            # ValidStates determine states in which the bug may be to be valid
+            valid_states: null
+
+            # ValidateByDefault determines whether a validation check is run for all pull
+            # requests by default
+            validate_by_default: false
+
     # DisabledJiraProjects are projects for which we will never try to create a link,
     # for example including `enterprise` here would disable linking for all issues
     # that start with `enterprise-` like `enterprise-4.` Matching is case-insenitive.
     disabled_jira_projects:
       - ""
+
+    # Options for specific orgs. The `*` wildcard will apply to all orgs.
+    orgs:
+        "":
+            # Default settings mapped by branch in any repo in this org.
+            # The `*` wildcard will apply to all branches.
+            default:
+                "":
+                    # AddExternalLink determines whether the pull request will be added to the Jira
+                    # bug using the ExternalBug tracker API after being validated
+                    add_external_link: false
+
+                    # AllowedSecurityLevels is a list of the name of jira issue security levels that the jira plugin can
+                    # link to in PRs. If an issue has a security level that is not in this list, the jira
+                    # plugin will not link the issue to the PR.
+                    allowed_security_levels:
+                      - ""
+
+                    # DependentBugStates determine states in which a bug's dependents bugs may be
+                    # to deem the child bug valid. If set, all blockers must have a valid state.
+                    dependent_bug_states: null
+
+                    # DependentBugTargetVersions determines the set of valid target
+                    # versions for dependent bugs. If set, all blockers must have a
+                    # valid target version.
+                    dependent_bug_target_versions: null
+
+                    # ExcludeDefaults excludes defaults from more generic Jira configurations.
+                    exclude_defaults: false
+
+                    # IsOpen determines whether a bug needs to be open to be valid
+                    is_open: false
+
+                    # StateAfterClose is the state to which the bug will be moved if all pull requests
+                    # in the external bug tracker have been closed.
+                    state_after_close:
+                        resolution: ' '
+                        status: ' '
+
+                    # StateAfterMerge is the state to which the bug will be moved after all pull requests
+                    # in the external bug tracker have been merged.
+                    state_after_merge:
+                        resolution: ' '
+                        status: ' '
+
+                    # StateAfterValidation is the state to which the bug will be moved after being
+                    # deemed valid and linked to a PR. Will implicitly be considered a part of `ValidStates`
+                    # if others are set.
+                    state_after_validation:
+                        resolution: ' '
+                        status: ' '
+
+                    # TargetVersion determines which release a bug needs to target to be valid
+                    target_version: ""
+
+                    # ValidStates determine states in which the bug may be to be valid
+                    valid_states: null
+
+                    # ValidateByDefault determines whether a validation check is run for all pull
+                    # requests by default
+                    validate_by_default: false
+
+            # Options for specific repos. The `*` wildcard will apply to all repos.
+            repos:
+                "":
+                    # Options for specific branches in this repo.
+                    # The `*` wildcard will apply to all branches.
+                    branches:
+                        "":
+                            # AddExternalLink determines whether the pull request will be added to the Jira
+                            # bug using the ExternalBug tracker API after being validated
+                            add_external_link: false
+
+                            # AllowedSecurityLevels is a list of the name of jira issue security levels that the jira plugin can
+                            # link to in PRs. If an issue has a security level that is not in this list, the jira
+                            # plugin will not link the issue to the PR.
+                            allowed_security_levels:
+                              - ""
+
+                            # DependentBugStates determine states in which a bug's dependents bugs may be
+                            # to deem the child bug valid. If set, all blockers must have a valid state.
+                            dependent_bug_states: null
+
+                            # DependentBugTargetVersions determines the set of valid target
+                            # versions for dependent bugs. If set, all blockers must have a
+                            # valid target version.
+                            dependent_bug_target_versions: null
+
+                            # ExcludeDefaults excludes defaults from more generic Jira configurations.
+                            exclude_defaults: false
+
+                            # IsOpen determines whether a bug needs to be open to be valid
+                            is_open: false
+
+                            # StateAfterClose is the state to which the bug will be moved if all pull requests
+                            # in the external bug tracker have been closed.
+                            state_after_close:
+                                resolution: ' '
+                                status: ' '
+
+                            # StateAfterMerge is the state to which the bug will be moved after all pull requests
+                            # in the external bug tracker have been merged.
+                            state_after_merge:
+                                resolution: ' '
+                                status: ' '
+
+                            # StateAfterValidation is the state to which the bug will be moved after being
+                            # deemed valid and linked to a PR. Will implicitly be considered a part of `ValidStates`
+                            # if others are set.
+                            state_after_validation:
+                                resolution: ' '
+                                status: ' '
+
+                            # TargetVersion determines which release a bug needs to target to be valid
+                            target_version: ""
+
+                            # ValidStates determine states in which the bug may be to be valid
+                            valid_states: null
+
+                            # ValidateByDefault determines whether a validation check is run for all pull
+                            # requests by default
+                            validate_by_default: false
 label:
     # AdditionalLabels is a set of additional labels enabled for use
     # on top of the existing "kind/*", "priority/*", and "area/*" labels.


### PR DESCRIPTION
This PR takes the logic, configuration, and bug lifecycle management
from the bugzilla plugin and adapts it for the jira plugin. All
functionality should be identical to the bugzilla plugin, but using Jira
instead. The previous functionality of this plugin is also untouched and
will continue working as expected.

/cc @alvaroaleman @stevekuznetsov