### PR TITLE
kubebuilder - upgrade the old versions used and reduces the versions to test against for those that still accepting patches (at least)

### DIFF
--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -169,7 +169,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-  - name: pull-kubebuilder-e2e-k8s-1-19-4
+  - name: pull-kubebuilder-e2e-k8s-1-19-16
     decorate: true
     always_run: true
     optional: true
@@ -187,7 +187,7 @@ presubmits:
         - ./test_e2e.sh
         env:
         - name: KIND_K8S_VERSION
-          value: "v1.19.4"
+          value: "v1.19.16"
         resources:
           requests:
             cpu: 4000m
@@ -195,11 +195,11 @@ presubmits:
           privileged: true
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
-      testgrid-tab-name: kubebuilder-e2e-1-19-4
+      testgrid-tab-name: kubebuilder-e2e-1-19-16
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-  - name: pull-kubebuilder-e2e-k8s-1-18-8
+  - name: pull-kubebuilder-e2e-k8s-1-18-20
     decorate: true
     always_run: true
     optional: true
@@ -217,7 +217,7 @@ presubmits:
         - ./test_e2e.sh
         env:
         - name: KIND_K8S_VERSION
-          value: "v1.18.8"
+          value: "v1.18.20"
         resources:
           requests:
             cpu: 4000m
@@ -225,127 +225,7 @@ presubmits:
           privileged: true
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
-      testgrid-tab-name: kubebuilder-e2e-1-18-8
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-  - name: pull-kubebuilder-e2e-k8s-1-17-11
-    decorate: true
-    always_run: true
-    optional: true
-    path_alias: sigs.k8s.io/kubebuilder
-    branches:
-    - ^master$
-    - ^feature/plugins-.+$
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220614-cde7860a33-master
-        command:
-        # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
-        - runner.sh
-        # this MUST be a relative directory with "./" or the runner will fail to find the file
-        - ./test_e2e.sh
-        env:
-        - name: KIND_K8S_VERSION
-          value: "v1.17.11"
-        resources:
-          requests:
-            cpu: 4000m
-        securityContext:
-          privileged: true
-    annotations:
-      testgrid-dashboards: sig-api-machinery-kubebuilder
-      testgrid-tab-name: kubebuilder-e2e-1-17-11
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-  - name: pull-kubebuilder-e2e-k8s-1-16-15
-    decorate: true
-    always_run: true
-    optional: false
-    path_alias: sigs.k8s.io/kubebuilder
-    branches:
-    - ^master$
-    - ^feature/plugins-.+$
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220614-cde7860a33-master
-        command:
-        # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
-        - runner.sh
-        # this MUST be a relative directory with "./" or the runner will fail to find the file
-        - ./test_e2e.sh
-        env:
-        - name: KIND_K8S_VERSION
-          value: "v1.16.15"
-        resources:
-          requests:
-            cpu: 4000m
-        securityContext:
-          privileged: true
-    annotations:
-      testgrid-dashboards: sig-api-machinery-kubebuilder
-      testgrid-tab-name: kubebuilder-e2e-1-16-15
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-  - name: pull-kubebuilder-e2e-k8s-1-15-12
-    decorate: true
-    always_run: true
-    optional: false
-    path_alias: sigs.k8s.io/kubebuilder
-    branches:
-    - ^master$
-    - ^feature/plugins-.+$
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220614-cde7860a33-master
-        command:
-        # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
-        - runner.sh
-        # this MUST be a relative directory with "./" or the runner will fail to find the file
-        - ./test_e2e.sh
-        env:
-        - name: KIND_K8S_VERSION
-          value: "v1.15.12"
-        resources:
-          requests:
-            cpu: 4000m
-        securityContext:
-          privileged: true
-    annotations:
-      testgrid-dashboards: sig-api-machinery-kubebuilder
-      testgrid-tab-name: kubebuilder-e2e-1-15-12
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-  - name: pull-kubebuilder-e2e-k8s-1-14-10
-    decorate: true
-    always_run: true
-    optional: false
-    path_alias: sigs.k8s.io/kubebuilder
-    branches:
-    - ^master$
-    - ^feature/plugins-.+$
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220614-cde7860a33-master
-        command:
-        # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
-        - runner.sh
-        # this MUST be a relative directory with "./" or the runner will fail to find the file
-        - ./test_e2e.sh
-        env:
-        - name: KIND_K8S_VERSION
-          value: "v1.14.10"
-        resources:
-          requests:
-            cpu: 4000m
-        securityContext:
-          privileged: true
-    annotations:
-      testgrid-dashboards: sig-api-machinery-kubebuilder
-      testgrid-tab-name: kubebuilder-e2e-1-14-10
+      testgrid-tab-name: kubebuilder-e2e-1-18-20
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"


### PR DESCRIPTION
**Description**

Upgrade the old versions used and reduces the versions to test against for those that still accepting at least patch releases

**Motivation**
- Reduce the time/effort to run the tests
- Solve issues that probably are facing because we using very old versions 
- We have no reason to still testing with so many old and no longer maintained k8s versions