### PR TITLE
skip tests not designed for dockershim in 1.23 presubmitt

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.23-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.23-windows-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
         - --aksengine-deploy-custom-k8s
         - --aksengine-agentpoolcount=2
         # Specific test args
-        - --test_args=--node-os-distro=windows --docker-config-file=$(DOCKER_CONFIG_FILE) -prepull-images=true --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
+        - --test_args=--node-os-distro=windows --docker-config-file=$(DOCKER_CONFIG_FILE) -prepull-images=true --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|\[Excluded:WindowsDocker\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
         - --ginkgo-parallel=4
         securityContext:
           privileged: true


### PR DESCRIPTION
The presubmit for 1.23 is failing on the tests that should not be included for dockershim based jobs. 

https://github.com/kubernetes/kubernetes/pull/110585

/sig windows
/assign @marosset 