### PR TITLE
Add ci checks as required for kube-openapi

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -366,6 +366,12 @@ branch-protection:
             users: []
             teams:
             - stage-bots
+        kube-openapi:
+          required_status_checks:
+            contexts:
+            - ci (1.x, true)
+            - ci (1.16, true)
+            - ci (1.x, false)
         kube-proxy:
           restrictions:
             users: []


### PR DESCRIPTION
Very much not sure about the name of these since they seem to be computed automatically, but I've tried to re-use the name that I add in the GUI when I try to add the requirement check.

cc @liggitt @BenTheElder 