### PR TITLE
Pubsub inrepoconfig presubmit

### DIFF
--- a/prow/test/integration/config/prow/cluster/sub.yaml
+++ b/prow/test/integration/config/prow/cluster/sub.yaml
@@ -24,6 +24,16 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --grace-period=110s
+        # This cookie file is only here to trigger the creation of a
+        # Gerrit-flavored Git client factory. So this makes this sub deployment
+        # "tied" to Gerrit.
+        #
+        # TODO (listx): Allow sub to be deployed with access to multiple
+        # GitHub/Gerrit credentials (and make it know which one to use based on
+        # the org/repo name). We can't simply deploy a 2nd sub deployment
+        # configured with GitHub creds to test that codepath because currently
+        # sub will always choose one or the other.
+        - --cookiefile=/etc/cookies/cookies
         - --dry-run=false
         ports:
         - name: http
@@ -31,6 +41,9 @@ spec:
         - name: metrics
           containerPort: 9090
         volumeMounts:
+        - name: cookies
+          mountPath: /etc/cookies
+          readOnly: true
         - name: config
           mountPath: /etc/config
           readOnly: true
@@ -41,11 +54,19 @@ spec:
           requests:
             cpu: "1"
             memory: "2Gi"
-        # Make sub use the Pub/Sub emulator running in the fakepubsub service.
         env:
+        # Make sub use the Pub/Sub emulator running in the fakepubsub service.
         - name: PUBSUB_EMULATOR_HOST
           value: fakepubsub.default:80
+        # When cloning from an inrepoconfig repo, don't bother verifying certs.
+        # This allows us to use "https://..." addresses to fakegitserver.
+        - name: GIT_SSL_NO_VERIFY
+          value: "1"
       volumes:
+      - name: cookies
+        secret:
+          defaultMode: 420
+          secretName: http-cookiefile
       - name: config
         configMap:
           name: config
@@ -104,3 +125,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: sub
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: http-cookiefile
+  namespace: default
+type: Opaque
+data:
+  # This is just "helloworld" in base64.
+  cookies: aGVsbG93b3JsZA==

--- a/prow/test/integration/config/prow/config.yaml
+++ b/prow/test/integration/config/prow/config.yaml
@@ -45,3 +45,11 @@ plank:
 pubsub_subscriptions:
   "project1":
   - "subscription1" # Subscribed to "topic1".
+
+in_repo_config:
+  enabled:
+   "org1/repo1": true
+   "fakegitserver.default/repo/repo2": true
+   "fakegitserver.default/repo/repo3": true
+   "fakegitserver.default/repo/org1/repo4": true
+   "fakegitserver.default/repo/org1/repo5": true

--- a/prow/test/integration/test/sub_test.go
+++ b/prow/test/integration/test/sub_test.go
@@ -26,6 +26,7 @@ import (
 	coreapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/test-infra/prow/gerrit/client"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	prowjobv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
@@ -34,6 +35,43 @@ import (
 	"k8s.io/test-infra/prow/test/integration/internal/fakepubsub"
 )
 
+func createGerritRepo(id, job string) string {
+	// We create PRs *before* uniquifying the repo with the given "id" string,
+	// because then we don't have to change the PR sha constants in
+	// TestPubSubSubscriptions.
+	template := `
+echo hello > README.txt
+git add README.txt
+git commit -m "commit 1"
+
+# Create fake PRs. These are "Gerrit" style refs. Technically we don't actually
+# use these ref names in these tests, but we have them here as an illustrative
+# example.
+for num in 1 2 3; do
+	git checkout -d master
+	echo "${num}" > "${num}"
+	git add "${num}"
+	git commit -m "PR${num}"
+	git update-ref "refs/changes/00/123/${num}" HEAD
+done
+
+git checkout master
+
+echo this-is-from-repo%s > README.txt
+git add README.txt
+git commit -m "uniquify"
+
+mkdir .prow
+cat <<EOF >.prow/presubmits.yaml
+%s
+EOF
+
+git add .prow/presubmits.yaml
+git commit -m "add inrepoconfig"
+`
+	return fmt.Sprintf(template, id, job)
+}
+
 func TestPubSubSubscriptions(t *testing.T) {
 	t.Parallel()
 
@@ -41,12 +79,67 @@ func TestPubSubSubscriptions(t *testing.T) {
 		PubsubEmulatorHost = "localhost:30303"
 		UidLabel           = "integration-test/uid"
 		Repo1HEADsha       = "8c5dc6fe1b5a63200f23a2364011e8270f0f7cd0"
+		Repo2HEADsha       = "0c035e2664a380bf17cbef8ba78c6381cc78e1ce"
+		Repo2PR1sha        = "458b96a96a74689447530035f5a71c426bacb505"
+		Repo3PR1sha        = Repo2PR1sha
+		Repo4PR1sha        = Repo2PR1sha
+		Repo5PR1sha        = Repo2PR1sha
+		Repo2PR2sha        = "eb02ec2e228b2102b531ec049ffaab9b8c1db346"
+		Repo3PR2sha        = Repo2PR2sha
+		Repo4PR2sha        = Repo2PR2sha
+		Repo2PR3sha        = "b9004c6430af9ffb4cb337dabeba4b6819597fa9"
+		Repo3PR3sha        = Repo2PR3sha
+		Repo4PR3sha        = Repo2PR3sha
+		Repo3HEADsha       = "97b866610ecdee8b90a7808b176c1fb3a859fa00"
+		Repo4HEADsha       = "4c028549d727a9deebf69b68b640837844222632"
+		Repo5HEADsha       = "c0ea4b30f3d9dc0bf1d3391d8e3a6bee39ad4de6"
 		CreateRepoRepo1    = `
 echo this-is-from-repo1 > README.txt
 git add README.txt
 git commit -m "commit 1"
 `
+		ProwJobDecorated = `
+presubmits:
+  - name: trigger-inrepoconfig-presubmit-via-pubsub-repo%s
+    always_run: false
+    decorate: true
+    spec:
+      containers:
+      - image: localhost:5001/alpine
+        command:
+        - sh
+        args:
+        - -c
+        - |
+          set -eu
+          echo "hello from trigger-inrepoconfig-presubmit-via-pubsub-repo%s"
+          cat README.txt
+`
+		ProwJobDecoratedCloneURI = `
+presubmits:
+  - name: trigger-inrepoconfig-presubmit-via-pubsub-repo%s
+    always_run: false
+    decorate: true
+    # Force this job to use a particular CloneURI.
+    clone_uri: "%s"
+    spec:
+      containers:
+      - image: localhost:5001/alpine
+        command:
+        - sh
+        args:
+        - -c
+        - |
+          set -eu
+          echo "hello from trigger-inrepoconfig-presubmit-via-pubsub-repo%s"
+          cat README.txt
+`
 	)
+
+	CreateRepo2 := createGerritRepo("2", fmt.Sprintf(ProwJobDecorated, "2", "2"))
+	CreateRepo3 := createGerritRepo("3", fmt.Sprintf(ProwJobDecorated, "3", "3"))
+	CreateRepo4 := createGerritRepo("4", fmt.Sprintf(ProwJobDecorated, "4", "4"))
+	CreateRepo5 := createGerritRepo("5", fmt.Sprintf(ProwJobDecoratedCloneURI, "5", "https://fakegitserver.default/repo/org1/repo5", "5"))
 
 	tests := []struct {
 		name       string
@@ -74,7 +167,7 @@ git commit -m "commit 1"
 						Repo:     "repo1",
 						BaseSHA:  Repo1HEADsha,
 						BaseRef:  "master",
-						CloneURI: "http://fakegitserver.default/repo/repo1",
+						CloneURI: "https://fakegitserver.default/repo/repo1",
 					},
 				},
 			},
@@ -82,6 +175,200 @@ git commit -m "commit 1"
 this-is-from-repo1
 `,
 		},
+		{
+			name: "inrepoconfig-presubmit2-explicit-cloneuri",
+			repoSetups: []fakegitserver.RepoSetup{
+				{
+					Name:      "repo2",
+					Script:    CreateRepo2,
+					Overwrite: true,
+				},
+			},
+			msg: fakepubsub.PubSubMessageForSub{
+				Attributes: map[string]string{
+					subscriber.ProwEventType: subscriber.PresubmitProwJobEvent,
+				},
+				Data: subscriber.ProwJobEvent{
+					Name: "trigger-inrepoconfig-presubmit-via-pubsub-repo2",
+					Refs: &prowjobv1.Refs{
+						CloneURI: "https://fakegitserver.default/repo/repo2",
+						Org:      "https://fakegitserver.default/repo",
+						Repo:     "repo2",
+						BaseSHA:  Repo2HEADsha,
+						BaseRef:  "master",
+						Pulls: []prowjobv1.Pull{
+							{
+								Number: 1,
+								SHA:    Repo2PR1sha,
+							},
+							{
+								Number: 2,
+								SHA:    Repo2PR2sha,
+							},
+							{
+								Number: 3,
+								SHA:    Repo2PR3sha,
+							},
+						},
+					},
+					Labels: map[string]string{
+						client.GerritRevision: "123",
+					},
+				},
+			},
+			expected: `hello from trigger-inrepoconfig-presubmit-via-pubsub-repo2
+this-is-from-repo2
+`,
+		},
+		{
+			name: "inrepoconfig-presubmit3",
+			repoSetups: []fakegitserver.RepoSetup{
+				{
+					Name:      "repo3",
+					Script:    CreateRepo3,
+					Overwrite: true,
+				},
+			},
+			msg: fakepubsub.PubSubMessageForSub{
+				Attributes: map[string]string{
+					subscriber.ProwEventType: subscriber.PresubmitProwJobEvent,
+				},
+				Data: subscriber.ProwJobEvent{
+					Name: "trigger-inrepoconfig-presubmit-via-pubsub-repo3",
+					Refs: &prowjobv1.Refs{
+						Org:  "https://fakegitserver.default/repo",
+						Repo: "repo3",
+						// RepoLink is used by clonerefs to determine whether
+						// the repo is from Git or GitHub. It is overridden by
+						// CloneURI (if set) for determining the clone URL to
+						// give to the "git" binary. RepoLink is appended with
+						// at ".git" suffix, whereas CloneURI is used as-is.
+						RepoLink: "https://fakegitserver.default/repo/repo3",
+						BaseSHA:  Repo3HEADsha,
+						BaseRef:  "master",
+						Pulls: []prowjobv1.Pull{
+							{
+								Number: 1,
+								SHA:    Repo3PR1sha,
+							},
+							{
+								Number: 2,
+								SHA:    Repo3PR2sha,
+							},
+							{
+								Number: 3,
+								SHA:    Repo3PR3sha,
+							},
+						},
+					},
+					Labels: map[string]string{
+						client.GerritRevision: "123",
+					},
+				},
+			},
+			expected: `hello from trigger-inrepoconfig-presubmit-via-pubsub-repo3
+this-is-from-repo3
+`,
+		},
+		{
+			name: "inrepoconfig-presubmit4-with-nested-directory",
+			repoSetups: []fakegitserver.RepoSetup{
+				{
+					Name:      "org1/repo4",
+					Script:    CreateRepo4,
+					Overwrite: true,
+				},
+			},
+			msg: fakepubsub.PubSubMessageForSub{
+				Attributes: map[string]string{
+					subscriber.ProwEventType: subscriber.PresubmitProwJobEvent,
+				},
+				Data: subscriber.ProwJobEvent{
+					Name: "trigger-inrepoconfig-presubmit-via-pubsub-repo4",
+					Refs: &prowjobv1.Refs{
+						Org:      "https://fakegitserver.default/repo/org1",
+						Repo:     "repo4",
+						RepoLink: "https://fakegitserver.default/repo/org1/repo4",
+						BaseSHA:  Repo4HEADsha,
+						BaseRef:  "master",
+						Pulls: []prowjobv1.Pull{
+							{
+								Number: 1,
+								SHA:    Repo4PR1sha,
+							},
+							{
+								Number: 2,
+								SHA:    Repo4PR2sha,
+							},
+							{
+								Number: 3,
+								SHA:    Repo4PR3sha,
+							},
+						},
+					},
+					Labels: map[string]string{
+						client.GerritRevision: "123",
+					},
+				},
+			},
+			expected: `hello from trigger-inrepoconfig-presubmit-via-pubsub-repo4
+this-is-from-repo4
+`,
+		},
+		{
+			name: "inrepoconfig-presubmit5-with-clone-uri-in-job-definition",
+			repoSetups: []fakegitserver.RepoSetup{
+				{
+					Name:      "org1/repo5",
+					Script:    CreateRepo5,
+					Overwrite: true,
+				},
+			},
+			msg: fakepubsub.PubSubMessageForSub{
+				Attributes: map[string]string{
+					subscriber.ProwEventType: subscriber.PresubmitProwJobEvent,
+				},
+				Data: subscriber.ProwJobEvent{
+					Name: "trigger-inrepoconfig-presubmit-via-pubsub-repo5",
+					Refs: &prowjobv1.Refs{
+						// Technically Org and Repo are not used by clonerefs as
+						// clone_uri is set on the job definition itself (see
+						// ProwJobDecoratedCloneURI). However sub needs Org and
+						// Repo to retrieve (clone) this inrepo job config.
+						Org:     "https://fakegitserver.default/repo/org1",
+						Repo:    "repo5",
+						BaseSHA: Repo5HEADsha,
+						BaseRef: "master",
+						Pulls: []prowjobv1.Pull{
+							{
+								Number: 1,
+								SHA:    Repo5PR1sha,
+							},
+						},
+					},
+					Labels: map[string]string{
+						client.GerritRevision: "123",
+					},
+				},
+			},
+			expected: `hello from trigger-inrepoconfig-presubmit-via-pubsub-repo5
+this-is-from-repo5
+`,
+		},
+	}
+
+	// Ensure that all repos are named uniquely, because otherwise they clobber
+	// each other when we create them against fakegitserver. This prevents
+	// programmer error when writing new tests.
+	allRepoDirs := []string{}
+	for _, tt := range tests {
+		for _, repoSetup := range tt.repoSetups {
+
+			allRepoDirs = append(allRepoDirs, repoSetup.Name)
+		}
+	}
+	if err := enforceUniqueRepoDirs(allRepoDirs); err != nil {
+		t.Fatal(err)
 	}
 
 	clusterContext := getClusterContext()
@@ -187,7 +474,7 @@ this-is-from-repo1
 			// log as much as possible to make it easier to see why a test
 			// failed), or when the test succeeds (where we clean up the ProwJob
 			// that was created by sub).
-			timeout := 30 * time.Second
+			timeout := 60 * time.Second
 			pollInterval := 500 * time.Millisecond
 			if waitErr := wait.Poll(pollInterval, timeout, expectJobSuccess); waitErr != nil {
 				if podName == nil {
@@ -239,4 +526,16 @@ this-is-from-repo1
 			}
 		})
 	}
+}
+
+func enforceUniqueRepoDirs(dirs []string) error {
+	seen := make(map[string]bool)
+	for _, dir := range dirs {
+		_, ok := seen[dir]
+		if ok {
+			return fmt.Errorf("directory %q already used", dir)
+		}
+		seen[dir] = true
+	}
+	return nil
 }


### PR DESCRIPTION
The fake (nonsense) cookie file we mount is only there to trigger the
code branch that detects whether to create a git client factory for
GitHub or for Gerrit. The --cookie-file flag makes sub's ProwYAML cache
initialization logic assume that all inrepoconfigs are cloned from
Gerrit.

For our purposes the contents of the cookie file
doesn't matter because we don't even hit the fakegerritserver URL for
cloning the repo because we use a direct CloneURI field.

Note that this tightly couples this deployment of sub to Gerrit (see the
TODO comment added in sub.yaml).

In the future if we want to add a test case without using the CloneURI
field, we would have to refactor how we initialize the inrepoconfig
cache (in particular how we set up the git client factories). Currently
we either always clone from GitHub or Gerrit (by prefixing "https://"
--- see tryGetCloneURIAndHost() in
prow/pubsub/subscriber/subscriber.go). Obviously neither choice will
work because we need to clone instead from
"http://fakegitserver.default/" ... for the integration tests to work.

/assign @mpherman2 
/cc @chaodaiG @cjwagner 