### PR TITLE
Add EKS presubmit to aws-efs-csi-driver

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-efs-csi-driver/aws-efs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-efs-csi-driver/aws-efs-csi-driver-presubmits.yaml
@@ -64,3 +64,27 @@ presubmits:
       testgrid-tab-name: e2e-test
       description: aws efs csi driver e2e test
       testgrid-num-columns-recent: '30'
+  - name: pull-aws-efs-csi-driver-external-test-eks
+    always_run: true
+    decorate: true
+    skip_branches:
+      - gh-pages
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-aws-credential-aws-oss-testing: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220614-cde7860a33-master
+          command:
+            - runner.sh
+          args:
+            - make
+            - test-e2e-external-eks
+          securityContext:
+            privileged: true
+    annotations:
+      testgrid-dashboards: provider-aws-efs-csi-driver
+      testgrid-tab-name: pull-external-test-eks
+      description: kubernetes/kubernetes external test on pull request on eks
+      testgrid-num-columns-recent: '30'


### PR DESCRIPTION
Currently e2e tests only run against kops, they also need to run against EKS to exercise EKS specific things like eksctl --disable-pod-imds

This passage is copy/pasted from EBS since they share the similar make rules/structure https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml#L139-L162.

(The "external" designation makes less sense in EFS context than EBS context. In EFS we just have ONE e2e suite, but in EBS we designate it "external" to disambiguate from "migration", "single-az", "multi-az". In any case I'd rather be consistent so I will keep the "external" and maybe clean up the naming later)