### PR TITLE
Fix `post-test-infra-upload-boskos-config` postsubmit job

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -466,7 +466,7 @@ postsubmits:
     branches:
     - ^master$
     max_concurrency: 1
-    run_if_changed: '^config/prow/cluster/build/boskos-resources.yaml$'
+    run_if_changed: '^config/prow/cluster/build/boskos-resources/boskos-resources.yaml$'
     decorate: true
     spec:
       serviceAccountName: deployer # TODO(fejta): should be pusher


### PR DESCRIPTION
```
 REDACTED  MCW0CDP3YY  ~  Desktop  Git  k8s-test-infra   master  4⬇  1✎  $   ll config/prow/cluster/build/boskos-resources/boskos-resources.yaml
-rw-r--r--  1 REDACTED  staff  9753 14 Jun 13:16 config/prow/cluster/build/boskos-resources/boskos-resources.yaml
 REDACTED  MCW0CDP3YY  ~  Desktop  Git  k8s-test-infra   master  4⬇  1✎  $   ll config/prow/cluster/build/boskos-resources.yaml
ls: config/prow/cluster/build/boskos-resources.yaml: No such file or directory
```

https://kubernetes.slack.com/archives/C09QZ4DQB/p1655207540950539

Some files we moved around and but the prowjob wasn't updated. 

/cc jupblb