### PR TITLE
label_sync: Add new global label - area/community-meeting

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -68,6 +68,7 @@ larger set of contributors to apply/remove them.
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
 | <a id="api-review" href="#api-review">`api-review`</a> | Categorizes an issue or PR as actively needing an API review.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="area/community-meeting" href="#area/community-meeting">`area/community-meeting`</a> | Issues or PRs that should potentially be discussed in a Kubernetes community meeting.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="area/dependency" href="#area/dependency">`area/dependency`</a> | Issues or PRs related to dependency changes| label | |
 | <a id="area/provider/aws" href="#area/provider/aws">`area/provider/aws`</a> | Issues or PRs related to aws provider <br><br> This was previously `area/platform/aws`, `area/platform/eks`, `sig/aws`, `aws`, | label | |
 | <a id="area/provider/azure" href="#area/provider/azure">`area/provider/azure`</a> | Issues or PRs related to azure provider <br><br> This was previously `area/platform/aks`, `area/platform/azure`, `sig/azure`, `azure`, | label | |

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -79,6 +79,12 @@ default:
         - name: area/platform/vsphere
         - name: sig/vmware
         - name: vmware
+    - color: 0052cc
+      description: Issues or PRs that should potentially be discussed in a Kubernetes community meeting.
+      name: area/community-meeting
+      target: both
+      prowPlugin: label
+      addedBy: anyone
     - color: 0ffa16
       description: Indicates a PR has been approved by an approver from all required OWNERS files.
       name: approved


### PR DESCRIPTION
Adding this label is a first step towards automating the
process of curating content for the K8s community meeting.
This label can be added by anyone and before a community
meeting, the host/set of people responsible for the meeting
filter through these issues and/or PRs and curate the content.

Fixes: https://github.com/Kubernetes/community/issues/6704

/cc @nimbinatus 